### PR TITLE
Fixes for issue

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -32,8 +32,9 @@ define(["dojo/_base/declare",
         "alfresco/preview/AlfDocumentPreview",
         "alfresco/documentlibrary/views/layouts/DocumentCarousel",
         "alfresco/documentlibrary/views/layouts/Carousel",
-        "dojo/_base/lang"], 
-        function(declare, AlfDocumentListView, template, AlfDocument, AlfDocumentPreview, DocumentCarousel, Carousel, lang) {
+        "dojo/_base/lang",
+        "dojo/dom-construct"], 
+        function(declare, AlfDocumentListView, template, AlfDocument, AlfDocumentPreview, DocumentCarousel, Carousel, lang, domConstruct) {
    
    return declare([AlfDocumentListView], {
       
@@ -134,6 +135,9 @@ define(["dojo/_base/declare",
        * @returns {object} A new [DocumentListRenderer]{@link module:alfresco/documentlibrary/views/DocumentListRenderer}
        */
       createDocumentListRenderer: function alfresco_documentlibrary_views_AlfFilmStripView__createDocumentListRenderer() {
+         // NOTE: Any previous previews should have been destroyed, but empty the previewNode just to be on the safe side
+         //       TODO: Possible memory leak to investigate here, because the call to empy the node *is* required.
+         domConstruct.empty(this.previewNode);
          this.contentCarousel = new DocumentCarousel({
             widgets: lang.clone(this.widgetsForContent),
             currentData: this.currentData,

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -75,8 +75,20 @@ define(["dojo/_base/declare",
          else if (this.isContainer === false)
          {
             // This is a document so we can subscribe to the expected request to display content
+            // TODO: This contains a temporary config override whilst we wait for full adoption of the 
+            //       Aikau only PDF.js preview plugin. This override can be removed after adoption occurs.
             this.widgets = [{
-               name: "alfresco/preview/AlfDocumentPreview"
+               name: "alfresco/preview/AlfDocumentPreview",
+               config: {
+                  widgetsForPluginsOverrides: [
+                     {
+                        id: "PdfJs",
+                        replace: true,
+                        name: "alfresco/preview/PdfJs/PdfJs",
+                        config: {}
+                     }
+                  ]
+               }
             }];
             this.alfSubscribe("ALF_FILMSTRIP_DOCUMENT_REQUEST__" + this.nodeRef, lang.hitch(this, this.requestDocument, this.nodeRef));
          }

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/Carousel.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/Carousel.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -96,7 +96,7 @@ define(["dojo/_base/declare",
          // Subscribe to selection topics...
          if (this.itemSelectionTopics)
          {
-            array.forEach(this.itemSelectionTopics, function(topic, index) {
+            array.forEach(this.itemSelectionTopics, function(topic) {
                this.alfSubscribe(topic, lang.hitch(this, this.selectItem));
             }, this);
          }
@@ -218,7 +218,7 @@ define(["dojo/_base/declare",
        * @param {element} rootNode The DOM element to add them into.
        */
       processWidgets: function alfresco_documentlibrary_views_layouts_Carousel__processWidgets(widgets, rootNode) {
-         var nodeToAdd = nodeToAdd = domConstruct.create("li", {}, rootNode);
+         var nodeToAdd = domConstruct.create("li", {}, rootNode);
          this.inherited(arguments, [widgets, nodeToAdd]);
       },
 
@@ -311,7 +311,7 @@ define(["dojo/_base/declare",
          domStyle.set(this.containerNode, "left", left);
 
          var itemsCount = lang.getObject("currentData.items.length", false, this);
-         domStyle.set(this.prevNode, "visibility", (this.firstDisplayedIndex == 0) ? "hidden": "visible");
+         domStyle.set(this.prevNode, "visibility", (this.firstDisplayedIndex === 0) ? "hidden": "visible");
          domStyle.set(this.nextNode, "visibility", (this.firstDisplayedIndex <= itemsCount-1 && this.lastDisplayedIndex >= itemsCount-1) ? "hidden": "visible");
 
       },

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest.js
@@ -28,10 +28,10 @@ define(["intern!object",
         "intern/chai!assert",
         "intern/chai!expect",
         "require",
-        "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, expect, require, TestCommon, keys) {
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, expect, require, TestCommon) {
 
+   var browser;
    var pause = 1500;
 
    // Setup some selectors for re-use...
@@ -55,8 +55,8 @@ define(["intern!object",
 
          
    registerSuite({
-      name: 'FilmStrip Setup',
-      'Test Previous Preview control is hidden': function () {
+      name: "FilmStrip Setup",
+      "Test Previous Preview control is hidden": function () {
          return TestCommon.loadTestWebScript(this.remote, "/FilmStripView", "Film Strip View Setup")
          .findByCssSelector(prevPreviewControlSelector)
             .isVisible()
@@ -65,7 +65,7 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Next Preview control is displayed': function () {
+      "Test Next Preview control is displayed": function () {
          return this.remote.findByCssSelector(nextPreviewControlSelector)
             .isVisible()
             .then(function(result) {
@@ -73,7 +73,7 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Previous Thumbnails Control is not displayed': function () {
+      "Test Previous Thumbnails Control is not displayed": function () {
          return this.remote.findByCssSelector(prevThumbnailControlSelector)
             .isVisible()
             .then(function(result) {
@@ -81,7 +81,7 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Next Thumbnails Control is displayed': function () {
+      "Test Next Thumbnails Control is displayed": function () {
          return this.remote.findByCssSelector(nextThumbnailControlSelector)
             .isVisible()
             .then(function(result) {
@@ -89,14 +89,14 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Preview Item Count': function () {
+      "Test Preview Item Count": function () {
          return this.remote.findAllByCssSelector(previewFrameItemsSelector)
             .then(function(elements) {
-               assert(elements.length === 4, "Expected 2 preview items, found: " + elements.length);
+               assert(elements.length === 2, "Expected 2 preview items, found: " + elements.length);
             })
          .end();
       },
-      'Test First Preview is displayed': function () {
+      "Test First Preview is displayed": function () {
          return this.remote.findByCssSelector(previewFrameItemsSelector + ":nth-child(1)")
             .isVisible()
             .then(function(result) {
@@ -104,7 +104,7 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Second Preview is hidden': function () {
+      "Test Second Preview is hidden": function () {
          return this.remote.findByCssSelector(previewFrameItemsSelector + ":nth-child(2)")
             .isVisible()
             .then(function(result) {
@@ -117,8 +117,8 @@ define(["intern!object",
    // NOTE: This suite relies on the previous suite having run first so that the test browser is displaying
    //       the correct page...
    registerSuite({
-      name: 'FilmStrip Preview Navigation',
-      'Test Next Preview Control': function () {
+      name: "FilmStrip Preview Navigation",
+      "Test Next Preview Control": function () {
          // Click on the next preview item to scroll along...
          return this.remote.findByCssSelector(nextPreviewControlSelector)
             .click()
@@ -143,7 +143,7 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Previous Preview Control displayed after Next Preview': function () {
+      "Test Previous Preview Control displayed after Next Preview": function () {
          return this.remote.findByCssSelector(prevPreviewControlSelector)
             .isVisible()
             .then(function(result) {
@@ -153,7 +153,7 @@ define(["intern!object",
             .sleep(pause) // Wait for just over a second for the animation to complete...
          .end();
       },
-      'Test Preview Control is hidden when used on second preview': function () {
+      "Test Preview Control is hidden when used on second preview": function () {
          return this.remote.findByCssSelector(prevPreviewControlSelector)
             .isVisible()
             .then(function(result) {
@@ -161,8 +161,7 @@ define(["intern!object",
             })
          .end();
       },
-      'Test Preview Navigation Click': function () {
-         var browser = this.remote;
+      "Test Preview Navigation Click": function () {
          return this.remote.findByCssSelector(previewFrameItemsSelector + ":nth-child(1)" + previewImgSelectorSuffix)
             .click()
          .end()
@@ -172,60 +171,57 @@ define(["intern!object",
          // Count the number of preview items...
          .findAllByCssSelector(previewFrameItemsSelector)
             .then(function(elements) {
-               assert(elements.length === 16, "Expected 14 preview items (+ 2 debug items), found: " + elements.length);
+               assert(elements.length === 14, "Expected 14 preview items, found: " + elements.length);
             })
-         .end()
-
-         // TODO: move this when the other tests are fixed...
-         .alfPostCoverageResults(browser);
+         .end();
       }
    });
 
-   // TODO: It appears that there are genuine bugs that need fixing in order for these tests to work...
-   //       1) Clicking on the preview folder is updating the preview to show the first item in the folder.
-
    // NOTE: This suite relies on the previous suite having run first so that the test browser is displaying
    //       the correct page...
-   // registerSuite({
-   //    name: 'FilmStrip Thumbnail Navigation',
-   //    'Test Thumbnail Scrolls With Preview': function () {
-   //        // Click the next preview selector 3 times (to check that the thumbnail frame scrolls)...
-   //       return this.remote
-   //          .findByCssSelector(nextPreviewControlSelector)
-   //          .click()
-   //          .sleep(pause)
-   //          .click()
-   //          .sleep(pause)
-   //          .click()
-   //          .sleep(pause)
-   //          .click()
-   //          .sleep(pause)
-   //       .end()
-   //       .findByCssSelector(prevThumbnailControlSelector)
-   //          .isVisible()
-   //          .then(function(visible) {
-   //             assert(visible === true, "The previous thumbnail selection should be visible");
-   //          })
-   //       .end();
-   //    },
-   //    'Test Preview Scrolls With Thumbnail Selection': function () {
-   //       // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-   //       // Move to the 3rd selection of thumbnails...
-   //       return this.remote.findByCssSelector(nextThumbnailControlSelector)
-   //          .click()
-   //          .sleep(pause)
-   //       .end()
+   registerSuite({
+      name: "FilmStrip Thumbnail Navigation",
+      "Test Thumbnail Scrolls With Preview": function () {
+          // Click the next preview selector 43 times (to check that the thumbnail frame scrolls)...
+         browser = this.remote;
+         return this.remote
+            .findByCssSelector(nextPreviewControlSelector)
+            .click()
+            .sleep(pause)
+            .click()
+            .sleep(pause)
+            .click()
+            .sleep(pause)
+            .click()
+            .sleep(pause)
+         .end()
+         .findByCssSelector(prevThumbnailControlSelector)
+            .isVisible()
+            .then(function(visible) {
+               assert(visible === true, "The previous thumbnail selection should be visible");
+            })
+         .end().alfPostCoverageResults(browser);
+      }
+      // TODO: Test needs completing
+      // ,
+      // "Test Preview Scrolls With Thumbnail Selection": function () {
+      //    // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
+      //    // Move to the 3rd selection of thumbnails...
+      //    return this.remote.findByCssSelector(nextThumbnailControlSelector)
+      //       .click()
+      //       .sleep(pause)
+      //    .end()
 
-   //       // TODO: Check that 3rd frame of thumbnails is displayed...
-   //       .findByCssSelector(thumbnailFrameItemsSelector + ":nth-child(10)" + thumbnailImgSelectorSuffix)
-   //          .click()
-   //          .sleep(pause)
-   //       .end()
+      //    // TODO: Check that 3rd frame of thumbnails is displayed...
+      //    .findByCssSelector(thumbnailFrameItemsSelector + ":nth-child(10)" + thumbnailImgSelectorSuffix)
+      //       .click()
+      //       .sleep(pause)
+      //    .end()
 
-   //       .sleep(pause)
-   //       // TODO: Check that 10th preview is displayed...
+      //    .sleep(pause)
+      //    // TODO: Check that 10th preview is displayed...
 
-   //       .alfPostCoverageResults(browser);
-   //    }
-   // });
+      //    .alfPostCoverageResults(browser);
+      // }
+   });
 });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-21 which was reporting an error with the prototype film strip view unit test not working. A couple of issues were uncovered, firstly we need to configure in the external Aikau PDF.js previewer plugin (to remove any YUI/Share dependencies) and there was also another issue with clearing out the old previewer on folder navigation. This will need further investigation to address any possible memory leaks in that view, but for now the view is behaving as expected from the user point of view.