### PR TITLE
AKU-80: Vagrant browser version review

### DIFF
--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -30,7 +30,7 @@ define(["./config/Suites"],
             chromeOptions: {
                excludeSwitches: ['ignore-certificate-errors']
             }
-         // },
+         } // ,
          // { browserName: 'firefox' }
       ],
 

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -25,13 +25,13 @@ define(["./config/Suites"],
       // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
       // capabilities options specified for an environment will be copied as-is
       environments: [
-         // {
-         //    browserName: 'chrome',
-         //    chromeOptions: {
-         //       excludeSwitches: ['ignore-certificate-errors']
-         //    }
-         // }//,
-         { browserName: 'firefox' }
+         {
+            browserName: 'chrome',
+            chromeOptions: {
+               excludeSwitches: ['ignore-certificate-errors']
+            }
+         // },
+         // { browserName: 'firefox' }
       ],
 
       // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service

--- a/aikau/src/test/vagrant/setup.sh
+++ b/aikau/src/test/vagrant/setup.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-SELENIUM_VERSION="selenium-server-standalone-2.43.0.jar"
-SELENIUM_VERSION_NUMBER="2.43"
+SELENIUM_VERSION="selenium-server-standalone-2.44.0.jar"
+SELENIUM_VERSION_NUMBER="2.44"
 PHANTOMJS_VERSION="phantomjs-1.9.7-linux-x86_64" #don't include .tar.bz2 ext.
 CHROMEDRIVER_VERSION="2.10"
+CHROME_VERSION="40.0.2214.95-1"
+FIREFOX_VERSION="34.0"
 
 set -e
 
@@ -25,7 +27,7 @@ else
    apt-get update
 
    # Install Java, Chrome, Xvfb, unzip, firefox and libicu48
-   apt-get -y install openjdk-7-jre google-chrome-stable xvfb unzip firefox libicu48
+   apt-get -y install openjdk-7-jre google-chrome-stable=$CHROME_VERSION xvfb unzip libicu48
 
    cd /tmp
 
@@ -43,6 +45,10 @@ else
    wget "http://selenium-release.storage.googleapis.com/$SELENIUM_VERSION_NUMBER/$SELENIUM_VERSION"
    mv $SELENIUM_VERSION /usr/local/bin
 
+   wget "https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"
+   tar -xjvf firefox-$FIREFOX_VERSION.tar.bz2
+   cp -r firefox /usr/local/bin/
+
    # So that running `vagrant provision` doesn't redownload everything
    touch /.installed
 fi
@@ -57,8 +63,10 @@ Xvfb :10 -screen 0 1366x768x24 -ac &
 echo "Starting Google Chrome (v`dpkg -s google-chrome-stable| grep Version|cut -d: -f2` w/ Chrome Driver v$CHROMEDRIVER_VERSION)..."
 google-chrome --remote-debugging-port=9222 &
 
-echo "Starting Firefox (v`dpkg -s firefox| grep Version|cut -d: -f2`)..."
+echo "Starting Firefox (v$FIREFOX_VERSION)..."
+cd /usr/local/bin/firefox
 firefox &
+cd - > /dev/null
 
 echo "Starting Phantomjs ($PHANTOMJS_VERSION)..."
 phantomjs --ignore-ssl-errors=true --web-security=false --webdriver=192.168.56.4:4444 &


### PR DESCRIPTION
Force browser versions to match specified ones & not blindly installing the latest.

FF still doesn't work, however, so I've set Intern to use Chrome (which does work with the specified versions).
Firefox and Selenium are still having issues, although there is a fix in progress. Once this ticket has been resolved I suggest you review Sel 2.45 and FF35 for compatibility: https://code.google.com/p/selenium/issues/detail?id=8390