### PR TITLE
AKU-103: Updated title handling to be localized.

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SetTitle.js
+++ b/aikau/src/main/resources/alfresco/header/SetTitle.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,8 +18,14 @@
  */
 
 /**
+ * This widget can be used to dynamically update the rendered value of a [Title]{@link module:alfresco/header/Title}
+ * widget. It was created so that it would be possible a title rendered by one Surf Component to be modified
+ * from within another Surf Component. It is not expected to be commonly used. Ideally all Aikau widgets should be
+ * rendered in a single Surf Component.
+ * 
  * @module alfresco/header/SetTitle
  * @extends external:dijit/_WidgetBase
+ * @mixes module:alfresco/core/Core
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -51,7 +57,7 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_header_SetTitle__postCreate() {
          this.alfPublish("ALF_UPDATE_PAGE_TITLE", {
-            title: this.title
+            title: this.message(this.title)
          });
       }
    });

--- a/aikau/src/main/resources/alfresco/header/Title.js
+++ b/aikau/src/main/resources/alfresco/header/Title.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,6 +18,11 @@
  */
 
 /**
+ * This widget can be used to render a title for a page in a large font. It will also set the
+ * title of the browser window when [setBrowserTitle]{@link module:alfresco/header/Title#setBrowserTitle}
+ * is configured to be true. It subscribes to the "ALF_UPDATE_PAGE_TITLE" topic in order support the
+ * requests to dynamically re-render the title with a new value.
+ * 
  * @module alfresco/header/Title
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
@@ -58,6 +63,8 @@ define(["dojo/_base/declare",
       label: null,
       
       /**
+       * This is the URL to navigate to when the title is clicked.
+       * 
        * @instance
        * @type {string}
        */
