### PR TITLE
AKU-69: Ensure that LogoutService attempts to refresh the page

### DIFF
--- a/aikau/src/main/resources/alfresco/services/LogoutService.js
+++ b/aikau/src/main/resources/alfresco/services/LogoutService.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -54,8 +54,21 @@ define(["dojo/_base/declare",
          this.serviceXhr({
             url: AlfConstants.URL_PAGECONTEXT + "dologout",
             method: "POST",
+            successCallback: this.reloadPage,
             callbackScope: this
          });
+      },
+
+      /**
+       * Refresh the current page to ensure logout occurs. This is the callback used by the
+       * [doLogout]{@link module:alfresco/services/LogoutService#doLogout} function and will
+       * be called on receiving the logout response. Attempting to reload the page will ensure
+       * that the user is shown login page having logged out.
+       *
+       * @instance
+       */
+      reloadPage: function alfresco_services_LogoutService__refresh() {
+         window.location.reload();
       }
    });
 });


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-69 which addresses an issue where issuing the logout POST does not result in a redirect. This ensures that if the logout POST request is successful that a callback is in place to attempt to reload the page (the user authentication will have been removed so they will automatically be redirected). If redirection occurs via the original logout POST then the callback won't be on the page so there shouldn't be an additional reload (e.g. it won't reload the login page having already loaded it)