### PR TITLE
AKU-127: Added alt text for WidgetInfo and added a unit test

### DIFF
--- a/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
+++ b/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,6 +18,10 @@
  */
 
 /**
+ * This module is used exclusively in client-debug mode in order to provide information about a specific
+ * widget. It is intended to provide a developer with information about the ID of a widget and a code
+ * snippet that can be used in a Surf Extension to find the widget in the model in order to work with it.
+ * 
  * @module alfresco/debug/WidgetInfo
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
@@ -62,22 +66,32 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
-       * 
+       * Sets up the image source and it's alt text.
        * 
        * @instance
        */
       postMixInProperties: function alfresco_debug_WidgetInfo__postMixInProperties() {
          this.imgSrc = require.toUrl("alfresco/debug") + "/css/images/info-16.png";
+         if (this.displayId)
+         {
+            this.altText = this.message("widgetInfo.alt.text", {
+               0: this.displayId
+            });
+         }
+         else
+         {
+            this.altText = this.message("widgetInfo.unknown.alt.text");
+         }
       },
 
       /**
-       * 
+       * Handles clicking on the info image and displays a tooltip dialog with information about the
+       * selecte widget.
        * 
        * @instance
        */
       showInfo: function alfresco_debug_WidgetInfo__showInfo() {
-
-         if (this.ttd == null)
+         if (!this.ttd)
          {
             this.displayIdLabel = this.message("widgetInfo.displayId.label");
             this.displayTypeLabel = this.message("widgetInfo.displayType.label");

--- a/aikau/src/main/resources/alfresco/debug/i18n/WidgetInfo.properties
+++ b/aikau/src/main/resources/alfresco/debug/i18n/WidgetInfo.properties
@@ -1,3 +1,5 @@
 widgetInfo.displayId.label=JSON Model ID:
 widgetInfo.displayType.label=Widget Type:
 widgetInfo.displaySnippetLabel.label=Find Widget Code Snippet:
+widgetInfo.alt.text=Information about widget {0}
+widgetInfo.unknown.alt.text=Information about a widget without an identifier

--- a/aikau/src/main/resources/alfresco/debug/templates/WidgetInfo.html
+++ b/aikau/src/main/resources/alfresco/debug/templates/WidgetInfo.html
@@ -1,3 +1,3 @@
 <div class="alfresco-debug-WidgetInfo">
-   <img src="${imgSrc}" class="image" data-dojo-attach-event="ondijitclick:showInfo">
+   <img src="${imgSrc}" class="image" alt="${altText}" data-dojo-attach-event="ondijitclick:showInfo">
 </div>

--- a/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
+++ b/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Widget Info Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/WidgetInfo", "Widget Info Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      teardown: function() {
+         browser.end().alfPostCoverageResults(browser);
+      },
+
+      "Test that developer mode isn't initally enabled": function() {
+         return browser.findAllByCssSelector(".alfresco-developer-mode-Enabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "Developer mode should not have been initially enabled");
+            });
+      },
+
+      "Test that WidgetInfo widgets aren't displayed": function() {
+         return browser.findByCssSelector(".alfresco-debug-WidgetInfo")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The WidgetInfo widgets should not be displayed when developer mode is off");
+            });
+      },
+
+      "Test toggling developer mode on": function() {
+         return browser.findByCssSelector("#TOGGLE_DEVELOPER_MODE_label")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-developer-mode-Enabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Developer mode was not enabled");
+            });
+      },
+
+      "Test that WidgetInfo widgets are now displayed": function() {
+         return browser.findByCssSelector(".alfresco-debug-WidgetInfo")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The WidgetInfo widgets were not displayed after enabling developer mode");
+            });
+      },
+
+      "Test that all widgets have info provided": function() {
+         return browser.findAllByCssSelector(".alfresco-debug-WidgetInfo")
+            .then(function(elements) {
+               assert.lengthOf(elements, 5, "Unexpected number of WidgetInfo widgets found");
+            });
+      },
+
+      "Test that alt text is generated": function() {
+         return browser.findByCssSelector(".alfresco-buttons-AlfButton .alfresco-debug-WidgetInfo img")
+            .getAttribute("alt")
+            .then(function(alt) {
+               assert.equal(alt, "Information about widget TOGGLE_DEVELOPER_MODE", "Alt text was not generated for image");
+            });
+      },
+
+      "Test that info tooltip can be displayed": function() {
+         return browser.findByCssSelector(".alfresco-buttons-AlfButton .alfresco-debug-WidgetInfo img")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-debug-WidgetInfoDialogPopup")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Info tooltip was not generated");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,7 +31,7 @@ define({
     * @type [string]
     */
    // Uncomment and add specific tests as necessary during development!
-   xbaseFunctionalSuites: ["src/test/resources/alfresco/html/HeadingTest"],
+   xbaseFunctionalSuites: ["src/test/resources/alfresco/debug/WidgetInfoTest"],
 
    /**
     * This is the base array of functional test suites
@@ -55,6 +55,8 @@ define({
       // TODO: This test is quarantined - the widget creation code is broken, but not required for production
       //       and there are plans to iterate on it anyway.
       // "src/test/resources/alfresco/creation/WidgetConfigTest",
+
+      "src/test/resources/alfresco/debug/WidgetInfoTest",
 
       "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest",
       "src/test/resources/alfresco/documentlibrary/CreateContentTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>WidgetInfo Test</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/WidgetInfo</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.js
@@ -1,0 +1,42 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "TOGGLE_DEVELOPER_MODE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Toggle Developer Mode",
+            publishTopic: "ALF_TOGGLE_DEVELOPER_MODE"
+         }
+      },
+      {
+         name: "alfresco/html/Label",
+         config: {
+            label: "No id"
+         }
+      },
+      {
+         id: "LABEL",
+         name: "alfresco/html/Label",
+         config: {
+            label: "Has id"
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-127 to ensure that alt text is generated for WidgetInfo widgets. I've also added a unit test (sorry, tests start with "Test"... can't help myself!)