### PR TITLE
Added additionalCssClasses support to TextArea and default CSS requirements.

### DIFF
--- a/aikau/.gitignore
+++ b/aikau/.gitignore
@@ -1,4 +1,5 @@
 # Ignored directories (please keep alphabetical)
+/bin/
 /code-coverage-reports/
 /docs/
 /node_modules/

--- a/aikau/src/main/resources/alfresco/forms/controls/TextArea.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TextArea.js
@@ -30,6 +30,14 @@ define(["alfresco/forms/controls/BaseFormControl",
    return declare([BaseFormControl], {
       
       /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {Array}
+       */
+      cssRequirements: [{cssFile:"./css/TextArea.css"}],
+      
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_TextArea__getWidgetConfig() {
@@ -64,7 +72,15 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        */
       createFormControl: function alfresco_forms_controls_TextArea__createFormControl(config, domNode) {
-         return new Textarea(config);
+         var textArea = new Textarea(config);
+         // Handle adding classes
+         var additionalCssClasses = "";
+         if (this.additionalCssClasses != null)
+         {
+            additionalCssClasses = this.additionalCssClasses;
+         }
+         domClass.add(this.domNode, "alfresco-forms-controls-TextArea " + additionalCssClasses);
+         return textArea;
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/forms/controls/TextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TextBox.js
@@ -74,8 +74,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        */
       createFormControl: function alfresco_forms_controls_TextBox__createFormControl(config, domNode) {
          var textBox = new ValidationTextBox(config);
-
-         // Handle  adding classes to control width...
+         // Handle adding classes
          var additionalCssClasses = "";
          if (this.additionalCssClasses != null)
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/css/TextArea.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/TextArea.css
@@ -1,0 +1,13 @@
+.alfresco-forms-controls-TextArea div.control .dijitTextArea {
+   border-color: @standard-border-color;
+}
+
+.alfresco-forms-controls-TextArea div.control .dijitTextAreaHover {
+   border-color: @hover-border-color;
+   background-image: none;
+   background-color: inherit;
+}
+
+.alfresco-forms-controls-TextArea div.control .dijitTextAreaFocused {
+   border-color: @focused-border-color;
+}


### PR DESCRIPTION
This ensures default CSS (for border etc.) of TextArea is same as other HTML form controls such as TextBox and that additionalCssClasses can be used.