### PR TITLE
AKU-142: Updates to  AlfDynamicPayloadButton

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfDynamicPayloadButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfDynamicPayloadButton.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -21,6 +21,8 @@
  * <p>Extends the standard Aikau button to allow the payload to dynamically be updated on published topics.
  * This allows a button to be contextually sensitive to changes on the page. Configure the updates by 
  * setting the [publishPayloadSubscriptions]{@link module:alfresco/buttons/AlfDynamicPayloadButton#publishPayloadSubscriptions}.</p>
+ * <p>It is also possible to configure the button to udpate the payload as the browser URL hash fragment
+ * changes (again using an optional mapping).
  *
  * @example <caption>This is an example configuration:</caption>
  * {
@@ -37,24 +39,51 @@
  *          {
  *             "topic": "MAP_SELECTED_DATA",
  *             "dataMapping": {
- *                "incomingPayload": "buttonPayload"
+ *                "incomingPayloadProperty": "buttonPayloadProperty"
  *             }
  *          }
- *       ]
+ *       ],
+ *       "useHash": true,
+ *       "hashDataMapping": {
+ *          "hashFragmentParameterName": "buttonPayloadProperty"
+ *       }
  *    }
  * }
  * 
  * @module alfresco/buttons/AlfDynamicPayloadButton
  * @extends alfresco/buttons/AlfButton
+ * @mixes module:alfresco/documentlibrary/_AlfHashMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/buttons/AlfButton",
+        "alfresco/buttons/AlfButton", 
+        "alfresco/documentlibrary/_AlfHashMixin",
         "dojo/_base/array",
