### PR TITLE
AKU-96: Copy to form in IE has bug

### DIFF
--- a/aikau/src/main/resources/alfresco/pickers/css/Picker.css
+++ b/aikau/src/main/resources/alfresco/pickers/css/Picker.css
@@ -1,49 +1,53 @@
 .alfresco-pickers-Picker {
-    height: 210px;
+   height: 210px;
 
-    & > div {
+   & > div {
       float: left;
-    }
+   }
 
-    .sub-pickers > div,
-    .picked-items > div {
-        float: left;
-        border: @standard-border;
-        margin: @standard-column-spacing @standard-column-spacing 0;
-        padding: @standard-column-spacing;
-        height: 270px;
-        overflow-y: auto;
-        min-width: 180px; /* avoid the box appearing very small. */
-    }
+   .sub-pickers > div,
+   .picked-items > div {
+      border: @standard-border;
+      float: left;
+      height: 270px;
+      margin: @standard-column-spacing @standard-column-spacing 0;
+      min-width: 180px; /* avoid the box appearing very small. */
+      overflow-y: scroll;
+      padding: @standard-column-spacing;
+   }
 
-    .sub-pickers {
-        /* Remove styling from DocumentList widgets */
-        .alfresco-documentlibrary-AlfDocumentList {
-            border: @standard-border;
-            margin: 0 2px;
-        }
-        .alfresco-lists-AlfList > div.info,
-        .alfresco-documentlibrary-views-layouts-AlfDocumentListView {
-            padding: 0;
-            margin: 0;
-        }
+   .sub-pickers {
 
-        /* Style Menu bar specially */
-        .alfresco-menus-AlfMenuBar {
-            border: none;
+      /* Remove styling from DocumentList widgets */
+      .alfresco-documentlibrary-AlfDocumentList {
+         border: @standard-border;
+         margin: 0 2px;
+      }
 
-            /* This needs this many selectors to override the style in _AlfMenuItemMixin.css */
-            .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
-                padding: @standard-column-spacing;
-            }
-        }
-    }
-    
-    .picked-items-label, .sub-pickers-label {
-        padding: @standard-column-spacing;
-    }
-    
-    .alfresco-documentlibrary-views-layouts-AlfDocumentListView > table > tbody > tr > td {
-        padding: 6px 8px 6px 0;
-    }
+      .alfresco-lists-AlfList > div.info,
+      .alfresco-documentlibrary-views-layouts-AlfDocumentListView {
+         margin: 0;
+         padding: 0;
+      }
+
+      /* Style Menu bar specially */
+      .alfresco-menus-AlfMenuBar {
+         border: none;
+         overflow-y: auto;
+
+         /* This needs this many selectors to override the style in _AlfMenuItemMixin.css */
+         .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
+            padding: @standard-column-spacing;
+         }
+      }
+   }
+
+   .picked-items-label,
+   .sub-pickers-label {
+      padding: @standard-column-spacing;
+   }
+   
+   .alfresco-documentlibrary-views-layouts-AlfDocumentListView > table > tbody > tr > td {
+      padding: 6px 8px 6px 0;
+   }
 }


### PR DESCRIPTION
This issue addresses https://issues.alfresco.com/jira/browse/AKU-96 which refers to an aesthetics-only bug in IE. Creating an automated test for this is impractical, so it has been tested manually, before and after the commit, and passes manual testing.