### PR TITLE
Added dynamic update of label text to alfresco/html/Heading component

### DIFF
--- a/aikau/src/main/resources/alfresco/html/Heading.js
+++ b/aikau/src/main/resources/alfresco/html/Heading.js
@@ -38,10 +38,12 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/Heading.html",
         "alfresco/core/Core",
+        "dojo/_base/lang",
         "dojo/dom-class",
         "dojo/dom-construct",
-        "dojo/dom-attr"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, domClass, domConstruct, domAttr) {
+        "dojo/dom-attr",
+        "dojo/query"],
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, lang, domClass, domConstruct, domAttr, domQuery) {
    
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
 
@@ -119,7 +121,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_html_Heading__postCreate() {
-         if(isNaN(this.level) || this.level < 1 || this.level > 6 || !this.label)
+         if (isNaN(this.level) || this.level < 1 || this.level > 6 || !this.label)
          {
             this.alfLog("error", "A heading must have a numeric level from 1 to 6 and must have a label", this);
          }
@@ -129,19 +131,46 @@ define(["dojo/_base/declare",
                innerHTML: this.encodeHTML(this.message(this.label))
             }, this.headingNode);
 
-            if(this.headingId)
+            if (this.headingId)
             {
                domAttr.set(heading, "id", this.headingId);
             }
          }
 
-         if(this.isHidden)
+         if (this.isHidden)
          {
             domClass.add(this.domNode, this._hiddenAccessibleClass);
          }
          else if (this.additionalCssClasses)
          {
             domClass.add(this.domNode, this.additionalCssClasses);
+         }
+      },
+      
+      /**
+       * @instance
+       */
+      postMixInProperties: function alfresco_html_Label__postMixInProperties() {
+         if (this.subscriptionTopic != null && lang.trim(this.subscriptionTopic) !== "")
+         {
+            this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, "onHeadingUpdate"));
+         }
+      },
+
+      /**
+       * 
+       * @instance
+       * @param {object} payload The details of the label update
+       */
+      onHeadingUpdate: function alfresco_html_Heading__onHeadingUpdate(payload) {
+         var update = lang.getObject("label", false, payload);
+         if (update != null)
+         {
+            var headingNodes = domQuery("h"+this.level, this.headingNode);
+            if (headingNodes && headingNodes.length === 1)
+            {
+               headingNodes[0].textContent = update;
+            }
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/html/Heading.js
+++ b/aikau/src/main/resources/alfresco/html/Heading.js
@@ -153,7 +153,7 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_html_Label__postMixInProperties() {
          if (this.subscriptionTopic != null && lang.trim(this.subscriptionTopic) !== "")
          {
-            this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, "onHeadingUpdate"));
+            this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.onHeadingUpdate));
          }
       },
 

--- a/aikau/src/test/resources/alfresco/html/HeadingTest.js
+++ b/aikau/src/test/resources/alfresco/html/HeadingTest.js
@@ -56,6 +56,25 @@ define(["intern!object",
             .then(function(text) {
                assert.equal(text, "<img src='1' onerror='window.hacked=true>");
             });
+      },
+      
+      "Test update heading label": function() {
+         return browser.findAllByCssSelector("#HEADING3 > h1")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "BEFORE PUBLISH LABEL");
+            })
+            .end()
+            
+            .findById("TEST_BUTTON")
+            .click()
+            .end()
+            
+            .findAllByCssSelector("#HEADING3 > h1")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "AFTER PUBLISH LABEL");
+            })
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/html/Heading.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/html/Heading.get.js
@@ -12,6 +12,17 @@ model.jsonModel = {
    ],
    widgets:[
       {
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            id: "TEST_BUTTON",
+            label: "Update heading button",
+            publishTopic: "UPDATE_HEADING_TOPIC",
+            publishPayload: {
+               label: "AFTER PUBLISH LABEL"
+            }
+         }
+      },
+      {
          id: "HEADING1",
          name: "alfresco/html/Heading",
          config: {
@@ -24,6 +35,14 @@ model.jsonModel = {
          config: {
             label: "<img src='1' onerror='window.hacked=true>",
             level: 4
+         }
+      },
+      {
+         id: "HEADING3",
+         name: "alfresco/html/Heading",
+         config: {
+            label: "BEFORE PUBLISH LABEL",
+            subscriptionTopic: "UPDATE_HEADING_TOPIC"
          }
       },
       {


### PR DESCRIPTION
Based on code for alfresco/html/Label that already does a similar job.

Uses the standard subscriptionTopic channel and updates the text of the inner heading node.