### PR TITLE
AKU-157: Updates to ensure that HiddenValue form control values can be set

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/HiddenValue.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/HiddenValue.js
@@ -24,14 +24,14 @@
  * capabilities of form controls so that additional data can be set as other fields are updated.
  *
  * @module alfresco/forms/controls/HiddenValue
- * @extends module:alfresco/forms/controls/DojoValidationTextBox
+ * @extends module:alfresco/forms/controls/TextBox
  * @author Dave Draper
  */
-define(["alfresco/forms/controls/DojoValidationTextBox",
+define(["alfresco/forms/controls/TextBox",
         "dojo/_base/declare"], 
-        function(DojoValidationTextBox, declare) {
+        function(TextBox, declare) {
    
-   return declare([DojoValidationTextBox], {
+   return declare([TextBox], {
       
       /**
        * Overrides the [inherited attribute]{@link module:alfresco/forms/controls/BaseFormControl#visibilityConfig} 
@@ -48,11 +48,9 @@ define(["alfresco/forms/controls/DojoValidationTextBox",
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_HiddenValue__getWidgetConfig() {
-         this.setValue(this.value);
          return {
             id : this.generateUuid(),
-            name: this.name,
-            value: ""
+            name: this.name
          };
       },
 
@@ -85,7 +83,15 @@ define(["alfresco/forms/controls/DojoValidationTextBox",
        * @param {object} value The value to set.
        */
       setValue: function alfresco_forms_controls_HiddenValue__setValue(value) {
-         this.___hiddenValue = value;
-      },
+         // this.___hiddenValue = value;
+         if (this.deferValueAssigment)
+         {
+            this.inherited(arguments);
+         }
+         else
+         {
+            this.___hiddenValue = value;
+         }
+      }
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
@@ -40,10 +40,6 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
       "Check the initial post (source field)": function () {
          return browser.findByCssSelector(".confirmationButton > span")
             .click()
@@ -65,6 +61,13 @@ define(["intern!object",
          return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden", ""))
             .then(function(elements) {
                assert(elements.length === 1, "Hidden field not posted correctly");
+            });
+      },
+
+      "Check the initial post (hidden field without auto set config)": function () {
+         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden2", "initial value"))
+            .then(function(elements) {
+               assert(elements.length === 1, "Second hidden field not posted correctly");
             });
       },
 
@@ -138,6 +141,19 @@ define(["intern!object",
          return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden", ""))
             .then(function(elements) {
                assert(elements.length === 1, "Hidden field not posted correctly");
+            });
+      },
+
+      "Check that hidden field value can be set by form value update": function() {
+         return browser.findByCssSelector("#SET_FORM_VALUE")
+            .click()
+         .end()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden2", "Value Set"))
+            .then(function(elements) {
+               assert(elements.length === 1, "Second hidden field not posted correctly");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/AutoSet.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/AutoSet.get.js
@@ -15,10 +15,25 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         id: "SET_FORM_VALUE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set Form Publication",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               hidden2: "Value Set"
+            }
+         }
+      },
+      {
          name: "alfresco/forms/Form",
          config: {
             okButtonPublishTopic: "POST_FORM",
+            setValueTopic: "SET_FORM_VALUE",
             scopeFormControls: false,
+            value: {
+               hidden2: "initial value"
+            },
             widgets: [
                {
                   id: "SOURCE",
@@ -79,15 +94,19 @@ model.jsonModel = {
                         }
                      ]
                   }
+               },
+               {
+                  id: "HIDDEN2",
+                  name: "alfresco/forms/controls/HiddenValue",
+                  config: {
+                     name: "hidden2"
+                  }
                }
             ]
          }
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-157 and ensures that the alfresco/forms/controls/HiddenValue form control can be set initially and via form value update. The unit tests have been updated to verify.