### PR TITLE
AKU-72, AKU-101: Updates to row and cell view layout widgets

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -33,8 +33,9 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Cell.html",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
-        "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, domClass) {
+        "dojo/dom-class",
+        "dojo/dom-attr"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, domClass, domAttr) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
       
@@ -56,11 +57,34 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
+       * Any additional CSS classes that should be applied to the rendered DOM element.
+       *
+       * @instance
+       * @type {string}
+       * @default  null
+       */
+      additionalCssClasses: null,
+
+      /**
+       * The number of columns that this cell should span. Defaults to null (indicating that
+       * a colspan attribute will not be set on the rendered DOM element).
+       *
+       * @instance
+       * @type {number}
+       * @default null
+       */
+      colspan: null,
+
+      /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        * 
        * @instance postCreate
        */
       postCreate: function alfresco_lists_views_layouts_Cell__postCreate() {
+         if (this.colspan)
+         {
+            domAttr.set(this.domNode, "colspan", this.colspan);
+         }
          if(this.additionalCssClasses)
          {
             domClass.add(this.domNode, this.additionalCssClasses);

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -34,8 +34,9 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Row.html",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing) {
+        "alfresco/core/CoreWidgetProcessing",
+        "dojo/dom-class"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing, domClass) {
 
    return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing], {
       
@@ -57,11 +58,21 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
+       * Any additional CSS classes that should be applied to the rendered DOM element.
+       *
+       * @instance
+       * @type {string}
+       * @default  null
+       */
+      additionalCssClasses: null,
+
+      /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        * 
        * @instance postCreate
        */
       postCreate: function alfresco_lists_views_layouts_Row__postCreate() {
+         domClass.add(this.domNode, this.additionalCssClasses ? this.additionalCssClasses : "");
          if (this.widgets)
          {
             if (this.widgetModelModifiers !== null)

--- a/aikau/src/test/resources/alfresco/lists/views/layouts/RowTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/layouts/RowTest.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Row Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Row", "Row Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+
+      "Test that row has additional CSS classes": function() {
+         return browser.findAllByCssSelector("tr.extra")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Additional CSS classes not applied correctly");
+            });
+      },
+
+      "Test colspan can be set on cell": function() {
+         return browser.findByCssSelector("#ONE_CELL td.alfresco-lists-views-layouts-Cell")
+            .getAttribute("colspan")
+            .then(function(colspan) {
+               assert.equal(colspan, 2, "Colspan attribute not set on cell");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -101,6 +101,8 @@ define({
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
       "src/test/resources/alfresco/layout/TwisterTest",
 
+      "src/test/resources/alfresco/lists/views/layouts/RowTest",
+
       "src/test/resources/alfresco/menus/AlfCheckableMenuItemTest",
       "src/test/resources/alfresco/menus/AlfContextMenuTest",
       "src/test/resources/alfresco/menus/AlfFormDialogMenuItemTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>Row (and Cell) Tests</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/Row</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.js
@@ -1,0 +1,95 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         id: "VIEW1",
+         name: "alfresco/lists/views/AlfListView",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     one: "data1",
+                     two: "data2",
+                     three: "data3"
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  id: "TWO_CELLS",
+                  name: "alfresco/lists/views/layouts/Row",
+                  config: {
+                     additionalCssClasses: "extra",
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "one"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "two"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "ONE_CELL",
+                  name: "alfresco/lists/views/layouts/Row",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              colspan: 2,
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "three"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};


### PR DESCRIPTION
This PR address both https://issues.alfresco.com/jira/browse/AKU-101 and https://issues.alfresco.com/jira/browse/AKU-72 and updates the Cell and Row view layout widgets to allow additionalCssClasses (on the Row) and colspan (on the Cell) attributes to be set.