### PR TITLE
AKU-71: Improvements to InlineEditProperty(Link)

### DIFF
--- a/aikau/.jshintrc
+++ b/aikau/.jshintrc
@@ -37,6 +37,8 @@
       "PDFJS": false
    },
 
+   "expr": true,
+
    "browser": true,
    "dojo": true
 }

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -388,7 +388,7 @@ define(["dojo/_base/declare",
          domClass.toggle(this.renderedValueNode, "hidden");
          domClass.toggle(this.editNode, "hidden");
          formWidget.focus(); // Focus on the input node so typing can occur straight away
-         event.stop(evt);
+         evt && event.stop(evt);
       },
       
       /**
@@ -401,7 +401,7 @@ define(["dojo/_base/declare",
          if (evt.ctrlKey === true && evt.charCode === 101)
          {
             // On ctrl-e simulate an edit click
-            event.stop(evt);
+            evt && event.stop(evt);
             this.onEditClick();
          }
       },
@@ -541,7 +541,7 @@ define(["dojo/_base/declare",
        */
       suppressFocusRequest: function alfresco_renderers_InlineEditProperty__suppressFocusRequest(evt) {
          this.alfLog("log", "Suppress click event");
-         event.stop(evt);
+         evt && event.stop(evt);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -169,24 +169,21 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          
          // If no topic has been provided then assume the default behaviour of editing document/folder properties
-         if (this.publishTopic == null)
+         if (!this.publishTopic)
          {
             this.setDefaultPublicationData();
          }
 
-         if (this.propertyToRender != null)
+         if (this.propertyToRender && !this.postParam)
          {
-            if (this.postParam == null && this.propertyToRender != null)
-            {
-               this.postParam = this.propertyToRender;
-            }
+            this.postParam = this.propertyToRender;
          }
          else
          {
             this.alfLog("warn", "Property to render attribute has not been set", this);
          }
 
-         if (this.editIconImageSrc == null || this.editIconImageSrc === "")
+         if (!this.editIconImageSrc)
          {
             this.editIconImageSrc = require.toUrl("alfresco/renderers") + "/css/images/edit-16.png";
          }
@@ -276,7 +273,7 @@ define(["dojo/_base/declare",
        */
       processHiddenDataRules: function alfresco_renderers_InlineEditProperty__processHiddenDataRules() {
          var additionalFormWidgets = [];
-         if (this.hiddenDataRules != null)
+         if (this.hiddenDataRules)
          {
             array.forEach(this.hiddenDataRules, lang.hitch(this, this.processHiddenDataRule, additionalFormWidgets));
          }
@@ -415,13 +412,13 @@ define(["dojo/_base/declare",
        * @param {object} e The key press event
        */
       onValueEntryKeyPress: function alfresco_renderers_InlineEditProperty__onValueEntryKeyPress(e) {
-         if(e.charOrCode == keys.ESCAPE)
+         if(e.charOrCode === keys.ESCAPE)
          {
             event.stop(e);
             this.onCancel();
          }
          // NOTE: This isn't currently working because Dojo form controls suppress certain keys, including ENTER...
-         else if(e.charOrCode == keys.ENTER)
+         else if(e.charOrCode === keys.ENTER)
          {
             event.stop(e);
             this.onSave();
@@ -432,6 +429,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       onSave: function alfresco_renderers_InlineEditProperty__onSave(evt) {
+         /*jshint unused:false*/
          if (this.isSaveAllowed === true)
          {
             var responseTopic = this.generateUuid();
@@ -473,6 +471,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The success payload
        */
       onSaveSuccess: function alfresco_renderers_InlineEditProperty__onSaveSuccess(payload) {
+         /*jshint unused:false*/
          this.alfUnsubscribeSaveHandles([this._saveSuccessHandle, this._saveFailureHandle]);
 
          this.alfLog("log", "Property '" + this.propertyToRender + "' successfully updated for node: ", this.currentItem);
@@ -506,6 +505,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The success payload
        */
       onSaveFailure: function alfresco_renderers_InlineEditProperty__onSaveFailure(payload) {
+         /*jshint unused:false*/
          this.alfUnsubscribeSaveHandles([this._saveSuccessHandle, this._saveFailureHandle]);
          this.alfLog("warn", "Property '" + this.propertyToRender + "' was not updated for node: ", this.currentItem);
          this.onCancel();

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -388,7 +388,7 @@ define(["dojo/_base/declare",
          domClass.toggle(this.renderedValueNode, "hidden");
          domClass.toggle(this.editNode, "hidden");
          formWidget.focus(); // Focus on the input node so typing can occur straight away
-         evt && evt.stop();
+         event.stop(evt);
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -47,15 +47,14 @@ define(["dojo/_base/declare",
         "dojo/dom-class",
         "dojo/html",
         "dojo/dom-attr",
-        "dojo/_base/fx",
         "dojo/keys",
         "dojo/_base/event",
         "service/constants/Default",
         "alfresco/forms/Form",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
-        function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, 
-                 template, lang, array, on, domClass, html, domAttr, fx, keys, event, AlfConstants, Form, DojoValidationTextBox) {
+        function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin,
+                 template, lang, array, on, domClass, html, domAttr, keys, event) {
 
    return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin], {
       
@@ -127,6 +126,13 @@ define(["dojo/_base/declare",
        * @default "inline-edit.edit.label"
        */
       editLabel: "inline-edit.edit.label",
+
+      /**
+       * Whether the widget should be put into edit mode when rendered value is clicked.
+       *
+       * @type  {boolean}
+       */
+      editOnClickRenderedValue: true,
 
       /**
        * The topic to publish when a property edit should be persisted. For convenience it is assumed that document
@@ -357,6 +363,17 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * This function is called whenever the user clicks on the rendered value. It checks an overridable
+       * instance variable (editOnClickRenderedValue), to see whether it should then launch into edit mode.
+       *
+       * @instance
+       * @param {object} evt Dojo-normalised event
+       */
+      onClickRenderedValue: function alfresco_renderers_InlineEditProperty__onClickRenderedValue(evt) {
+         this.editOnClickRenderedValue && this.onEditClick(evt);
+      },
+
+      /**
        * This function is called whenever the user clicks on the edit icon. It hides the display DOM node
        * and shows the edit DOM nodes.
        * 
@@ -371,7 +388,7 @@ define(["dojo/_base/declare",
          domClass.toggle(this.renderedValueNode, "hidden");
          domClass.toggle(this.editNode, "hidden");
          formWidget.focus(); // Focus on the input node so typing can occur straight away
-         if (evt !== undefined) event.stop(evt);
+         evt && evt.stop();
       },
       
       /**
@@ -525,22 +542,6 @@ define(["dojo/_base/declare",
       suppressFocusRequest: function alfresco_renderers_InlineEditProperty__suppressFocusRequest(evt) {
          this.alfLog("log", "Suppress click event");
          event.stop(evt);
-      },
-      
-      /**
-       * TODO: Replace with CSS3
-       * @instance
-       */
-      showEditIcon: function alfresco_renderers_InlineEditProperty__showEditIcon() {
-         fx.fadeIn({ node: this.editIconNode }).play();
-      },
-      
-      /**
-       * TODO: Replace with CSS3
-       * @instance
-       */
-      hideEditIcon: function alfresco_renderers_InlineEditProperty__hideEditIcon() {
-         fx.fadeOut({ node: this.editIconNode }).play();
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -31,9 +31,8 @@ define(["dojo/_base/declare",
         "dijit/a11yclick",
         "dojo/_base/lang",
         "dojo/on",
-        "dojo/_base/event",
-        "dojo/dom-style"], 
-        function(declare, InlineEditProperty, _ItemLinkMixin, a11yclick, lang, on, event, domStyle) {
+        "dojo/_base/event"],
+        function(declare, InlineEditProperty, _ItemLinkMixin, a11yclick, lang, on, event) {
 
    return declare([InlineEditProperty, _ItemLinkMixin], {
       
@@ -67,11 +66,11 @@ define(["dojo/_base/declare",
        */
       onLinkClick: function alfresco_renderers_InlineEditPropertyLink__onLinkClick(evt) {
          event.stop(evt);
-         if (this.linkPublishTopic != null && lang.trim(this.linkPublishTopic) !== "")
+         if (this.linkPublishTopic && lang.trim(this.linkPublishTopic))
          {
-            var publishGlobal = (this.linkPublishGlobal != null) ? this.linkPublishGlobal : false;
-            var publishToParent = (this.linkPublishToParent != null) ? this.linkPublishToParent : false;
-            var publishPayload = this.generatePayload(this.linkPublishPayload, 
+            var publishGlobal = this.linkPublishGlobal || false,
+               publishToParent = this.linkPublishToParent || false,
+               publishPayload = this.generatePayload(this.linkPublishPayload,
                                                       this.currentItem,
                                                       null, 
                                                       this.linkPublishPayloadType, 

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -38,6 +38,14 @@ define(["dojo/_base/declare",
    return declare([InlineEditProperty, _ItemLinkMixin], {
       
       /**
+       * Whether the widget should be put into edit mode when rendered value is clicked.
+       *
+       * @override
+       * @type  {boolean}
+       */
+      editOnClickRenderedValue: false,
+
+     /**
        * Extends the [inherited function]{@link module:alfresco/renderers/Property#postCreate} to add the linking
        * capability.
        * 
@@ -46,7 +54,6 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_renderers_InlineEditPropertyLink__postCreate() {
          this.inherited(arguments);
          this.own(on(this.renderedValueNode, a11yclick, lang.hitch(this, this.onLinkClick)));
-         domStyle.set(this.renderedValueNode, "cursor", "pointer");
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -65,7 +65,7 @@ define(["dojo/_base/declare",
        * @param {object} evt The click event.
        */
       onLinkClick: function alfresco_renderers_InlineEditPropertyLink__onLinkClick(evt) {
-         event.stop(evt);
+         evt && event.stop(evt);
          if (this.linkPublishTopic && lang.trim(this.linkPublishTopic))
          {
             var publishGlobal = this.linkPublishGlobal || false,

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -1,40 +1,48 @@
-.alfresco-renderers-Property.alfresco_renderers_InlineEditProperty {
-  /*margin-left: 20px; */
-}
-
-.alfresco-renderers-InlineEditProperty .alfresco-renderers-Property {
-  margin-left: 0;
-}
-
-.alfresco-renderers-InlineEditProperty .editIcon {
-   cursor: pointer;
-   height: 16px;
-   width: 16px;
-   display: inline-block;
-   opacity: 0;
-}
-
-.alfresco-renderers-InlineEditProperty .action {
-   cursor: pointer;
-   font-family: @standard-font;
-   color: @general-font-color;
-   font-size: @normal-font-size;
-   display: inline-block;
-   height: 85%;
-   vertical-align: middle;
-}
-
-.alfresco-renderers-InlineEditProperty .action.disabled {
-   cursor: default;
-   color: @de-emphasized-font-color;
-}
-
-.alfresco-renderers-InlineEditProperty > .editor {
-   height: 40px;
-   display: inline-block;
-}
-
-.alfresco-renderers-InlineEditProperty > .editor > .alfresco-forms-Form {
-   display: inline-block;
-   vertical-align: bottom;
+.alfresco-renderers-InlineEditProperty {
+   &:hover .editIcon {
+      opacity: 1;
+   }
+   .inlineEditValue {
+      cursor: pointer;
+      line-height: 20px;
+      &.hidden ~ .editIcon {
+         display: none;
+      }
+      &:focus ~ .editIcon {
+         opacity: 1;
+      }
+   }
+   .alfresco-renderers-Property {
+      margin-left: 0;
+   }
+   .editIcon {
+      cursor: pointer;
+      display: inline-block;
+      height: 16px;
+      line-height: 20px;
+      opacity: 0;
+      transition: opacity .2s ease-out;
+      width: 16px;
+   }
+   .action {
+      color: @general-font-color;
+      cursor: pointer;
+      display: inline-block;
+      font-family: @standard-font;
+      font-size: @normal-font-size;
+      height: 85%;
+      vertical-align: middle;
+      &.disabled {
+         color: @de-emphasized-font-color;
+         cursor: default;
+      }
+   }
+   > .editor {
+      display: inline-block;
+      height: 40px;
+      > .alfresco-forms-Form {
+         display: inline-block;
+         vertical-align: bottom;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
@@ -1,5 +1,5 @@
-<span class="alfresco-renderers-InlineEditProperty ${renderedValueClass}" data-dojo-attach-event="onmouseover:showEditIcon,onmouseout:hideEditIcon">
-   <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress" class="${renderedValueClass}" tabindex="0">${renderedValuePrefix}${renderedValue}${renderedValueSuffix}</span>
+<span class="alfresco-renderers-InlineEditProperty ${renderedValueClass}">
+   <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${renderedValuePrefix}${renderedValue}${renderedValueSuffix}</span>
    <span data-dojo-attach-point="editNode" class="editor hidden" data-dojo-attach-event="onkeypress:onValueEntryKeyPress,onclick:suppressFocusRequest">
       <span data-dojo-attach-point="formWidgetNode"></span>
       <span class="action save" data-dojo-attach-point="saveLinkNode" data-dojo-attach-event="ondijitclick:onSave" tabindex="0">${saveLabel}</span>

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -41,6 +41,10 @@ define(["intern!object",
                .end();
          },
 
+         beforeEach: function() {
+            browser.end();
+         },
+
          teardown: function() {
             browser.alfPostCoverageResults(browser);
          },
@@ -50,16 +54,14 @@ define(["intern!object",
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "Test", "Value not rendered correctly");
-               })
-               .end();
+               });
          },
 
          "Edit widget not initially created": function() {
             return browser.findAllByCssSelector("#INLINE_EDIT > .editWidgetNode > *")
                .then(function(elements) {
                   assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
-               })
-               .end();
+               });
          },
 
          "Edit icon initially invisible": function() {
@@ -67,8 +69,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Icon should not be displayed");
-               })
-               .end();
+               });
          },
 
          "Icon appears on focus": function() {
@@ -76,14 +77,13 @@ define(["intern!object",
                .then(function(element) {
                   element.type(""); // Focus on element
 
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isTrue(result, "Edit icon was not revealed on focus");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "Icon disappears on blur": function() {
@@ -91,14 +91,13 @@ define(["intern!object",
                .then(function(element) {
                   element.type([keys.SHIFT, keys.TAB]); // Focus away from element
 
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit icon was not hidden on blur");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "Icon appears on mouseover": function() {
@@ -110,22 +109,20 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit icon was not revealed on mouse over");
-               })
-               .end();
+               });
          },
 
          "Icon hides on mouseout": function() {
             return browser.findByCssSelector("body")
                .moveMouseTo(0, 0)
                .then(function() {
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit icon was not hidden on mouse out");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "Edit widgets are created on edit": function() {
@@ -136,8 +133,7 @@ define(["intern!object",
             .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
                .then(null, function() {
                   assert(false, "Clicking edit icon did not create the validation text box");
-               })
-               .end();
+               });
          },
 
          "Read property is hidden when editing": function() {
@@ -145,8 +141,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Read-only span was not hidden");
-               })
-               .end();
+               });
          },
 
          "Save and cancel buttons are displayed when editing": function() {
@@ -161,8 +156,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Cancel button not visible when editing");
-               })
-               .end();
+               });
          },
 
          "Escape key cancels editing": function() {
@@ -174,8 +168,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-               })
-               .end();
+               });
          },
 
          "Clicking on property fires topic": function() {
@@ -186,8 +179,7 @@ define(["intern!object",
             .findAllByCssSelector(TestCommon.topicSelector("TEST_PROPERTY_LINK_CLICK", "publish", "any"))
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "Property link topic not published on click");
-               })
-               .end();
+               });
          },
 
          "Clicking on property does not start editing": function() {
@@ -195,15 +187,15 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Edit box revealed when clicking on property value");
-               })
-               .end();
+               });
          },
 
          "Clicking on cancel button stops editing": function() {
             return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
                .moveMouseTo()
                .then(function() {
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  return browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .click()
                      .end()
 
@@ -222,10 +214,8 @@ define(["intern!object",
                      .isDisplayed()
                      .then(function(result) {
                         assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "CTRL-E starts editing": function() {
@@ -238,8 +228,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit box not revealed on CTRL-E");
-               })
-               .end();
+               });
          },
 
          "Changes published on save": function() {
@@ -274,8 +263,7 @@ define(["intern!object",
             .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "hiddenData", "hidden_update"))
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "Hidden value didn't get included");
-               })
-               .end();
+               });
          },
 
          "Readonly view displayed when finished editing": function() {
@@ -288,8 +276,7 @@ define(["intern!object",
             .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "New", "Read-only value not updated correctly");
-               })
-               .end();
+               });
          }
 
       });

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -33,11 +33,11 @@ define(["intern!object",
       var browser;
 
       registerSuite({
-         name: "InlineEditProperty",
+         name: "InlineEditPropertyLink",
 
          setup: function() {
             browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/InlineEditProperty", "InlineEditProperty")
+            return TestCommon.loadTestWebScript(this.remote, "/InlineEditPropertyLink", "InlineEditPropertyLink")
                .end();
          },
 
@@ -178,28 +178,52 @@ define(["intern!object",
                .end();
          },
 
-         "Clicking on read-only value starts editing": function() {
+         "Clicking on property fires topic": function() {
             return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
                .click()
                .end()
 
-            .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
+            .findAllByCssSelector(TestCommon.topicSelector("TEST_PROPERTY_LINK_CLICK", "publish", "any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Property link topic not published on click");
+               })
+               .end();
+         },
+
+         "Clicking on property does not start editing": function() {
+            return browser.findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
                .isDisplayed()
                .then(function(result) {
-                  assert.isTrue(result, "Edit box not revealed when clicking on read-only value");
+                  assert.isFalse(result, "Edit box revealed when clicking on property value");
                })
                .end();
          },
 
          "Clicking on cancel button stops editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT .action.cancel")
-               .click()
-               .end()
+            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+               .moveMouseTo()
+               .then(function() {
+                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                     .click()
+                     .end()
 
-            .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
-               .isDisplayed()
-               .then(function(result) {
-                  assert.isTrue(result, "Read-only value not revealed on cancelling edit");
+                  .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+                     .isDisplayed()
+                     .then(function(result) {
+                        assert.isFalse(result, "Edit mode not entered when clicking on icon");
+                     })
+                     .end()
+
+                  .findByCssSelector("#INLINE_EDIT .action.cancel")
+                     .click()
+                     .end()
+
+                  .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+                     .isDisplayed()
+                     .then(function(result) {
+                        assert.isTrue(result, "Read-only value not revealed on cancelling edit");
+                     })
+                     .end();
                })
                .end();
          },
@@ -219,7 +243,14 @@ define(["intern!object",
          },
 
          "Changes published on save": function() {
-            return browser.findByCssSelector("#INLINE_EDIT .dijitInputContainer input")
+            return browser.findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isTrue(result, "Edit box not visible");
+               })
+               .end()
+
+            .findByCssSelector("#INLINE_EDIT .dijitInputContainer input")
                .clearValue()
                .type("New")
                .end()
@@ -259,44 +290,6 @@ define(["intern!object",
                   assert.equal(text, "New", "Read-only value not updated correctly");
                })
                .end();
-         },
-
-         "Inline-edit select restores values on failed save": function() {
-            return browser.findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
-               .then(function(element) {
-                  browser.moveMouseTo(element)
-                     .then(function() {
-                           browser.findByCssSelector("#INLINE_SELECT .editIcon")
-                              .click()
-                              .end()
-
-                           .findByCssSelector("#INLINE_SELECT .alfresco-forms-controls-BaseFormControl .dijitArrowButtonInner")
-                              .click()
-                              .end()
-
-                           .findByCssSelector(".dijitPopup table tr:nth-child(2) td.dijitMenuItemLabel")
-                              .click()
-                              .end()
-
-                           .findByCssSelector("#INLINE_SELECT .action.save")
-                              .click()
-                              .end()
-
-                           .findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
-                              .isDisplayed()
-                              .then(function(result) {
-                                 assert.isTrue(result, "Read-only span not revealed on failed save");
-                              })
-
-                           .getVisibleText()
-                              .then(function(text) {
-                                 assert.equal(text, "1", "Read-only value not restored correctly after failed save");
-                              })
-                              .end();
-                        }
-
-                     );
-               });
          }
 
       });

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -46,7 +46,8 @@ define(["intern!object",
          },
 
          teardown: function() {
-            browser.alfPostCoverageResults(browser);
+            return browser.end()
+               .alfPostCoverageResults(browser);
          },
 
          "Property is rendered correctly": function() {

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -41,8 +41,13 @@ define(["intern!object",
                .end();
          },
 
+         beforeEach: function() {
+            browser.end();
+         },
+
          teardown: function() {
-            browser.alfPostCoverageResults(browser);
+            browser.end()
+               .alfPostCoverageResults(browser);
          },
 
          "Property is rendered correctly": function() {
@@ -50,16 +55,14 @@ define(["intern!object",
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "Test", "Value not rendered correctly");
-               })
-               .end();
+               });
          },
 
          "Edit widget not initially created": function() {
             return browser.findAllByCssSelector("#INLINE_EDIT > .editWidgetNode > *")
                .then(function(elements) {
                   assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
-               })
-               .end();
+               });
          },
 
          "Edit icon initially invisible": function() {
@@ -67,8 +70,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Icon should not be displayed");
-               })
-               .end();
+               });
          },
 
          "Icon appears on focus": function() {
@@ -76,14 +78,13 @@ define(["intern!object",
                .then(function(element) {
                   element.type(""); // Focus on element
 
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isTrue(result, "Edit icon was not revealed on focus");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "Icon disappears on blur": function() {
@@ -91,14 +92,13 @@ define(["intern!object",
                .then(function(element) {
                   element.type([keys.SHIFT, keys.TAB]); // Focus away from element
 
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit icon was not hidden on blur");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "Icon appears on mouseover": function() {
@@ -110,22 +110,20 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit icon was not revealed on mouse over");
-               })
-               .end();
+               });
          },
 
          "Icon hides on mouseout": function() {
             return browser.findByCssSelector("body")
                .moveMouseTo(0, 0)
                .then(function() {
-                  browser.findByCssSelector("#INLINE_EDIT .editIcon")
+                  browser.end()
+                     .findByCssSelector("#INLINE_EDIT .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit icon was not hidden on mouse out");
-                     })
-                     .end();
-               })
-               .end();
+                     });
+               });
          },
 
          "Edit widgets are created on edit": function() {
@@ -136,8 +134,7 @@ define(["intern!object",
             .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
                .then(null, function() {
                   assert(false, "Clicking edit icon did not create the validation text box");
-               })
-               .end();
+               });
          },
 
          "Read property is hidden when editing": function() {
@@ -145,8 +142,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Read-only span was not hidden");
-               })
-               .end();
+               });
          },
 
          "Save and cancel buttons are displayed when editing": function() {
@@ -161,8 +157,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Cancel button not visible when editing");
-               })
-               .end();
+               });
          },
 
          "Escape key cancels editing": function() {
@@ -174,8 +169,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-               })
-               .end();
+               });
          },
 
          "Clicking on read-only value starts editing": function() {
@@ -187,8 +181,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit box not revealed when clicking on read-only value");
-               })
-               .end();
+               });
          },
 
          "Clicking on cancel button stops editing": function() {
@@ -200,8 +193,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-               })
-               .end();
+               });
          },
 
          "CTRL-E starts editing": function() {
@@ -214,8 +206,7 @@ define(["intern!object",
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit box not revealed on CTRL-E");
-               })
-               .end();
+               });
          },
 
          "Changes published on save": function() {
@@ -243,8 +234,7 @@ define(["intern!object",
             .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "hiddenData", "hidden_update"))
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "Hidden value didn't get included");
-               })
-               .end();
+               });
          },
 
          "Readonly view displayed when finished editing": function() {
@@ -257,45 +247,42 @@ define(["intern!object",
             .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "New", "Read-only value not updated correctly");
-               })
-               .end();
+               });
          },
 
          "Inline-edit select restores values on failed save": function() {
             return browser.findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
                .then(function(element) {
-                  browser.moveMouseTo(element)
+                  return browser.moveMouseTo(element)
                      .then(function() {
-                           browser.findByCssSelector("#INLINE_SELECT .editIcon")
-                              .click()
-                              .end()
+                        return browser.end()
+                           .findByCssSelector("#INLINE_SELECT .editIcon")
+                           .click()
+                           .end()
 
-                           .findByCssSelector("#INLINE_SELECT .alfresco-forms-controls-BaseFormControl .dijitArrowButtonInner")
-                              .click()
-                              .end()
+                        .findByCssSelector("#INLINE_SELECT .alfresco-forms-controls-BaseFormControl .dijitArrowButtonInner")
+                           .click()
+                           .end()
 
-                           .findByCssSelector(".dijitPopup table tr:nth-child(2) td.dijitMenuItemLabel")
-                              .click()
-                              .end()
+                        .findByCssSelector(".dijitPopup table tr:nth-child(2) td.dijitMenuItemLabel")
+                           .click()
+                           .end()
 
-                           .findByCssSelector("#INLINE_SELECT .action.save")
-                              .click()
-                              .end()
+                        .findByCssSelector("#INLINE_SELECT .action.save")
+                           .click()
+                           .end()
 
-                           .findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
-                              .isDisplayed()
-                              .then(function(result) {
-                                 assert.isTrue(result, "Read-only span not revealed on failed save");
-                              })
+                        .findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
+                           .isDisplayed()
+                           .then(function(result) {
+                              assert.isTrue(result, "Read-only span not revealed on failed save");
+                           })
 
-                           .getVisibleText()
-                              .then(function(text) {
-                                 assert.equal(text, "1", "Read-only value not restored correctly after failed save");
-                              })
-                              .end();
-                        }
-
-                     );
+                        .getVisibleText()
+                           .then(function(text) {
+                              assert.equal(text, "1", "Read-only value not restored correctly after failed save");
+                           });
+                     });
                });
          }
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -126,6 +126,7 @@ define({
       'src/test/resources/alfresco/renderers/FileTypeTest',
       'src/test/resources/alfresco/renderers/IndicatorsTest',
       'src/test/resources/alfresco/renderers/InlineEditPropertyTest',
+      'src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest',
       'src/test/resources/alfresco/renderers/ProgressTest',
       'src/test/resources/alfresco/renderers/PropertyTest',
       'src/test/resources/alfresco/renderers/PropertyLinkTest',

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>InlineEditPropertyLink Test</shortname>
+  <description>This WebScript defines the InlineEditPropertyLink page test</description>
+  <family>aikau-unit-tests</family>
+  <url>/InlineEditPropertyLink</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
@@ -1,0 +1,78 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "aikauTesting/mockservices/MockCrudService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets:[
+      {
+         name: "alfresco/documentlibrary/views/AlfDocumentListView",
+         config: {
+            id: "LIST",
+            currentData: {
+               items: [
+                  {
+                     name: "Test",
+                     option: "1"
+                  }
+               ]
+            },
+            widgets:[
+               {
+                  name: "alfresco/documentlibrary/views/layouts/Row",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/documentlibrary/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "INLINE_EDIT",
+                                    name: "alfresco/renderers/InlineEditPropertyLink",
+                                    config: {
+                                       propertyToRender: "name",
+                                       linkPublishTopic: "TEST_PROPERTY_LINK_CLICK",
+                                       linkPublishPayload: {},
+                                       publishTopic: "ALF_CRUD_UPDATE",
+                                       publishPayloadType: "PROCESS",
+                                       publishPayloadModifiers: ["processCurrentItemTokens"],
+                                       publishPayloadItemMixin: true,
+                                       publishPayload: {
+                                          url: "api/solr/facet-config/{name}"
+                                       },
+                                       hiddenDataRules: [
+                                          {
+                                             name: "hiddenData",
+                                             rulePassValue: "hidden_update",
+                                             ruleFailValue: "",
+                                             is: ["New"]
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};


### PR DESCRIPTION
This pull request addresses https://issues.alfresco.com/jira/browse/AKU-71 which was created to address several usability and functional improvements to be made to the InlineEditProperty (and by extension the InlineEditPropertyLink) controls.