### PR TITLE
AKU-41: Add support for Manage Aspects action

### DIFF
--- a/aikau/src/grunt/shell.js
+++ b/aikau/src/grunt/shell.js
@@ -33,6 +33,15 @@ module.exports = function(grunt) {
                }
             }
          },
+         vagrantProvision: {
+            command: "vagrant provision",
+            options: {
+               execOptions: {
+                  cwd: alfConfig.dir.vagrant,
+                  maxBuffer: "Infinite"
+               }
+            }
+         },
          vagrantHalt: {
             command: "vagrant halt",
             options: {

--- a/aikau/src/grunt/vagrant.js
+++ b/aikau/src/grunt/vagrant.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
       "shell:vagrantMountSharedFoldersFix",
       "shell:vagrantReloadAndProvision"
    ]);
-   grunt.registerTask("vup", ["shell:vagrantUp"]);
+   grunt.registerTask("vup", ["shell:vagrantUp","shell:vagrantProvision"]);
    grunt.registerTask("vdown", ["shell:vagrantHalt"]);
 
 };

--- a/aikau/src/main/resources/alfresco/core/ObjectProcessingMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ObjectProcessingMixin.js
@@ -64,7 +64,21 @@ define(["dojo/_base/declare",
        */
       processInstanceTokens: function alfresco_core_ObjectProcessingMixin__processInstanceTokens(v) {
          // Only replace a value if it actually exists, otherwise leave the token exactly as is.
-         var u = lang.replace(v, lang.hitch(this, this.safeReplace, this));
+         var u;
+         var re = /^{[a-zA-Z_$][0-9a-zA-Z_$]*}$/g;
+         if (re.test(v))
+         {
+            var tokenWithoutBraces = v.slice(1,-1);
+            if (typeof this[tokenWithoutBraces])
+            {
+               u = this[tokenWithoutBraces];
+            }
+         }
+         else
+         {
+            u = lang.replace(v, lang.hitch(this, this.safeReplace, this));
+         }
+         // var u = lang.replace(v, lang.hitch(this, this.safeReplace, this));
          return u;
       },
 
@@ -177,11 +191,11 @@ define(["dojo/_base/declare",
        */
       applyFunction: function alfresco_core_ObjectProcessingMixin__applyFunction(o, key, f) {
          var v = o[key];
-         if (typeof f == "function")
+         if (typeof f === "function")
          {
             v = f.apply(this, [v]);
          }
-         else if (typeof this[f] == "function")
+         else if (typeof this[f] === "function")
          {
            v = this[f].apply(this, [v]);
          }

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1151,12 +1151,12 @@ define(["dojo/_base/declare",
          this.initialConfig = this.getWidgetConfig();
          
          // Use the _disabled property if not already set...
-         if (typeof this.initialConfig.disabled == "undefined") 
+         if (typeof this.initialConfig.disabled === "undefined") 
          {
             this.initialConfig.disabled = this._disabled;
          }
 
-         if (this.additionalCssClasses != null)
+         if (this.additionalCssClasses)
          {
             domClass.add(this.domNode, this.additionalCssClasses);
          }
@@ -1175,7 +1175,7 @@ define(["dojo/_base/declare",
             this.completeWidgetSetup();
          }
 
-         if (this.valueSubscriptionTopic != null)
+         if (this.valueSubscriptionTopic)
          {
             this.alfSubscribe(this.valueSubscriptionTopic, lang.hitch(this, "valueSubscribe"));
          }
@@ -1350,7 +1350,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      completeWidgetSetup: function alfresco_forms_controls_BaseFormControl__setupChangeEvents() {
+      completeWidgetSetup: function alfresco_forms_controls_BaseFormControl__completeWidgetSetup() {
          this.placeWidget();
          this.widgetProcessingCompleteSubscription = this.alfSubscribe("ALF_WIDGET_PROCESSING_COMPLETE", lang.hitch(this, this.onWidgetAddedToDocument), true);
       },

--- a/aikau/src/main/resources/alfresco/forms/controls/SimplePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/SimplePicker.js
@@ -130,7 +130,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * 
        * @instance
        */
-      completeWidgetSetup: function alfresco_forms_controls_SimplePicker__setupChangeEvents() {
+      completeWidgetSetup: function alfresco_forms_controls_SimplePicker__completeWidgetSetup() {
          this.inherited(arguments);
          var value = this.getValue();
          if (ObjectTypeUtils.isArray(value))

--- a/aikau/src/main/resources/alfresco/pickers/PickedItems.js
+++ b/aikau/src/main/resources/alfresco/pickers/PickedItems.js
@@ -267,10 +267,9 @@ define(["dojo/_base/declare",
          setPickedItems: function alfresco_pickers_PickedItems_setPickedItems(items) {
             if (ObjectTypeUtils.isArray(items))
             {
-               this.currentData.items = items;
-               array.forEach(this.currentData.items, function(item, index) {
-                  item.index = index;
-               });
+               array.forEach(this.currentData.items, function(item) {
+                  this.addPickedItem(item);
+               }, this);
             }
             else
             {

--- a/aikau/src/main/resources/alfresco/pickers/PickedItems.js
+++ b/aikau/src/main/resources/alfresco/pickers/PickedItems.js
@@ -110,17 +110,23 @@ define(["dojo/_base/declare",
             this.removeUploadDragAndDrop(this.domNode);
             // this.setupKeyboardNavigation();
 
+            // Initialise the data...
+            this.currentData = {
+               items: []
+            };
+
+            if (ObjectTypeUtils.isArray(this.value))
+            {
+               this.setPickedItems(this.value);
+            }
+            
             this.alfSubscribe("ALF_ITEM_SELECTED", lang.hitch(this, this.addPickedItem));
             this.alfSubscribe("ALF_ITEM_REMOVED", lang.hitch(this, this.removePickedItem));
             this.alfSubscribe("ALF_SET_PICKED_ITEMS", lang.hitch(this, this.onSetPickedItems));
             this.alfSubscribe("ALF_ITEM_MOVED_DOWN", lang.hitch(this, this.onReorder, 1));
             this.alfSubscribe("ALF_ITEM_MOVED_UP", lang.hitch(this, this.onReorder, -1));
 
-            // Initialise the data...
-            this.currentData = {
-               items: ObjectTypeUtils.isArray(this.value) ? this.value : []
-            };
-            this.renderView();
+            this.renderView(false);
             this.isValid();
          },
 
@@ -267,7 +273,7 @@ define(["dojo/_base/declare",
          setPickedItems: function alfresco_pickers_PickedItems_setPickedItems(items) {
             if (ObjectTypeUtils.isArray(items))
             {
-               array.forEach(this.currentData.items, function(item) {
+               array.forEach(items, function(item) {
                   this.addPickedItem(item);
                }, this);
             }
@@ -275,7 +281,7 @@ define(["dojo/_base/declare",
             {
                this.alfLog("warn", "No items supplied to 'setPickedItems' function", items, this);
             }
-            this.renderView();
+            this.renderView(false);
             this.isValid();
          },
 

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -1397,6 +1397,14 @@ define(["dojo/_base/declare",
        */
       onMoveDocumentsFailure: function alfresco_services_ActionService__onMoveDocumentsSuccess(response, originalRequestConfig) {
          // TODO: Publish an error message.
+      },
+
+      /**
+       *
+       * @param {object} item The item to perform the action on
+       */
+      onActionManageAspects: function alfresco_services_ActionService__onActionManageAspects(item) {
+         this.alfPublish("ALF_MANAGE_ASPECTS_REQUEST", { item: item });
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
@@ -1,0 +1,568 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This service handles requests to manage the aspects on particular node. The aspects that are available
+ * to be added (and optionally those that can be added and removed) are expected to be provided as configuration
+ * attributes when instantiating this service.
+ *
+ * @module alfresco/services/actions/ManageAspectsService
+ * @extends module:alfresco/core/Core
+ * @mixes module:alfresco/core/CoreXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "alfresco/core/CoreXhr",
+        "service/constants/Default",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "alfresco/core/ObjectTypeUtils"],
+        function(declare, AlfCore, AlfCoreXhr, AlfConstants, lang, array, ObjectTypeUtils) {
+
+   return declare([AlfCore, AlfCoreXhr], {
+
+      /**
+       * An array of the i18n files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/ManageAspectsService.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/ManageAspectsService.properties"}],
+
+      /**
+       * This is the array of available aspects that are available. 
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      availableAspects: null,
+
+      /**
+       * This is the array of available aspects can be added to a node. If this is not provided then it
+       * is assumed that all the aspected configured in the 
+       * [availableAspects]{@link module:alfresco/services/actions/ManageAspectsService#availableAspects}
+       * array can be added to a node.
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      addableAspects: null,
+
+      /**
+       * This is the array of available aspects can be removed from a node. If this is not provided then it
+       * is assumed that all the aspected configured in the 
+       * [availableAspects]{@link module:alfresco/services/actions/ManageAspectsService#availableAspects}
+       * array can be removed from a node.
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      removableAspects: null,
+
+      /**
+       * The key of each aspect that is used as the unique identifier of that aspect.
+       *
+       * @instance
+       * @type {string}
+       * @default "id"
+       */
+      itemKey: "id",
+
+      /**
+       * Sets up the service using the configuration provided. This will check to see what aspects are available,
+       * addable and removable. If no addble or removable aspects are explicitly configured then it is assumed that
+       * all available aspects are both addable and removable. Only aspects that are configured as being available
+       * will be displayed in the manage aspects picker, only aspects that are addable can be added in the manage
+       * aspects picker and only aspects that are removable can be removed in the manage aspects picker.
+       *
+       * @instance
+       * @param {array} args Constructor arguments
+       */
+      constructor: function alfresco_services_actions_ManageAspectsService__constructor(args) {
+         lang.mixin(this, args);
+         this.alfSubscribe("ALF_MANAGE_ASPECTS_REQUEST", lang.hitch(this, this.onManageAspects));
+
+         if (!this.availableAspects)
+         {
+            this.availableAspects = [];
+         }
+         if (!this.addableAspects)
+         {
+            // If no explicitly addable aspects have been declared, then all available aspects are addable
+            this.addableAspects = lang.clone(this.availableAspects);
+         }
+         if (!this.removableAspects)
+         {
+            // If no explicitly removable aspects have been declared, then all available aspects are removable
+            this.removableAspects = lang.clone(this.availableAspects);
+         }
+
+         // Clone the available aspects for use as determining which aspects to display...
+         this.aspectsToDisplay = lang.clone(this.availableAspects);
+
+         // Process the final available aspects list to convert arrays of Strings into arrays of objects
+         // and make an attempt at generating a user-friendly label for the aspect...
+         var availableAspects = [];
+         array.forEach(this.availableAspects, lang.hitch(this, this.processAspect, availableAspects));
+         this.availableAspects = availableAspects;
+      },
+
+      /**
+       *
+       * @param {object} item The item to perform the action on
+       */
+      onManageAspects: function alfresco_services_actions_ManageAspectsService__onManageAspects(payload) {
+         if (payload && payload.item && payload.item.nodeRef)
+         {
+            // This is the array of aspects that are currently applied to the node. These will automatically
+            // be hidden from the list of available aspects to be applied...
+            var aspects = [];
+
+            // The aspects may already be available in the node data, if not they will need to be requested...
+            if (payload.item.node && payload.item.node.aspects)
+            {
+               // Aspects are already provided, use these...
+               array.forEach(payload.item.node.aspects, lang.hitch(this, this.processAspect, aspects));
+               this.showAspectsDialog(payload.item, aspects);
+            }
+            else
+            {
+               // We need to request the aspects for the current node...
+               this.onAspects(payload.item);
+            }
+         }
+         else
+         {
+            this.alfLog("warning", "A request was made to manage aspects, but no 'item.nodeRef' was provided in the 'payload' object", payload, this);
+         }
+      },
+
+      /**
+       * Displays a dialog containing a [SimplePicker]{@link module:alfresco/forms/controls/SimplePicker} control
+       * that allows the user to select which aspects they wish to have applie to the current item.
+       * 
+       * @param {object} item The item to modify the applied aspects of.
+       * @param {array} currentAspects The array of aspects that are currently applied to the item.
+       */
+      showAspectsDialog: function alfresco_services_actions_ManageAspectsService__onAspectsDialog(item, currentAspects) {
+         var responseTopic = this.generateUuid();
+         var subscriptionHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onActionManageAspectsConfirmation), true);
+         
+         var dialogTitle = this.message("services.actionservice.ManageAspects.dialogTitle", {
+            0: item.displayName
+         });
+
+         this.alfPublish("ALF_CREATE_FORM_DIALOG_REQUEST", {
+            dialogId: "ALF_MANAGE_ASPECTS_DIALOG",
+            dialogTitle: dialogTitle,
+            formSubmissionTopic: responseTopic,
+            formSubmissionPayloadMixin: {
+               item: item,
+               subscriptionHandle: subscriptionHandle,
+               originallySelected: lang.clone(currentAspects)
+            },
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/SimplePicker",
+                  config: {
+                     label: "services.actionservice.ManageAspects.label",
+                     description: "services.actionservice.ManageAspects.description",
+                     name: "selectedAspects",
+                     itemKey: this.itemKey,
+                     propertyToRender: "label",
+                     noItemsMessage: "services.actionservice.ManageAspects.noAspects",
+                     availableItemsLabel: "services.actionservice.ManageAspects.available",
+                     pickedItemsLabel: "services.actionservice.ManageAspects.applied",
+                     value: currentAspects,
+                     currentData: {
+                        items: this.availableAspects
+                     },
+                     aspectsToDisplay: this.aspectsToDisplay,
+                     addableAspects: this.addableAspects,
+                     removableAspects: this.removableAspects,
+                     widgetsForAvailableItemsView: this.widgetsForAvailableItemsView,
+                     widgetsForPickedItemsView: this.widgetsForPickedItemsView
+                  }
+               }
+            ]
+         });
+      },
+
+      /**
+       * Handles requests to retrieve the currently applied aspects to the supplied item. It is expected that the
+       * item will have a "nodeRef" attribute.
+       * 
+       * @param {object} item The item to retrieve the currently applied aspects to.
+       */
+      onAspects: function alfresco_services_actions_ManageAspectsService__onAspects(item) {
+         this.serviceXhr({url: AlfConstants.PROXY_URI + "slingshot/doclib/aspects/node/" + item.nodeRef,
+                          method: "GET",
+                          item: item,
+                          successCallback: this.onAspectsSuccess,
+                          failureCallback: this.onAspectsFailure,
+                          callbackScope: this});
+      },
+
+      /**
+       * Handles successful requests to retrieve the currently applied aspects for a given node.
+       * 
+       * @param {object} response The response object from the XHR request
+       * @param  {object} originalRequestConfig The object passed when making the original XHR request
+       */
+      onAspectsSuccess: function  alfresco_services_actions_ManageAspectsService__onAspectsSuccess(response, originalRequestConfig) {
+         if (response && response.current)
+         {
+            var aspects = [];
+            array.forEach(response.current, lang.hitch(this, this.processAspect, aspects));
+            this.showAspectsDialog(originalRequestConfig.item, aspects);
+         }
+         else
+         {
+            this.alfLog("error", "The response to a request for currently available aspects did not contain a 'current' attribute", response, originalRequestConfig, this);
+         }
+      },
+
+      /**
+       * Inspects the supplied aspect data and adds it into the aspects array if it is an object or constructs
+       * an object for it if it is a string.
+       * 
+       * @param {array} The array of aspects to add the current aspect data into
+       * @param {object|string} The current aspect data
+       */
+      processAspect: function alfresco_services_actions_ManageAspectsService__processAspect(aspects, aspect) {
+         if (ObjectTypeUtils.isString(aspect)) {
+            aspects.push({
+               id: aspect,
+               label: this.processAspectLabel(aspect)
+            });
+         }
+         else if (ObjectTypeUtils.isObject(aspect))
+         {
+            if (!aspect.label)
+            {
+               aspect.label = this.processAspectLabel(aspect[this.itemKey]);
+            }
+            aspects.push(aspect);
+         }
+         else
+         {
+            this.alfLog("warn", "Unexpected aspect data encountered when processing current aspects", aspect, this);
+         }
+      },
+
+      /**
+       * Attempts to convert an aspect into user friendly label. This assumes that aspects are mapped to 
+       * as follows, if the aspect is "cm:complianceable" then the NLS key is expected to be: "aspect.cm_complianceable"
+       * 
+       * @param {string} aspect The aspect to get a user friendly label for
+       * @return {string} A user friendly label for the aspect (or the original aspect if one can't be found)
+       */
+      processAspectLabel: function alfresco_services_actions_ManageAspectsService__processAspectLabel(aspect) {
+         var label = aspect;
+         var nlsKey = "aspect." + aspect.replace(":", "_");
+         var nlsValue = this.message(nlsKey);
+         if (nlsKey !== nlsValue)
+         {
+            label = nlsValue;
+         }
+         return label;
+      },
+
+      /**
+       * Handles failed requests to retrieve the currently applied aspects for a given node.
+       * 
+       * @param {object} response The response object from the XHR request
+       * @param  {object} originalRequestConfig The object passed when making the original XHR request
+       */
+      onAspectsFailure: function  alfresco_services_actions_ManageAspectsService__onAspectsFailure(response, originalRequestConfig) {
+         this.alfLog("error", "It was not possible to retrieve a list of currently available aspects", response, originalRequestConfig, this);
+         this.alfPublish("ALF_DISPLAY_PROMPT", {
+            message: this.message("services.actionservice.ManageAspects.aspectRetrievalFailed", {
+               "0": originalRequestConfig.item.displayName
+            })
+         });
+      },
+
+      /**
+       * This function should be called when a user confirms the changes that they have made to aspects for a
+       * particular item (e.g. document or folder).
+       * 
+       * @param {object} payload The payload containing the updated aspects.
+       */
+      onActionManageAspectsConfirmation: function alfresco_services_ActionService__onActionManageAspectsConfirmation(payload) {
+         // Clean up any subscription handles
+         if (payload && payload.subscriptionHandle)
+         {
+            this.alfUnsubscribe(payload.subscriptionHandle);
+            delete payload.subscriptionHandle;
+         }
+
+         // Generate the arrays of added and removed aspects...
+         var added = [];
+         var removed= [];
+         array.forEach(payload.selectedAspects, lang.hitch(this, this.findAdded, payload.originallySelected, added));
+         array.forEach(payload.originallySelected, lang.hitch(this, this.findRemoved, payload.selectedAspects, removed));
+
+         // Post the update...
+         var data = {
+            added: added,
+            removed: removed
+         };
+         this.serviceXhr({url: AlfConstants.PROXY_URI + "slingshot/doclib/aspects/node/" + payload.item.nodeRef,
+                          method: "POST",
+                          item: payload.item,
+                          data: data,
+                          successCallback: this.onUpdateSuccess,
+                          failureCallback: this.onUpdateFailure,
+                          callbackScope: this});
+      },
+
+      /**
+       * This function generates the data to be posted when updating the applied aspects. The Alfresco Repository API
+       * expects an "added" array to be provided in the POST body so this function will construct that array
+       * from the data provided by the form submissions.
+       * 
+       * @param {array} originallySelected The originally selected aspects when the dialog was opened.
+       * @param {array} added The array of added aspects to populate
+       * @param {object} aspect The current for consideration of adding to the "added" array
+       */
+      findAdded: function alfresco_services_actions_ManageAspectsService__findAdded(originallySelected, added, aspect) {
+         // Was the current item (that is now selected) in the original array of selected items?
+         var found = array.some(originallySelected, function(item) {
+            return item[this.itemKey] === aspect[this.itemKey];
+         }, this);
+
+         if (found === false)
+         {
+            added.push(aspect[this.itemKey]);
+         }
+      },
+
+      /**
+       * This function generates the data to be posted when updating the applied aspects. The Alfresco Repository API
+       * expects a "removed" array to be provided in the POST body so this function will construct that array
+       * from the data provided by the form submissions.
+       * 
+       * @param {array} originallySelected The originally selected aspects when the dialog was opened.
+       * @param {array} removed The array of removed aspects to populate
+       * @param {object} aspect The current for consideration of adding to the "removed" array
+       */
+      findRemoved: function alfresco_services_actions_ManageAspectsService__findRemoved(selected, removed, aspect) {
+         // Was the current item (that was in the original array of selected items) in the new array of selected items?
+         var found = array.some(selected, function(item) {
+            return item[this.itemKey] === aspect[this.itemKey];
+         }, this);
+
+         if (found === false)
+         {
+            removed.push(aspect[this.itemKey]);
+         }
+      },
+
+      /**
+       * Handles successful requests update aspects on a node.
+       * 
+       * @param {object} response The response object from the XHR request
+       * @param  {object} originalRequestConfig The object passed when making the original XHR request
+       */
+      onUpdateSuccess: function  alfresco_services_actions_ManageAspectsService__onUpdateSuccess(response, originalRequestConfig) {
+         this.alfLog("info", "Aspects updated successfully", response, originalRequestConfig, this);
+      },
+
+      /**
+       * Handles failed requests to update aspects on a node.
+       * 
+       * @param {object} response The response object from the XHR request
+       * @param  {object} originalRequestConfig The object passed when making the original XHR request
+       */
+      onUpdateFailure: function  alfresco_services_actions_ManageAspectsService__onUpdateFailure(response, originalRequestConfig) {
+         this.alfLog("error", "Aspects were not updated", response, originalRequestConfig, this);
+         this.alfPublish("ALF_DISPLAY_PROMPT", {
+            message: this.message("services.actionservice.ManageAspects.aspectUpdateFailed", {
+               "0": originalRequestConfig.item.displayName
+            })
+         });
+      },
+
+      /**
+       * This is the model to use for rendering the items that are available for selection.
+       *
+       * @instance
+       * @type {object}
+       */
+      widgetsForAvailableItemsView: [
+         {
+            name: "alfresco/lists/views/AlfListView",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Row",
+                     config: {
+                        visibilityConfig: {
+                           rules: [
+                              {
+                                 topic: "ALF_ITEM_REMOVED",
+                                 attribute: "{itemKey}",
+                                 is: ["{itemKey}"],
+                                 useCurrentItem: true,
+                                 strict: false
+                              }
+                           ]
+                        },
+                        invisibilityConfig: {
+                           rules: [
+                              {
+                                 topic: "ALF_ITEM_SELECTED",
+                                 attribute: "{itemKey}",
+                                 is: ["{itemKey}"],
+                                 useCurrentItem: true,
+                                 strict: false
+                              }
+                           ]
+                        },
+                        widgets: [
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/Property",
+                                       config: {
+                                          propertyToRender: "{propertyToRender}"
+                                       }
+                                    }
+                                 ]
+                              }
+                           },
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 width: "20px",
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/PublishAction",
+                                       config: {
+                                          publishPayloadType: "CURRENT_ITEM",
+                                          publishGlobal: false,
+                                          publishToParent: false,
+                                          renderFilter: [
+                                             {
+                                                property: "{itemKey}",
+                                                values: "{addableAspects}"
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        ],
+                        renderFilter: [
+                           {
+                              property: "{itemKey}",
+                              values: "{aspectsToDisplay}"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ],
+
+      /**
+       * This is the model to use for rendering the items that have been picked.
+       *
+       * @instance
+       * @type {object}
+       */
+      widgetsForPickedItemsView: [
+         {
+            name: "alfresco/lists/views/layouts/Row",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/renderers/Reorder",
+                              config: {
+                                 propertyToRender: "{propertyToRender}",
+                                 moveUpPublishTopic: "ALF_ITEM_MOVED_UP",
+                                 moveUpPublishPayloadType: "CURRENT_ITEM",
+                                 moveDownPublishTopic: "ALF_ITEM_MOVED_DOWN",
+                                 moveDownPublishPayloadType: "CURRENT_ITEM"
+                              }
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/renderers/Property",
+                              config: {
+                                 propertyToRender: "{propertyToRender}"
+                              }
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        width: "20px",
+                        widgets: [
+                           {
+                              name: "alfresco/renderers/PublishAction",
+                              config: {
+                                 iconClass: "delete-16",
+                                 publishTopic: "ALF_ITEM_REMOVED",
+                                 publishPayloadType: "CURRENT_ITEM",
+                                 renderFilter: [
+                                    {
+                                       property: "{itemKey}",
+                                       values: "{removableAspects}"
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ],
+               renderFilter: [
+                  {
+                     property: "{itemKey}",
+                     values: "{aspectsToDisplay}"
+                  }
+               ]
+            }
+         }
+      ]
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/actions/i18n/ManageAspectsService.properties
+++ b/aikau/src/main/resources/alfresco/services/actions/i18n/ManageAspectsService.properties
@@ -1,0 +1,28 @@
+## Manage Aspects
+services.actionservice.ManageAspects.dialogTitle=Aspects for {0}
+services.actionservice.ManageAspects.label=Select Aspects
+services.actionservice.ManageAspects.description=
+services.actionservice.ManageAspects.noAspects=There are no aspects that can be selected
+services.actionservice.ManageAspects.available=Available aspects to add
+services.actionservice.ManageAspects.applied=Currently selected
+services.actionservice.ManageAspects.aspectRetrievalFailed=It was not possible to retrieve the aspects applied to {0}
+services.actionservice.ManageAspects.aspectUpdateFailed=It was not possible to update the aspects applied to {0}
+
+
+## Aspects NLS values
+aspect.cm_complianceable=Complianceable
+aspect.cm_dublincore=Dublin Core
+aspect.cm_effectivity=Effectivity
+aspect.cm_emailed=Emailed
+aspect.cm_generalclassifiable=Classifiable
+aspect.cm_summarizable=Summarizable
+aspect.cm_taggable=Taggable
+aspect.cm_templatable=Templatable
+aspect.cm_versionable=Versionable
+aspect.emailserver_aliasable=Aliasable (Email)
+aspect.app_inlineeditable=Inline Editable
+aspect.cm_geographic=Geographic
+aspect.exif_exif=EXIF
+aspect.audio_audio=Audio
+aspect.cm_indexControl=Index Control
+aspect.dp_restrictable=Restrictable

--- a/aikau/src/test/resources/alfresco/forms/SingleTextFieldFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/SingleTextFieldFormTest.js
@@ -76,7 +76,7 @@ define(["intern!object",
             .type("test")
             .pressKeys(keys.RETURN)
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "search", "test"))
+         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "search", "test"))
             .then(function(elements) {
                assert(elements.length === 1, "Enter key doesn't submit data");
             })

--- a/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerTest.js
@@ -40,16 +40,20 @@ define(["intern!object",
 
    registerSuite({
       name: "Document Picker Test",
+
       setup: function() {
          browser = this.remote;
          return TestCommon.loadTestWebScript(this.remote, "/DocumentPicker", "DocumentPicker").end();
       },
+
       beforeEach: function() {
          browser.end();
       },
+
       teardown: function() {
          return browser.end().alfPostCoverageResults(browser);
       },
+
       "Test picker dialog can be displayed": function () {
          return browser.findByCssSelector("#DOCUMENT_PICKER .alfresco-layout-VerticalWidgets > span > span > span")
             .click()
@@ -63,6 +67,7 @@ define(["intern!object",
             )
          .end();
       },
+
       "Test Shared Files sub-picker is shown": function() {
          // Select "Shared Files" (the results for this are mocked)
          return browser.findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:first-child .dijitMenuItem:nth-child(5)")
@@ -77,6 +82,7 @@ define(["intern!object",
             )
          .end();
       },
+
       "Test Shared files result count": function() {
          // Count the mocked results...
          return browser.findAllByCssSelector(".alfresco-lists-views-AlfListView tr")
@@ -85,6 +91,7 @@ define(["intern!object",
             })
          .end();
       },
+
       "Test first item in picker can be added": function() {
          // Check the first item has an ADD publish action image...
          return browser.findByCssSelector(".alfresco-lists-views-AlfListView tr:nth-child(1) .alfresco-renderers-PublishAction > img")
@@ -96,6 +103,7 @@ define(["intern!object",
             )
          .end();
       },
+
       "Test item gets picked": function() {
          // Click the ADD publish action image to add the item to the picked items...
          return browser.findByCssSelector(".alfresco-lists-views-AlfListView tr:nth-child(1) .alfresco-renderers-PublishAction > img")
@@ -109,6 +117,7 @@ define(["intern!object",
             })
          .end();
       },
+
       "Test picked items are reflected when closing dialog": function() {
          // Close the dialog...
          return browser.findByCssSelector(".alfresco-dialog-AlfDialog .footer .alfresco-buttons-AlfButton:first-child > span")
@@ -122,6 +131,7 @@ define(["intern!object",
             })
          .end();
       },
+
       "Test picked items are retained": function() {
          return browser.findByCssSelector("#DOCUMENT_PICKER .alfresco-layout-VerticalWidgets > span.alfresco-buttons-AlfButton.confirmationButton > span > span")
             .then(function(){}, function() {})
@@ -136,6 +146,7 @@ define(["intern!object",
             })
          .end();
       },
+
       "Test previously picked item can be removed": function() {
          // Check the remove item image exists...
          return browser.findByCssSelector(".picked-items tr .alfresco-renderers-PublishAction > img")
@@ -147,6 +158,7 @@ define(["intern!object",
             )
          .end();
       },
+
       "Test previously picked item gets removed": function() {
          // Remove the previously selected item...
          return browser.findByCssSelector(".picked-items tr .alfresco-renderers-PublishAction > img")
@@ -163,6 +175,7 @@ define(["intern!object",
             })
          .end();
       },
+
       "Test an item can be only picked once": function() {
          // Open the dialog again and add some more...
          return browser.findByCssSelector("#DOCUMENT_PICKER .alfresco-layout-VerticalWidgets > span > span > span")
@@ -184,6 +197,7 @@ define(["intern!object",
             })
          .end();
       },
+
       "Test picking another item": function() {
          // Add another item...
          return browser.findByCssSelector(".alfresco-lists-views-AlfListView tr:nth-child(3) .alfresco-renderers-PublishAction > img")
@@ -195,6 +209,7 @@ define(["intern!object",
             })
          .end();
       },
+      
       "Test both items are shown as picked when dialog closed": function() {
          // Close the dialog...
          return browser.findByCssSelector(".alfresco-dialog-AlfDialog .footer .alfresco-buttons-AlfButton:first-child > span")

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -114,7 +114,7 @@ define(["intern!object",
          .end()
 
          // Post the form...
-         .findByCssSelector("#FD2 .confirmationButton")
+         .findByCssSelector("#FD2 .confirmationButton > span")
             .click()
          .end()
 

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -57,7 +57,7 @@ define(["intern!object",
       "Test publication on dialog show": function() {
          return browser.findAllByCssSelector(TestCommon.topicSelector("DISPLAYED_FD1", "publish", "any"))
             .then(function(elements) {
-               assert.lengthOf(elements, 1, "Could not find topic published when displayed dialog")
+               assert.lengthOf(elements, 1, "Could not find topic published when displayed dialog");
             });
       },
 
@@ -73,7 +73,7 @@ define(["intern!object",
          .end()
          .findAllByCssSelector(".alfresco-dialog-AlfDialog")
             .then(function(elements) {
-               assert.lengthOf(elements, 1, "The previous dialog without an ID was not destroyed")
+               assert.lengthOf(elements, 1, "The previous dialog without an ID was not destroyed");
             });
       },
 
@@ -88,7 +88,7 @@ define(["intern!object",
          .end()
          .findAllByCssSelector(".alfresco-dialog-AlfDialog")
             .then(function(elements) {
-               assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed")
+               assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed");
             });
       },
 
@@ -102,7 +102,7 @@ define(["intern!object",
          .end()
          .findAllByCssSelector(".alfresco-dialog-AlfDialog")
             .then(function(elements) {
-               assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed")
+               assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This tests the Manage Aspects action in the [ActionService]{@link module:alfresco/services/ActionService}.
+ * 
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Manage Aspects Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/ManageAspects", "Manage Aspects Test").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+
+      "Test aspects dialog opens (when requesting aspects)": function() {
+         // Check that dialog opens when the button simulating the action request is clicked...
+         return browser.findByCssSelector("#MANAGE_ASPECTS1_label")
+            .click()
+         .end()
+         .findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG.alfresco-dialog-AlfDialog")
+            .then(null, function() {
+               assert(false, "The manage aspects dialog did not appear");
+            });
+      },
+
+      "Test available aspects count": function() {
+         // Count the number of available aspects (the applied aspects should not be shown)...
+         // NOTE: elements might exist, but just be hidden
+         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .sub-pickers .alfresco-lists-views-AlfListView tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 14, "Incorrect number of available aspects");
+            });
+      },
+
+      "Test selected aspects count": function() {
+         // Cound the aspects that are currently applied...
+         // NOTE: aspects not in the available list should be hidden
+         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .picked-items .alfresco-lists-views-AlfListView tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Incorrect number of selected aspects");
+            });
+      },
+
+      "Test that classifiable aspect is not displayed as available": function() {
+         // Classifiable should be the first aspect in the available list and it should not be displayed
+         // (because it is already applied!)
+         return browser.findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .sub-pickers  .alfresco-lists-views-AlfListView tr:nth-child(1)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The classifiable aspect is shown as available");
+            });
+      },
+
+      "Test that only addable aspects have add icon displayed": function() {
+         // cm:effectivity should not be addable because it is not in the addable list
+         // It should be the 3rd row in the available list
+         // It's PublishAction should not have been rendered
+         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .sub-pickers .alfresco-lists-views-AlfListView tr:nth-child(3) .alfresco-renderers-PublishAction > img")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The cm:effectivity aspect should not be addable");
+            });
+      },
+
+      "Test that only removable aspects have the remove icon displayed": function() {
+         // cm:versionable should be pre-selected but not removable because it is not in the removable list
+         // It should bee the 2nd row in the available list
+         // It's PublishAction should not have been rendered
+         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .picked-items .alfresco-lists-views-AlfListView tr:nth-child(2) .alfresco-renderers-PublishAction > img")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The cm:versionable aspect should not be removable");
+            });
+      },
+
+      "Test adding an aspect": function() {
+         return browser.findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .sub-pickers .alfresco-lists-views-AlfListView tr:nth-child(2) .alfresco-renderers-PublishAction > img")
+            .click()
+         .end()
+         .findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .picked-items .alfresco-lists-views-AlfListView tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "Aspect wasn't added");
+            });
+      },
+
+      "Test removing an aspect": function() {
+         // Clicking on the cm:classifiable item should allow it to be removed and display it in the available list
+         return browser.findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .picked-items .alfresco-lists-views-AlfListView tr:nth-child(1) .alfresco-renderers-PublishAction > img")
+            .click()
+         .end()
+         .findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .sub-pickers  .alfresco-lists-views-AlfListView tr:nth-child(1)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Aspect wasn't removed");
+            });
+      },
+
+      "Test saving upated aspects": function() {
+         // Clicking on the confirmation button in the dialog should post the correct added and remove payload...
+         return browser.findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .confirmationButton > span")
+            .click()
+         .end()
+         .findByCssSelector(".mx-row:nth-child(2) .mx-payload")
+            .getVisibleText()
+            .then(function(payload) {
+               assert.equal(payload, "{\"added\":[\"cm:complianceable\"],\"removed\":[\"cm:generalclassifiable\"]}", "The added/removed payload wasn't generated correctly");
+            });
+      },
+
+      "Test aspects dialog opens (when current aspects are provided)": function() {
+         return browser.sleep(500).findByCssSelector("#MANAGE_ASPECTS2_label")
+            .click()
+         .end()
+         .findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG.alfresco-dialog-AlfDialog")
+            .then(null, function() {
+               assert(false, "The manage aspects dialog did not appear");
+            });
+      },
+
+      "Test pre-configured aspects count": function()  {
+         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .picked-items .alfresco-lists-views-AlfListView tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "Incorrect number of selected aspects");
+            });
+      },
+
+      "Test cancelling aspects dialog ": function() {
+         return browser.findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .cancellationButton > span")
+            .click()
+         .end()
+         .sleep(500)
+         .findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The dialog was not hidden");
+            });
+      },
+
+      "Test managing aspects when aspects can't be retrieved": function() {
+         // By using a node that the mock service doesn't cater for we can rely on a 404 producing an error...
+         return browser.sleep(500).findByCssSelector("#MANAGE_ASPECTS3_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_PROMPT", "message", "It was not possible to retrieve the aspects applied to No Data Node"))
+            .then(null, function() {
+               assert(false, "The error prompt was not requested when failing to retrieve aspects");
+            });
+      },
+
+      "Test failure to save aspect changes": function() {
+         // By using a node that the mock service doesn't cater for we can rely on a 404 producing an error...
+         return browser.sleep(500).findByCssSelector("#MANAGE_ASPECTS4_label")
+            .click()
+         .end()
+         .findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .confirmationButton > span")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_PROMPT", "message", "It was not possible to update the aspects applied to Save Fail Node"))
+            .then(null, function() {
+               assert(false, "The error prompt was not requested when failure occurred saving data");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -39,7 +39,7 @@ define({
     * @instance
     * @type [string]
     */
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 
@@ -147,6 +147,8 @@ define({
       "src/test/resources/alfresco/services/SearchServiceTest",
       "src/test/resources/alfresco/services/SiteServiceTest",
       "src/test/resources/alfresco/services/UserServiceTest",
+
+      "src/test/resources/alfresco/services/actions/ManageAspectsTest",
 
       "src/test/resources/alfresco/search/AlfSearchResultTest",
       "src/test/resources/alfresco/search/FacetFiltersTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -39,7 +39,7 @@ define({
     * @instance
     * @type [string]
     */
-   xbaseFunctionalSuites: [
+   baseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>Manage Aspects Test</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/ManageAspects</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
@@ -1,0 +1,133 @@
+model.jsonModel = {
+   services: [
+      {
+            name: "alfresco/services/LoggingService",
+            config: {
+               loggingPreferences: {
+                  enabled: true,
+                  all: true
+               }
+            }
+      },
+      "alfresco/services/DialogService",
+      "alfresco/services/ActionService",
+      {
+         name: "alfresco/services/actions/ManageAspectsService",
+         config: {
+            availableAspects: ["cm:generalclassifiable",
+                               "cm:complianceable",
+                               "cm:effectivity",
+                               "cm:summarizable",
+                               "cm:versionable",
+                               "cm:templatable",
+                               "cm:emailed",
+                               "emailserver:aliasable",
+                               "app:inlineeditable",
+                               "cm:geographic",
+                               "exif:exif",
+                               "audio:audio",
+                               "cm:indexControl",
+                               "dp:restrictable"],
+            addableAspects: ["cm:generalclassifiable",
+                             "cm:complianceable",
+                             "cm:summarizable",
+                             "cm:versionable",
+                             "cm:templatable",
+                             "cm:emailed",
+                             "emailserver:aliasable",
+                             "app:inlineeditable"],
+            removableAspects: ["cm:generalclassifiable"]
+         }
+      }
+   ],
+   // We want to test...
+   // 1. Request where aspects are provided
+   // 2. Request where aspects must be retrieved
+   // 3. Request where aspect retrieval fails
+   // 4. Request where update fails
+   // 5. Request using service where some aspects are not addable
+   // 6. Request using service where some aspects are not removable
+   widgets: [
+      {
+         id: "MANAGE_ASPECTS1",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Manage Aspects (no aspects in payload)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: "onActionManageAspects",
+               document: {
+                  nodeRef: "workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                  displayName: "Some Node Title"
+               }
+            }
+         }
+      },
+      {
+         id: "MANAGE_ASPECTS2",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Manage Aspects (includes current aspects)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: "onActionManageAspects",
+               document: {
+                  nodeRef: "workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                  displayName: "Some Other Node Title",
+                  node: {
+                     aspects: [
+                        "cm:generalclassifiable",
+                        "cm:complianceable",
+                        "cm:effectivity"
+                     ]
+                  }
+               }
+            }
+         }
+      },
+      {
+         id: "MANAGE_ASPECTS3",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Manage Aspects (fail on aspect request)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: "onActionManageAspects",
+               document: {
+                  nodeRef: "going://to/fail",
+                  displayName: "No Data Node"
+               }
+            }
+         }
+      },
+      {
+         id: "MANAGE_ASPECTS4",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Manage Aspects (fail on save)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: "onActionManageAspects",
+               document: {
+                  nodeRef: "going://to/fail",
+                  displayName: "Save Fail Node",
+                  node: {
+                     aspects: [
+                        "cm:generalclassifiable"
+                     ]
+                  }
+               }
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/ManageAspectsMockXhr"
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/ManageAspectsMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/ManageAspectsMockXhr.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/ManageAspectsMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr",
+        "dojo/text!./responseTemplates/ManageAspects/ConfiguredAspects.json",
+        "dojo/text!./responseTemplates/ManageAspects/UpdateSuccess.json"], 
+        function(declare, MockXhr, ConfiguredAspects, UpdateSuccess) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_ManageAspectsMockXhr__setupServer() {
+         try
+         {
+            // Request for configured aspects
+            // http://localhost:8081/share/proxy/alfresco/slingshot/doclib/aspects/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/aspects/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":7962},
+                                     ConfiguredAspects]);
+
+            // Request to successfully update aspects...
+            //http://localhost:8081/share/proxy/alfresco/slingshot/doclib/action/aspects/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e
+            this.server.respondWith("POST",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/aspects/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":7962},
+                                     UpdateSuccess]);
+
+            // TODO: Add failure to update? Or leave as 404?
+            
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ManageAspects/ConfiguredAspects.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ManageAspects/ConfiguredAspects.json
@@ -1,0 +1,3 @@
+{
+   "current": ["cm:auditable","cm:ownable","sys:referenceable","cm:titled","rn:renditioned","cm:author","cm:taggable","sys:localized","cm:generalclassifiable","cm:likesRatingSchemeRollups","cm:versionable","cm:rateable"]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ManageAspects/UpdateSuccess.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/ManageAspects/UpdateSuccess.json
@@ -1,0 +1,16 @@
+{
+   "totalResults": 1,
+   "overallSuccess": true,
+   "successCount": 1,
+   "failureCount": 0,
+   "results":
+   [
+      {
+         "id": "Project Contract.pdf",
+         "action": "manageAspects",
+         "nodeRef": "workspace:\/\/SpacesStore\/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+         "type": "document",
+         "success": true
+      }
+   ]
+}


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-41 and adds support for handling Manage Aspects in Aikau. It also fixes up some failing unit tests and makes a minor adjustment to the Vagrant Grunt commands (because provisioning is required after starting the VM).