### PR TITLE
Update release notes for 1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,6 @@ Surf uses the Dojo framework for AMD module loading and Aikau widgets make use o
 #### Testing
 The atomic nature of the widgets means that they are easily unit testable and Aikau makes use of the Intern JavaScript testing framework, driven by Grunt and uses Vagrant for multi-platform, cross-browser testing. It uses node-coverage to capture code coverage results of its unit tests.
 
-## Getting Started
-Once you've cloned this repository you should complete the following steps:
-
-1. Download and install Virtual Box
-2. Download and install Vagrant
-3. Download and install Node.js
-4. Run "mvn install" from the main Maven module
-5. Run "npm install" from within the "aikau" Maven sub-module to download and install the required Node.js packages
-6. Run "grunt vup" from within the "aikau" Maven sub-module to provision your Vagrant test environment
-
 ## Learning Aikau
 We've written a tutorial that takes you through the process of building a standalone Aikau client. We're in the process of converting it into GitHub markdown files - the chapters that have been converted so far start [here](https://github.com/Alfresco/Aikau/blob/master/tutorial/chapters/About.md "Link to Tutorial").
 
@@ -33,3 +23,5 @@ There is also an [Alfresco Wiki page](https://wiki.alfresco.com/wiki/Aikau_frame
 
 ## Contributing to Aikau
 We will gladly be welcoming contributions from the Alfresco Community - however, we would be grateful if you could please review and adhere to the [contribution acceptance criteria](https://github.com/Alfresco/Aikau/wiki/Contribution-Acceptance-Criteria) before generating any pull requests.
+
+Setup instructions are available for [Linux](https://github.com/Alfresco/Aikau/wiki/Aikau%20Setup%20(Linux) "Link to setup instructions for Linux"), [Windows](https://github.com/Alfresco/Aikau/wiki/Aikau%20Setup%20(Windows) "Link to setup instructions for OS X") and [OS X](https://github.com/Alfresco/Aikau/wiki/Aikau%20Setup%20(OS%20X) "Link to setup instructions for OS X")

--- a/aikau/src/main/ReleaseNotes.md
+++ b/aikau/src/main/ReleaseNotes.md
@@ -34,6 +34,8 @@ Resolved issues (see https://issues.alfresco.com/jira/browse/<issue-number>:
 ----------------
 1.0.6:
 * [AKU-41](https://issues.alfresco.com/jira/browse/AKU-41)   - Add Manage Aspects support
+* [AKU-41](https://issues.alfresco.com/jira/browse/AKU-72)   - Add colspan support to Cell
+* [AKU-102](https://issues.alfresco.com/jira/browse/AKU-101) - Add additionalCssClasses support to Row
 * [AKU-102](https://issues.alfresco.com/jira/browse/AKU-102) - NLS updates for alfresco/html/Heading
 * [AKU-103](https://issues.alfresco.com/jira/browse/AKU-103) - NLS updates for alfresco/header/SetTitle
 * [AKU-105](https://issues.alfresco.com/jira/browse/AKU-105) - Add notification after joining site

--- a/aikau/src/main/ReleaseNotes.md
+++ b/aikau/src/main/ReleaseNotes.md
@@ -3,7 +3,7 @@ Aikau 1.0.4 Release Notes
 
 Current deprecations:
 ---------------------
-This release:
+Previous releases:
 * alfresco/documentlibrary/views/AlfDocumentListView             (use: alfresco/lists/views/AlfListView)
 * alfresco/documentlibrary/views/DocumentListRenderer            (use: alfresco/lists/views/ListRenderer)
 * alfresco/documentlibrary/views/_AlfAdditionalViewControlMixin  (use: alfresco/lists/views/_AlfAdditionalViewControlMixin)
@@ -22,18 +22,31 @@ This release:
 * alfresco/renderers/SearchResultPropertyLink                    (use: alfresco/search/SearchResultPropertyLink)
 * alfresco/renderers/SearchThumbnail                             (use: alfresco/search/SearchThumbnail)
 * alfresco/upload/AlfUpload                                      (use: alfresco/services/UploadService)
-
-Previous releases:
-* alfresco/dialogs/AlfDialogService             (use: alfresco/services/Dialog) 
-* alfresco/forms/controls/DojoValidationTextBox (use: alfresco/forms/controls/TextBox)
-* alfresco/forms/controls/DojoCheckBox          (use: alfresco/forms/controls/CheckBox)
-* alfresco/forms/controls/DojoDateTextBox       (use: alfresco/forms/controls/DateTextBox)
-* alfresco/forms/controls/DojoRadioButtons      (use: alfresco/forms/controls/RadioButtons)
-* alfresco/forms/controls/DojoSelect            (use: alfresco/forms/controls/Select)
-* alfresco/forms/controls/DojoTextarea          (use: alfresco/forms/controls/TextArea)
+* alfresco/dialogs/AlfDialogService                              (use: alfresco/services/Dialog) 
+* alfresco/forms/controls/DojoValidationTextBox                  (use: alfresco/forms/controls/TextBox)
+* alfresco/forms/controls/DojoCheckBox                           (use: alfresco/forms/controls/CheckBox)
+* alfresco/forms/controls/DojoDateTextBox                        (use: alfresco/forms/controls/DateTextBox)
+* alfresco/forms/controls/DojoRadioButtons                       (use: alfresco/forms/controls/RadioButtons)
+* alfresco/forms/controls/DojoSelect                             (use: alfresco/forms/controls/Select)
+* alfresco/forms/controls/DojoTextarea                           (use: alfresco/forms/controls/TextArea)
 
 Resolved issues (see https://issues.alfresco.com/jira/browse/<issue-number>:
 ----------------
+1.0.6:
+* [AKU-41](https://issues.alfresco.com/jira/browse/AKU-41)   - Add Manage Aspects support
+* [AKU-102](https://issues.alfresco.com/jira/browse/AKU-102) - NLS updates for alfresco/html/Heading
+* [AKU-103](https://issues.alfresco.com/jira/browse/AKU-103) - NLS updates for alfresco/header/SetTitle
+* [AKU-105](https://issues.alfresco.com/jira/browse/AKU-105) - Add notification after joining site
+* [AKU-108](https://issues.alfresco.com/jira/browse/AKU-108) - Allow form values to be set via publication
+* [AKU-109](https://issues.alfresco.com/jira/browse/AKU-109) - Fix typo in sites menu
+* [AKU-119](https://issues.alfresco.com/jira/browse/AKU-119) - Add IDs to dialogs from alfresco/services/DialogService
+
+1.0.5:
+* [AKU-40](https://issues.alfresco.com/jira/browse/AKU-40) - Remove picked items from simple picker available list
+* [AKU-81](https://issues.alfresco.com/jira/browse/AKU-81) - Allow copy/move content into empty document libraries
+* [AKU-96](https://issues.alfresco.com/jira/browse/AKU-96) - CSS updates to copy/move action dialogs
+* [AKU-97](https://issues.alfresco.com/jira/browse/AKU-97) - Ensure en locale files are generated
+
 1.0.4:
 * [AKU-17](https://issues.alfresco.com/jira/browse/AKU-17) - Implement standalone Aikau transient notifications
 * [AKU-76](https://issues.alfresco.com/jira/browse/AKU-76) - Updated NPM to use specific tested versions

--- a/aikau/src/main/ReleaseNotes.md
+++ b/aikau/src/main/ReleaseNotes.md
@@ -1,4 +1,4 @@
-Aikau 1.0.4 Release Notes
+Aikau 1.0.6 Release Notes
 =========================
 
 Current deprecations:


### PR DESCRIPTION
This PR updates the release notes for 1.0.6 (and adds the forgotten release notes for 1.0.5) as well as updating the main readme to provide links to the new setup instructions