### PR TITLE
Fix missing links to published chapters

### DIFF
--- a/tutorial/chapters/Contents.md
+++ b/tutorial/chapters/Contents.md
@@ -10,9 +10,9 @@
 8. [Widget Dialogs](./Tutorial8.md)
 9. [Actions in Lists](./Tutorial9.md)
 10. [Inline Editing Properties](./Tutorial10.md)
-11. Sorting and Pagination
-12. Introducing Menus
-13. Introducing Layout
+11. [Sorting and Pagination](./Tutorial11.md)
+12. [Introducing Menus](./Tutorial12.md)
+13. [Introducing Layout](./Tutorial13.md)
 14. Recap for User Management
 15. Introducing Rendering Filters
 16. More Form Controls


### PR DESCRIPTION
Contents page didn't link to the newly published tutorial chapters