@@ -73,6 +80,18 @@ define(["dojo/_base/declare",
       setBrowserTitle: false,
 
       /**
+       * This is the prefix to apply before the [label]{@link module:alfresco/header/Title#label} when
+       * setting the browser window title. It defaults to a standard Alfresco prefix but should be 
+       * overridden if required. The browser title will only be set when [setBrowserTitle]{@link module:alfresco/header/Title#setBrowserTitle}
+       * is set to true.
+       * 
+       * @instance
+       * @type {string}
+       * @default "Alfresco"
+       */
+      browserTitlePrefix: "Alfresco",
+
+      /**
        * It's important to perform label encoding before buildRendering occurs (e.g. before postCreate)
        * to ensure that an unencoded label isn't set and then replaced. 
        * 
@@ -81,7 +100,12 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_header_Title__postMixInProperties() {
          if (this.label)
          {
-            this.label = this.encodeHTML(this.label != null ? this.label : "");
+            var label = this.label ? this.label : "";
+            this.label = this.message(this.encodeHTML(label));
+         }
+         if (this.browserTitlePrefix)
+         {
+            this.browserTitlePrefix = this.encodeHTML(this.browserTitlePrefix);
          }
       },
       
@@ -90,10 +114,9 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_header_Title__postCreate() {
          this.textNode.innerHTML = this.label;
-
          if (this.setBrowserTitle === true)
          {
-            document.title = "Alfresco \u00bb " + this.label; // Set the browser title
+            document.title = this.browserTitlePrefix + " \u00bb " + this.label; // Set the browser title
          }
          
          if (this.targetUrl)
@@ -112,8 +135,9 @@ define(["dojo/_base/declare",
       updatePageTitle: function alfresco_header_Title__updatePageTitle(payload) {
          if (payload && payload.title)
          {
-            this.textNode.innerHTML = payload.title;
-            document.title = "Alfresco \u00bb " + payload.title; // Set the browser title
+            var title = this.message(payload.title);
+            this.textNode.innerHTML = this.message(payload.title);
+            document.title = this.browserTitlePrefix + " \u00bb " + title; // Set the browser title
          }
       }
    });

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -28,231 +28,313 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, expect, assert, require, TestCommon, keys) {
 
+   var browser;
    registerSuite({
-      name: 'Header Widgets Test',
+      name: "Basic Header Widgets Tests",
 
-      'Basic Test': function () {
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/HeaderWidgets", "Basic Header Widgets Test").end();
+      },
 
-         var browser = this.remote;
-         var testname = "Header Widgets Test";
-         return TestCommon.loadTestWebScript(this.remote, "/HeaderWidgets", testname)
+      beforeEach: function() {
+         browser.end();
+      },
 
-         // Check that the header CSS is applied...
-         .findByCssSelector(".alfresco-layout-LeftAndRight.alfresco-header-Header")
-            .then(function(element){}, function(err) {
-               assert(false, "Test #1a - The header CSS was not applied correctly");
-            })
-            .end()
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+      
+      "Test that header CSS is applied": function () {
+         // Check that the header CSS is applied...         
+         return browser.findByCssSelector(".alfresco-layout-LeftAndRight.alfresco-header-Header")
+            .then(function(){}, function() {
+               assert(false, "The header CSS was not applied correctly");
+            });
+      },
 
-         // Test the title text...
-         .findByCssSelector(".alfresco-header-Title > .text")
+      "Test title text is correct": function() {
+         return browser.findByCssSelector(".alfresco-header-Title > .text")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "Test Title", "Test #1b - The title was not set correctly");
-            })
-            .end()
+               assert.equal(resultText, "Test Title", "The title was not set correctly");
+            });
+      },
 
-         // Click on the popup... 
-         .findByCssSelector("#HEADER_POPUP_text")
+      "Test initial user status": function() {
+         return browser.findByCssSelector("#HEADER_POPUP_text")
             .click()
-            .end()
+         .end()
 
          // Check the preset user status...
          .findByCssSelector("#PRESET_STATUS > div.status")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "Test Status", "Test #1c - Preset status not set correctly");
-            })
-            .end()
+               assert.equal(resultText,"Test Status", "Preset status not set correctly");
+            });
+      },
 
-         .findByCssSelector("#PRESET_STATUS > div.lastUpdate > span")
+      "Test initial status time": function() {
+         return browser.findByCssSelector("#PRESET_STATUS > div.lastUpdate > span")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "over 15 years ago", "Test #1d - Preset status time not displayed as expected");
-            })
-            .end()
+               assert.equal(resultText,"over 15 years ago", "Preset status time not displayed as expected");
+            });
+      },
 
-         // Check the unset user status...
-         .findByCssSelector("#NO_STATUS > div.status")
+      "Test unset status displayed correctly": function() {
+         return browser.findByCssSelector("#NO_STATUS > div.status")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "What are you thinking?", "Test #1e - Unset status not displayed correctly");
-            })
-            .end()
+               assert.equal(resultText, "What are you thinking?", "Unset status not displayed correctly");
+            });
+      },
 
-         .findByCssSelector("#NO_STATUS > div.lastUpdate")
+      "Test unset status time displayed correctly": function() {
+         return browser.findByCssSelector("#NO_STATUS > div.lastUpdate")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "Last updated: never", "Test #1f - Unset status time not displayed as expected");
-            })
-            .end()
+               assert.equal(resultText, "Last updated: never", "Unset status time not displayed as expected");
+            });
+      },
 
-         // Click on a status to display the update dialog...
-         .findByCssSelector("#NO_STATUS > div.status")
+      "Test status dialog is displayed on click": function() {
+         return browser.findByCssSelector("#NO_STATUS > div.status")
             .click()
             .sleep(500)
-            .end()
+         .end()
 
          .findByCssSelector(".alfresco-dialog-AlfDialog")
-            .then(function(element){}, function(err) {
-               assert(false, "Test #2a - The update dialog was not displayed");
-            })
-            .end()
-         .findByCssSelector(".alfresco-dialog-AlfDialog .dijitDialogTitleBar > span")
+            .then(function(){}, function() {
+               assert(false, "The update dialog was not displayed");
+            });
+      },
+
+      "Test status dialog text is correct": function() {
+         return browser.findByCssSelector(".alfresco-dialog-AlfDialog .dijitDialogTitleBar > span")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "What Are You Thinking?", "Test #2b - User status dialog title not set correctly");
-            })
-            .end()
+               assert.equal(resultText, "What Are You Thinking?", "User status dialog title not set correctly");
+            });
+      },
 
-         // Update the status...
-         .findByCssSelector("#NO_STATUS_STATUS_TEXTAREA")
+      "Test new status published correctly": function() {
+         return browser.findByCssSelector("#NO_STATUS_STATUS_TEXTAREA")
             .clearValue()
             .type("Status Update")
-            //.sleep(500)
             .pressKeys([keys.TAB])
             .pressKeys([keys.RETURN])
             .sleep(250)
-            .end()
+         .end()
 
          // Check that the status update was posted correctly...
          .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "status", "Status Update"))
             .then(function(elements) {
-               assert(elements.length == 1, "Test #2c - User status not published correctly");
-            })
-            .end()
+               assert.lengthOf(elements, 1, "User status not published correctly");
+            });
+      },
 
+      "Test setting status updates via PubSub (status)": function() {
          // Use the menus to simulate a status update...
          // (with the bonus of checking the header versions of the menu items work)...
-         .findByCssSelector("#HEADER_POPUP_text")
+         return browser.findByCssSelector("#HEADER_POPUP_text")
             .click()
-            .end()
-            .sleep(150)
+         .end()
+         .sleep(150)
          .findByCssSelector("#CASCADE_1_text")
             .click()
-            .end()
-            .sleep(150)
+         .end()
+         .sleep(150)
          .findByCssSelector("#MENU_ITEM_1_text")
             .click()
-            .end()
-            .sleep(150)
+         .end()
+         .sleep(150)
 
          // Open the popup again...
          .findByCssSelector("#HEADER_POPUP_text")
             .click()
-            .end()
+         .end()
 
          // Check the preset user status (which should be updated)...
          .findByCssSelector("#NO_STATUS > div.status")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "Button Update", "Test #3a - Status not updated");
-            })
-            .end()
-         .findByCssSelector("#NO_STATUS > div.lastUpdate > span")
+               assert.equal(resultText, "Button Update", "Status not updated");
+            });
+      },
+
+      "Test setting status updates via PubSub (time)": function() {
+         return browser.findByCssSelector("#NO_STATUS > div.lastUpdate > span")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText == "over 15 years ago", "Test #3b - Status time not updated");
+               assert.equal(resultText, "over 15 years ago", "Status time not updated");
             })
-            .end()
+         .end();
 
+      },
+
+      "Test recent sites displayed (first site)": function() {
          // Click on the sites menus...
-         .findByCssSelector("#SITES_MENU_text")
+         return browser.findByCssSelector("#SITES_MENU_text") 
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#HEADER_SITES_MENU_RECENT_site1 a")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "Site1", "Test #4a - First recent site not rendered correctly");
-            })
-            .end()
-         .findByCssSelector("#HEADER_SITES_MENU_RECENT_site2 a")
+               assert.equal(text, "Site1", "First recent site not rendered correctly");
+            });
+      },
+
+      "Test recent sites displayed (second site)": function() {
+         return browser.findByCssSelector("#HEADER_SITES_MENU_RECENT_site2 a")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "Site2", "Test #4b - Sccond recent site not rendered correctly");
-            })
-            .end()
+               assert.equal(text, "Site2", "Sccond recent site not rendered correctly");
+            });
+      },
 
-         .findByCssSelector("#SITES_MENU_FAVOURITES_text")
+      "Test favourite sites displayed (first site)": function() {
+         return browser.findByCssSelector("#SITES_MENU_FAVOURITES_text")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#HEADER_SITES_MENU_FAVOURITE_site1 a")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "Site1", "Test #5a - First favourite site not rendered correctly");
-            })
-            .end()
+               assert(text === "Site1", "First favourite site not rendered correctly");
+            });
+      },
 
-         .findByCssSelector("#HEADER_SITES_MENU_FAVOURITE_site2 a")
+      "Test favourite sites displayed (second site)": function() {
+         return browser.findByCssSelector("#HEADER_SITES_MENU_FAVOURITE_site2 a")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "Site2", "Test #5b - Second favourite site not rendered correctly");
-            })
-            .end()
-
-         .alfPostCoverageResults(browser);
+               assert(text === "Site2", "Second favourite site not rendered correctly");
+            });
       },
 
-      'Add Favourite Test': function() {
-         var browser = this.remote;
-         var testname = "Add Favourite";
-         return TestCommon.loadTestWebScript(this.remote, "/AddFavouriteSite", testname)
+      "Test updating title": function() {
+         return browser.findByCssSelector("#SET_TITLE_BUTTON")
+            .click()
+         .end()
+         .findByCssSelector(".alfresco-header-Title > .text")
+            .getVisibleText()
+            .then(function(resultText) {
+               assert.equal(resultText, "Updated Title", "The title was not updated");
+            });
+      }
+   });
 
-            .end()
+   registerSuite({
+      name: "Add Favourites Tests",
 
-            .findByCssSelector("#SITES_MENU_text")
-               .click()
-               .sleep(500)
-               .end()
-
-            .findByCssSelector("#SITES_MENU_ADD_FAVOURITE_text")
-               .click()
-               .end()
-
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_ADD_FAVOURITE_SITE", "publish", "last"))
-               .then(function(elements) {
-                  assert(elements.length == 1, "Test #1a - Add favourite topic not published");
-               })
-               .end()
-
-            .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "site", "site1"))
-               .then(function(elements) {
-                  assert(elements.length == 1, "Test #1b - Favourite not added correctly");
-               })
-               .end()
-
-            .alfPostCoverageResults(browser);
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AddFavouriteSite", "Add Favourites Tests").end();
       },
 
-      'Remove Favourite Test': function() {
-         var browser = this.remote;
-         var testname = "Remove Favourite";
-         return TestCommon.loadTestWebScript(this.remote, "/RemoveFavouriteSite", testname)
-            
-            .findByCssSelector("#SITES_MENU_text")
-               .click()
-               .sleep(500)
-               .end()
+      beforeEach: function() {
+         browser.end();
+      },
 
-            .findByCssSelector("#SITES_MENU_REMOVE_FAVOURITE_text")
-               .click()
-               .end()
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+      
+      "Test add favourite request published": function() {
+         return browser.findByCssSelector("#SITES_MENU_text")
+            .click()
+            .sleep(500)
+         .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_REMOVE_FAVOURITE_SITE", "publish", "last"))
+         .findByCssSelector("#SITES_MENU_ADD_FAVOURITE_text")
+            .click()
+         .end()
+
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_ADD_FAVOURITE_SITE", "publish", "last"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Add favourite topic not published");
+            });
+      },
+
+      "Test favourite request published correctly": function() {
+         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "site", "site1"))
                .then(function(elements) {
-                  assert(elements.length == 1, "Test #1a - Remove favourite topic not published");
-               })
-               .end()
+                  assert.lengthOf(elements, 1, "Favourite not added correctly");
+               });
+      }
+   });
 
-            .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "site", "site1"))
-               .then(function(elements) {
-                  assert(elements.length == 1, "Test #1b - Favourite not removed correctly");
-               })
-               .end()
-            
-            .alfPostCoverageResults(browser);
+   registerSuite({
+      name: "Remove Favourites Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/RemoveFavouriteSite", "Add Favourites Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+      
+      "Test remove favourite request published": function() {
+         return browser.findByCssSelector("#SITES_MENU_text")
+            .click()
+            .sleep(500)
+         .end()
+
+         .findByCssSelector("#SITES_MENU_REMOVE_FAVOURITE_text")
+            .click()
+         .end()
+
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_REMOVE_FAVOURITE_SITE", "publish", "last"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Remove favourite topic not published");
+            });
+      },
+
+      "Test remove request published correctly": function() {
+         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "site", "site1"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Favourite not removed correctly");
+            });
+      }
+   });
+
+   registerSuite({
+      name: "Set Title Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/SetTitle", "Set Title Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+      
+      "Test title gets set": function() {
+         return browser.findByCssSelector(".alfresco-header-Title > .text")
+            .getVisibleText()
+            .then(function(resultText) {
+               assert.equal(resultText, "Updated Title", "The title was not updated");
+            });
+      },
+
+      "Test document title": function() {
+         return browser.execute("return document.title;")
+            .then(function(title) {
+               assert(title.indexOf("Unit Tests" === 0), "The document title was not updated");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/HeaderWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/HeaderWidgets.get.js
@@ -86,7 +86,18 @@ model.jsonModel = {
                {
                   name: "alfresco/header/Title",
                   config: {
-                     label: "Test Title"
+                     label: "test.page.title"
+                  }
+               },
+               {
+                  id: "SET_TITLE_BUTTON",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Change Title",
+                     publishTopic: "ALF_UPDATE_PAGE_TITLE",
+                     publishPayload: {
+                        title: "test.page.updated.title"
+                     }
                   }
                }
             ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/HeaderWidgets.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/HeaderWidgets.get.properties
@@ -1,0 +1,2 @@
+test.page.title=Test Title
+test.page.updated.title=Updated Title

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>Set Title Test</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/SetTitle</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.js
@@ -1,0 +1,41 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/VerticalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/header/Title",
+                  config: {
+                     browserTitlePrefix: "Unit Tests",
+                     label: "Original Title"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/header/SetTitle",
+         config: {
+            title: "test.page.updated.title"
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.properties
@@ -1,0 +1,1 @@
+test.page.updated.title=Updated Title


### PR DESCRIPTION
Addresses https://issues.alfresco.com/jira/browse/AKU-103. Updated both the Title and SetTitle widgets to check for localized versions of supplied strings. Also added better support for document title prefixing. Updated the unit tests to conform to best practices and added unit tests for new features.