### PR TITLE
AKU-81: Update Container Pickers to use PathTree

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/ContainerPicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/ContainerPicker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -28,12 +28,22 @@
  * @mixes module:alfresco/core/CoreWidgetProcessing
  * @author Dave Draper
  */
-define(["alfresco/forms/controls/Picker",
-        "dojo/_base/declare"],
-        function(Picker, declare) {
+define(["dojo/_base/declare",
+         "alfresco/forms/controls/Picker",
+         "alfresco/pickers/ContainerPicker"],
+        function(declare, Picker) {
 
    return declare([Picker], {
 
+      /**
+       * Overrides the default picker module.
+       *
+       * @instance
+       * @type {string}
+       * @default "alfresco/pickers/ContainerPicker"
+       */
+      pickerWidget: "alfresco/pickers/ContainerPicker",
+      
       /**
        * This should be overridden to define the widget model for rendering the picker that appears within the
        * dialog.
@@ -42,137 +52,62 @@ define(["alfresco/forms/controls/Picker",
        * @type {object}
        * @default []
        */
-      configForPicker: {
-         generatePubSubScope: true,
-         widgetsForPickedItems: [
+      configForPickedItems: {
+         singleItemMode: true,
+         widgets: [
             {
-               name: "alfresco/pickers/PickedItems",
-               assignTo: "pickedItemsWidget"
-            }
-         ],
-         widgetsForRootPicker: [
-            {
-               name: "alfresco/menus/AlfVerticalMenuBar",
+               name: "alfresco/lists/views/layouts/Row",
                config: {
                   widgets: [
                      {
-                        name: "alfresco/menus/AlfMenuBarItem",
+                        name: "alfresco/lists/views/layouts/Cell",
                         config: {
-                           label: "picker.myFiles.label",
-                           publishTopic: "ALF_ADD_PICKER",
-                           publishOnRender: "true",
-                           publishPayload: {
-                              currentPickerDepth: 0,
-                              picker: [
-                                 {
-                                    name: "alfresco/pickers/ContainerListPicker",
-                                    config: {
-                                       nodeRef: "alfresco://user/home",
-                                       path: "/"
-                                    }
-                                 }
-                              ]
-                           }
-                        }
-                     },
-                     {
-                        name: "alfresco/menus/AlfMenuBarItem",
-                        config: {
-                           label: "picker.sharedFiles.label",
-                           publishTopic: "ALF_ADD_PICKER",
-                           publishPayload: {
-                              currentPickerDepth: 0,
-                              picker: [
-                                 {
-                                    name: "alfresco/pickers/ContainerListPicker",
-                                    config: {
-                                       nodeRef: "alfresco://company/shared",
-                                       filter: {
-                                          path: "/"
+                           width: "20px",
+                           widgets: [
+                              {
+                                 name: "alfresco/renderers/FileType",
+                                 config: {
+                                    size: "small",
+                                    renderAsLink: false,
+                                    currentItem: {
+                                       node: {
+                                          type: "cm:folder",
+                                          nodeRef: "dummy://data/value"
                                        }
                                     }
                                  }
-                              ]
-                           }
+                              }
+                           ]
                         }
                      },
                      {
-                        name: "alfresco/menus/AlfMenuBarItem",
+                        name: "alfresco/lists/views/layouts/Cell",
                         config: {
-                           label: "picker.repository.label",
-                           publishTopic: "ALF_ADD_PICKER",
-                           publishPayload: {
-                              currentPickerDepth: 0,
-                              picker: [
-                                 {
-                                    name: "alfresco/pickers/ContainerListPicker",
-                                    config: {
-                                       nodeRef: "alfresco://company/home",
-                                       path: "/"
-                                    }
+                           widgets: [
+                              {
+                                 name: "alfresco/renderers/Property",
+                                 config: {
+                                    propertyToRender: "name",
+                                    renderAsLink: false
                                  }
-                              ]
-                           }
+                              }
+                           ]
                         }
                      },
                      {
-                        name: "alfresco/menus/AlfMenuBarItem",
+                        name: "alfresco/lists/views/layouts/Cell",
                         config: {
-                           label: "picker.recentSites.label",
-                           publishTopic: "ALF_ADD_PICKER",
-                           publishPayload: {
-                              currentPickerDepth: 0,
-                              picker: [
-                                 {
-                                    name: "alfresco/pickers/SingleItemPicker",
-                                    config: {
-                                       currentPickerDepth: 1,
-                                       widgetsForSubPicker: [
-                                          {
-                                             name: "alfresco/pickers/ContainerListPicker",
-                                             config: {
-                                                siteMode: true,
-                                                libraryRoot: "{siteNodeRef}",
-                                                nodeRef: "{siteNodeRef}",
-                                                path: "/"
-                                             }
-                                          }
-                                       ],
-                                       requestItemsTopic: "ALF_GET_RECENT_SITES"
-                                    }
+                           width: "20px",
+                           widgets: [
+                              {
+                                 name: "alfresco/renderers/PublishAction",
+                                 config: {
+                                    iconClass: "delete-16",
+                                    publishTopic: "ALF_ITEM_REMOVED",
+                                    publishPayloadType: "CURRENT_ITEM"
                                  }
-                              ]
-                           }
-                        }
-                     },
-                     {
-                        name: "alfresco/menus/AlfMenuBarItem",
-                        config: {
-                           label: "picker.favouriteSites.label",
-                           publishTopic: "ALF_ADD_PICKER",
-                           publishPayload: {
-                              currentPickerDepth: 0,
-                              picker: [
-                                 {
-                                    name: "alfresco/pickers/SingleItemPicker",
-                                    config: {
-                                       currentPickerDepth: 1,
-                                       widgetsForSubPicker: [
-                                          {
-                                             name: "alfresco/pickers/ContainerListPicker",
-                                             config: {
-                                                siteMode: true,
-                                                libraryRoot: "{siteNodeRef}",
-                                                nodeRef: "{siteNodeRef}",
-                                                path: "/"
-                                             }
-                                          }
-                                       ],
-                                       requestItemsTopic: "ALF_GET_FAVOURITE_SITES"
-                                    }
-                                 }
-                              ]
-                           }
+                              }
+                           ]
                         }
                      }
                   ]

--- a/aikau/src/main/resources/alfresco/forms/controls/Picker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Picker.js
@@ -274,6 +274,15 @@ define(["alfresco/forms/controls/BaseFormControl",
       configForPicker: null,
 
       /**
+       * This is the widget to use as the root picker.
+       *
+       * @instance
+       * @type {string}
+       * @default "alfresco/pickers/Picker"
+       */
+      pickerWidget: "alfresco/pickers/Picker",
+
+      /**
        * 
        * @instance
        * @type {object}
@@ -303,7 +312,7 @@ define(["alfresco/forms/controls/BaseFormControl",
                            handleOverflow: false,
                            widgetsContent: [
                               {
-                                 name: "alfresco/pickers/Picker",
+                                 name: "{pickerWidget}",
                                  config: {}
                               }
                            ],

--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -30,9 +30,8 @@ define(["dojo/_base/declare",
         "alfresco/navigation/Tree",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "dojo/_base/lang",
-        "dojo/_base/array",
-        "dojo/when"], 
-        function(declare, Tree, _AlfDocumentListTopicMixin, lang, array, when) {
+        "dojo/_base/array"], 
+        function(declare, Tree, _AlfDocumentListTopicMixin, lang, array) {
    
    return declare([Tree, _AlfDocumentListTopicMixin], {
       
@@ -55,13 +54,12 @@ define(["dojo/_base/declare",
        * @param {object} payload 
        */
       onFilterChange: function alfresco_navigation_PathTree__onFilterChange(payload) {
-         if (payload != null && 
-             payload.path != null)
+         if (payload && payload.path !== null && payload.path !== undefined)
          {
             this.alfLog("log", "Filter updated", payload);
             var pathElements = payload.path.split("/");
             
-            if (this.tree != null && pathElements.length > 0)
+            if (this.tree !== null && this.tree !== undefined && pathElements.length > 0)
             {
                var rootNode = this.tree.getChildren()[0];
                pathElements.shift();
@@ -81,7 +79,7 @@ define(["dojo/_base/declare",
        */
       expandPathElement: function alfresco_navigation_PathTree__expandPathElement(node, pathElements) {
          this.alfLog("log", "Expanding path nodes: ", node, pathElements);
-         if (node != null && !node.isExpanded)
+         if (node !== null && !node.isExpanded)
          {
             // It's almost certain that the node won't be expanded when first requested, and this is likely
             // to be because the data load is deferred (e.g. awaiting the results of the XHR request to get
@@ -90,8 +88,8 @@ define(["dojo/_base/declare",
             this.alfLog("log", "Node load deferred", node._loadDeferred);
             node._loadDeferred.then(lang.hitch(this, "expandPathElement", node, pathElements));
          }
-         else if (node != null &&
-                  pathElements != null &&
+         else if (node !== null &&
+                  pathElements !== null &&
                   pathElements.length > 0)
          {
             // If the node is expanded and there are more path elements to process then we can
@@ -99,9 +97,9 @@ define(["dojo/_base/declare",
             var childNodes = node.getChildren(),
                 pathElement = pathElements.shift(),
                 filteredNodes = array.filter(childNodes, function(item) {
-               return item.item.name == pathElement;
+               return item.item.name === pathElement;
             });
-            if (filteredNodes.length == 1)
+            if (filteredNodes.length === 1)
             {
                // There should only ever be one result, but it's important to check...
                // at least an invalid path (e.g. to a deleted or moved folder) will not

--- a/aikau/src/main/resources/alfresco/navigation/Tree.js
+++ b/aikau/src/main/resources/alfresco/navigation/Tree.js
@@ -233,7 +233,7 @@ define(["dojo/_base/declare",
          this.tree = new Tree({
             model: this.treeModel,
             showRoot: this.showRoot,
-            onClick: lang.hitch(this, "onClick"),
+            onClick: lang.hitch(this, this.onClick),
             onOpen: lang.hitch(this, this.onNodeExpand),
             onClose: lang.hitch(this, this.onNodeCollapse)
          });

--- a/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
@@ -47,6 +47,82 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Overrides the default picked items configuration to match the payloads provided by the 
+       * [PathTree]{@link module:alfresco/navigation/PathTree} widget.
+       *
+       * @instance
+       * @type {array}
+       */
+      widgetsForPickedItems: [
+         {
+            name: "alfresco/pickers/PickedItems",
+            assignTo: "pickedItemsWidget",
+            config: {
+               singleItemMode: "{singleItemMode}",
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Row",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 width: "20px",
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/FileType",
+                                       config: {
+                                          size: "small",
+                                          renderAsLink: false,
+                                          currentItem: {
+                                             node: {
+                                                type: "cm:folder"
+                                             }
+                                          }
+                                       }
+                                    }
+                                 ]
+                              }
+                           },
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/Property",
+                                       config: {
+                                          propertyToRender: "name",
+                                          renderAsLink: false
+                                       }
+                                    }
+                                 ]
+                              }
+                           },
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 width: "20px",
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/PublishAction",
+                                       config: {
+                                          iconClass: "delete-16",
+                                          publishTopic: "ALF_ITEM_REMOVED",
+                                          publishPayloadType: "CURRENT_ITEM"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ],
+
+      /**
        * The default widgets for the picker. This can be overridden at instantiation based on what is required to be
        * displayed in the picker.
        *
@@ -73,25 +149,12 @@ define(["dojo/_base/declare",
                                     currentPickerDepth: 1,
                                     widgetsForSubPicker: [
                                        {
-                                          name: "alfresco/layout/VerticalWidgets",
+                                          name: "alfresco/navigation/PathTree",
                                           config: {
-                                             widgets: [
-                                                {
-                                                   name: "alfresco/pickers/ContainerListPicker",
-                                                   config: {
-                                                      siteMode: false,
-                                                      libraryRoot: "{siteNodeRef}",
-                                                      nodeRef: "{siteNodeRef}",
-                                                      path: "/"
-                                                   }
-                                                },
-                                                {
-                                                   name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                                   config: {
-                                                      compactMode: true
-                                                   }
-                                                }
-                                             ]
+                                             showRoot: false,
+                                             rootNode: "{siteNodeRef}",
+                                             filterPaths: ["^/documentLibrary/(.*)$"],
+                                             publishTopic: "ALF_ITEM_SELECTED"
                                           }
                                        }
                                     ],
@@ -119,32 +182,12 @@ define(["dojo/_base/declare",
                                        {
                                           name: "alfresco/navigation/PathTree",
                                           config: {
+                                             showRoot: false,
                                              rootNode: "{siteNodeRef}",
-                                             rootLabel: ""
+                                             filterPaths: ["^/documentLibrary/(.*)$"],
+                                             publishTopic: "ALF_ITEM_SELECTED"
                                           }
                                        }
-                                       // {
-                                       //    name: "alfresco/layout/VerticalWidgets",
-                                       //    config: {
-                                       //       widgets: [
-                                       //          {
-                                       //             name: "alfresco/pickers/ContainerListPicker",
-                                       //             config: {
-                                       //                siteMode: true,
-                                       //                libraryRoot: "{siteNodeRef}",
-                                       //                nodeRef: "{siteNodeRef}",
-                                       //                path: "/"
-                                       //             }
-                                       //          },
-                                       //          {
-                                       //             name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                       //             config: {
-                                       //                compactMode: true
-                                       //             }
-                                       //          }
-                                       //       ]
-                                       //    }
-                                       // }
                                     ],
                                     requestItemsTopic: "ALF_GET_FAVOURITE_SITES"
                                  }
@@ -168,25 +211,12 @@ define(["dojo/_base/declare",
                                     currentPickerDepth: 1,
                                     widgetsForSubPicker: [
                                        {
-                                          name: "alfresco/layout/VerticalWidgets",
+                                          name: "alfresco/navigation/PathTree",
                                           config: {
-                                             widgets: [
-                                                {
-                                                   name: "alfresco/pickers/ContainerListPicker",
-                                                   config: {
-                                                      siteMode: true,
-                                                      libraryRoot: "{siteNodeRef}",
-                                                      nodeRef: "{siteNodeRef}",
-                                                      path: "/"
-                                                   }
-                                                },
-                                                {
-                                                   name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                                   config: {
-                                                      compactMode: true
-                                                   }
-                                                }
-                                             ]
+                                             showRoot: false,
+                                             rootNode: "{siteNodeRef}",
+                                             filterPaths: ["^/documentLibrary/(.*)$"],
+                                             publishTopic: "ALF_ITEM_SELECTED"
                                           }
                                        }
                                     ],
@@ -207,25 +237,11 @@ define(["dojo/_base/declare",
                            pickerLabel: "Path",
                            picker: [
                               {
-                                 name: "alfresco/layout/VerticalWidgets",
+                                 name: "alfresco/navigation/PathTree",
                                  config: {
-                                    widgets: [
-                                       {
-                                          name: "alfresco/pickers/ContainerListPicker",
-                                          config: {
-                                             nodeRef: "alfresco://company/shared",
-                                             filter: {
-                                                path: "/"
-                                             }
-                                          }
-                                       },
-                                       {
-                                          name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                          config: {
-                                             compactMode: true
-                                          }
-                                       }
-                                    ]
+                                    showRoot: false,
+                                    rootNode: "alfresco://company/shared",
+                                    publishTopic: "ALF_ITEM_SELECTED"
                                  }
                               }
                            ]
@@ -242,25 +258,11 @@ define(["dojo/_base/declare",
                            pickerLabel: "Path",
                            picker: [
                               {
-                                 name: "alfresco/layout/VerticalWidgets",
+                                 name: "alfresco/navigation/PathTree",
                                  config: {
-                                    widgets: [
-                                       {
-                                          name: "alfresco/pickers/ContainerListPicker",
-                                          config: {
-                                             nodeRef: "alfresco://company/home",
-                                             filter: {
-                                                path: "/"
-                                             }
-                                          }
-                                       },
-                                       {
-                                          name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                          config: {
-                                             compactMode: true
-                                          }
-                                       }
-                                    ]
+                                    showRoot: false,
+                                    rootNode: "alfresco://company/home",
+                                    publishTopic: "ALF_ITEM_SELECTED"
                                  }
                               }
                            ]
@@ -277,25 +279,11 @@ define(["dojo/_base/declare",
                            pickerLabel: "Path",
                            picker: [
                               {
-                                 name: "alfresco/layout/VerticalWidgets",
+                                 name: "alfresco/navigation/PathTree",
                                  config: {
-                                    widgets: [
-                                       {
-                                          name: "alfresco/pickers/ContainerListPicker",
-                                          config: {
-                                             nodeRef: "alfresco://user/home",
-                                             filter: {
-                                                path: "/"
-                                             }
-                                          }
-                                       },
-                                       {
-                                          name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                          config: {
-                                             compactMode: true
-                                          }
-                                       }
-                                    ]
+                                    showRoot: false,
+                                    rootNode: "alfresco://user/home",
+                                    publishTopic: "ALF_ITEM_SELECTED"
                                  }
                               }
                            ]

--- a/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -39,26 +39,7 @@ define(["dojo/_base/declare",
             name: "alfresco/pickers/PickedItems",
             assignTo: "pickedItemsWidget",
             config: {
-               singleItemMode: this.singleItemMode
-            }
-         }];
-
-         this.inherited(arguments);
-      },
-
-      /**
-       * Overrides the default picked items configuration to match the payloads provided by the 
-       * [PathTree]{@link module:alfresco/navigation/PathTree} widget.
-       *
-       * @instance
-       * @type {array}
-       */
-      widgetsForPickedItems: [
-         {
-            name: "alfresco/pickers/PickedItems",
-            assignTo: "pickedItemsWidget",
-            config: {
-               singleItemMode: "{singleItemMode}",
+               singleItemMode: this.singleItemMode,
                widgets: [
                   {
                      name: "alfresco/lists/views/layouts/Row",
@@ -76,7 +57,8 @@ define(["dojo/_base/declare",
                                           renderAsLink: false,
                                           currentItem: {
                                              node: {
-                                                type: "cm:folder"
+                                                type: "cm:folder",
+                                                nodeRef: "dummy://data/value"
                                              }
                                           }
                                        }
@@ -119,9 +101,10 @@ define(["dojo/_base/declare",
                   }
                ]
             }
-         }
-      ],
-
+         }];
+         this.inherited(arguments);
+      },
+      
       /**
        * The default widgets for the picker. This can be overridden at instantiation based on what is required to be
        * displayed in the picker.

--- a/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
@@ -79,7 +79,7 @@ define(["dojo/_base/declare",
                                                 {
                                                    name: "alfresco/pickers/ContainerListPicker",
                                                    config: {
-                                                      siteMode: true,
+                                                      siteMode: false,
                                                       libraryRoot: "{siteNodeRef}",
                                                       nodeRef: "{siteNodeRef}",
                                                       path: "/"
@@ -117,27 +117,34 @@ define(["dojo/_base/declare",
                                     currentPickerDepth: 1,
                                     widgetsForSubPicker: [
                                        {
-                                          name: "alfresco/layout/VerticalWidgets",
+                                          name: "alfresco/navigation/PathTree",
                                           config: {
-                                             widgets: [
-                                                {
-                                                   name: "alfresco/pickers/ContainerListPicker",
-                                                   config: {
-                                                      siteMode: true,
-                                                      libraryRoot: "{siteNodeRef}",
-                                                      nodeRef: "{siteNodeRef}",
-                                                      path: "/"
-                                                   }
-                                                },
-                                                {
-                                                   name: "alfresco/documentlibrary/AlfDocumentListPaginator",
-                                                   config: {
-                                                      compactMode: true
-                                                   }
-                                                }
-                                             ]
+                                             rootNode: "{siteNodeRef}",
+                                             rootLabel: ""
                                           }
                                        }
+                                       // {
+                                       //    name: "alfresco/layout/VerticalWidgets",
+                                       //    config: {
+                                       //       widgets: [
+                                       //          {
+                                       //             name: "alfresco/pickers/ContainerListPicker",
+                                       //             config: {
+                                       //                siteMode: true,
+                                       //                libraryRoot: "{siteNodeRef}",
+                                       //                nodeRef: "{siteNodeRef}",
+                                       //                path: "/"
+                                       //             }
+                                       //          },
+                                       //          {
+                                       //             name: "alfresco/documentlibrary/AlfDocumentListPaginator",
+                                       //             config: {
+                                       //                compactMode: true
+                                       //             }
+                                       //          }
+                                       //       ]
+                                       //    }
+                                       // }
                                     ],
                                     requestItemsTopic: "ALF_GET_FAVOURITE_SITES"
                                  }

--- a/aikau/src/main/resources/alfresco/pickers/Picker.js
+++ b/aikau/src/main/resources/alfresco/pickers/Picker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -36,10 +36,11 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Picker.html",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
+        "alfresco/core/ObjectProcessingMixin",
         "dojo/_base/lang"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, lang) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, ObjectProcessingMixin, lang) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, ObjectProcessingMixin], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -133,13 +134,15 @@ define(["dojo/_base/declare",
          if (this.showPickedItems === true)
          {
             this._processsingPickedItems = true;
-            this.processWidgets(lang.clone(this.widgetsForPickedItems), this.pickedItemsNode);
+            var clonedPickedItemsWidgets = lang.clone(this.widgetsForPickedItems);
+            this.processObject(["processInstanceTokens"], clonedPickedItemsWidgets);
+            this.processWidgets(clonedPickedItemsWidgets, this.pickedItemsNode);
             if (this.pickedItemsLabel) {
                this.pickedItemsLabelNode.innerHTML = this.message(this.pickedItemsLabel);
             }
          }
 
-         if (this.widgetsForRootPicker != null)
+         if (this.widgetsForRootPicker !== null)
          {
             this.processWidgets(lang.clone(this.widgetsForRootPicker), this.subPickersNode);
             if (this.subPickersLabel) {
@@ -167,7 +170,7 @@ define(["dojo/_base/declare",
             for (var i=pickerDepth; i < this.currentPickers.length; i++)
             {
                var picker = this.currentPickers[i];
-               if (picker != null && typeof picker.destroyRecursive === "function")
+               if (picker !== null && typeof picker.destroyRecursive === "function")
                {
                   picker.destroyRecursive();
                }
@@ -178,9 +181,9 @@ define(["dojo/_base/declare",
          }
 
          // Add the new picker...
-         if (payload.picker != null)
+         if (payload.picker !== null && payload.picker !== undefined)
          {
-            if (payload.picker.config == null)
+            if (payload.picker.config === null || payload.picker.config === undefined)
             {
                payload.picker.config = {};
             }
@@ -211,7 +214,7 @@ define(["dojo/_base/declare",
             this._processsingPickedItems = false;
             this.pickedItemsWidget.setPickedItems(this.value);
          }
-         else if (widgets == null || widgets.length != 1)
+         else if (widgets === null || widgets.length !== 1)
          {
             this.alfLog("warn", "A single picker widget was expected but " + widgets.length + " were created", widgets, this);
          }
@@ -244,7 +247,7 @@ define(["dojo/_base/declare",
          var value = [];
          if (this.showPickedItems === true)
          {
-            if (this.pickedItemsWidget != null)
+            if (this.pickedItemsWidget !== null)
             {
                value = this.pickedItemsWidget.currentData.items;
             }

--- a/aikau/src/main/resources/alfresco/pickers/Picker.js
+++ b/aikau/src/main/resources/alfresco/pickers/Picker.js
@@ -134,9 +134,7 @@ define(["dojo/_base/declare",
          if (this.showPickedItems === true)
          {
             this._processsingPickedItems = true;
-            var clonedPickedItemsWidgets = lang.clone(this.widgetsForPickedItems);
-            this.processObject(["processInstanceTokens"], clonedPickedItemsWidgets);
-            this.processWidgets(clonedPickedItemsWidgets, this.pickedItemsNode);
+            this.processWidgets(lang.clone(this.widgetsForPickedItems), this.pickedItemsNode);
             if (this.pickedItemsLabel) {
                this.pickedItemsLabelNode.innerHTML = this.message(this.pickedItemsLabel);
             }

--- a/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+      "intern/chai!expect",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, expect, assert, require, TestCommon) {
+
+      var browser;
+      registerSuite({
+         name: "ContainerPicker Tests",
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ContainerPicker", "ContainerPicker Tests").end();
+         },
+         beforeEach: function() {
+            browser.end();
+         },
+         teardown: function() {
+            browser.end().alfPostCoverageResults(browser);
+         },
+         "Test picker dialog can be displayed": function () {
+            return browser.findByCssSelector("#FOLDER_PICKER .alfresco-layout-VerticalWidgets > span > span > span")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-pickers-Picker")
+               .then(
+                  function(){}, 
+                  function() {
+                     assert(false, "The dialog has NOT opened with the picker");
+                  }
+               );
+         },
+         "Test Recent Sites sub-picker is shown": function() {
+            // Select "Recent Sites" (the results for this are mocked)
+            return browser.findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:first-child .dijitMenuItem:nth-child(1)")
+               .click()
+            .end()
+            .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "The Recent Sites sub-picker was not shown");
+               });
+         },
+         "Test Recent Sites result count": function() {
+            // Count the mocked results...
+            return browser.findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(2) .alfresco-menus-AlfMenuBar .dijitMenuItem")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Unexpected number of Recent Sites shown");
+               });
+         },
+         "Test selecting Recent site shows sub-picker": function() {
+            // Count the mocked results...
+            return browser.findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(2) .alfresco-menus-AlfMenuBar .dijitMenuItem:first-child")
+               .click()
+            .end()
+             .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "The tree sub-picker was not shown");
+               });
+         },
+         "Test selecting a container": function() {
+            // Using implicit wait of findAll... here...
+            return browser.findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(3) .dijitTreeNodeContainer .dijitTreeRow .dijitTreeLabel").end()
+            .findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(3) .dijitTreeNodeContainer .dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .findAllByCssSelector(".alfresco-pickers-Picker .picked-items tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "The container was not picked");
+               });
+         }
+      });
+   });

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+      "intern/chai!expect",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, expect, assert, require, TestCommon) {
+
+      var browser;
+      registerSuite({
+         name: "Path Tree Tests",
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/PathTree", "Path Tree Tests").end();
+         },
+         beforeEach: function() {
+            browser.end();
+         },
+         teardown: function() {
+            browser.end().alfPostCoverageResults(browser);
+         },
+         "Test root is shown on TREE1": function() {
+            return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Custom Root", "The root node of TREE1 was not as expected");
+               });
+         },
+         "Test that root is NOT shown on TREE2": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The root node of TREE2 was displayed unexpectedly");
+               });
+         },
+         "Test that first node of TREE2 is Document Library": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Document Library", "The root node of TREE2 was not as expected");
+               });
+         },
+         "Test that clicking on TREE1 publishes default topic": function() {
+            return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.topicSelector("ALF_DOCUMENTLIST_PATH_CHANGED", "publish", "last"))
+               .then(null, function() {
+                  assert(false, "The topic published by clicking on TREE1 nodes is not the default publishTopic");
+               });
+         },
+         "Test that clicking on TREE1 publishes path": function() {
+            return browser.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "path", "/"))
+               .then(null, function() {
+                  assert(false, "Clicking on the root of TREE1 did not publish the expected path");
+               });
+         },
+         "Test that clicking on TREE2 publishes custom topic": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.topicSelector("ALF_ITEM_SELECTED", "publish", "last"))
+               .then(null, function() {
+                  assert(false, "The topic published by clicking on TREE1 nodes is not requested custom topic");
+               });
+         },
+         "Test that TREE1 has NOT filtered site containers": function() {
+            return browser.findAllByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 5, "TREE1 did not have the expected number of nodes under the root");
+               });
+         },
+         "Test that TREE2 has filtered site containers": function() {
+            return browser.findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "TREE2 did not have the expected number of nodes under the root");
+               });
+         },
+         "Test that TREE2 Document Library is NOT expanded": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The child nodes of the Document Library in TREE2 were initially displayed");
+               });
+         },
+         "Test that child nodes of TREE2 Document Library are not loaded": function() {
+            return browser.findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The child nodes of the Document Library in TREE2 were loaded before being requested");
+               });
+         },
+         "Test that opening a node loads its children": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeExpando")
+               .click()
+            .end()
+            .findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "The child nodes of the Document Library in TREE2 were not loaded when requested");
+               });
+         },
+         "Test that paths are correct for child nodes": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > div:first-child div.dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "path", "/documentLibrary/Agency Files/"))
+               .then(null, function() {
+                  assert(false, "Clicking on a child node of TREE2 did not publish the expected path");
+               });
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/NotificationServiceTest"
+      "src/test/resources/alfresco/forms/controls/ContainerPickerTest"
    ],
 
    /**
@@ -80,6 +80,7 @@ define({
       "src/test/resources/alfresco/forms/controls/AutoSetTest",
       "src/test/resources/alfresco/forms/controls/BaseFormTest",
       "src/test/resources/alfresco/forms/controls/ComboBoxTest",
+      "src/test/resources/alfresco/forms/controls/ContainerPickerTest",
       "src/test/resources/alfresco/forms/controls/DocumentPickerTest",
       "src/test/resources/alfresco/forms/controls/DateTextBoxTest", // TODO: NEEDS FIXING
       "src/test/resources/alfresco/forms/controls/FormButtonDialogTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/ContainerListPicker.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/ContainerListPicker.get.js
@@ -13,8 +13,7 @@ model.jsonModel = {
       },
       "alfresco/services/DialogService",
       "alfresco/services/DocumentService",
-      "alfresco/services/SiteService",
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/SiteService"
    ],
    widgets: [
       {
@@ -48,6 +47,9 @@ model.jsonModel = {
                ]
             }
          }
+      },
+      {
+         name: "aikauTesting/mockservices/ContainerListPickerMockXhr"
       },
       {
          name: "alfresco/logging/SubscriptionLog"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ContainerPicker.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ContainerPicker.get.js
@@ -13,15 +13,18 @@ model.jsonModel = {
       },
       "alfresco/services/DialogService",
       "alfresco/services/DocumentService",
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/SiteService"
    ],
    widgets:[
       {
          name: "alfresco/forms/controls/ContainerPicker",
          config: {
-            id: "DOCUMENT_PICKER",
-            label: "Items"
+            id: "FOLDER_PICKER",
+            label: "Folders"
          }
+      },
+      {
+         name: "aikauTesting/mockservices/ContainerListPickerMockXhr"
       },
       {
          name: "alfresco/logging/SubscriptionLog"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>PathTree Test</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/PathTree</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
@@ -21,6 +21,8 @@ model.jsonModel = {
                {
                   name: "alfresco/layout/HorizontalWidgets",
                   config: {
+                     widgetMarginLeft: 10,
+                     widgetMarginRight: 10,
                      widgets: [
                         {
                            name: "alfresco/layout/ClassicWindow",
@@ -28,10 +30,11 @@ model.jsonModel = {
                               title: "Showing Root",
                               widgets: [
                                  {
+                                    id: "TREE1",
                                     name: "alfresco/navigation/PathTree",
                                     config: {
                                        rootNode: "workspace://SpacesStore/b4cff62a-664d-4d45-9302-98723eac1319",
-                                       rootLabel: "Site"
+                                       rootLabel: "Custom Root"
                                     }
                                  }
                               ]
@@ -40,9 +43,10 @@ model.jsonModel = {
                         {
                            name: "alfresco/layout/ClassicWindow",
                            config: {
-                              title: "Hidng Root",
+                              title: "Hiding Root, filtering paths",
                               widgets: [
                                  {
+                                    id: "TREE2",
                                     name: "alfresco/navigation/PathTree",
                                     config: {
                                        showRoot: false,

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
@@ -1,0 +1,76 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         name: "aikauTesting/WaitForMockXhrService",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/HorizontalWidgets",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/layout/ClassicWindow",
+                           config: {
+                              title: "Showing Root",
+                              widgets: [
+                                 {
+                                    name: "alfresco/navigation/PathTree",
+                                    config: {
+                                       rootNode: "workspace://SpacesStore/b4cff62a-664d-4d45-9302-98723eac1319",
+                                       rootLabel: "Site"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/layout/ClassicWindow",
+                           config: {
+                              title: "Hidng Root",
+                              widgets: [
+                                 {
+                                    name: "alfresco/navigation/PathTree",
+                                    config: {
+                                       showRoot: false,
+                                       filterPaths: ["^/documentLibrary/(.*)$"],
+                                       rootNode: "workspace://SpacesStore/b4cff62a-664d-4d45-9302-98723eac1319",
+                                       publishTopic: "ALF_ITEM_SELECTED",
+                                       publishPayloadType: "CURRENT_ITEM"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+
+               }
+               
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PathTreeMockXhr"
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/ContainerListPickerMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/ContainerListPickerMockXhr.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/ContainerListPickerMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr",
+        "dojo/text!./responseTemplates/ContainerListPicker/RecentSites.json",
+        "dojo/text!./responseTemplates/ContainerListPicker/Site.json",
+        "dojo/text!./responseTemplates/ContainerListPicker/DocumentLibrary.json"], 
+        function(declare, MockXhr, RecentSites, Site, DocumentLibrary) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_ContainerListPickerMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/api/people/guest/sites/recent",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":982},
+                                     RecentSites]);
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/treenode/node/alfresco/company/home/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":3028},
+                                     Site]);
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":2563},
+                                     DocumentLibrary]); 
+            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+            
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PathTreeMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PathTreeMockXhr.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This mock XHR server has been written to unit test the [PathTree]{@Link module:alfresco/navigation/PathTree} widget.
+ * 
+ * @module aikauTesting/mockservices/PathTreeMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr",
+        "dojo/text!./responseTemplates/PathTree/Site.json",
+        "dojo/text!./responseTemplates/PathTree/DocumentLibrary.json",
+        "dojo/text!./responseTemplates/PathTree/BudgetFiles.json"], 
+        function(declare, MockXhr, Site, DocumentLibrary, BudgetFiles) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_PreviewMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/treenode/node/alfresco/company/home/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":2565},
+                                     Site]);
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":2565},
+                                     DocumentLibrary]);
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":829},
+                                     BudgetFiles]); 
+            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+            
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ContainerListPicker/DocumentLibrary.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ContainerListPicker/DocumentLibrary.json
@@ -1,0 +1,99 @@
+{
+   "totalResults": 4,
+   "resultsTrimmed": false,
+   "parent":
+   {
+      "nodeRef": "workspace://SpacesStore/8f2105b4-daaf-4874-9e8a-2152569d109b",
+      "userAccess":
+      {
+         "create": true,
+         "edit": true,
+         "delete": true
+      }
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace://SpacesStore/8bb36efb-c26d-4d2b-9199-ab6922f53c28",
+         "name": "Agency Files",
+         "description": "This folder holds the agency related files for the project",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "cm:taggable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/8ab12916-4897-47fb-94eb-1ab699822ecb",
+         "name": "Budget Files",
+         "description": "This folder holds the project budget and invoices",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "cm:taggable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/a211774d-ba6d-4a35-b97f-dacfaac7bde3",
+         "name": "Meeting Notes",
+         "description": "This folder holds notes from the project review meetings",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/38745585-816a-403f-8005-0a55c0aec813",
+         "name": "Presentations",
+         "description": "This folder holds presentations from the project",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      }
+   ]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ContainerListPicker/RecentSites.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ContainerListPicker/RecentSites.json
@@ -1,0 +1,36 @@
+
+[
+{
+   "url": "\/alfresco\/s\/api\/sites\/swsdp",
+   "sitePreset": "site-dashboard",
+   "shortName": "swsdp",
+   "title": "Sample: Web Site Design Project",
+   "description": "This is a Sample Alfresco Team site.",
+   "node": "\/alfresco\/s\/api\/node\/workspace\/SpacesStore\/b4cff62a-664d-4d45-9302-98723eac1319",
+   "tagScope": "\/alfresco\/s\/api\/tagscopes\/workspace\/SpacesStore\/b4cff62a-664d-4d45-9302-98723eac1319",
+   "siteManagers":
+   [
+         "admin",
+         "mjackson"
+   ],
+   "isPublic": true,
+   "visibility": "PUBLIC"
+}
+      ,
+{
+   "url": "\/alfresco\/s\/api\/sites\/site-2",
+   "sitePreset": "site-dashboard",
+   "shortName": "site-2",
+   "title": "Site 2",
+   "description": "",
+   "node": "\/alfresco\/s\/api\/node\/workspace\/SpacesStore\/02f8ef7e-17b1-45a9-b89f-a4f51a60d7e3",
+   "tagScope": "\/alfresco\/s\/api\/tagscopes\/workspace\/SpacesStore\/02f8ef7e-17b1-45a9-b89f-a4f51a60d7e3",
+   "siteManagers":
+   [
+         "admin"
+   ],
+   "isPublic": true,
+   "visibility": "PUBLIC"
+}
+      
+]

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ContainerListPicker/Site.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ContainerListPicker/Site.json
@@ -1,0 +1,124 @@
+{
+   "totalResults": 5,
+   "resultsTrimmed": false,
+   "parent":
+   {
+      "nodeRef": "workspace://SpacesStore/b4cff62a-664d-4d45-9302-98723eac1319",
+      "userAccess":
+      {
+         "create": true,
+         "edit": true,
+         "delete": true
+      }
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace://SpacesStore/64f69e69-f61e-42a3-8697-95eea1f2bda2",
+         "name": "dataLists",
+         "description": "Data Lists",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/059c5bc7-2d38-4dc5-96b8-d09cd3c69b4c",
+         "name": "discussions",
+         "description": "",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/8f2105b4-daaf-4874-9e8a-2152569d109b",
+         "name": "documentLibrary",
+         "description": "Document Library",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/0e24b99c-41f0-43e1-a55e-fb9f50d73820",
+         "name": "links",
+         "description": "",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/cdefb3a9-8f55-4771-a9e3-06fa370250f6",
+         "name": "wiki",
+         "description": "",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "sys:localized"
+         ]
+      }
+   ]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PathTree/BudgetFiles.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PathTree/BudgetFiles.json
@@ -1,0 +1,37 @@
+{
+   "totalResults": 1,
+   "resultsTrimmed": false,
+   "parent":
+   {
+      "nodeRef": "workspace://SpacesStore/8ab12916-4897-47fb-94eb-1ab699822ecb",
+      "userAccess":
+      {
+         "create": true,
+         "edit": true,
+         "delete": true
+      }
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace://SpacesStore/d56afdc3-0174-4f8c-bce8-977cafd712ab",
+         "name": "Invoices",
+         "description": "This folder holds invoices for the project",
+         "hasChildren": false,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      }
+   ]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PathTree/DocumentLibrary.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PathTree/DocumentLibrary.json
@@ -1,0 +1,99 @@
+{
+   "totalResults": 4,
+   "resultsTrimmed": false,
+   "parent":
+   {
+      "nodeRef": "workspace://SpacesStore/8f2105b4-daaf-4874-9e8a-2152569d109b",
+      "userAccess":
+      {
+         "create": true,
+         "edit": true,
+         "delete": true
+      }
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace://SpacesStore/8bb36efb-c26d-4d2b-9199-ab6922f53c28",
+         "name": "Agency Files",
+         "description": "This folder holds the agency related files for the project",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "cm:taggable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/8ab12916-4897-47fb-94eb-1ab699822ecb",
+         "name": "Budget Files",
+         "description": "This folder holds the project budget and invoices",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "cm:taggable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/a211774d-ba6d-4a35-b97f-dacfaac7bde3",
+         "name": "Meeting Notes",
+         "description": "This folder holds notes from the project review meetings",
+         "hasChildren": false,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/38745585-816a-403f-8005-0a55c0aec813",
+         "name": "Presentations",
+         "description": "This folder holds presentations from the project",
+         "hasChildren": false,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "cm:ownable",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      }
+   ]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PathTree/Site.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PathTree/Site.json
@@ -1,0 +1,125 @@
+
+{
+   "totalResults": 5,
+   "resultsTrimmed": false,
+   "parent":
+   {
+      "nodeRef": "workspace://SpacesStore/b4cff62a-664d-4d45-9302-98723eac1319",
+      "userAccess":
+      {
+         "create": true,
+         "edit": true,
+         "delete": true
+      }
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace://SpacesStore/64f69e69-f61e-42a3-8697-95eea1f2bda2",
+         "name": "dataLists",
+         "description": "Data Lists",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/059c5bc7-2d38-4dc5-96b8-d09cd3c69b4c",
+         "name": "discussions",
+         "description": "",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/8f2105b4-daaf-4874-9e8a-2152569d109b",
+         "name": "documentLibrary",
+         "description": "Document Library",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "cm:titled",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/0e24b99c-41f0-43e1-a55e-fb9f50d73820",
+         "name": "links",
+         "description": "",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "sys:localized"
+         ]
+      },
+      {
+         "nodeRef": "workspace://SpacesStore/cdefb3a9-8f55-4771-a9e3-06fa370250f6",
+         "name": "wiki",
+         "description": "",
+         "hasChildren": true,
+         "userAccess":
+         {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "aspects": 
+         [
+            "cm:auditable",
+            "st:siteContainer",
+            "cm:ownable",
+            "cm:tagscope",
+            "sys:referenceable",
+            "sys:localized"
+         ]
+      }
+   ]
+}


### PR DESCRIPTION
This issue addresses https://issues.alfresco.com/jira/browse/AKU-81. It swaps out the previously used "alfresco/pickers/ContainerListPicker" with an "alfresco/navigation/PathTree" to make it possible for root container in empty sites to be selected.

Additional updates to the PathTree include the ability to swap out names for descriptions when a node has the st:siteContainer aspect applied as well as the ability to filter specific paths via RegEx.

Unit tests have been added for the PathTree and the ContainerPicker widgets