### PR TITLE
AKU-73: Update pom.xml files to use public Surf artefacts

### DIFF
--- a/aikau-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/aikau-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,12 +26,12 @@
       <dependency>
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf</artifactId>
-         <version>5.0.1-SNAPSHOT</version>
+         <version>5.1-SNAPSHOT</version>
       </dependency>
       <dependency>
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf-api</artifactId>
-         <version>5.0.1-SNAPSHOT</version>
+         <version>5.1-SNAPSHOT</version>
       </dependency>
       <dependency>
          <groupId>org.tuckey</groupId>

--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -12,24 +12,6 @@
    <name>Aikau</name>
    <description>Aikau is a meta-framework for Alfresco specific UI development</description>
 
-   <dependencies>
-
-      <!-- This is used for the LESS CSS processing. It allows us to include LESS code in both
-          the Theme XML files and in widget CSS files. We deliberately exclude it's preferred
-          Rhino version so as to avoid conflicts with our own dependencies. -->
-      <dependency>
-         <groupId>com.asual.lesscss</groupId>
-         <artifactId>lesscss-engine</artifactId>
-         <version>1.5.0</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.mozilla</groupId>
-               <artifactId>rhino</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-   </dependencies>
-
    <build>
       <!-- Everything gets place into the META-INF folder of the JAR because Surf (the expected platform for Aikau)
            will be able to access resources from that location via the /res/ path -->

--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -14,21 +14,6 @@
 
    <dependencies>
 
-      <!-- Surf is required for unit testing application -->
-      <dependency>
-         <groupId>org.springframework.extensions.surf</groupId>
-         <artifactId>spring-surf-api</artifactId>
-         <version>5.0.1-SNAPSHOT</version>
-      </dependency>
-
-      <!-- Required for unit test application -->
-      <dependency>
-         <groupId>org.tuckey</groupId>
-         <artifactId>urlrewritefilter</artifactId>
-         <version>4.0.4</version>
-         <scope>runtime</scope>
-      </dependency>
-
       <!-- This is used for the LESS CSS processing. It allows us to include LESS code in both
           the Theme XML files and in widget CSS files. We deliberately exclude it's preferred
           Rhino version so as to avoid conflicts with our own dependencies. -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf-api</artifactId>
          <version>5.1-SNAPSHOT</version>
+         <scope>test</scope>
       </dependency>
 
       <!-- Required for unit test application -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
       <dependency>
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf-api</artifactId>
-         <version>5.0.1-SNAPSHOT</version>
+         <version>5.1-SNAPSHOT</version>
       </dependency>
 
       <!-- Required for unit test application -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf-api</artifactId>
          <version>5.1-SNAPSHOT</version>
-         <scope>test</scope>
+         <scope>runtime</scope>
       </dependency>
 
       <!-- Required for unit test application -->
@@ -62,7 +62,9 @@
                <artifactId>rhino</artifactId>
             </exclusion>
          </exclusions>
+         <scope>runtime</scope>
       </dependency>
+
    </dependencies>
 
    <modules>


### PR DESCRIPTION
This PR updates the pom.xml files to place dependencies on Surf libs that are publicly available on the Alfresco Nexus repository that support the standalone Aikau clients and the unit test server. This will make it possible to build a client using Maven without needing to clone and build the Aikau source code (after 1.0.3 is released)