### PR TITLE
AKU-134: CrudService: failureCallback support

### DIFF
--- a/aikau/.csscomb.json
+++ b/aikau/.csscomb.json
@@ -10,7 +10,7 @@
    "space-after-colon": " ",
    "space-after-combinator": " ",
    "space-after-opening-brace": "\n",
-   "space-after-selector-delimiter": "\n",
+   "space-after-selector-delimiter": " ",
    "space-before-closing-brace": "\n",
    "space-before-colon": "",
    "space-before-combinator": " ",

--- a/aikau/src/grunt/http.js
+++ b/aikau/src/grunt/http.js
@@ -18,7 +18,22 @@ module.exports = function(grunt) {
       // grunt-http (http abilities within grunt)
       http: {
          clientPatchModuleReload: {},
-         clientPatchCacheBust: {}
+         clientPatchCacheBust: {},
+         testAppReloadWebScripts: {
+            options: {
+               url: "http://localhost:8089/aikau/page/index",
+               method: "POST",
+               form: {
+                  reset: "on"
+               }
+            }
+         },
+         testAppClearCaches: {
+            options: {
+               url: "http://localhost:8089/aikau/page/caches/dependency/clear",
+               method: "POST"
+            }
+         }
       }
 
    });

--- a/aikau/src/grunt/shell.js
+++ b/aikau/src/grunt/shell.js
@@ -27,6 +27,9 @@ module.exports = function(grunt) {
          mavenInstall: {
             command: "mvn install"
          },
+         mavenProcessTestResources: {
+            command: "mvn -q process-test-resources"
+         },
 
          // Vagrant
          vagrantUp: {

--- a/aikau/src/grunt/testing.js
+++ b/aikau/src/grunt/testing.js
@@ -19,6 +19,9 @@ module.exports = function(grunt) {
    // Restart the test server
    grunt.registerTask("restartTestApp", ["shell:stopTestApp", "startUnitTestApp"]);
 
+   // Build and then clear cached stuff
+   grunt.registerTask("updateTest", ["shell:mavenProcessTestResources", "http:testAppReloadWebScripts", "http:testAppClearCaches"]);
+
    // Start jetty server if not already running. Use waitServer to check startup finished
    grunt.registerTask("startUnitTestApp", "Spawn a Maven process to start the Jetty server running the unit test application", function() {
       grunt.log.writeln("Check Jetty unit test application state...");

--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -60,7 +60,7 @@ define(["dojo/_base/declare",
        */
       cleanupJSONResponse: function alfresco_core_CoreXhr__cleanupJSONResponse(input) {
          var r = input;
-         if (typeof input == "string")
+         if (typeof input === "string")
          {
             r = input.replace(/,}/g, "}");
          }
@@ -98,18 +98,19 @@ define(["dojo/_base/declare",
        * @param {serviceXhrConfig} config The configuration for the request
        */
       serviceXhr: function alfresco_core_CoreXhr__serviceXhr(config) {
+         /*jshint maxcomplexity:12*/
 
          var _this = this;
 
          if (config)
          {
-            if (typeof config.url == "undefined")
+            if (!config.url)
             {
                this.alfLog("error", "An XHR request was made but no URL was provided", config);
             }
             else
             {
-               var headers = (config.headers) ? config.headers : { 'Content-Type': 'application/json' };
+               var headers = (config.headers) ? config.headers : { "Content-Type": "application/json" };
                if (this.isCsrfFilterEnabled())
                {
                   headers[this.getCsrfHeader()] = this.getCsrfToken();
@@ -117,11 +118,11 @@ define(["dojo/_base/declare",
 
                // Attempt to parse the data, but reset to null if not possible...
                var data;
-               if (headers['Content-Type'] == 'application/json')
+               if (headers["Content-Type"] === "application/json")
                {
                   try
                   {
-                     data = (config.data != null) ? JSON.stringify(config.data) : null;
+                     data = (config.data && JSON.stringify(config.data)) || null;
                   }
                   catch (e)
                   {
@@ -142,13 +143,13 @@ define(["dojo/_base/declare",
                }).then(function(response) {
 
                   var id = lang.getObject("requestId", false, config);
-                  if (id != null)
+                  if (id)
                   {
                      delete _this.serviceRequests[id];
                   }
 
                   // HANDLE SUCCESS...
-                  if (typeof response == "string" && lang.trim(response) !== "")
+                  if (typeof response === "string" && lang.trim(response))
                   {
                      try
                      {
@@ -160,9 +161,9 @@ define(["dojo/_base/declare",
                      }
 
                   }
-                  if (typeof config.successCallback == "function")
+                  if (typeof config.successCallback === "function")
                   {
-                     var callbackScope = (config.successCallbackScope ? config.successCallbackScope : (config.callbackScope ? config.callbackScope : _this));
+                     var callbackScope = config.successCallbackScope || config.callbackScope || _this;
                      config.successCallback.call(callbackScope, response, config);
                   }
                   else
@@ -178,7 +179,7 @@ define(["dojo/_base/declare",
                      var redirect = response.response.getHeader("Location");
                      if (redirect)
                      {
-                        if (redirect.indexOf("http://") == 0 || redirect.indexOf("https://") == 0 ) {
+                        if (redirect.indexOf("http://") === 0 || redirect.indexOf("https://") === 0 ) {
                            window.location.href = redirect;
                         }
                         else {
@@ -195,11 +196,11 @@ define(["dojo/_base/declare",
 
                   // HANDLE FAILURE...
                   var id = lang.getObject("requestId", false, config);
-                  if (id != null)
+                  if (id)
                   {
                      delete _this.serviceRequests[id];
                   }
-                  if (typeof response == "string" && lang.trim(response) !== "")
+                  if (typeof response === "string" && lang.trim(response))
                   {
                      try
                      {
@@ -210,9 +211,9 @@ define(["dojo/_base/declare",
                         _this.alfLog("error", "An error occurred parsing an XHR JSON failure response", response, this);
                      }
                   }
-                  if (typeof config.failureCallback == "function")
+                  if (typeof config.failureCallback === "function")
                   {
-                     var callbackScope = (config.failureCallbackScope ? config.failureCallbackScope : (config.callbackScope ? config.callbackScope : _this));
+                     var callbackScope = config.failureCallbackScope || config.callbackScope || _this;
                      config.failureCallback.call(callbackScope, response, config);
                   }
                   else
@@ -223,7 +224,7 @@ define(["dojo/_base/declare",
                }, function(response) {
 
                   // HANDLE PROGRESS...
-                  if (typeof response == "string" && lang.trim(response) !== "")
+                  if (typeof response === "string" && lang.trim(response))
                   {
                      try
                      {
@@ -234,9 +235,9 @@ define(["dojo/_base/declare",
                         _this.alfLog("error", "An error occurred parsing an XHR JSON progress response", response, this);
                      }
                   }
-                  if (typeof config.progressCallback == "function")
+                  if (typeof config.progressCallback === "function")
                   {
-                     var callbackScope = (config.progressCallbackScope ? config.progressCallbackScope : (config.callbackScope ? config.callbackScope : _this));
+                     var callbackScope = config.progressCallbackScope || config.callbackScope || _this;
                      config.progressCallback.call(callbackScope, response, config);
                   }
                   else
@@ -349,7 +350,7 @@ define(["dojo/_base/declare",
        */
       onStopRequest: function alfresco_core_CoreXhr__onStopRequest(payload) {
          var id = lang.getObject("requestId", false, payload);
-         if (id != null && this.serviceRequests[id])
+         if (id && this.serviceRequests[id])
          {
             this.alfLog("info", "Stopping XHR request: " + id);
             this.serviceRequests[id].cancel();
@@ -421,7 +422,7 @@ define(["dojo/_base/declare",
             if (token)
             {
                // remove quotes to support Jetty app-server - bug where it quotes a valid cookie value see ALF-18823
-               token = token.replace(/"/g, '');
+               token = token.replace(/"/g, "");
             }
          }
          return token;

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -32,7 +32,7 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/json"],
-        function(declare, AlfCore, CoreXhr, AlfConstants, AlfDialog, lang, array, dojoJson) {
+        function(declare, AlfCore, CoreXhr, AlfConstants, AlfDialog, lang) {
    
    return declare([AlfCore, CoreXhr], {
       
@@ -70,7 +70,7 @@ define(["dojo/_base/declare",
        */
       refreshRequest: function alfresco_services_CrudService__refreshRequest(response, originalRequestConfig) {
          var responseTopic = lang.getObject("alfTopic", false, originalRequestConfig);
-         if (responseTopic != null)
+         if (responseTopic)
          {
             this.alfPublish(responseTopic + "_SUCCESS", response);
          }
@@ -80,7 +80,7 @@ define(["dojo/_base/declare",
          }
 
          var message = lang.getObject("successMessage", false, originalRequestConfig);
-         if (message == null)
+         if (!message)
          {
             message = this.message("crudservice.generic.success.message");
          }
@@ -91,18 +91,14 @@ define(["dojo/_base/declare",
          });
 
          var noRefresh = lang.getObject("data.noRefresh", false, originalRequestConfig);
-         if (noRefresh != null && noRefresh === true)
+         if (noRefresh === true)
          {
             // Don't make a refresh request...
          }
          else
          {
             // When refreshing, check to see if a pubSubScope was provided...
-            var pubSubScope = lang.getObject("data.pubSubScope", false, originalRequestConfig);
-            if (pubSubScope == null)
-            {
-               pubSubScope = "";
-            }
+            var pubSubScope = lang.getObject("data.pubSubScope", false, originalRequestConfig) || "";
             this.alfPublish(pubSubScope + "ALF_DOCLIST_RELOAD_DATA");
          }
       },
@@ -126,7 +122,7 @@ define(["dojo/_base/declare",
          else
          {
             var urlType = payload.urlType;
-            if (urlType == null || urlType === "PROXY")
+            if (!urlType || urlType === "PROXY")
             {
                url = AlfConstants.PROXY_URI + url;
             }
@@ -171,7 +167,7 @@ define(["dojo/_base/declare",
          {
             this.serviceXhr({url: url,
                              data: this.clonePayload(payload),
-                             alfTopic: (payload.alfResponseTopic ? payload.alfResponseTopic : null),
+                             alfTopic: payload.alfResponseTopic || null,
                              method: "GET"});
          }
       },
@@ -185,7 +181,7 @@ define(["dojo/_base/declare",
       onGetOne: function alfresco_services_CrudService__onGetOne(payload) {
          // TODO: Need to append the identifier to specify the object to retrieve
          var url = this.getUrlFromPayload(payload);
-         if (url !== null)
+         if (url)
          {
             this.serviceXhr({url: url,
                              data: this.clonePayload(payload),

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -338,12 +338,6 @@ define(["dojo/_base/declare",
        */
       failureCallback: function alfresco_services_CrudService__failureCallback(response, originalRequestConfig) {
 
-         // Get the failure message and display a notification
-         var message = originalRequestConfig.failureMessage || this.message("crudservice.generic.failure.message");
-         this.alfPublish("ALF_DISPLAY_PROMPT", {
-            message: message
-         });
-
          // Publish failure topic as necessary
          if (originalRequestConfig.alfTopic) {
             this.alfPublish(originalRequestConfig.alfTopic + "_FAILURE", {
@@ -351,6 +345,12 @@ define(["dojo/_base/declare",
                response: response
             });
          }
+
+         // Get the failure message and display a notification
+         var message = originalRequestConfig.failureMessage || this.message("crudservice.generic.failure.message");
+         this.alfPublish("ALF_DISPLAY_PROMPT", {
+            message: message
+         });
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -19,7 +19,7 @@
 
 /**
  * This is a generic service for handling CRUD requests between widgets and the repository.
- * 
+ *
  * @module alfresco/services/CrudService
  * @extends module:alfresco/core/Core
  * @author Dave Draper
@@ -33,19 +33,20 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/json"],
         function(declare, AlfCore, CoreXhr, AlfConstants, AlfDialog, lang) {
-   
+
    return declare([AlfCore, CoreXhr], {
-      
+
       /**
        * An array of the i18n files to use with this service.
-       * 
+       *
        * @instance
        * @type {object[]}
        * @default [{i18nFile: "./i18n/CrudService.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/CrudService.properties"}],
-      
+
       /**
+       * Constructor
        * 
        * @instance
        * @param {array} args Constructor arguments
@@ -58,30 +59,26 @@ define(["dojo/_base/declare",
          this.alfSubscribe("ALF_CRUD_UPDATE", lang.hitch(this, this.onUpdate));
          this.alfSubscribe("ALF_CRUD_DELETE", lang.hitch(this, this.onDelete));
       },
-      
+
       /**
        * This is called whenever a create, update or delete operation is performed to ensure that
        * any associated list views are refreshed. It does this by publishing on the "ALF_DOCLIST_RELOAD_DATA"
        * topic (for historical reasons - a more generic topic should be used in the future).
-       * 
+       *
        * @instance
        * @param {object} response The response from the original XHR request.
        * @param {object} originalRequestConfig The configuration passed to the original XHR request.
        */
       refreshRequest: function alfresco_services_CrudService__refreshRequest(response, originalRequestConfig) {
          var responseTopic = lang.getObject("alfTopic", false, originalRequestConfig);
-         if (responseTopic)
-         {
+         if (responseTopic) {
             this.alfPublish(responseTopic + "_SUCCESS", response);
-         }
-         else
-         {
+         } else {
             this.alfLog("warn", "It was not possible to publish requested CRUD data because the 'responseTopic' attribute was not set on the original request", response, originalRequestConfig);
          }
 
          var message = lang.getObject("successMessage", false, originalRequestConfig);
-         if (!message)
-         {
+         if (!message) {
             message = this.message("crudservice.generic.success.message");
          }
 
@@ -91,12 +88,9 @@ define(["dojo/_base/declare",
          });
 
          var noRefresh = lang.getObject("data.noRefresh", false, originalRequestConfig);
-         if (noRefresh === true)
-         {
+         if (noRefresh === true) {
             // Don't make a refresh request...
-         }
-         else
-         {
+         } else {
             // When refreshing, check to see if a pubSubScope was provided...
             var pubSubScope = lang.getObject("data.pubSubScope", false, originalRequestConfig) || "";
             this.alfPublish(pubSubScope + "ALF_DOCLIST_RELOAD_DATA");
@@ -108,30 +102,22 @@ define(["dojo/_base/declare",
        * is not found. This is called from all the CRUD handling functions. The payload is expected to contain
        * a 'url' attribute that maps to a Repository WebScript. This function will automatically prefix it
        * with the appropriate proxy stem.
-       * 
+       *
        * @instance
        * @param {object} payload
        * @returns {string} The URL to use to make the CRUD request or null if no 'url' attribute was provided.
        */
       getUrlFromPayload: function alfresco_services_CrudService__getUrlFromPayload(payload) {
          var url = lang.getObject("url", false, payload);
-         if (url === null)
-         {
+         if (!url) {
             this.alfLog("warn", "A request was made to service a CRUD request but no 'url' attribute was provided on the payload", payload, this);
-         }
-         else
-         {
+         } else {
             var urlType = payload.urlType;
-            if (!urlType || urlType === "PROXY")
-            {
+            if (!urlType || urlType === "PROXY") {
                url = AlfConstants.PROXY_URI + url;
-            }
-            else if (urlType === "SHARE")
-            {
+            } else if (urlType === "SHARE") {
                url = AlfConstants.URL_SERVICECONTEXT + url;
-            }
-            else
-            {
+            } else {
                this.alfLog("warn", "An unknown URL type was requested, using provided URL", payload, this);
             }
          }
@@ -139,8 +125,8 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This is a utility function for cloning a payload and removing attributes that should
-       * not be passed onto the [serviceXhr]{@link module:alfresco/core/CoreXhr#serviceXhr} function
+       * This is a utility function for cloning a payload and removing attributes that should not be
+       * passed onto the [serviceXhr] {@link module:alfresco/core/CoreXhr#serviceXhr} function
        *
        * @param {object} payload The payload to clone
        * @returns {object} The cloned payload
@@ -155,20 +141,21 @@ define(["dojo/_base/declare",
 
       /**
        * Makes a GET request to the Repository using the 'url' attribute provided in the payload passed
-       * in the publication on the topic that this function subscribes to. The 'url' is expected to be a 
-       * Repository WebScript URL and should not include the Repository proxy stem. 
-       * 
+       * in the publication on the topic that this function subscribes to. The 'url' is expected to be a
+       * Repository WebScript URL and should not include the Repository proxy stem.
+       *
        * @instance
-       * @param {object} payload 
+       * @param {object} payload
        */
       onGetAll: function alfresco_services_CrudService__onGetAll(payload) {
          var url = this.getUrlFromPayload(payload);
-         if (url !== null)
-         {
-            this.serviceXhr({url: url,
-                             data: this.clonePayload(payload),
-                             alfTopic: payload.alfResponseTopic || null,
-                             method: "GET"});
+         if (url) {
+            this.serviceXhr({
+               url: url,
+               data: this.clonePayload(payload),
+               alfTopic: payload.alfResponseTopic || null,
+               method: "GET"
+            });
          }
       },
 
@@ -176,16 +163,17 @@ define(["dojo/_base/declare",
        * TODO: This needs to be completed.
        *
        * @instance
-       * @param {object} payload 
+       * @param {object} payload
        */
       onGetOne: function alfresco_services_CrudService__onGetOne(payload) {
          // TODO: Need to append the identifier to specify the object to retrieve
          var url = this.getUrlFromPayload(payload);
-         if (url)
-         {
-            this.serviceXhr({url: url,
-                             data: this.clonePayload(payload),
-                             method: "GET"});
+         if (url) {
+            this.serviceXhr({
+               url: url,
+               data: this.clonePayload(payload),
+               method: "GET"
+            });
          }
       },
 
@@ -193,35 +181,43 @@ define(["dojo/_base/declare",
        * Creates a new item via the supplied URL. The payload needs to contain both a 'url' attribute
        * (that indicates the REST API to call) and a 'data' attribute (that defines the object to be
        * created).
-       * 
+       *
        * @instance
-       * @param {object} payload 
+       * @param {object} payload
        */
       onCreate: function alfresco_services_CrudService__onCreate(payload) {
          var url = this.getUrlFromPayload(payload);
-         this.serviceXhr({url: url,
-                          data: this.clonePayload(payload),
-                          method: "POST",
-                          successMessage: payload.successMessage,
-                          alfTopic: payload.alfResponseTopic,
-                          successCallback: this.refreshRequest,
-                          callbackScope: this});
+         this.serviceXhr({
+            url: url,
+            data: this.clonePayload(payload),
+            method: "POST",
+            alfTopic: payload.alfResponseTopic,
+            successMessage: payload.successMessage,
+            successCallback: this.refreshRequest,
+            failureMessage: payload.failureMessage,
+            failureCallback: this.failureCallback,
+            callbackScope: this
+         });
       },
 
       /**
        *
        * @instance
-       * @param {object} payload 
+       * @param {object} payload
        */
       onUpdate: function alfresco_services_CrudService__onUpdate(payload) {
          var url = this.getUrlFromPayload(payload);
-         this.serviceXhr({url: url,
-                          data: this.clonePayload(payload),
-                          method: "PUT",
-                          successMessage: payload.successMessage,
-                          alfTopic: payload.alfResponseTopic,
-                          successCallback: this.refreshRequest,
-                          callbackScope: this});
+         this.serviceXhr({
+            url: url,
+            data: this.clonePayload(payload),
+            method: "PUT",
+            alfTopic: payload.alfResponseTopic,
+            successMessage: payload.successMessage,
+            successCallback: this.refreshRequest,
+            failureMessage: payload.failureMessage,
+            failureCallback: this.failureCallback,
+            callbackScope: this
+         });
       },
 
       /**
@@ -229,22 +225,18 @@ define(["dojo/_base/declare",
        * that is set to true, then a dialog will be displayed prompting the user to confirm the delete
        * action. The payload can optionally contain localized messages for the dialog title, prompt
        * and button labels.
-       * 
+       *
        * @instance
-       * @param {object} payload 
+       * @param {object} payload
        */
       onDelete: function alfresco_services_CrudService__onDelete(payload) {
          // TODO: Need to determine whether or not the ID should be provided in the payload or
          //       as part of the URL.
          var url = this.getUrlFromPayload(payload);
-         if (url !== null)
-         {
-            if (payload.requiresConfirmation === true)
-            {
+         if (url !== null) {
+            if (payload.requiresConfirmation === true) {
                this.requestDeleteConfirmation(url, payload);
-            }
-            else
-            {
+            } else {
                this.performDelete(url, payload);
             }
          }
@@ -253,7 +245,7 @@ define(["dojo/_base/declare",
       /**
        * Called from [onDelete]{@link module:alfresco/services/CrudService#onDelete} when user confirmation
        * for the delete action is required. Displays a dialog prompting the user to confirm the action.
-       * The dialog title, prompt and button labels can all be configured via the attributes on the 
+       * The dialog title, prompt and button labels can all be configured via the attributes on the
        * supplied payload.
        *
        * @instance
@@ -265,10 +257,10 @@ define(["dojo/_base/declare",
          var responseTopic = this.generateUuid();
          this._deleteHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onDeleteConfirmation), true);
 
-         var title = (payload.confirmationTitle) ? payload.confirmationTitle : this.message("crudservice.generic.delete.title");
-         var prompt = (payload.confirmationPrompt) ? payload.confirmationPrompt : this.message("crudservice.generic.delete.prompt");
-         var confirmButtonLabel = (payload.confirmationButtonLabel) ? payload.confirmationButtonLabel : this.message("crudservice.generic.delete.confirmationButtonLabel");
-         var cancelButtonLabel = (payload.cancellationButtonLabel) ? payload.cancellationButtonLabel : this.message("crudservice.generic.delete.cancellationButtonLabel");
+         var title = payload.confirmationTitle || this.message("crudservice.generic.delete.title");
+         var prompt = payload.confirmationPrompt || this.message("crudservice.generic.delete.prompt");
+         var confirmButtonLabel = payload.confirmationButtonLabel || this.message("crudservice.generic.delete.confirmationButtonLabel");
+         var cancelButtonLabel = payload.cancellationButtonLabel || this.message("crudservice.generic.delete.cancellationButtonLabel");
 
          var dialog = new AlfDialog({
             generatePubSubScope: false,
@@ -284,7 +276,8 @@ define(["dojo/_base/declare",
                         url: url,
                         pubSubScope: payload.pubSubScope,
                         responseTopic: payload.responseTopic,
-                        successMessage: payload.successMessage
+                        successMessage: payload.successMessage,
+                        failureMessage: payload.failureMessage
                      }
                   }
                },
@@ -311,24 +304,53 @@ define(["dojo/_base/declare",
        * @param {object} payload The original payload
        */
       performDelete: function alfresco_services_CrudService__performDelete(url, payload) {
-         this.serviceXhr({url: url,
-                          method: "DELETE",
-                          data: this.clonePayload(payload),
-                          alfTopic: payload.responseTopic,
-                          successMessage: payload.successMessage,
-                          successCallback: this.refreshRequest,
-                          callbackScope: this});
+         this.serviceXhr({
+            url: url,
+            method: "DELETE",
+            data: this.clonePayload(payload),
+            alfTopic: payload.responseTopic,
+            successMessage: payload.successMessage,
+            successCallback: this.refreshRequest,
+            failureMessage: payload.failureMessage,
+            failureCallback: this.failureCallback,
+            callbackScope: this
+         });
       },
 
       /**
        * This function is called when the user confirms that they wish to peform the delete action.
-       * 
+       *
        * @instance
        * @param {object} payload An object containing the the deletion details.
        */
       onDeleteConfirmation: function alfresco_services_CrudService__onDeleteConfirmation(payload) {
          this.alfUnsubscribeSaveHandles([this._deleteHandle]);
          this.performDelete(payload.url, payload);
+      },
+
+      /**
+       * This is called whenever a create, update or delete operation fails. It will generate a notification
+       * with a message (optionally supplied as failureMessage in the payload).
+       *
+       * @instance
+       * @param {object} response The response from the original XHR request.
+       * @param {object} originalRequestConfig The configuration passed to the original XHR request.
+       */
+      failureCallback: function alfresco_services_CrudService__failureCallback(response, originalRequestConfig) {
+
+         // Get the failure message and display a notification
+         var message = originalRequestConfig.failureMessage || this.message("crudservice.generic.failure.message");
+         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+            message: message
+         });
+
+         // Publish failure topic as necessary
+         if (originalRequestConfig.alfTopic) {
+            this.alfPublish(originalRequestConfig.alfTopic + "_FAILURE", {
+               requestConfig: originalRequestConfig,
+               response: response
+            });
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -340,7 +340,7 @@ define(["dojo/_base/declare",
 
          // Get the failure message and display a notification
          var message = originalRequestConfig.failureMessage || this.message("crudservice.generic.failure.message");
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfPublish("ALF_DISPLAY_PROMPT", {
             message: message
          });
 

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -31,6 +31,14 @@ define(["dojo/_base/declare",
       return declare([AlfCore], {
 
          /**
+          * An array of the i18n files to use with this widget.
+          *
+          * @instance
+          * @type {Array}
+          */
+         i18nRequirements: [{i18nFile: "./i18n/NotificationService.properties"}],
+
+         /**
           * Sets up the subscriptions for the NotificationService
           *
           * @instance
@@ -74,13 +82,19 @@ define(["dojo/_base/declare",
          onDisplayPrompt: function alfresco_services_NotificationService__onDisplayPrompt(payload) {
             var message = lang.getObject("message", false, payload);
             if (message) {
-               var config = {
-                  text: message
-               };
-               if (payload.title) {
-                  config.title = payload.title;
-               }
-               Alfresco.util.PopupManager.displayMessage(config);
+               this.alfPublish("ALF_CREATE_DIALOG_REQUEST", {
+                  dialogId: "NOTIFICATION_PROMPT",
+                  dialogTitle: this.message("notification.prompt.title"),
+                  textContent: message,
+                  widgetsButtons: [
+                     {
+                        name: "alfresco/buttons/AlfButton",
+                        config: {
+                           label: "notification.ok.label"
+                        }
+                     }
+                  ]
+               });
             } else {
                this.alfLog("warn", "It was not possible to display the message because no suitable 'message' attribute was provided", payload);
             }

--- a/aikau/src/main/resources/alfresco/services/i18n/CrudService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/CrudService.properties
@@ -4,3 +4,4 @@ crudservice.generic.delete.confirmationButtonLabel=Yes
 crudservice.generic.delete.cancellationButtonLabel=No
 
 crudservice.generic.success.message=Operation Completed Successfully
+crudservice.generic.failure.message=Operation Failed

--- a/aikau/src/main/resources/alfresco/services/i18n/NotificationService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/NotificationService.properties
@@ -1,0 +1,2 @@
+notification.prompt.title=Notification
+notification.ok.label=OK

--- a/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
@@ -35,7 +35,7 @@ define(["intern!object",
 
          setup: function() {
             browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/NotificationService", "NotificationService")
+            return TestCommon.loadTestWebScript(this.remote, "/CrudService", "CrudService")
                .end();
          },
 
@@ -43,34 +43,53 @@ define(["intern!object",
             browser.end();
          },
 
-         teardown: function() {
-            browser.end()
-               .alfPostCoverageResults(browser);
-         },
-
-         "Notification displays on button click": function() {
-            return browser.findByCssSelector("#NOTIFICATION_BUTTON_SMALL")
+         "Valid DELETE call succeeds": function() {
+            return browser.findById("DELETE_SUCCESS_BUTTON")
                .click()
-               .sleep(1000) // Simulate delay of notification appearing and user focusing on it
                .end()
 
-            .findByCssSelector(".alfresco-notifications-AlfNotification__message")
-               .isDisplayed()
-               .then(function(notificationDisplayed) {
-                  assert.isTrue(notificationDisplayed, "Notification not displayed");
-               });
-         },
-
-         "Notification hides after displaying": function() {
-            return browser.setFindTimeout(5000)
-               .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message");
-         },
-
-         "Topic publishes after notification hidden": function() {
-            return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_NOTIFICATION_DESTROYED", "publish", "any"))
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_SUCCESS", "publish", "any"))
                .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Post-notification topic not published");
+                  assert.lengthOf(elements, 1, "Delete did not succeed");
                });
+         },
+
+         "Invalid DELETE call fails": function() {
+            return browser.findById("DELETE_FAILURE_BUTTON")
+               .click()
+               .end()
+
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_FAILURE", "publish", "any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Invalid delete did not fail");
+               });
+         },
+
+         "Failed DELETE displays failure message": function() {
+            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+               .then(function(dialogBody) {
+                  return dialogBody.getVisibleText()
+                     .then(function(messageText) {
+                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                        assert.equal(trimmed, "Test failure message", "Failure message not displayed");
+                     });
+               });
+         },
+
+         // "Notification hides after displaying": function() {
+         //    return browser.setFindTimeout(5000)
+         //       .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message");
+         // },
+
+         // "Topic publishes after notification hidden": function() {
+         //    return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_NOTIFICATION_DESTROYED", "publish", "any"))
+         //       .then(function(elements) {
+         //          assert.lengthOf(elements, 1, "Post-notification topic not published");
+         //       });
+         // },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
          }
       });
    });

--- a/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!expect",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, expect, assert, require, TestCommon) {
+
+      var browser;
+
+      registerSuite({
+         name: "CrudService",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NotificationService", "NotificationService")
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         teardown: function() {
+            browser.end()
+               .alfPostCoverageResults(browser);
+         },
+
+         "Notification displays on button click": function() {
+            return browser.findByCssSelector("#NOTIFICATION_BUTTON_SMALL")
+               .click()
+               .sleep(1000) // Simulate delay of notification appearing and user focusing on it
+               .end()
+
+            .findByCssSelector(".alfresco-notifications-AlfNotification__message")
+               .isDisplayed()
+               .then(function(notificationDisplayed) {
+                  assert.isTrue(notificationDisplayed, "Notification not displayed");
+               });
+         },
+
+         "Notification hides after displaying": function() {
+            return browser.setFindTimeout(5000)
+               .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message");
+         },
+
+         "Topic publishes after notification hidden": function() {
+            return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_NOTIFICATION_DESTROYED", "publish", "any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Post-notification topic not published");
+               });
+         }
+      });
+   });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>CrudService Test</shortname>
+  <description>This WebScript defines the CrudService page test</description>
+  <family>aikau-unit-tests</family>
+  <url>/CrudService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
@@ -1,0 +1,40 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/CrudService",
+      "alfresco/services/NotificationService"
+   ],
+   widgets:[
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "DELETE_SUCCESS_BUTTON",
+         config: {
+            label: "Successful delete call",
+            publishTopic: "ALF_CRUD_DELETE",
+            publishPayload: {
+               url: "resources/123",
+               responseTopic: "ALF_CRUD_DELETED"
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/CrudServiceMockXhr"
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
@@ -12,7 +12,8 @@ model.jsonModel = {
          }
       },
       "alfresco/services/CrudService",
-      "alfresco/services/NotificationService"
+      "alfresco/services/NotificationService",
+      "alfresco/services/DialogService"
    ],
    widgets:[
       {
@@ -24,6 +25,19 @@ model.jsonModel = {
             publishPayload: {
                url: "resources/123",
                responseTopic: "ALF_CRUD_DELETED"
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "DELETE_FAILURE_BUTTON",
+         config: {
+            label: "Failed delete call",
+            publishTopic: "ALF_CRUD_DELETE",
+            publishPayload: {
+               url: "resources/234",
+               responseTopic: "ALF_CRUD_DELETED",
+               failureMessage: "Test failure message"
             }
          }
       },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
@@ -37,7 +37,57 @@ model.jsonModel = {
             publishPayload: {
                url: "resources/234",
                responseTopic: "ALF_CRUD_DELETED",
-               failureMessage: "Test failure message"
+               failureMessage: "Test delete-failure message"
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "UPDATE_SUCCESS_BUTTON",
+         config: {
+            label: "Successful update call",
+            publishTopic: "ALF_CRUD_UPDATE",
+            publishPayload: {
+               url: "resources/123",
+               alfResponseTopic: "ALF_CRUD_UPDATED"
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "UPDATE_FAILURE_BUTTON",
+         config: {
+            label: "Failed update call",
+            publishTopic: "ALF_CRUD_UPDATE",
+            publishPayload: {
+               url: "resources/234",
+               alfResponseTopic: "ALF_CRUD_UPDATED",
+               failureMessage: "Test update-failure message"
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_SUCCESS_BUTTON",
+         config: {
+            label: "Successful create call",
+            publishTopic: "ALF_CRUD_CREATE",
+            publishPayload: {
+               url: "resources/123",
+               alfResponseTopic: "ALF_CRUD_CREATED"
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_FAILURE_BUTTON",
+         config: {
+            label: "Failed create call",
+            publishTopic: "ALF_CRUD_CREATE",
+            publishPayload: {
+               url: "resources/234",
+               alfResponseTopic: "ALF_CRUD_CREATED",
+               failureMessage: "Test create-failure message"
             }
          }
       },

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CrudServiceMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CrudServiceMockXhr.js
@@ -22,12 +22,8 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-      "aikauTesting/MockXhr",
-      "dojo/text!./responseTemplates/ContainerListPicker/RecentSites.json",
-      "dojo/text!./responseTemplates/ContainerListPicker/Site.json",
-      "dojo/text!./responseTemplates/ContainerListPicker/DocumentLibrary.json"
-   ],
-   function(declare, MockXhr, RecentSites, Site, DocumentLibrary) {
+        "aikauTesting/MockXhr"],
+        function(declare, MockXhr) {
 
       return declare([MockXhr], {
 
@@ -39,8 +35,9 @@ define(["dojo/_base/declare",
          setupServer: function alfresco_testing_mockservices_ContainerListPickerMockXhr__setupServer() {
             try {
                this.server.respondWith("DELETE", "/aikau/proxy/alfresco/resources/123", [200, {}, ""]);
+               this.server.respondWith("POST", "/aikau/proxy/alfresco/resources/123", [200, {}, ""]);
+               this.server.respondWith("PUT", "/aikau/proxy/alfresco/resources/123", [200, {}, ""]);
                this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
-
             } catch (e) {
                this.alfLog("error", "The following error occurred setting up the mock server", e);
             }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CrudServiceMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CrudServiceMockXhr.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/ContainerListPickerMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+      "aikauTesting/MockXhr",
+      "dojo/text!./responseTemplates/ContainerListPicker/RecentSites.json",
+      "dojo/text!./responseTemplates/ContainerListPicker/Site.json",
+      "dojo/text!./responseTemplates/ContainerListPicker/DocumentLibrary.json"
+   ],
+   function(declare, MockXhr, RecentSites, Site, DocumentLibrary) {
+
+      return declare([MockXhr], {
+
+         /**
+          * This sets up the fake server with all the responses it should provide.
+          *
+          * @instance
+          */
+         setupServer: function alfresco_testing_mockservices_ContainerListPickerMockXhr__setupServer() {
+            try {
+               this.server.respondWith("DELETE", "/aikau/proxy/alfresco/resources/123", [200, {}, ""]);
+               this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+
+            } catch (e) {
+               this.alfLog("error", "The following error occurred setting up the mock server", e);
+            }
+         }
+      });
+   });


### PR DESCRIPTION
This addresses issue https://issues.alfresco.com/jira/browse/AKU-134 which highlights that there is no failure callback on the CrudService, meaning errors can be swallowed. Also includes a single-line (non-breaking) tweak to the CSSComb settings [optional CSS formatting plugin].