### PR TITLE
AKU-17 & AKU-42: Implement notifications, and above dialogs

### DIFF
--- a/aikau/.jshintrc
+++ b/aikau/.jshintrc
@@ -22,7 +22,7 @@
    "nonbsp": true,
    "nonew": true,
    "notypeof": true,
-   "quotmark": true,
+   "quotmark": "double",
    "shadow": "outer",
    "singleGroups": true,
    "undef": true,

--- a/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
+++ b/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An Alfresco styled notification.
+ *
+ * @module alfresco/notifications/AlfNotification
+ * @author Martin Doyle
+ */
+define([
+      'alfresco/core/Core',
+
+      'dojo/_base/declare',
+      'dojo/_base/lang',
+      'dojo/dom-class',
+
+      'dijit/_TemplatedMixin',
+      'dijit/_WidgetBase',
+
+      'dojo/text!./templates/AlfNotification.html'
+   ],
+   function(AlfCore, declare, lang, domClass, _TemplatedMixin, _WidgetBase, template) {
+
+      return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
+
+         /**
+          * An array of the CSS files to use with this widget.
+          *
+          * @instance cssRequirements {Array}
+          * @type {object[]}
+          * @default [{cssFile:'./css/AlfNotification.css'}]
+          */
+         cssRequirements: [{
+            cssFile: './css/AlfNotification.css'
+         }],
+
+         /**
+          * The HTML template to use for the widget.
+          *
+          * @instance
+          * @type {String}
+          */
+         templateString: template,
+
+         /**
+          * How many milliseconds to wait before destroying this widget after the notification has been hidden
+          *
+          * @instance
+          * @type  {number}
+          * @default 1000
+          */
+         destroyAfterHideMs: 1000,
+
+         /**
+          * Estimate how many seconds it might take a user to focus on a notification
+          *
+          * @instance
+          * @type  {number}
+          * @default 1
+          */
+         notificationFocusSecs: 1,
+
+         /**
+          * How many words per second a person will read, used to determine how long to display the message.
+          * First attempt to gauge how long to show message ... may need refining!
+          *
+          * @instance
+          * @type  {number}
+          * @default 5
+          */
+         wordsPerSecond: 5,
+
+         /**
+          * Called after widget created, but not sub-widgets
+          *
+          * @instance
+          */
+         postCreate: function alfresco_notifications_AlfNotification__postCreate() {
+            this.inherited(arguments);
+            document.body.appendChild(this.domNode);
+         },
+
+         /**
+          * Called once all widgets and sub-widgets have loaded
+          *
+          * @instance
+          */
+         startup: function alfresco_notifications_AlfNotification__startup() {
+            this.inherited(arguments);
+            setTimeout(lang.hitch(this, this.show), 0); // Add to page before showing, else transition fails
+         },
+
+         /**
+          * Hide the notification (and destroy it)
+          *
+          * @instance
+          */
+         hide: function alfresco_notifications_AlfNotification__hide() {
+            domClass.remove(this.domNode, 'alfresco-notifications-AlfNotification--visible');
+            setTimeout(lang.hitch(this, this.destroy), this.destroyAfterHideMs);
+         },
+
+         /**
+          * Show the notification
+          *
+          * @instance
+          */
+         show: function alfresco_notifications_AlfNotification__show() {
+            domClass.add(this.domNode, 'alfresco-notifications-AlfNotification--visible');
+            var messageText = this.messageNode.textContent || this.message.innerText || '',
+               messageWords = messageText.split(/\W+/),
+               autoHideSecs = Math.ceil(messageWords.length / this.wordsPerSecond) + this.notificationFocusSecs;
+            setTimeout(lang.hitch(this, this.hide), autoHideSecs * 1000);
+         }
+      });
+   }
+);

--- a/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
+++ b/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
@@ -23,19 +23,14 @@
  * @module alfresco/notifications/AlfNotification
  * @author Martin Doyle
  */
