### PR TITLE
AKU-164: Added more specific CSS selector to ensure that it "wins"

### DIFF
--- a/aikau/src/main/resources/alfresco/header/css/SearchBox.css
+++ b/aikau/src/main/resources/alfresco/header/css/SearchBox.css
@@ -143,7 +143,7 @@
 }
 
 /* This overrides the header menu bar settings to ensure that the popup menu item is the right height */
-.alfresco-share .alfresco-header-SearchBox-menu .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
+.alfresco-share .alfresco-header-SearchBox-menu .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
     height: 16px;
     margin-top: 0;
     margin-left: -2px;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-164. It makes the SearchBox selector for setting height of menu items more specific to ensure that the correct height is maintained when the SearchBox is used inside the alfresco/header/Header layout widget.