### PR TITLE
Feature/aku 65

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentListPaginator.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentListPaginator.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -128,7 +128,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onDocumentsPerPageChange: function alfresco_documentlibrary_AlfDocumentListPaginator__onDocumentsPerPageChange(payload) {
-         if (payload && payload.value && payload.value != this.documentsPerPage)
+         if (payload && payload.value && payload.value !== this.documentsPerPage)
          {
             this.documentsPerPage = payload.value;
          }
@@ -168,7 +168,7 @@ define(["dojo/_base/declare",
        */
       onDocumentsLoaded: function alfresco_documentlibrary_AlfDocumentListPaginator__onDocumentsLoaded(payload) {
          this.alfLog("log", "New Documents Loaded", payload);
-         if (payload != null)
+         if (payload !== null)
          {
             if (this.__paginationControlsAvailable === true)
             {
@@ -189,7 +189,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The data to use to update the widgets
        */
       processLoadedDocuments: function alfresco_documentlibrary_AlfDocumentListPaginator__processLoadedDocuments(payload) {
-         if (payload.totalDocuments != null && payload.startIndex != null)
+         if (payload.totalDocuments !== null && payload.startIndex !== null)
          {
             if (payload.totalDocuments === 0)
             {
@@ -208,13 +208,13 @@ define(["dojo/_base/declare",
                // Update the page back action to disable if on the first page...
                if (this.pageBack)
                {
-                  this.pageBack.set("disabled", (this.currentPage == 1));
+                  this.pageBack.set("disabled", this.currentPage === 1);
                }
                
                // Update the page forward action to disable if on the last page...
                if (this.pageForward)
                {
-                  this.pageForward.set("disabled", (this.currentPage == this.totalPages));
+                  this.pageForward.set("disabled", this.currentPage === this.totalPages);
                }
                
                // Update the page marker to show the current page...
@@ -225,10 +225,10 @@ define(["dojo/_base/declare",
                }
                
                // Delete the previous page selector group contents...
-               if (this.pageSelectorGroup != null)
+               if (this.pageSelectorGroup !== null)
                {
                   var _this = this;
-                  array.forEach(this.pageSelectorGroup.getChildren(), function(widget, index) {
+                  array.forEach(this.pageSelectorGroup.getChildren(), function(widget) {
                      _this.pageSelectorGroup.removeChild(widget);
                      widget.destroy();
                   });
@@ -243,7 +243,7 @@ define(["dojo/_base/declare",
                   {
                      // Comments below assume 25 docs per page...
                      var pageEnd;
-                     if (i+1 != this.totalPages)
+                     if (i+1 !== this.totalPages)
                      {
                         // If we're not getting the labels for the last page...
                         pageEnd = pageStart + this.documentsPerPage - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
@@ -257,23 +257,23 @@ define(["dojo/_base/declare",
                      var label = this.message("alf-documentlist-paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalDocuments});
                      var menuItem = new AlfCheckableMenuItem({
                         label: label,
-                        value: (i+1),
+                        value: i+1,
                         group: "PAGE_SELECTION_GROUP",
-                        checked: (this.currentPage == i+1),
+                        checked: this.currentPage === i+1,
                         publishTopic: this.pubSubScope + this.pageSelectionTopic,
                         publishPayload: {
                            label: label,
-                           value: (i+1)
+                           value: i+1
                         }
                      });
 
-                     if (this.pageSelectorGroup != null)
+                     if (this.pageSelectorGroup !== null)
                      {
                         this.pageSelectorGroup.addChild(menuItem);
                      }
                      else
                      {
-                        if (this.__initialPageSelectorItems == null)
+                        if (this.__initialPageSelectorItems === null)
                         {
                            this.__initialPageSelectorItems = [];
                         }
@@ -396,7 +396,7 @@ define(["dojo/_base/declare",
                                     label: label25,
                                     value: 25,
                                     group: "DOCUMENTS_PER_PAGE_GROUP",
-                                    checked: (this.documentsPerPage == 25),
+                                    checked: this.documentsPerPage === 25,
                                     publishTopic: this.docsPerpageSelectionTopic,
                                     publishPayload: {
                                        label: label25,
@@ -410,7 +410,7 @@ define(["dojo/_base/declare",
                                     label: label50,
                                     value: 50,
                                     group: "DOCUMENTS_PER_PAGE_GROUP",
-                                    checked: (this.documentsPerPage == 50),
+                                    checked: this.documentsPerPage === 50,
                                     publishTopic: this.docsPerpageSelectionTopic,
                                     publishPayload: {
                                        label: label50,
@@ -424,7 +424,7 @@ define(["dojo/_base/declare",
                                     label: label75,
                                     value: 75,
                                     group: "DOCUMENTS_PER_PAGE_GROUP",
-                                    checked: (this.documentsPerPage == 75),
+                                    checked: this.documentsPerPage === 75,
                                     publishTopic: this.docsPerpageSelectionTopic,
                                     publishPayload: {
                                        label: label75,
@@ -438,7 +438,7 @@ define(["dojo/_base/declare",
                                     label: label100,
                                     value: 100,
                                     group: "DOCUMENTS_PER_PAGE_GROUP",
-                                    checked: (this.documentsPerPage == 100),
+                                    checked: this.documentsPerPage === 100,
                                     publishTopic: this.docsPerpageSelectionTopic,
                                     publishPayload: {
                                        label: label100,
@@ -478,7 +478,7 @@ define(["dojo/_base/declare",
 
          // Check to see if any document data was provided before widget instantiation completed and
          // if so process it with the now available widgets...
-         if (this.__deferredLoadedDocumentData != null)
+         if (this.__deferredLoadedDocumentData !== null)
          {
             this.processLoadedDocuments(this.__deferredLoadedDocumentData);
          }

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -882,6 +882,7 @@ define(["dojo/_base/declare",
 
       /**
        * Publishes the details of the documents that have been loaded (primarily for multi-selection purposes)
+       * and stores any requested starting index and total records data.
        *
        * @instance
        * @param {object} response The original response.

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -890,27 +890,27 @@ define(["dojo/_base/declare",
          // Publish the details of the loaded documents. The initial use case for this was to allow
          // the selected items menu to know how many items were available for selection but it
          // clearly has many other uses...
-         var totalDocuments = this.currentData.items.length;
-         var startIndex = 0;
-         if (response != null)
+         this.totalRecords = this.currentData.items.length;
+         this.startIndex = 0;
+         if (response !== null)
          {
             var tmp = lang.getObject(this.totalResultsProperty, false, response);
-            if (tmp != null)
+            if (tmp !== null)
             {
-               totalDocuments = tmp;
+               this.totalRecords = tmp;
             }
 
             tmp = lang.getObject(this.startIndexProperty, false, response);
-            if (tmp != null)
+            if (tmp !== null)
             {
-               startIndex = tmp;
+               this.startIndex = tmp;
             }
          }
 
          this.alfPublish(this.documentsLoadedTopic, {
             documents: this.currentData.items,
-            totalDocuments: totalDocuments,
-            startIndex: startIndex
+            totalDocuments: this.totalRecords,
+            startIndex: this.startIndex
          });
       },
 

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -223,6 +223,13 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Handles requests to change the number of items shown for each page of data in the list. When the page
+       * size is increased or decreased the current page will be adjusted to attempt to keep the items that the
+       * user was looking at in the requested page. This is simple when increasing the page size, but harder when
+       * decreasing the page size. When decreasing the page size the page requested will represent the beginning
+       * of the larger page size of data, e.g. when going from 50 - 25 items per page, if the user was on page 2 
+       * (51-100) then page 3 (51-75) would be requested.
+       * 
        * @instance
        * @param {object} payload The details of the new page size
        */

--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -114,7 +114,7 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_menus_AlfCheckableMenuItem__postCreate() {
 
-         if (this.publishPayload == null)
+         if (!this.publishPayload)
          {
             this.publishPayload = {};
          }
@@ -122,7 +122,7 @@ define(["dojo/_base/declare",
          if (this.hashName)
          {
             var currHash = ioQuery.queryToObject(hash());
-            this.checked = (currHash[this.hashName] && currHash[this.hashName] === this.value);
+            this.checked = currHash[this.hashName] && currHash[this.hashName] === this.value;
          }
 
          this.alfLog("log", "Create checkable cell");
@@ -134,7 +134,7 @@ define(["dojo/_base/declare",
 
          if (this.group)
          {
-            this.alfSubscribe("ALF_CHECKABLE_MENU_ITEM__" + this.group, lang.hitch(this, "onGroupSelection"));
+            this.alfSubscribe("ALF_CHECKABLE_MENU_ITEM__" + this.group, lang.hitch(this, this.onGroupSelection));
          }
 
          this.inherited(arguments);
@@ -149,7 +149,7 @@ define(["dojo/_base/declare",
          // some other widget).
          if (this.publishTopic)
          {
-            this.subscriptionHandle = this.alfSubscribe(this.publishTopic, lang.hitch(this, "onPublishTopicEvent"));
+            this.subscriptionHandle = this.alfSubscribe(this.publishTopic, lang.hitch(this, this.onPublishTopicEvent));
          }
       },
 
@@ -162,14 +162,16 @@ define(["dojo/_base/declare",
        */
       onPublishTopicEvent: function alfresco_menus_AlfCheckableMenuItem__onPublishTopicEvent(payload) {
          if (payload &&
-             payload.selected != null &&
-             payload.value == this.value)
+             payload.selected !== null &&
+             payload.value === this.value)
          {
             if (this.group)
             {
                // Clear all group settings if the payload value matches the value represented by the
                // widget. We need to ensure that only one item in the group is selected...
-               this.alfPublish("ALF_CHECKABLE_MENU_ITEM__" + this.group, {});
+               this.alfPublish("ALF_CHECKABLE_MENU_ITEM__" + this.group, {
+                  value: this.value
+               });
                this.checked = payload.selected;
             }
             else
@@ -273,8 +275,11 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onGroupSelection: function alfresco_menus_AlfCheckableMenuItem__toggleSelection(payload) {
-         this.checked = false;
-         this.render();
+         if (payload.value !== this.value)
+         {
+            this.checked = false;
+            this.render();
+         } 
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -28,6 +28,7 @@ define(["intern!object",
         function (registerSuite, expect, assert, require, TestCommon) {
 
    var browser;
+   var pause = 500;
    registerSuite({
       name: "Pagination Test",
       "Test page selector drop-down label intialization": function () {
@@ -82,7 +83,7 @@ define(["intern!object",
             .click()
          .end()
          // sped up - hopefully at some point in the future we can remove this sleep!         
-         .sleep(1000)
+         .sleep(pause)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -107,7 +108,7 @@ define(["intern!object",
       "Test clicking next page updates page selector drop-down label": function () {
          return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
-            .sleep(1000)
+            .sleep(pause)
          .end()
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
@@ -133,7 +134,7 @@ define(["intern!object",
       "Test previous page button updates page selector drop-down label": function() {
          return this.remote.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
             .click()
-            .sleep(1000)
+            .sleep(pause)
          .end()
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
@@ -168,7 +169,7 @@ define(["intern!object",
       "Test next page button (to last page) disables next page button": function() {
          return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
-            .sleep(1000)
+            .sleep(pause)
          .end()
          .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
@@ -188,7 +189,7 @@ define(["intern!object",
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
             .click()
          .end()
-         .sleep(1000)
+         .sleep(pause)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -218,6 +219,17 @@ define(["intern!object",
             })
          .end();
       },
+      "Test Results Per Page Group": function () {
+         // This tests the external results per page menu, to ensure it picks up changes correctly...
+         return this.remote.findByCssSelector("#MENU_BAR_POPUP_text")
+            .click()
+         .end()
+         .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(4) td.alf-selected-icon")
+            .then(function(elements) {
+               assert(elements.length === 1, "Results per page widget check box not highlighted correctly");
+            })
+         .end();
+      },
       "Test reducing page size adjusts current page (100 to 25 on last page)": function() {
          // This tests that when we reduce the page size on the last page jump to an 
          // appropriate page for the smaller page size. Although we're on the last page (201-243) for
@@ -230,7 +242,7 @@ define(["intern!object",
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(1) td:nth-child(3)")
             .click()
          .end()
-         .sleep(1000)
+         .sleep(pause)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -242,29 +254,7 @@ define(["intern!object",
             .then(function(text) {
                assert(text === "9", "Page number not correct, expected '9' but saw: " + text);
             })
-         .end();
+         .end().alfPostCoverageResults(browser);
       }
-
-
-      // ,
-      // "Test Results Per Page Group": function () {
-      //    // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-      //    var browser = this.remote;
-      //    var testname = "Pagination Test";
-         
-      //    return browser.findByCssSelector("#MENU_BAR_POPUP_text")
-      //       .click()
-      //       .end()
-
-      //    .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(2) td.alf-selected-icon")
-      //       .then(function(elements) {
-      //          TestCommon.log(testname, "Checking results group updated correctly");
-      //          assert(elements.length === 1, "Test #6a - Results per page widget updated correctly");
-      //       })
-      //       .end()
-
-
-      //    .alfPostCoverageResults(browser);
-      // }
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -27,207 +27,244 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+   var browser;
    registerSuite({
-      name: 'Pagination Test',
-      'Check initial state': function () {
-
-         // var browser = this.remote;
-         var testname = "Pagination Test";
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator", testname)
-
-         // Make sure the page has loaded...
-         .findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
+      name: "Pagination Test",
+      "Test page selector drop-down label intialization": function () {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
             .end()
-
-         // Check that the hard-coded data renders the paginators initial state correctly...
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Checking initial drop-down state");
-               assert(text === "1-3 of 3", "Test #1a - Hard coded data didn't yield correct page data: " + text);
+               assert(text === "1-25 of 243", "Page selector menu label didn't initialize correctly, expected '1-25 of 243' but saw: " + text);
             })
-            .end()
-
-         // Check that the previous and next controls are disabled...
-         .findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking previous button enablement");
-               assert(elements.length === 1, "Test #1b - The previous page button should be disabled");
-            })
-            .end()
-         .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking next button enablement");
-               assert(elements.length === 1, "Test #1b - The next page button should be disabled");
-            })
-            .end();
+         .end();
       },
-      'Test First Page': function () {
+      "Test prevous page button is disabled on page load": function() {
+         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+            .then(function(elements) {
+               assert(elements.length === 1, "The previous page button should be disabled");
+            })
+         .end();
+      },
+      "Test next page button is enabled on page load": function() {
+         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+            .then(function(elements) {
+               assert(elements.length === 0, "The next page button should be enabled");
+            })
+         .end();
+      },
+      "Test items loaded correctly (check first row of 25 items)": function() {
+         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "1", "First displayed row should be 1, saw: " + text);
+            })
+         .end();
+      },
+      "Test items loaded correctly (check last row of 25 items)": function() {
+         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(25) span.value")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "25", "First displayed row should be 25, saw: " + text);
+            })
+         .end();
+      },
+      "Test 50 items per page selection update page selector drop-down label": function () {
          // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-
-         var browser = this.remote;
-         var testname = "Pagination Test";
-         
-         // Switch to 50 results per page (will load data via Mock XHR request)...
-         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+         // Switch to 50 results per page...
+         return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
             .sleep(100)
-            .end()
-
+         .end()
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(2) td:nth-child(3)")
             .click()
-            .end()
-
+         .end()
          // sped up - hopefully at some point in the future we can remove this sleep!         
-         .sleep(2000)
-
+         .sleep(1000)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Checking drop-down label after first page load");
-               assert(text === "1-50 of 57", "Test #2a - First page not displayed correctly: " + text);
+               assert(text === "1-50 of 243", "Page selector label not updated correctly after switching to 50 items per page: " + text);
             })
-            .end()
-
-          // Check that the previous is still disabled but next is now enabled...
-         .findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking previous page button state (after first page load)");
-               assert(elements.length === 1, "Test #2b - The previous page button should be disabled");
-            })
-            .end()
-         .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking next page button state (after first page load)");
-               assert(elements.length === 0, "Test #2c - The next page button should now be enabled");
-            })
-            .end();
+         .end();
       },
-      'Test Next Page Button': function () {
-         // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-         var browser = this.remote;
-         var testname = "Pagination Test";
-         
-         // Click the next button...
-         return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+      "Test previous page button is still disabled (after increasing page size)": function() {
+         this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+            .then(function(elements) {
+               assert(elements.length === 1, "The previous page button should still be disabled");
+            })
+         .end();
+      },
+      "Test next page button is still enabled (after increasing page size)": function() {
+         this.remote.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+            .then(function(elements) {
+               assert(elements.length === 0, "The next page button should still be enabled");
+            })
+         .end();
+      },
+      "Test clicking next page updates page selector drop-down label": function () {
+         return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
             .sleep(1000)
-            .end()
-
+         .end()
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Checking drop down label for second page");
-               assert(text === "51-57 of 57", "Test #3a - Second page not displayed correctly: " + text);
+               assert(text === "51-100 of 243", "Page selector label not correct, expected '51-100 of 243' but saw: " + text);
             })
-            .end()
-
-          // Check that the previous is still disabled but next is now enabled...
-         .findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking previous page button state for second page");
-               assert(elements.length === 0, "Test #3b - The previous page button should now be enabled");
-            })
-            .end()
-         .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking next page button for second page");
-               assert(elements.length === 1, "Test #3c - The next page button should now be disabled");
-            })
-            .end();
+         .end();
       },
-      'Test Previous Page Button': function () {
-         // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-         var browser = this.remote;
-         var testname = "Pagination Test";
-         
-         // Click the previous button...
-         return browser.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
-            .click()
-            .sleep(2000)
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               TestCommon.log(testname, "Checking drop-down label after using previous page button");
-               assert(text === "1-50 of 57", "Test #4a - First page not displayed correctly: " + text);
-            })
-            .end()
-
-          // Check that the previous is still disabled but next is now enabled...
-         .findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+      "Test clicking next page enables previous page button": function () {
+         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
-               TestCommon.log(testname, "Checking previous button state after using previous page button");
-               assert(elements.length === 1, "Test #4b - The previous page button should now be enabled");
+               assert(elements.length === 0, "The previous page button should now be enabled");
             })
-            .end()
-         .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking next button state after using previous page button");
-               assert(elements.length === 0, "Test #4c - The next page button should now be disabled");
-            })
-            .end();
+         .end();
       },
-      'Test Page Selection': function () {
-         // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-         var browser = this.remote;
-         var testname = "Pagination Test";
-         
-         // Select page 2 via the drop down...
-         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_dropdown tr:nth-child(2) td:nth-child(3)")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+      "Test next page button is still enabled (after using next page button)": function() {
+         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+            .then(function(elements) {
+               assert(elements.length === 0, "The next page button should still be enabled");
+            })
+         .end();
+      },
+      "Test previous page button updates page selector drop-down label": function() {
+         return this.remote.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
             .click()
             .sleep(1000)
-            .end()
-
+         .end()
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Checking drop down label after selecting page");
-               assert(text === "51-57 of 57", "Test #5a - Second page not displayed correctly: " + text);
+               assert(text === "1-50 of 243", "Page selector label not correct, expected '1-50 of 243' but saw: " + text);
             })
-            .end()
-
-          // Check that the previous is still disabled but next is now enabled...
-         .findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+         .end();
+      },
+      "Test previous page button is disabled (after previous page action)": function() {
+         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
-               TestCommon.log(testname, "Checking previous button state after selecting page");
-               assert(elements.length === 0, "Test #5b - The previous page button should now be enabled");
+               assert(elements.length === 1, "The previous page button should now be disabled");
             })
-            .end()
+         .end();
+      },
+      "Test page selection updates page selector label correctly": function () {
+         // Select the 4th page, because there are 5 pages and we want to click next page to check that
+         // using the next page button will disable the next page button when the last page is reached...
+         return this.remote.findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+            .click()
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
+            .click()
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "151-200 of 243", "Page selector label not correct, expected '151-200 of 243' but saw: " + text);
+            })
+         .end();
+      },
+      "Test next page button (to last page) disables next page button": function() {
+         return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+            .click()
+            .sleep(1000)
+         .end()
          .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
-               TestCommon.log(testname, "Checking next button state after selecting page");
-               assert(elements.length === 1, "Test #5c - The next page button should now be disabled");
+               assert(elements.length === 1, "The next page button should be disabled when next paging to the last page");
             })
-            .end();
+         .end();
       },
-      'Test Results Per Page Group': function () {
-         // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-         var browser = this.remote;
-         var testname = "Pagination Test";
-         
-         return browser.findByCssSelector("#MENU_BAR_POPUP_text")
+      "Test increasing page size adjusts current page (50 to 100 on last page)": function() {
+         // This tests that when we increase the page size on the last page, we don't attempt to load 
+         // a page of data that won't exist... instead, we should load a smaller page number to 
+         // accommodate the larger page size.
+         // Select 100 items per page and the page number should go from 5 to 3...
+         return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            .end()
-
-         .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(2) td.alf-selected-icon")
-            .then(function(elements) {
-               TestCommon.log(testname, "Checking results group updated correctly");
-               assert(elements.length === 1, "Test #6a - Results per page widget updated correctly");
+            .sleep(100)
+         .end()
+         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
+            .click()
+         .end()
+         .sleep(1000)
+         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "201-243 of 243", "Page selector label not correct, expected '201-243 of 243' but saw: " + text);
             })
-            .end()
-
-
-         .alfPostCoverageResults(browser);
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "3", "Page number not correct, expected '3' but saw: " + text);
+            })
+         .end();
+      },
+      "Test items loaded correctly for incomplete page(check first row of 100 items": function() {
+         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "201", "First displayed row should be 201, saw: " + text);
+            })
+         .end();
+      },
+      "Test items loaded correctly (check last row of 100 items": function() {
+         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(43) span.value")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "243", "First displayed row should be 243, saw: " + text);
+            })
+         .end();
+      },
+      "Test reducing page size adjusts current page (100 to 25 on last page)": function() {
+         // This tests that when we reduce the page size on the last page jump to an 
+         // appropriate page for the smaller page size. Although we're on the last page (201-243) for
+         // 100 items per page, we want to jump to the penultimate page for 25 items per page (201-225)
+         // as this is the most appropriate page for where we were.
+         return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+            .click()
+            .sleep(100)
+         .end()
+         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(1) td:nth-child(3)")
+            .click()
+         .end()
+         .sleep(1000)
+         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "201-225 of 243", "Page selector label not correct, expected '201-225 of 243' but saw: " + text);
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text === "9", "Page number not correct, expected '9' but saw: " + text);
+            })
+         .end();
       }
+
+
+      // ,
+      // "Test Results Per Page Group": function () {
+      //    // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
+      //    var browser = this.remote;
+      //    var testname = "Pagination Test";
+         
+      //    return browser.findByCssSelector("#MENU_BAR_POPUP_text")
+      //       .click()
+      //       .end()
+
+      //    .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(2) td.alf-selected-icon")
+      //       .then(function(elements) {
+      //          TestCommon.log(testname, "Checking results group updated correctly");
+      //          assert(elements.length === 1, "Test #6a - Results per page widget updated correctly");
+      //       })
+      //       .end()
+
+
+      //    .alfPostCoverageResults(browser);
+      // }
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -77,13 +77,13 @@ define(["intern!object",
          // Switch to 50 results per page...
          return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            .sleep(100)
+            // .sleep(100)
          .end()
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(2) td:nth-child(3)")
             .click()
          .end()
          // sped up - hopefully at some point in the future we can remove this sleep!         
-         .sleep(pause)
+         // .sleep(pause)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -108,7 +108,7 @@ define(["intern!object",
       "Test clicking next page updates page selector drop-down label": function () {
          return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
-            .sleep(pause)
+            // .sleep(pause)
          .end()
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
@@ -134,7 +134,7 @@ define(["intern!object",
       "Test previous page button updates page selector drop-down label": function() {
          return this.remote.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
             .click()
-            .sleep(pause)
+            // .sleep(pause)
          .end()
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
@@ -169,7 +169,7 @@ define(["intern!object",
       "Test next page button (to last page) disables next page button": function() {
          return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
-            .sleep(pause)
+            // .sleep(pause)
          .end()
          .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
@@ -184,12 +184,12 @@ define(["intern!object",
          // Select 100 items per page and the page number should go from 5 to 3...
          return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            .sleep(100)
+            // .sleep(100)
          .end()
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
             .click()
          .end()
-         .sleep(pause)
+         // .sleep(pause)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -237,12 +237,12 @@ define(["intern!object",
          // as this is the most appropriate page for where we were.
          return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            .sleep(100)
+            // .sleep(100)
          .end()
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(1) td:nth-child(3)")
             .click()
          .end()
-         .sleep(pause)
+         // .sleep(pause)
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,7 +31,7 @@ define({
     * @type [string]
     */
    // Uncomment and add specific tests as necessary during development!
-   // baseFunctionalSuites: ['src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest'],
+   // baseFunctionalSuites: ['src/test/resources/alfresco/documentlibrary/PaginationTest'],
 
    /**
     * This is the base array of functional test suites

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -11,8 +11,12 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/DocumentService",
-      "alfresco/services/ErrorReporter"
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
+      }
    ],
    widgets: [
       {
@@ -40,29 +44,29 @@ model.jsonModel = {
                   }
                }
             ]
-         },
+         }
       },
       {
          id: "LIST",
          name: "alfresco/lists/AlfSortablePaginatedList",
          config: {
             useHash: false,
-            currentData: {
-               items: [
-                  {
-                     id: "A",
-                     displayName: "A"
-                  },
-                  {
-                     id: "B",
-                     displayName: "B"
-                  },
-                  {
-                     id: "C",
-                     displayName: "C"
-                  }
-               ]
-            },
+            // currentData: {
+            //    items: [
+            //       {
+            //          id: "A",
+            //          displayName: "A"
+            //       },
+            //       {
+            //          id: "B",
+            //          displayName: "B"
+            //       },
+            //       {
+            //          id: "C",
+            //          displayName: "C"
+            //       }
+            //    ]
+            // },
             widgets: [
                {
                   name: "alfresco/documentlibrary/views/AlfDocumentListView",
@@ -79,7 +83,7 @@ model.jsonModel = {
                                           {
                                              name: "alfresco/renderers/Property",
                                              config: {
-                                                propertyToRender: "displayName"
+                                                propertyToRender: "index"
                                              }
                                           }
                                        ]
@@ -94,9 +98,9 @@ model.jsonModel = {
             ]
          }
       },
-      {
-         name: "aikauTesting/mockservices/PaginationMockXhr"
-      },
+      // {
+      //    name: "aikauTesting/mockservices/PaginationMockXhr"
+      // },
       {
          name: "alfresco/logging/SubscriptionLog",
          config: {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -51,22 +51,6 @@ model.jsonModel = {
          name: "alfresco/lists/AlfSortablePaginatedList",
          config: {
             useHash: false,
-            // currentData: {
-            //    items: [
-            //       {
-            //          id: "A",
-            //          displayName: "A"
-            //       },
-            //       {
-            //          id: "B",
-            //          displayName: "B"
-            //       },
-            //       {
-            //          id: "C",
-            //          displayName: "C"
-            //       }
-            //    ]
-            // },
             widgets: [
                {
                   name: "alfresco/documentlibrary/views/AlfDocumentListView",
@@ -98,9 +82,6 @@ model.jsonModel = {
             ]
          }
       },
-      // {
-      //    name: "aikauTesting/mockservices/PaginationMockXhr"
-      // },
       {
          name: "alfresco/logging/SubscriptionLog",
          config: {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginationService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginationService.js
@@ -29,6 +29,13 @@ define(["dojo/_base/declare",
 
    return declare([AlfCore], {
 
+      /**
+       * The topic to subscribe to to service requests for list data
+       *
+       * @instance
+       * @type {string}
+       * @default null
+       */
       loadDataSubscriptionTopic: null,
 
       /**
@@ -45,6 +52,13 @@ define(["dojo/_base/declare",
          }
       },
 
+      /**
+       * This function simulates paginated results. Given a page size and a page number it will generate
+       * a set of results (up to 243 items) for that request.
+       * 
+       * @instance
+       * @param {object} payload
+       */
       onLoadDataRequest: function alfresco_testing_mockservices_PaginationService__onLoadDataRequest(payload) {
          var totalRecords = 243;
          var pageSize = payload.pageSize !== null ? payload.pageSize: 25;

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginationService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginationService.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/PaginationService
+ * @extends module:alfresco/core/Core
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "dojo/_base/lang"],
+         function(declare, AlfCore, lang) {
+
+   return declare([AlfCore], {
+
+      loadDataSubscriptionTopic: null,
+
+      /**
+       *
+       *
+       * @instance
+       * @param {array} args The constructor arguments.
+       */
+      constructor: function alfresco_testing_mockservices_PaginationService__constructor(args) {
+         lang.mixin(this, args);
+         if (this.loadDataSubscriptionTopic)
+         {
+            this.alfSubscribe(this.loadDataSubscriptionTopic, lang.hitch(this, this.onLoadDataRequest));
+         }
+      },
+
+      onLoadDataRequest: function alfresco_testing_mockservices_PaginationService__onLoadDataRequest(payload) {
+         var totalRecords = 243;
+         var pageSize = payload.pageSize !== null ? payload.pageSize: 25;
+         var page = payload.page !== null ? payload.page: 1;
+         var items = [];
+         var startIndex = (page - 1) * pageSize;
+         var stopIndex = startIndex + pageSize;
+         stopIndex = stopIndex > totalRecords ? totalRecords : stopIndex;
+         for (var i=startIndex; i<stopIndex; i++)
+         {
+            items.push({
+               index: i+1
+            });
+         }
+         var responsePayload = {
+            response: {
+               totalRecords: totalRecords,
+               startIndex: startIndex,
+               items: items
+            }
+         };
+
+         var alfTopic = payload.alfResponseTopic ? payload.alfResponseTopic : "ALF_RETRIEVE_DOCUMENTS_REQUEST";
+         this.alfPublish(alfTopic + "_SUCCESS", responsePayload);
+      }
+   });
+});


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-65 which was reporting a problem with how pagination was being handled when changing the page size. To address this issue I've re-written the unit test and swapped out the previous mock XHR service with a service that generates results (based on the requested page and page size). The test has been updated to conform to new standards and the code has been rewritten to match the test.

As well as making suggested JSHint improvements the updates are that the AlfList stores the current startIndex and totalRecords state and that the AlfSortablePaginatedList uses that data to work out the best page number to request based on the new page size. The page number requested is worked out based on the change in page size.