### PR TITLE
AKU-171: Updated test page to use localization for fixed options

### DIFF
--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
@@ -44,8 +44,8 @@ model.jsonModel = {
                         changesTo: "INVALID_DATA",
                         updateTopics: "INVALID_DATA",
                         fixed: [
-                           {label:"One",value:"1"},
-                           {label:"Two",value:"2"},
+                           {label:"select.test.fixed.option.one",value:"1"},
+                           {label:"select.test.fixed.option.two",value:"2"},
                            {value:"NO LABEL"},
                            {INVALID:"DATA"}
                         ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.properties
@@ -1,0 +1,2 @@
+select.test.fixed.option.one=One
+select.test.fixed.option.two=Two


### PR DESCRIPTION
This issue addresses https://issues.alfresco.com/jira/browse/AKU-171 it seems like the fixed options already do go through NLS processing, but I've updated the test page to add a WebScript properties file and make use of it. The existing test case already validates that the label is correct.