### PR TITLE
Add JSHint to project

### DIFF
--- a/aikau/package.json
+++ b/aikau/package.json
@@ -24,6 +24,7 @@
       "intern": "2.2.2",
       "jade": "1.9.1",
       "jsdoc": "3.3.0-beta1",
+      "jshint-stylish": "1.0.0",
       "load-grunt-tasks": "3.1.0",
       "lodash": "3.1.0",
       "mkdirp": "0.3.5",

--- a/aikau/src/grunt/_config.js
+++ b/aikau/src/grunt/_config.js
@@ -7,6 +7,8 @@ module.exports = {
       alfWidgets: "src/test/resources/alfresco_widgets.json",
       coverageReports: "code-coverage-reports/*.json",
       css: "src/main/resources/**/*.css",
+      gruntFile: "Gruntfile.js",
+      gruntTasks: "src/grunt/**/*.js",
       html: "src/main/resources/alfresco/**/*.html",
       js: "src/main/resources/alfresco/**/*.js",
       jsdocConfig: "conf.json",

--- a/aikau/src/grunt/linting.js
+++ b/aikau/src/grunt/linting.js
@@ -1,0 +1,18 @@
+var alfConfig = require("./_config");
+
+module.exports = function(grunt) {
+   grunt.config.merge({
+      jshint: {
+         options: {
+            reporter: require("jshint-stylish"),
+            jshintrc: true,
+            force: true
+         },
+         all: [
+            alfConfig.files.gruntFile,
+            alfConfig.files.gruntTasks,
+            alfConfig.files.js
+         ]
+      }
+   });
+};


### PR DESCRIPTION
Add isolated tasks (i.e. not called by anything else) for performing JSHint on the project. Could be integrated into a build process in the future.