### PR TITLE
Update JSHint to allow empty blocks

### DIFF
--- a/aikau/.jshintrc
+++ b/aikau/.jshintrc
@@ -18,7 +18,6 @@
    "maxstatements": 30,
    "newcap": true,
    "noarg": true,
-   "noempty": true,
    "nonbsp": true,
    "nonew": true,
    "notypeof": true,


### PR DESCRIPTION
Update JSHint to allow empty blocks