### PR TITLE
AKU-150: Calendar display issues with long site name

### DIFF
--- a/aikau/src/grunt/watch.js
+++ b/aikau/src/grunt/watch.js
@@ -5,10 +5,7 @@ module.exports = function(grunt) {
       watch: {
          test: {
             files: [alfConfig.files.testScripts],
-            tasks: ["intern:dev"],
-            options: {
-               interrupt: true
-            }
+            tasks: ["intern:dev"]
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/header/Title.js
+++ b/aikau/src/main/resources/alfresco/header/Title.js
@@ -35,8 +35,10 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Title.html",
         "dojo/_base/lang",
         "alfresco/core/Core",
-        "service/constants/Default"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, lang, AlfCore, AlfConstants) {
+        "service/constants/Default",
+        "dojo/dom-class",
+        "dojo/dom-style"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, lang, AlfCore, AlfConstants, domClass, domStyle) {
    
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
       
@@ -118,7 +120,13 @@ define(["dojo/_base/declare",
          {
             document.title = this.browserTitlePrefix + " \u00bb " + this.label; // Set the browser title
          }
-         
+         if (this.maxWidth) {
+            this.textNode.title = this.label;
+            domClass.add(this.textNode, "has-max-width");
+            domStyle.set(this.textNode, {
+               maxWidth: this.maxWidth
+            });
+         }
          if (this.targetUrl)
          {
             this.textNode.href = AlfConstants.URL_PAGECONTEXT + this.targetUrl;

--- a/aikau/src/main/resources/alfresco/header/css/Title.css
+++ b/aikau/src/main/resources/alfresco/header/css/Title.css
@@ -1,20 +1,25 @@
-.alfresco-share h1.alfresco-header-Title {
-   margin-top: 19px;
-   font-weight: normal;
-   font-size: 185%;
-}
-
-.alfresco-share h1.alfresco-header-Title > .text {
-   font-family: Open Sans Condensed, Arial, sans-serif;
-   color: #333 !important;
-   text-decoration: none;
-}
-
-.alfresco-share .share-header-title {
-   border-bottom: 1px solid #ccc;
-}
-
-.alfresco-share .share-header-title > div {
-   background-color: #fafafa;
-   height: 67px;
+.alfresco-share {
+   h1.alfresco-header-Title {
+      font-size: 185%;
+      font-weight: normal;
+      margin-top: 19px;
+      > .text {
+         color: #333 !important;
+         font-family: Open Sans Condensed, Arial, sans-serif;
+         text-decoration: none;
+         &.has-max-width {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            display: inline-block;
+         }
+      }
+   }
+   .share-header-title {
+      border-bottom: 1px solid #ccc;
+      > div {
+         background-color: #fafafa;
+         height: 67px;
+      }
+   }
 }

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -319,6 +319,42 @@ define(["intern!object",
    });
 
    registerSuite({
+      name: "Title Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Title", "Title Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+      
+      "Test title gets set": function() {
+         return browser.findByCssSelector(".alfresco-header-Title:nth-child(2)")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "This is a title", "The title was not set");
+            });
+      },
+
+      "Long title is truncated": function() {
+         return browser.findByCssSelector(".alfresco-header-Title:nth-child(3) .text")
+         .then(function(elem){
+            return elem.getSize();
+         })
+         .then(function(size){
+            assert.equal(size.width, 300, "Long title width incorrect");
+         })
+         .screenie(); // For visual verification of ellipsis if required
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   registerSuite({
       name: "Set Title Tests",
 
       setup: function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>Title Test</shortname>
+  <family>aikau-unit-tests</family>
+  <url>/Title</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.js
@@ -1,0 +1,41 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/VerticalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/header/Title",
+                  config: {
+                     label: "This is a title"
+                  }
+               },
+               {
+                  name: "alfresco/header/Title",
+                  config: {
+                     label: "ThisIsAReallyLongTitleWithoutAnySpacesInIt",
+                     maxWidth: "300px"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      },
+      {
+         name: "aikauTesting/TestCoverageResults"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses issue https://issues.alfresco.com/jira/browse/AKU-150 where long site names caused display issues on narrow browsers. This has been implemented by permitting a new maxWidth property to be passed through to the alfresco/header/Title control.