### PR TITLE
AKU-124: Added alfresco/lists/views/layouts/EditableRow widget with unit test

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/KeyboardNavigationSuppressionMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/KeyboardNavigationSuppressionMixin.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * 
+ * @module alfresco/lists/KeyboardNavigationSuppressionMixin
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "dojo/on",
+        "dojo/_base/event",
+        "dojo/keys"], 
+        function(declare, on, event, keys) {
+   
+   return declare(null, {
+      
+      /**
+       * Checks for the CTRL-e combination and when detected moves into edit mode.
+       * 
+       * @instance
+       * @param {object} evt The keypress event
+       */
+      onKeyPress: function alfresco_lists_KeyboardNavigationSuppressionMixin__onKeyPress(evt) {
+         if (evt.ctrlKey === true && evt.charCode === 101)
+         {
+            // On ctrl-e simulate an edit click
+            evt && event.stop(evt);
+            if (typeof this.onEditClick === "function")
+            {
+               this.onEditClick();
+            }
+         }
+      },
+
+      /**
+       * This function is connected via the widget template. It occurs whenever a key is pressed whilst
+       * focus is on the input field for updating the property value. All keypress events other than the
+       * enter and escape key are ignored. Enter will save the data, escape will cancel editing
+       * 
+       * @instance
+       * @param {object} e The key press event
+       */
+      onValueEntryKeyPress: function alfresco_lists_KeyboardNavigationSuppressionMixin__onValueEntryKeyPress(e) {
+         if(e.charOrCode === keys.ESCAPE)
+         {
+            event.stop(e);
+            if (typeof this.onCancel === "function")
+            {
+               this.onCancel();
+            }
+         }
+         // NOTE: This isn't currently working because Dojo form controls suppress certain keys, including ENTER...
+         else if(e.charOrCode === keys.ENTER)
+         {
+            event.stop(e);
+            if (typeof this.onSave === "function")
+            {
+               this.onSave();
+            }
+         }
+      },
+
+      /**
+       * Emits a custom event to notify any containers that use keyboard navigation that handling
+       * keyboard events needs to be suppressed whilst editing is taking place. If the argument
+       * is passed as false then it emits a custom event that indicates to containers that keyboard
+       * navigation can resume.
+       *
+       * @instance
+       * @param {boolean} suppress Whether or not to suppress keyboard navigation
+       */
+      suppressContainerKeyboardNavigation: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressContainerKeyboardNavigation(suppress) {
+         on.emit(this.domNode, "onSuppressKeyNavigation", {
+            bubbles: true,
+            cancelable: true,
+            suppress: suppress
+         });
+      },
+
+      /**
+       * A common use of this widget is to be placed inside a 
+       * [_MultiItemRendererMixin]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin}
+       * that listens for click events on any of the DOM elements inside each row so that it can focus
+       * on the correct item when clicked on. Therefore it is necessary to prevent focus being "stolen" whilst
+       * clicking on the edit control so this function handles click events and prevents them from bubbling
+       * any further out through the DOM.
+       *
+       * @instance
+       * @param {object} evt The click event
+       */
+      suppressFocusRequest: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressFocusRequest(evt) {
+         evt && event.stop(evt);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/EditableRow.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/EditableRow.js
@@ -1,0 +1,315 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>This extends the standard [Row widget]{@link module:alfresco/lists/views/layouts/Row} to provide the ability to
+ * toggle between the standard mode (for reading data) and an edit mode.</p>
+ * <p>It is expected that edit mode will be able to handle user input and during this mode the normal list keyboard
+ * navigation behaviour (e.g. the ability to use the cursor keys to navigate up and down the list) will be suspended
+ * until edit mode is exited. When a row has focus in read mode the user can use a combination of the CONTROL and "E"
+ * keys to enter edit mode, and in edit mode they can use the ESCAPE key to cancel.</p>
+ * <p>Developers should include widgets for entering and existing edit mode (e.g. they could include a 
+ * [PublishAction widget]{@link module:alfresco/renderers/PublishAction} in the read view to enter edit mode and a
+ * [button]{@link module:alfresco/buttons/AlfButton} to exit edit mode).</p>
+ * <p>A typical usage might be to create a [form]{@link module:alfresco/forms/Form} as the edit mode. In this scenario
+ * it would be expected to set the [okButtonPublishTopic]{@link module:alfresco/forms/Form#okButtonPublishTopic}
+ * to use the [readModeSavePublishTopic]{@link module:alfresco/lists/views/layouts/EditableRow#readModeSavePublishTopic}
+ * and the [cancelButtonPublishTopic]{@link module:alfresco/forms/Form#cancelButtonPublishTopic} to use the
+ * [readModeCancelPublishTopic]{@link module:alfresco/lists/views/layouts/EditableRow#readModeCancelPublishTopic}. An even
+ * better approach would be to go via an intermediary service so that edit mode is only exited on successful update
+ * of data to the repository.</p>
+ * 
+ * @module alfresco/lists/views/layouts/EditableRow
+ * @extends module:alfresco/lists/views/layouts/Row
+ * @mixes module:alfresco/core/ObjectProcessingMixin
+ * @mixes module:alfresco/lists/KeyboardNavigationSuppressionMixin
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/views/layouts/Row",
+        "alfresco/core/ObjectProcessingMixin",
+        "alfresco/lists/KeyboardNavigationSuppressionMixin",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "dojo/dom-construct",
+        "dojo/dom-class",
+        "dojo/dom-style",
+        "dojo/on"], 
+        function(declare, Row, ObjectProcessingMixin, KeyboardNavigationSuppressionMixin,
+                 lang, array, domConstruct, domClass, domStyle, on) {
+
+   return declare([Row, ObjectProcessingMixin, KeyboardNavigationSuppressionMixin], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/EditableRow.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/EditableRow.css"}],
+   
+      /**
+       * This is the default topic that will be subscribed to once edit mode has been entered (e.g.
+       * during the [createEditModeWidgets]{@link module:alfresco/lists/views/layouts/EdiableRow#createEditModeWidgets}
+       * function. This value can be overridden through configuration if required.
+       *
+       * @instance
+       * @type {string}
+       * @default "ALF_EDITABLE_ROW_READ_MODE"
+       */
+      readModeSavePublishTopic: "ALF_EDITABLE_ROW_READ_MODE_SAVE",
+
+      /**
+       * This is the default topic that will be subscribed to once edit mode has been entered (e.g.
+       * during the [createEditModeWidgets]{@link module:alfresco/lists/views/layouts/EdiableRow#createEditModeWidgets}
+       * function. This value can be overridden through configuration if required.
+       *
+       * @instance
+       * @type {string}
+       * @default "ALF_EDITABLE_ROW_READ_MODE"
+       */
+      readModeCancelPublishTopic: "ALF_EDITABLE_ROW_READ_MODE_CANCEL",
+
+      /**
+       * This is the default topic that will be subscribed to in order to process requests to enter 
+       * edit mode. This value can be overrridden through configuration if required.
+       *
+       * @instance
+       * @type {string}
+       * @default "ALF_EDITABLE_ROW_EDIT_MODE"
+       */
+      editModePublishTopic: "ALF_EDITABLE_ROW_EDIT_MODE",
+
+      /**
+       *
+       * @instance
+       */
+      postCreate: function alfresco_lists_views_layouts_EditableRow__postCreate() {
+         // Generate a new pubSubScope to ensure that each row only responds to requests to enter
+         // edit mode from widgets within itself...
+         if (!this.pubSubScope)
+         {
+            this.pubSubScope = this.generateUuid();
+         }
+
+         domClass.add(this.domNode, this.additionalCssClasses ? this.additionalCssClasses : "");
+         domClass.add(this.domNode, "alfresco-lists-views-layouts-EditableRow");
+
+         // NOTE: We don't rely on the inherited widget capabilities for creating the initial widgets because
+         // it doesn't clone the model. We need to ensure that the model is cloned so that variable substitution
+         // behaves correctly each time we enter the read mode (e.g. after making changes to data)...
+         this.createReadModeWidgets();
+
+         // Use the onKeyPress function from the KeyboardNavigationSuppressionMixin to capture CTRL-E events
+         // to enter edit mode...
+         on(this.domNode, "keypress", lang.hitch(this, this.onKeyPress));
+
+         if (this.widgetsForEditMode)
+         {
+            this.alfSubscribe(this.editModePublishTopic, lang.hitch(this, this.onEditMode));
+         }
+         else
+         {
+            this.alfLog("warn", "No widgets were provided for editing the row", this);
+         }
+      },
+
+      /**
+       * Used to indicate whether or not the the [widgetsForEditMode]{@link module:alfresco/lists/views/layouts/EditableRow#widgetsForEditMode}
+       * should be processed.
+       *
+       * @instance
+       * @type {Boolean}
+       * @default  true
+       */
+      _alfEditModeProcessing: false,
+
+      /**
+       * This is an extension point for handling the completion of calls to 
+       * [processWidgets]{@link module:alfresco/core/Core#processWidgets}. After processing the 
+       * initial (read display) widgets the [_alfEditModeProcessing]{@link module:alfresco/lists/views/layouts/EdiableRow#_alfEditModeProcessing}
+       * attribute is set to true to indicate that the next iteration will represent the completion
+       * of the creation of the edit display widgets.
+       *
+       * @instance
+       * @param {Array} widgets An array of all the widgets that have been processed
+       */
+      allWidgetsProcessed: function alfresco_lists_views_layouts_EditableRow__allWidgetsProcessed(widgets) {
+         if (!this._alfEditModeProcessing)
+         {
+            // Need to count the number of cells, so we can figure out the colspan for our edit cell...
+            // The assumption here is that there is one cell per widget...
+            this._requiredColspan = widgets.length;
+
+            this._readWidgets = widgets;
+
+            // Set this after creating the basic row widgets, next time we enter this function we
+            this._alfEditModeProcessing = true;
+         }
+         else
+         {
+            this._editWidgets = widgets;
+         }
+      },
+
+      /**
+       * Cleans up the mode by destroying the widgets, emptying the node and then recreating them.
+       *
+       * @instance
+       * @param {array} widgets The widgets to destroy
+       * @param {object} node The DOM node to empty.
+       */
+      cleanUpMode: function alfresco_lists_views_layouts_EditableRow__cleanUpMode(widgets, node) {
+         if (widgets)
+         {
+            array.forEach(widgets, function(widget) {
+               if (typeof widget.destroy === "function")
+               {
+                  widget.destroy(false);
+               }
+            });
+            domConstruct.empty(node);
+         }
+      },
+
+      /**
+       * Handles save events. Just because edit mode is exited does not mean that any data needs to be updated (e.g. the user
+       * could have requested to cancel editing). However when a save is required this function will be used to update the
+       * currentItem with the updated data.
+       * 
+       * @instance
+       * @param {object} payload The payload containing the updated data for the currentItem
+       */
+      onSave: function alfresco_lists_views_layouts_EditableRow__onSave(payload) {
+         // Update the current item value...
+         lang.mixin(this.currentItem, payload);
+
+         // Re-build the read display...
+         this.cleanUpMode(this._readWidgets, this.containerNode);
+         this._alfEditModeProcessing = false;
+         this.createReadModeWidgets();
+
+         // Switch back into read mode to reveal the updated data...
+         this.onReadMode();
+      },
+
+      /**
+       * Handles requests to enter edit mode for the row.
+       * 
+       * @param {object} payload The payload on the request to enter read mode.
+       */
+      onReadMode: function alfresco_lists_views_layouts_EditableRow__onReadMode(/* jshint unused:false */ payload) {
+         this.suppressContainerKeyboardNavigation(false);
+
+         // Show read mode and hide edit mode...
+         domStyle.set(this.domNode, "display", "table-row");
+         domStyle.set(this.editModeCell, "display", "none");
+
+         // Destroy the edit widgets...
+         this.cleanUpMode(this._editWidgets, this.editWidgetsNode);
+      },
+
+      /**
+       * Delegate edit clicks (issued from the [KeyboardNavigationSuppressionMixin]{@link module:alfresco/lists/KeyboardNavigationSuppressionMixin})
+       * to the [onEditMode]{@link module:alfresco/lists/views/layouts/EdiableRow#onEditMode} function.
+       *
+       * @instance
+       */
+      onEditClick: function alfresco_lists_views_layouts_EditableRow__onEditClick() {
+         this.onEditMode();
+      },
+
+      /**
+       * Handles requests to enter edit mode for the row.
+       * 
+       * @param {object} payload The payload on the request to enter edit mode.
+       */
+      onEditMode: function alfresco_lists_views_layouts_EditableRow__onEditMode(/* jshint unused:false */ payload) {
+         this.suppressContainerKeyboardNavigation(true);
+         if (!this._editModeInitialised)
+         {
+            // Create nodes for edit mode and process widgets...
+            this.createEditModeWidgets();
+            this.alfSubscribe(this.readModeSavePublishTopic, lang.hitch(this, this.onSave));
+            this.alfSubscribe(this.readModeCancelPublishTopic, lang.hitch(this, this.onReadMode));
+            this._editModeInitialised = true;
+         }
+
+         // Create the edit mode widgets...
+         var widgets = lang.clone(this.widgetsForEditMode);
+         this.processObject(["processCurrentItemTokens"], widgets);
+         this.processWidgets(widgets, this.editWidgetsNode);
+
+         domStyle.set(this.domNode, "display", "none");
+         domStyle.set(this.editModeCell, "display", "table-row");
+      },
+
+      /** 
+       * Creates the widgets for the read display.
+       * 
+       * @instance
+       */
+      createReadModeWidgets: function alfresco_lists_views_layouts_EditableRow__createReadModeWidgets() {
+         if (this.widgets)
+         {
+            var widgets = lang.clone(this.widgets);
+            if (this.widgetModelModifiers !== null)
+            {
+               this.processObject(this.widgetModelModifiers, widgets);
+            }
+            this.processWidgets(widgets, this.containerNode);
+         }
+      },
+
+      /**
+       * Used to create the DOM elements to display the edit mode. This is called the first time that the
+       * [onEditMode]{@link module:alfresco/lists/views/layouts/EdiableRow#onEditMode} is executed.
+       *
+       * @instance
+       */
+      createEditModeWidgets: function alfresco_lists_views_layouts_EditableRow__createEditModeWidgets() {
+         // We need to construct some elements for the edit mode widgets to go into. All the 
+         // edit mode widgets will live under a single cell that is not displayed in read mode.
+         this.editRowNode = domConstruct.create("tr", {
+            "class": "editRowNode"
+         }, this.domNode, "after");
+         this.editModeCell = domConstruct.create("td", {
+            colspan: this._requiredColspan
+         }, this.editRowNode, "last");
+
+         // Setup event handler so prevent the outer list from swallowing keyboard activity when in
+         // edit mode...
+         on(this.editModeCell, "keypress", lang.hitch(this, this.onValueEntryKeyPress));
+         on(this.editModeCell, "click", lang.hitch(this, this.suppressFocusRequest));
+
+         this.editWidgetsNode = domConstruct.create("div", {}, this.editModeCell);
+      },
+
+      /**
+       * The JSON model describing the widgets to use to create the edit mode. This needs to be
+       * configured in order to edit mode to work at all.
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      widgetsForEditMode: null
+   });
+});

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -40,6 +40,7 @@ define(["dojo/_base/declare",
         "dijit/_OnDijitClickMixin",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/renderers/_PublishPayloadMixin",
+        "alfresco/lists/KeyboardNavigationSuppressionMixin",
         "dojo/text!./templates/InlineEditProperty.html",
         "dojo/_base/lang",
         "dojo/_base/array",
@@ -53,10 +54,10 @@ define(["dojo/_base/declare",
         "alfresco/forms/Form",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
-        function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin,
+        function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin,
                  template, lang, array, on, domClass, html, domAttr, keys, event) {
 
-   return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin], {
+   return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin], {
       
       /**
        * The array of file(s) containing internationalised strings.
@@ -193,23 +194,6 @@ define(["dojo/_base/declare",
          this.cancelLabel = this.message(this.cancelLabel);
          this.editAltText = this.message(this.editAltText, {
             0: this.renderedValue
-         });
-      },
-
-      /**
-       * Emits a custom event to notify any containers that use keyboard navigation that handling
-       * keyboard events needs to be suppressed whilst editing is taking place. If the argument
-       * is passed as false then it emits a custom event that indicates to containers that keyboard
-       * navigation can resume.
-       *
-       * @instance
-       * @param {boolean} suppress Whether or not to suppress keyboard navigation
-       */
-      suppressContainerKeyboardNavigation: function alfresco_renderers_InlineEditProperty__suppressContainerKeyboardNavigation(suppress) {
-         on.emit(this.domNode, "onSuppressKeyNavigation", {
-            bubbles: true,
-            cancelable: true,
-            suppress: suppress
          });
       },
 
@@ -389,43 +373,6 @@ define(["dojo/_base/declare",
       },
       
       /**
-       * Checks for the CTRL-e combination and when detected moves into edit mode.
-       * 
-       * @instance
-       * @param {object} evt The keypress event
-       */
-      onKeyPress: function alfresco_renderers_InlineEditProperty__onKeyPress(evt) {
-         if (evt.ctrlKey === true && evt.charCode === 101)
-         {
-            // On ctrl-e simulate an edit click
-            evt && event.stop(evt);
-            this.onEditClick();
-         }
-      },
-      
-      /**
-       * This function is connected via the widget template. It occurs whenever a key is pressed whilst
-       * focus is on the input field for updating the property value. All keypress events other than the
-       * enter and escape key are ignored. Enter will save the data, escape will cancel editing
-       * 
-       * @instance
-       * @param {object} e The key press event
-       */
-      onValueEntryKeyPress: function alfresco_renderers_InlineEditProperty__onValueEntryKeyPress(e) {
-         if(e.charOrCode === keys.ESCAPE)
-         {
-            event.stop(e);
-            this.onCancel();
-         }
-         // NOTE: This isn't currently working because Dojo form controls suppress certain keys, including ENTER...
-         else if(e.charOrCode === keys.ENTER)
-         {
-            event.stop(e);
-            this.onSave();
-         }
-      },
-
-      /**
        * @instance
        */
       onSave: function alfresco_renderers_InlineEditProperty__onSave(evt) {
@@ -526,22 +473,6 @@ define(["dojo/_base/declare",
          // Reset the input field...
          this.getFormWidget().setValue(this.renderedValue);
          this.renderedValueNode.focus();
-      },
-
-      /**
-       * A common use of this widget is to be placed inside a 
-       * [_MultiItemRendererMixin]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin}
-       * that listens for click events on any of the DOM elements inside each row so that it can focus
-       * on the correct item when clicked on. Therefore it is necessary to prevent focus being "stolen" whilst
-       * clicking on the edit control so this function handles click events and prevents them from bubbling
-       * any further out through the DOM.
-       *
-       * @instance
-       * @param {object} evt The click event
-       */
-      suppressFocusRequest: function alfresco_renderers_InlineEditProperty__suppressFocusRequest(evt) {
-         this.alfLog("log", "Suppress click event");
-         evt && event.stop(evt);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -34,9 +34,8 @@ define(["dojo/_base/declare",
         "alfresco/renderers/_JsNodeMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "dojo/text!./templates/PublishAction.html",
-        "alfresco/core/Core",
-        "service/constants/Default"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, template, AlfCore, AlfConstants) {
+        "alfresco/core/Core"], 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, template, AlfCore) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, AlfCore], {
       
@@ -92,23 +91,24 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_PublishAction__postMixInProperties() {
-         if (this.iconClass == null || this.iconClass === "")
-         {
-            this.imageSrc = require.toUrl("alfresco/renderers") + "/css/images/add-icon-16.png";
-         }
-         else
+         if (this.iconClass)
          {
             this.imageSrc = require.toUrl("alfresco/renderers") + "/css/images/" + this.iconClass + ".png";
          }
+         else
+         {
+            this.imageSrc = require.toUrl("alfresco/renderers") + "/css/images/add-icon-16.png";
+         }
 
          // Localize the alt text...
+         var altTextId = this.currentItem ? this.currentItem[this.propertyToRender] : "";
          this.altText = this.message(this.altText, {
-            0: (this.currentItem != null ? this.currentItem[this.propertyToRender] : "")
+            0: altTextId
          });
 
          this.publishPayload = this.getGeneratedPayload();
-         this.publishGlobal = (this.publishGlobal != null) ? this.publishGlobal : false;
-         this.publishToParent = (this.publishToParent != null) ? this.publishToParent : false;
+         this.publishGlobal = this.publishGlobal || false;
+         this.publishToParent = this.publishToParent || false;
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/lists/views/layouts/EditableRowTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/layouts/EditableRowTest.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Editable Row Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/EditableRow", "Editable Row Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check there are two editable rows": function() {
+         return browser.findAllByCssSelector(".alfresco-lists-views-layouts-EditableRow")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "The wrong number of editable rows were found");
+            });
+      },
+
+      "Check there are 6 cells": function() {
+         return browser.findAllByCssSelector(".alfresco-lists-views-layouts-Cell")
+            .then(function(elements) {
+               assert.lengthOf(elements, 6, "The wrong number of cells were found");
+            });
+      },
+
+      "Check the value of the first property": function() {
+         // The assumption here is that we'll work with the first of 4 properties... 
+         // If the test ever fails, check this holds true first!
+         return browser.findByCssSelector(".alfresco-renderers-Property .value")
+            .getVisibleText()
+            .then(function(resultText) {
+               assert.equal(resultText, "rhubarb", "Property value not initialised as expected");
+            });
+      },
+
+      "Check that edit mode widgets haven't been created yet": function() {
+         return browser.findAllByCssSelector(".alfresco-forms-Form")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "Edit mode widgets were unexpectedly created");
+            });
+      },
+
+      "Enter edit mode (mouse)": function() {
+         return browser.findByCssSelector(".alfresco-lists-views-layouts-EditableRow:nth-child(1) .alfresco-renderers-PublishAction > img")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-forms-Form")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Edit mode widgets were not created");
+            });
+      },
+
+      "Check the initial form value": function() {
+         return browser.findByCssSelector("#LABEL_FIELD .dijitInputContainer input")
+            .getProperty("value")
+            .then(function(resultText) {
+               assert.equal(resultText, "rhubarb", "The form field value was not set correctly");
+            });
+      },
+
+      "Update form value and cancel": function() {
+         return browser.findByCssSelector("#LABEL_FIELD .dijitInputContainer input")
+            .clearValue()
+            .type("bananas")
+         .end()
+         .findByCssSelector(".cancelButton > span")
+            .click()
+         .end()
+         .findByCssSelector(".alfresco-renderers-Property .value")
+            .getVisibleText()
+            .then(function(resultText) {
+               assert.equal(resultText, "rhubarb", "The property should not have been updated");
+            });
+      },
+
+      "Check form is re-initialised": function() {
+         return browser.findByCssSelector(".alfresco-lists-views-layouts-EditableRow:nth-child(1) .alfresco-renderers-PublishAction > img")
+            .click()
+         .end()
+         .findByCssSelector("#LABEL_FIELD .dijitInputContainer input")
+            .getProperty("value")
+            .then(function(resultText) {
+               assert.equal(resultText, "rhubarb", "The form field value was not re-initialised");
+            });
+      },
+
+      "Update form value and save": function() {
+         return browser.findByCssSelector("#LABEL_FIELD .dijitInputContainer input")
+            .clearValue()
+            .type("bananas")
+         .end()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .findByCssSelector(".alfresco-renderers-Property .value")
+            .getVisibleText()
+            .then(function(resultText) {
+               assert.equal(resultText, "bananas", "The property should not have been updated");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -118,6 +118,7 @@ define({
       "src/test/resources/alfresco/layout/TwisterTest",
 
       "src/test/resources/alfresco/lists/views/layouts/RowTest",
+      "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
 
       "src/test/resources/alfresco/menus/AlfCheckableMenuItemTest",
       "src/test/resources/alfresco/menus/AlfContextMenuTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/EditableRow.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/EditableRow.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>Editable Row Tests</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/EditableRow</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/EditableRow.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/EditableRow.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/EditableRow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/EditableRow.get.js
@@ -1,0 +1,122 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         id: "VIEW",
+         name: "alfresco/lists/views/AlfListView",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     id: "1",
+                     label: "rhubarb",
+                     value: "custard"
+                  },
+                  {
+                     id: "2",
+                     label: "strawberries",
+                     value: "cream"
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  name: "alfresco/lists/views/layouts/EditableRow",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "label"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "value"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/PublishAction",
+                                    config: {
+                                       iconClass: "edit-16",
+                                       publishTopic: "ALF_EDITABLE_ROW_EDIT_MODE",
+                                       publishPayload: {
+                                          editMode: true
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ],
+                     widgetsForEditMode: [
+                        {
+                           name: "alfresco/forms/Form",
+                           config: {
+                              okButtonPublishTopic: "ALF_EDITABLE_ROW_READ_MODE_SAVE",
+                              cancelButtonPublishTopic: "ALF_EDITABLE_ROW_READ_MODE_CANCEL",
+                              widgets: [
+                                 {
+                                    id: "LABEL_FIELD",
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       name: "label",
+                                       label: "Label",
+                                       value: "{label}"
+                                    }
+                                 },
+                                 {
+                                    id: "VALUE_FIELD",
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       name: "value",
+                                       label: "Value",
+                                       value: "{value}"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-124 and adds a new widget and unit test that allows rows to be created with an edit mode that can be toggled into. This mode suppresses keyboard navigation handling to ensure that users can enter data into forms, etc.