### PR TITLE
AKU-13: Add support for stacked dialogs

### DIFF
--- a/aikau/src/test/resources/alfresco/.jshintrc
+++ b/aikau/src/test/resources/alfresco/.jshintrc
@@ -1,0 +1,35 @@
+{
+   "bitwise": true,
+   "curly": true,
+   "eqeqeq": true,
+   "forin": true,
+   "freeze": true,
+   "funcscope": true,
+   "immed": true,
+   "indent": 3,
+   "iterator": true,
+   "latedef": true,
+   "maxcomplexity": 10,
+   "maxdepth": 50,
+   "maxerr": 50,
+   "maxlen": 250,
+   "maxparams": 50,
+   "maxstatements": 30,
+   "newcap": true,
+   "noarg": true,
+   "nonbsp": true,
+   "nonew": true,
+   "notypeof": true,
+   "quotmark": "double",
+   "shadow": "outer",
+   "singleGroups": true,
+   "undef": true,
+   "unused": true,
+
+   "globals": {},
+
+   "expr": true,
+
+   "dojo": true,
+   "node": true
+}

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -69,6 +69,39 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "LAUNCH_OUTER_DIALOG_BUTTON",
+         config: {
+            label: "Launch outer dialog",
+            publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Outer dialog",
+               dialogId: "OUTER_DIALOG",
+               widgetsContent: [
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     id: "LAUNCH_INNER_DIALOG_BUTTON",
+                     config:{
+                        label: "Launch inner dialog",
+                        publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                        publishPayload: {
+                           dialogTitle: "Inner dialog",
+                           dialogId: "INNER_DIALOG",
+                           textContent: "Inner dialog content",
+                           publishOnShow: [
+                              {
+                                 publishTopic: "DISPLAYED_INNER_DIALOG",
+                                 publishPayload: {}
+                              }
+                           ]
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "alfresco/logging/SubscriptionLog"
       },
       {


### PR DESCRIPTION
This addresses issue https://issues.alfresco.com/jira/browse/AKU-13 and adds unit testing for the previous stacked dialogs work. Also, new .jshintrc file is added to deal with the fact that the tests run in a non-browser environment.