### PR TITLE
AKU-83: Update Checkbox to honour string to boolean conversion requests

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1406,7 +1406,33 @@ define(["dojo/_base/declare",
                this.alfLog("log", "An exception was thrown retrieving the value for field: '" + this.fieldId + "'");
             }
          }
+         value = this.convertStringValuesToBoolean(value);
+         return value;
+      },
 
+      /**
+       * Indicates whether or not string values should be converted to a boolean value if possible. This is checked
+       * during [getValue]{@link module:alfresco/forms/controls/BaseFormControl#getValue} and
+       * [setValue]{@link module:alfresco/forms/controls/BaseFormControl#setValue} to handle value conversion in and out
+       * of the widget. This attribute should be honoured if overriding those functions.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      _convertStringValuesToBooleans: false,
+
+      /**
+       * If the supplied argument is a string then this will convert that value into a boolean. Conversion will only
+       * take place if the string is either "true" or "false" otherwise the supplied value will be returned. This conversion
+       * will only take place if [_convertStringValuesToBooleans]{@link module:alfresco/forms/controls/BaseFormControl#convertStringValuesToBoolean}
+       * is set to true (which is not the default value).
+       *
+       * @instance
+       * @param {object} value
+       * @returns {object}
+       */
+      convertStringValuesToBoolean: function alfresco_forms_controls_BaseFormControl__convertStringValuesToBoolean(value) {
          if (this._convertStringValuesToBooleans === true && ObjectTypeUtils.isString(value))
          {
             if (value.toLowerCase() === "true")
@@ -1420,7 +1446,7 @@ define(["dojo/_base/declare",
          }
          return value;
       },
-      
+
       /**
        * 
        * @instance

--- a/aikau/src/main/resources/alfresco/forms/controls/CheckBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/CheckBox.js
@@ -86,6 +86,7 @@ define(["alfresco/forms/controls/BaseFormControl",
                value = this.value;
             }
          }
+         value = this.convertStringValuesToBoolean(value);
          this.alfLog("log", "Returning value for field: '" + this.name + "': ", value);
          return value;
       },
@@ -97,10 +98,17 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {object} value The value to set.
        */
       setValue: function alfresco_forms_controls_CheckBox__setValue(value) {
-         this.alfLog("log", "Setting field: '" + this.name + "' with value: ", value);
-         if (this.wrappedWidget)
+         if (this.deferValueAssigment)
          {
-            this.wrappedWidget.set("checked", value);
+            this.inherited(arguments);
+         }
+         else
+         {
+            this.alfLog("log", "Setting field: '" + this.name + "' with value: ", value);
+            if (this.wrappedWidget)
+            {
+               this.wrappedWidget.set("checked", value);
+            }
          }
       },
       


### PR DESCRIPTION
This PR addresses an additional issue found when running 1.0.4-SNAPSHOT against 5.0.1 in that it was not possible to create a new search facet. The issue had been introduced as part of the XSS fix and will need an additional update in the 5.0.1 branch when the final 1.0.4 release is specified.