### PR TITLE
Fix line endings

### DIFF
--- a/aikau/.gitattributes
+++ b/aikau/.gitattributes
@@ -1,0 +1,2 @@
+# Default line-endings for repo
+* text eol=lf


### PR DESCRIPTION
Add a new .gitattributes file to force all line endings for the repo to be "lf". For more info, see https://help.github.com/articles/dealing-with-line-endings.