### PR TITLE
ALF-109: Correcting typos in AlfSitesMenu

### DIFF
--- a/aikau/src/main/resources/alfresco/header/i18n/AlfSitesMenu.properties
+++ b/aikau/src/main/resources/alfresco/header/i18n/AlfSitesMenu.properties
@@ -8,8 +8,8 @@ useful.sites.label=Useful
 site-finder.label=Site Finder
 create-site.label=Create Site
 my-sites.label=My Sites
-add-favourite-site.label=Add Current site to Favorites
-remove-favourite-site.label=Remove Current site from Favorites
+add-favourite-site.label=Add current site to Favorites
+remove-favourite-site.label=Remove current site from Favorites
 
 # Message menu item labels...
 loading.label=Loading...


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-109. Just corrects a couple of typos that have been spotted.