### PR TITLE
AKU-9: Add initial release notes file

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -56,6 +56,16 @@
             <directory>${basedir}/src/main/resources/alfresco</directory>
          </resource>
 
+         <!-- Put the release notes in the root of the JAR file -->
+         <resource>
+            <targetPath>.</targetPath>
+            <filtering>true</filtering>
+            <includes>
+               <include>ReleaseNotes.txt</include>
+            </includes>
+            <directory>${basedir}/src/main/</directory>
+         </resource>
+
          <!-- ...but everything else goes into a standard path -->
          <resource>
             <targetPath>META-INF/js/lib</targetPath>

--- a/aikau/src/main/ReleaseNotes.txt
+++ b/aikau/src/main/ReleaseNotes.txt
@@ -1,0 +1,22 @@
+Aikau 1.0.3 Release Notes
+=========================
+
+Current deprecations:
+---------------------
+* alfresco/dialogs/AlfDialogService             (use: alfresco/services/Dialog) 
+* alfresco/forms/controls/DojoValidationTextBox (use: alfresco/forms/controls/TextBox)
+* alfresco/forms/controls/DojoCheckBox          (use: alfresco/forms/controls/CheckBox)
+* alfresco/forms/controls/DojoDateTextBox       (use: alfresco/forms/controls/DateTextBox)
+* alfresco/forms/controls/DojoRadioButtons      (use: alfresco/forms/controls/RadioButtons)
+* alfresco/forms/controls/DojoSelect            (use: alfresco/forms/controls/Select)
+* alfresco/forms/controls/DojoTextarea          (use: alfresco/forms/controls/TextArea)
+
+Resolved issues (see https://issues.alfresco.com/jira/browse/<issue-number>:
+----------------
+* AKU-9  - Add release notes
+* AKU-21 - Filmstrip view fixes
+* AKU-22 - Inline edit cursor update
+* AKU-24 - Remove potential XSS vulnerability in alfresco/forms/controls/Select
+* AKU-65 - Pagination handling updates
+* AKU-71 - Improvements to alfresco/renderers/InlineEditPropertyLink
+


### PR DESCRIPTION
I've created an initial release notes file, we can iterate on the style and content in this and future sprints, but I just wanted to get something in place for the time being.