-define([
-      'alfresco/core/Core',
-
-      'dojo/_base/declare',
-      'dojo/_base/lang',
-      'dojo/dom-class',
-
-      'dijit/_TemplatedMixin',
-      'dijit/_WidgetBase',
-
-      'dojo/text!./templates/AlfNotification.html'
-   ],
-   function(AlfCore, declare, lang, domClass, _TemplatedMixin, _WidgetBase, template) {
+define(["alfresco/core/Core",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/dom-class",
+        "dijit/_TemplatedMixin",
+        "dijit/_WidgetBase",
+        "dojo/text!./templates/AlfNotification.html"],
+        function(AlfCore, declare, lang, domClass, _TemplatedMixin, _WidgetBase, template) {
 
       return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
 
@@ -44,10 +39,10 @@ define([
           *
           * @instance cssRequirements {Array}
           * @type {object[]}
-          * @default [{cssFile:'./css/AlfNotification.css'}]
+          * @default [{cssFile:"./css/AlfNotification.css"}]
           */
          cssRequirements: [{
-            cssFile: './css/AlfNotification.css'
+            cssFile: "./css/AlfNotification.css"
          }],
 
          /**
@@ -112,7 +107,7 @@ define([
           * @instance
           */
          hide: function alfresco_notifications_AlfNotification__hide() {
-            domClass.remove(this.domNode, 'alfresco-notifications-AlfNotification--visible');
+            domClass.remove(this.domNode, "alfresco-notifications-AlfNotification--visible");
             setTimeout(lang.hitch(this, this.destroy), this.destroyAfterHideMs);
          },
 
@@ -122,8 +117,8 @@ define([
           * @instance
           */
          show: function alfresco_notifications_AlfNotification__show() {
-            domClass.add(this.domNode, 'alfresco-notifications-AlfNotification--visible');
-            var messageText = this.messageNode.textContent || this.message.innerText || '',
+            domClass.add(this.domNode, "alfresco-notifications-AlfNotification--visible");
+            var messageText = this.messageNode.textContent || this.message.innerText || "",
                messageWords = messageText.split(/\W+/),
                autoHideSecs = Math.ceil(messageWords.length / this.wordsPerSecond) + this.notificationFocusSecs;
             setTimeout(lang.hitch(this, this.hide), autoHideSecs * 1000);

--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -1,0 +1,31 @@
+/* Centering technique from http://www.smashingmagazine.com/2013/08/09/absolute-horizontal-vertical-centering-css */
+.alfresco-notifications-AlfNotification {
+   left: 0;
+   opacity: 0;
+   position: absolute;
+   right: 0;
+   top: 52.5%;
+   transition: opacity .2s ease-out, top .2s ease-out;
+   z-index: 9999; /* This isn't ideal, but searching all z-indexes is even worse (better solution possible?) */
+   &__container {
+      background: #666;
+      border-radius: 0 0 5px 5px;
+      box-shadow: @standard-box-shadow;
+      box-sizing: border-box;
+      margin: 0 auto;
+      padding: 20px;
+      position: relative;
+      top: -50%;
+      width: 400px;
+   }
+   &__message {
+      color: #fff;
+      font-family: @standard-font;
+      font-size: @normal-font-size;
+      line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
+   }
+   &--visible {
+      opacity: 1;
+      top: 50%;
+   }
+}

--- a/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
+++ b/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
@@ -1,0 +1,5 @@
+<div class="alfresco-notifications-AlfNotification">
+   <div class="alfresco-notifications-AlfNotification__container">
+      <span class="alfresco-notifications-AlfNotification__message" data-dojo-attach-point="messageNode" aria-live="assertive" role="status">${message}</span>
+   </div>
+</div>

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -23,11 +23,10 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-      "alfresco/core/Core",
-      "dojo/_base/lang",
-      "alfresco/notifications/AlfNotification"
-   ],
-   function(declare, AlfCore, lang, AlfNotification) {
+        "alfresco/core/Core",
+        "dojo/_base/lang",
+        "alfresco/notifications/AlfNotification"],
+        function(declare, AlfCore, lang, AlfNotification) {
 
       return declare([AlfCore], {
 
@@ -39,8 +38,8 @@ define(["dojo/_base/declare",
           */
          constructor: function alfresco_services_NotificationService__constructor(args) {
             lang.mixin(this, args);
-            this.alfSubscribe("ALF_DISPLAY_NOTIFICATION", lang.hitch(this, "onDisplayNotification"));
-            this.alfSubscribe("ALF_DISPLAY_PROMPT", lang.hitch(this, "onDisplayPrompt"));
+            this.alfSubscribe("ALF_DISPLAY_NOTIFICATION", lang.hitch(this.onDisplayNotification));
+            this.alfSubscribe("ALF_DISPLAY_PROMPT", lang.hitch(this.onDisplayPrompt));
          },
 
          /**

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -23,76 +23,74 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/Core",
-        "dojo/_base/lang"],
-        function(declare, AlfCore, lang) {
-   
-   return declare([AlfCore], {
-      
-      /**
-       * Declare the dependencies on "legacy" JS files that this is wrapping.
-       * 
-       * @instance
-       * @type {String[]}
-       */
-      nonAmdDependencies: ["/js/yui-common.js",
-                           "/js/alfresco.js"],
+      "alfresco/core/Core",
+      "dojo/_base/lang",
+      "alfresco/notifications/AlfNotification"
+   ],
+   function(declare, AlfCore, lang, AlfNotification) {
 
-      /**
-       * Sets up the subscriptions for the NotificationService
-       * 
-       * @instance
-       * @param {array} args Constructor arguments
-       */
-      constructor: function alfresco_services_NotificationService__constructor(args) {
-         lang.mixin(this, args);
-         this.alfSubscribe("ALF_DISPLAY_NOTIFICATION", lang.hitch(this, "onDisplayNotification"));
-         this.alfSubscribe("ALF_DISPLAY_PROMPT", lang.hitch(this, "onDisplayPrompt"));
-      },
-      
-      /**
-       * Displays a notification to the user
-       * 
-       * @instance
-       * @param {object} payload The The details of the notification.
-       */
-      onDisplayNotification: function alfresco_services_NotificationService__onDisplayNotification(payload) {
-         var message = lang.getObject("message", false, payload);
-         if (message != null)
-         {
-            Alfresco.util.PopupManager.displayMessage({
-               text: message
-            });
-         }
-         else
-         {
-            this.alfLog("warn", "It was not possible to display the message because no 'message' attribute was provided", payload);
-         }
-      },
+      return declare([AlfCore], {
 
-      /**
-       * Displays a prompt to the user
-       *
-       * @instance
-       * @param {object} payload The The details of the notification.
-       */
-      onDisplayPrompt: function alfresco_services_NotificationService__onDisplayPrompt(payload) {
-         var message = lang.getObject("message", false, payload);
-         if (message != null)
-         {
-            var config = {
-               text: message
-            };
-            if (payload.title)
-            {
-               config.title = payload.title;
+         /**
+          * Declare the dependencies on "legacy" JS files that this is wrapping.
+          *
+          * @instance
+          * @type {String[]}
+          */
+         nonAmdDependencies: [
+            "/js/yui-common.js",
+            "/js/alfresco.js"
+         ],
+
+         /**
+          * Sets up the subscriptions for the NotificationService
+          *
+          * @instance
+          * @param {array} args Constructor arguments
+          */
+         constructor: function alfresco_services_NotificationService__constructor(args) {
+            lang.mixin(this, args);
+            this.alfSubscribe("ALF_DISPLAY_NOTIFICATION", lang.hitch(this, "onDisplayNotification"));
+            this.alfSubscribe("ALF_DISPLAY_PROMPT", lang.hitch(this, "onDisplayPrompt"));
+         },
+
+         /**
+          * Displays a notification to the user
+          *
+          * @instance
+          * @param {object} payload The The details of the notification.
+          */
+         onDisplayNotification: function alfresco_services_NotificationService__onDisplayNotification(payload) {
+            var message = lang.getObject("message", false, payload);
+            if (message) {
+               var newNotification = new AlfNotification({
+                  message: payload.message
+               });
+               newNotification.startup();
+            } else {
+               this.alfLog("warn", "It was not possible to display the message because no suitable 'message' attribute was provided", payload);
             }
-            Alfresco.util.PopupManager.displayMessage(config);
+         },
+
+         /**
+          * Displays a prompt to the user
+          *
+          * @instance
+          * @param {object} payload The The details of the notification.
+          */
+         onDisplayPrompt: function alfresco_services_NotificationService__onDisplayPrompt(payload) {
+            var message = lang.getObject("message", false, payload);
+            if (message) {
+               var config = {
+                  text: message
+               };
+               if (payload.title) {
+                  config.title = payload.title;
+               }
+               Alfresco.util.PopupManager.displayMessage(config);
+            } else {
+               this.alfLog("warn", "It was not possible to display the message because no suitable 'message' attribute was provided", payload);
+            }
          }
-         else
-         {
-            this.alfLog("warn", "It was not possible to display the message because no 'message' attribute was provided", payload);
-         }
-      }
+      });
    });
-});

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -32,17 +32,6 @@ define(["dojo/_base/declare",
       return declare([AlfCore], {
 
          /**
-          * Declare the dependencies on "legacy" JS files that this is wrapping.
-          *
-          * @instance
-          * @type {String[]}
-          */
-         nonAmdDependencies: [
-            "/js/yui-common.js",
-            "/js/alfresco.js"
-         ],
-
-         /**
           * Sets up the subscriptions for the NotificationService
           *
           * @instance

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!expect",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, expect, assert, require, TestCommon) {
+
+      var browser;
+
+      registerSuite({
+         name: "NotificationService",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NotificationService", "NotificationService")
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         teardown: function() {
+            browser.end()
+               .alfPostCoverageResults(browser);
+         },
+
+         "Notification displays on button click": function() {
+            return browser.findByCssSelector("#NOTIFICATION_BUTTON_SMALL")
+               .click()
+               .sleep(1000) // Simulate delay of notification appearing and user focusing on it
+               .end()
+
+            .findByCssSelector(".alfresco-notifications-AlfNotification__message")
+               .isDisplayed()
+               .then(function(notificationDisplayed) {
+                  assert.isTrue(notificationDisplayed, "Notification not displayed");
+               });
+         },
+
+         "Notification hides after displaying": function() {
+            return browser.setFindTimeout(5000)
+               .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message");
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -19,7 +19,7 @@
 
 /**
  * This provides the configuration for test suites.
- * 
+ *
  * @author Richard Smith
  */
 define({
@@ -31,7 +31,9 @@ define({
     * @type [string]
     */
    // Uncomment and add specific tests as necessary during development!
-   // baseFunctionalSuites: ['src/test/resources/alfresco/documentlibrary/PaginationTest'],
+   xbaseFunctionalSuites: [
+      'src/test/resources/alfresco/services/NotificationServiceTest'
+   ],
 
    /**
     * This is the base array of functional test suites
@@ -79,13 +81,13 @@ define({
       'src/test/resources/alfresco/forms/controls/BaseFormTest',
       'src/test/resources/alfresco/forms/controls/ComboBoxTest',
       'src/test/resources/alfresco/forms/controls/DocumentPickerTest',
-      'src/test/resources/alfresco/forms/controls/DateTextBoxTest',  // TODO: NEEDS FIXING
+      'src/test/resources/alfresco/forms/controls/DateTextBoxTest', // TODO: NEEDS FIXING
       'src/test/resources/alfresco/forms/controls/FormButtonDialogTest',
       'src/test/resources/alfresco/forms/controls/MultipleEntryFormControlTest',
       'src/test/resources/alfresco/forms/controls/SelectTest',
       'src/test/resources/alfresco/forms/controls/TextBoxTest',
       'src/test/resources/alfresco/forms/controls/ValidationTest',
-      'src/test/resources/alfresco/forms/controls/XssPreventionTest', 
+      'src/test/resources/alfresco/forms/controls/XssPreventionTest',
 
       'src/test/resources/alfresco/header/HeaderWidgetsTest',
       'src/test/resources/alfresco/header/WarningTest',
@@ -139,6 +141,7 @@ define({
       'src/test/resources/alfresco/renderers/ThumbnailTest',
       'src/test/resources/alfresco/renderers/XhrActionsTest',
 
+      'src/test/resources/alfresco/services/NotificationServiceTest',
       'src/test/resources/alfresco/services/SearchServiceTest',
       'src/test/resources/alfresco/services/SiteServiceTest',
       'src/test/resources/alfresco/services/UserServiceTest',
@@ -164,7 +167,7 @@ define({
     * @instance
     * @type [string]
     */
-   localFunctionalSuites: function localFunctionalSuites(){
+   localFunctionalSuites: function localFunctionalSuites() {
       return this.setupFunctionalSuites.concat(
          this.baseFunctionalSuites.concat(
             this.localOnlyFunctionalSuites.concat(
@@ -188,7 +191,7 @@ define({
     * @instance
     * @type [string]
     */
-   vmFunctionalSuites: function vmFunctionalSuites(){
+   vmFunctionalSuites: function vmFunctionalSuites() {
       return this.setupFunctionalSuites.concat(
          this.baseFunctionalSuites.concat(
             this.vmOnlyFunctionalSuites.concat(
@@ -212,7 +215,7 @@ define({
     * @instance
     * @type [string]
     */
-   slFunctionalSuites: function slFunctionalSuites(){
+   slFunctionalSuites: function slFunctionalSuites() {
       return this.setupFunctionalSuites.concat(
          this.baseFunctionalSuites.concat(
             this.slOnlyFunctionalSuites.concat(
@@ -236,7 +239,7 @@ define({
     * @instance
     * @type [string]
     */
-   gridFunctionalSuites: function gridFunctionalSuites(){
+   gridFunctionalSuites: function gridFunctionalSuites() {
       return this.setupFunctionalSuites.concat(
          this.baseFunctionalSuites.concat(
             this.gridOnlyFunctionalSuites.concat(
@@ -252,7 +255,7 @@ define({
     * @instance
     * @type [string]
     */
-   setupFunctionalSuites: [],//['src/test/resources/alfresco/DebugEnable'],
+   setupFunctionalSuites: [], //['src/test/resources/alfresco/DebugEnable'],
 
    /**
     * This is the array of functional test suites for teardown purposes
@@ -260,6 +263,6 @@ define({
     * @instance
     * @type [string]
     */
-   teardownFunctionalSuites: []//['src/test/resources/alfresco/DebugDisable']
+   teardownFunctionalSuites: [] //['src/test/resources/alfresco/DebugDisable']
 
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>NotificationService Test</shortname>
+  <description>This WebScript defines the NotificationService page test</description>
+  <family>aikau-unit-tests</family>
+  <url>/NotificationService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -1,0 +1,84 @@
+/*jshint maxlen:500*/
+model.jsonModel = {
+   services: [
+      {
+            name: "alfresco/services/LoggingService",
+            config: {
+               loggingPreferences: {
+                  enabled: true,
+                  all: true
+               }
+            }
+      },
+      "alfresco/services/NotificationService",
+      "alfresco/services/DialogService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "NOTIFICATION_BUTTON_SMALL",
+         config: {
+            label: "Display notification (short)",
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "This is a message."
+            }
+         }
+      }, {
+         name: "alfresco/buttons/AlfButton",
+         id: "NOTIFICATION_BUTTON_MEDIUM",
+         config: {
+            label: "Display notification (medium)",
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "This is my test notification message. It is of, what I consider to be, a medium length."
+            }
+         }
+      }, {
+         name: "alfresco/buttons/AlfButton",
+         id: "NOTIFICATION_BUTTON_LARGE",
+         config: {
+            label: "Display notification (long)",
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "This is a longer message. I shall Lorem Ipsum it. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum auctor feugiat tristique. Nulla sed egestas elit. Quisque malesuada eget felis eget auctor. Aenean mattis quam nisl, sit amet sollicitudin ex posuere eget."
+            }
+         }
+      }, {
+         name: "alfresco/buttons/AlfButton",
+         id: "DIALOG_BUTTON",
+         config: {
+            label: "Display dialog",
+            publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Dialog title",
+               widgetsContent: [
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        label: "This is a label to help extend the dialog to cover the notification",
+                        level: 3
+                     }
+                  },
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     id: "NOTIFICATION_BUTTON_DIALOG",
+                     config: {
+                        label: "This is a really long label to make sure the button and dialog hide the notification",
+                        publishTopic: "ALF_DISPLAY_NOTIFICATION",
+                        publishPayload: {
+                           message: "This is an in-dialog message."
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      }, {
+         name: "alfresco/logging/SubscriptionLog"
+      }, {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -25,7 +25,8 @@ model.jsonModel = {
                message: "This is a message."
             }
          }
-      }, {
+      },
+      {
          name: "alfresco/buttons/AlfButton",
          id: "NOTIFICATION_BUTTON_MEDIUM",
          config: {
@@ -35,7 +36,8 @@ model.jsonModel = {
                message: "This is my test notification message. It is of, what I consider to be, a medium length."
             }
          }
-      }, {
+      },
+      {
          name: "alfresco/buttons/AlfButton",
          id: "NOTIFICATION_BUTTON_LARGE",
          config: {
@@ -45,7 +47,8 @@ model.jsonModel = {
                message: "This is a longer message. I shall Lorem Ipsum it. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum auctor feugiat tristique. Nulla sed egestas elit. Quisque malesuada eget felis eget auctor. Aenean mattis quam nisl, sit amet sollicitudin ex posuere eget."
             }
          }
-      }, {
+      },
+      {
          name: "alfresco/buttons/AlfButton",
          id: "DIALOG_BUTTON",
          config: {
@@ -75,9 +78,11 @@ model.jsonModel = {
                ]
             }
          }
-      }, {
+      },
+      {
          name: "alfresco/logging/SubscriptionLog"
-      }, {
+      },
+      {
          name: "aikauTesting/TestCoverageResults"
       }
    ]


### PR DESCRIPTION
This pull request addresses issues https://issues.alfresco.com/jira/browse/AKU-17 and https://issues.alfresco.com/jira/browse/AKU-42, which is about re-implementing notifications after the Aikau separation broke the link to the library that fulfilled the notifications, and also ensures that notifications appear above dialogs.
NOTE: It was not possible to test the z-index visibility using Intern/Selenium, so for the moment this has had to be tested manually.