### PR TITLE
Include extension module in Aikau JAR

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <groupId>org.alfresco</groupId>
       <artifactId>aikau-parent</artifactId>
-      <version>1.0.4-SNAPSHOT</version>
+   <version>1.0.4-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 
@@ -31,6 +31,13 @@
                <include>ReleaseNotes.txt</include>
             </includes>
             <directory>${basedir}/src/main/</directory>
+         </resource>
+
+         <resource>
+            <!-- Path has to be aligned with version because Surf caches by XML path -->
+            <targetPath>./alfresco/site-data/extensions/${project.version}</targetPath>
+            <filtering>true</filtering>
+            <directory>${basedir}/src/main/resources/extension-module</directory>
          </resource>
 
          <!-- ...but everything else goes into a standard path -->

--- a/aikau/src/main/resources/extension-module/aikau-extension.xml
+++ b/aikau/src/main/resources/extension-module/aikau-extension.xml
@@ -1,0 +1,36 @@
+<extension>
+   <id>Aikau ${project.version} Extension</id>
+   <modules>
+      <module>
+         <id>Aikau ${project.version} Config Module</id>
+         <version>${project.version}</version>
+         <auto-deploy>true</auto-deploy>
+         <auto-deploy-index>${project.version}</auto-deploy-index>
+         <configurations>
+            <config evaluator="string-compare" condition="WebFramework" replace="false">
+               <web-framework>
+                  <dojo-pages>
+                     <enabled>true</enabled>
+                     <loader-trace-enabled>false</loader-trace-enabled>
+                     <bootstrap-file>/res/js/lib/dojo-1.9.0/dojo/dojo.js</bootstrap-file>
+                     <page-widget>alfresco/core/Page</page-widget>
+                     <base-url>/res/</base-url>
+                     <default-less-configuration>/js/aikau/${project.version}/alfresco/css/less/defaults.less</default-less-configuration><messages-object>Alfresco</messages-object>
+                     <packages>
+                         <package name="service"      location="../service"/>
+                         <package name="dojo"         location="js/lib/dojo-1.9.0/dojo"/>
+                         <package name="dijit"        location="js/lib/dojo-1.9.0/dijit"/>
+                         <package name="dojox"        location="js/lib/dojo-1.9.0/dojox"/>
+                         <package name="alfresco"     location="js/aikau/${project.version}/alfresco"/>
+                         <package name="surf"         location="js/surf"/>
+                         <package name="cm"           location="js/lib/code-mirror"/>
+                         <package name="jquery"       location="js/lib/jquery-1.11.1" main="jquery-1.11.1.min"/>
+                         <package name="jqueryui"     location="js/lib/jquery-ui-1.11.1" main="jquery-ui.min"/>
+                     </packages>
+                  </dojo-pages>
+               </web-framework>
+            </config>
+         </configurations>
+      </module>
+   </modules>
+</extension>


### PR DESCRIPTION
We're going to need this for 1.0.4 to go with Alfresco 5.0.1 updates. This update generates a new Surf extension module in the build which is configured to ensure that the latest version of Aikau that is found will be used. This means that it is only necessary to update pom.xml dependencies rather than re-configuring surf.xml files for each update.