### PR TITLE
AKU-97: Add en localisation files during build

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -67,7 +67,29 @@
 
       <plugins>
 
-         <plugin>
+        <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
+            <executions>
+                <execution>
+                    <id>duplicate-english-messages</id>
+                    <phase>generate-resources</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <target>
+                    <copy todir="${project.build.outputDirectory}/META-INF/js/aikau/${project.version}">
+                        <fileset dir="${basedir}/src/main/resources" includes="alfresco/**/*.properties"/>
+                        <mapper from="^([^_]*).properties$" to="\1_en.properties" type="regexp"/>
+                    </copy>
+                </target>
+            </configuration>
+        </plugin>
+
+        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <version>2.9</version>


### PR DESCRIPTION
This addresses issue https://issues.alfresco.com/jira/browse/AKU-97, whereby there's a need to ensure the _en.properties files are available for when English is not the default locale.