-        "dojo/_base/lang"], 
-        function(declare, AlfButton, array, lang) {
+        "dojo/_base/lang",
+        "dojo/io-query",
+        "dojo/hash"], 
+        function(declare, AlfButton, _AlfHashMixin, array, lang, ioQuery, hash) {
    
-   return declare([AlfButton], {
+   return declare([AlfButton, _AlfHashMixin], {
+
+      /**
+       * Indicates whether not has values can be used to map data into the button payload.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      useHash: false,
+
+      /**
+       * An optional mapping of hash fragment data to publish payload data. This allows only certain elements
+       * of the hash to be used and for them to be assigned to specific properties of the published payload.
+       *
+       * @instance
+       * @type {object}
+       * @default null
+       */
+      hashDataMapping: null,
 
       /**
        * Represents the topics that will trigger an update of the button payload. Each topic can have it's own
@@ -77,7 +106,34 @@ define(["dojo/_base/declare",
        */
       postMixInProperties: function alfresco_buttons_AlfDynamicPayloadButton__postMixInProperties() {
          this.inherited(arguments);
-         array.forEach(this.publishPayloadSubscriptions, lang.hitch(this, this.setupPayloadSubscriptions))
+         array.forEach(this.publishPayloadSubscriptions, lang.hitch(this, this.setupPayloadSubscriptions));
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/buttons/AlfButton#postCreate} to check
+       * update the payload based on the browser URL hash and set up handlers for hash changes (if 
+       * [useHash]{@link module:alfresco/buttons/AlfDynamicPayloadButton#useHash} is true).
+       * 
+       * @instance
+       */
+      postCreate: function alfresco_buttons_AlfDynamicPayloadButton__postCreate() {
+         this.inherited(arguments);
+         if (this.useHash)
+         {
+            var hashString = hash();
+            var currHash = ioQuery.queryToObject(hashString);
+            if (this.hashDataMapping)
+            {
+               this.mapData(this.hashDataMapping, currHash);
+            }
+            else
+            {
+               // If no data mapping has been provided then mix the entire hash in
+               lang.mixin(this.publishPayload, currHash);
+            }
+
+            this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onHashChanged));
+         }
       },
 
       /**
@@ -107,7 +163,7 @@ define(["dojo/_base/declare",
        */
       onPayloadUpdate: function alfresco_buttons_AlfDynamicPayloadButton__onPayloadUpdate(dataMapping, payload) {
          // Make sure that there is a payload object to work with...
-         if (this.publishPayload == null)
+         if (!this.publishPayload)
          {
             this.publishPayload = {};
          }
@@ -115,20 +171,52 @@ define(["dojo/_base/declare",
          if (dataMapping)
          {
             // Map data as requested...
-            for (var key in dataMapping)
+            this.mapData(dataMapping, payload);
+         }
+         else
+         {
+            // Mixin the entire payload if none is provided...
+            lang.mixin(this.publishPayload, payload);
+         }
+      },
+
+      /**
+       * Maps the data provided into the payload based on the dataMapping provided.
+       *
+       * @instance
+       * @param {object} dataMapping The mapping to use for the data
+       * @param {object} data The data to be mapped
+       */
+      mapData: function alfresco_buttons_AlfDynamicPayloadButton__mapData(dataMapping, data) {
+         for (var key in dataMapping)
+         {
+            if (dataMapping.hasOwnProperty(key))
             {
                // Check that the data actually exists...
-               var value = lang.getObject(key, false, payload);
-               if (value != null)
+               var value = lang.getObject(key, false, data);
+               if (value)
                {
                   // ...and then set it as requested
                   lang.setObject(dataMapping[key], value, this.publishPayload);
                }
             }
          }
+      },
+
+      /**
+       * This function is called whenever the browser URL hash fragment is changed.e end of the fragment
+       * 
+       * @instance
+       * @param {object} payload
+       */
+      onHashChanged: function alfresco_buttons_AlfDynamicPayloadButton__onHashChanged(payload) {
+         if (this.hashDataMapping)
+         {
+            this.mapData(this.hashDataMapping, payload);
+         }
          else
          {
-            // Mixin the entire payload if none is provided...
+            // If no data mapping has been provided then mix the entire hash in
             lang.mixin(this.publishPayload, payload);
          }
       }

--- a/aikau/src/test/resources/alfresco/buttons/DynamicPayloadButtonTest.js
+++ b/aikau/src/test/resources/alfresco/buttons/DynamicPayloadButtonTest.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+      function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Dynamic Payload Button Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/dynamicPayloadButton#initial=test", "Dynamic Payload Button Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check the original payload": function() {
+         return browser.findByCssSelector("#DYNAMIC_BUTTON_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "value"))
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Original Value", "The original payload value has been changed unexpectedly");
+            });
+      },
+
+      "Check the original hash based payload": function() {
+         return browser.findByCssSelector("#DYNAMIC_BUTTON_2_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "initial"))
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "test", "The original payload value has been changed unexpectedly");
+            });
+      },
+
+      "Override the complete payload": function() {
+         return browser.findByCssSelector("#FULL_OVERRIDE_label")
+            .click()
+         .end()
+         .findByCssSelector("#DYNAMIC_BUTTON_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "value"))
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Override 1", "The original payload value was not updated");
+            });
+      },
+
+      "Mixin in values and override": function() {
+         return browser.findByCssSelector("#MIXIN_WITH_OVERRIDES_label")
+            .click()
+         .end()
+         .findByCssSelector("#DYNAMIC_BUTTON_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "value"))
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Override 2", "The original payload value was not updated");
+            });
+      },
+
+      "Check additional data was included in payload": function() {
+         return browser.findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("DYNAMIC_BUTTON_TOPIC", "additional", "data", "extra data"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Additional data was not found");
+            });
+      },
+
+      "Mixin in values without an override": function() {
+         return browser.findByCssSelector("#MIXIN_NO_OVERRIDES_label")
+            .click()
+         .end()
+         .findByCssSelector("#DYNAMIC_BUTTON_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "value"))
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Override 2", "The previously updated payload value changed again unexpectedly");
+            });
+      },
+
+      "Check additional data  performs override": function() {
+         return browser.findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("DYNAMIC_BUTTON_TOPIC", "additional", "data", "bonus data"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Additional data was not found");
+            });
+      },
+
+      "Override via has update": function() {
+         return browser.findByCssSelector("#HASH_OVERRIDE_label")
+            .click()
+         .end()
+         .findByCssSelector("#DYNAMIC_BUTTON_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "value"))
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Override3", "The previously updated payload value was not updated via hash change");
+            });
+      },
+
+      "Add extra data via has update": function() {
+         return browser.findByCssSelector("#HASH_OVERRIDE_EXTRA_label")
+            .click()
+         .end()
+         .findByCssSelector("#DYNAMIC_BUTTON_label")
+            .click()
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("DYNAMIC_BUTTON_TOPIC", "additional", "hash", "hashData"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Additional data provided via hash was not found");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -45,6 +45,8 @@ define({
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 
+      "src/test/resources/alfresco/buttons/DynamicPayloadButtonTest",
+
       "src/test/resources/alfresco/charts/ccc/PieChartTest",
 
       "src/test/resources/alfresco/core/AdvancedVisibilityConfigTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/dynamicPayloadButton.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/dynamicPayloadButton.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>Dynamic Payload Button Test</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/dynamicPayloadButton</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/dynamicPayloadButton.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/dynamicPayloadButton.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/dynamicPayloadButton.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/dynamicPayloadButton.get.js
@@ -1,0 +1,125 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets: [
+      {
+         id: "DYNAMIC_BUTTON",
+         name: "alfresco/buttons/AlfDynamicPayloadButton",
+         config: {
+            label: "Dynamic Button",
+            publishTopic: "DYNAMIC_BUTTON_TOPIC",
+            publishPayload: {
+               value: "Original Value"
+            },
+            publishPayloadSubscriptions: [
+               {
+                  topic: "MIXIN_COMPLETE_PAYLOAD"
+               },
+               {
+                  topic: "MAP_SELECTED_DATA_WITH_OVERRIDES",
+                  dataMapping: {
+                     updatedValue: "value",
+                     additional: "additional.data"
+                  }
+               },
+               {
+                  topic: "MAP_SELECTED_DATA_NO_OVERRIDES",
+                  dataMapping: {
+                     additional: "additional.data"
+                  }
+               }
+            ],
+            useHash: true,
+            hashDataMapping: {
+               hashValue: "value",
+               additionalHash: "additional.hash"
+            }
+         }
+      },
+      {
+         id: "DYNAMIC_BUTTON_2",
+         name: "alfresco/buttons/AlfDynamicPayloadButton",
+         config: {
+            label: "Dynamic Button 2",
+            publishTopic: "DYNAMIC_BUTTON_TOPIC_2",
+            publishPayload: {
+               value: "Another Value"
+            },
+            useHash: true
+         }
+      },
+      {
+         id: "FULL_OVERRIDE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Override payload",
+            publishTopic: "MIXIN_COMPLETE_PAYLOAD",
+            publishPayload: {
+               value: "Override 1"
+            }
+         }
+      },
+      {
+         id: "MIXIN_WITH_OVERRIDES",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Mixin With Overrides",
+            publishTopic: "MAP_SELECTED_DATA_WITH_OVERRIDES",
+            publishPayload: {
+               updatedValue: "Override 2",
+               additional: "extra data"
+            }
+         }
+      },
+      {
+         id: "MIXIN_NO_OVERRIDES",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Mixin Without Overrides",
+            publishTopic: "MAP_SELECTED_DATA_NO_OVERRIDES",
+            publishPayload: {
+               additional: "bonus data"
+            }
+         }
+      },
+      {
+         id: "HASH_OVERRIDE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Update URL hash",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "hashValue=Override3",
+               type: "HASH"
+            }
+         }
+      },
+      {
+         id: "HASH_OVERRIDE_EXTRA",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Update URL hash",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "hashValue=Override3&additionalHash=hashData",
+               type: "HASH"
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-142 and adds the missing unit test for the alfresco/buttons/AlfDynamicPayloadButton as well as adding in additional hash fragment supporting capabilities.