### PR TITLE
AKU-174: Added a strict mode to BUILD payload generation

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/_PublishPayloadMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_PublishPayloadMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -204,6 +204,7 @@ define(["dojo/_base/declare",
             {
                var type = value.alfType;
                var property = value.alfProperty;
+               var strict = value.alfStrict;
 
                if (type === "item" && currentItem)
                {
@@ -216,6 +217,20 @@ define(["dojo/_base/declare",
                else
                {
                   this.alfLog("warn", "A payload was defined with 'alfType' and 'alfProperty' attributes but the 'alfType' attribute was neither 'item' nor 'payload' (which are the only supported types), or the target object was null", this);
+               }
+
+               // If the target value can't be found then issue a warning or throw an error depending on the alfStrict setting
+               if (value === undefined)
+               {
+                  var msg = "A BUILD payload was defined referencing an attribute that doens't exist. Tried to use property '" + property + "' in type'" + type;
+                  if (strict === true)
+                  {
+                     throw new Error(msg);
+                  }
+                  else
+                  {
+                     this.alfLog("warn", msg, this);
+                  }
                }
             }
             else

--- a/aikau/src/test/resources/alfresco/core/PublishPayloadMixinTest.js
+++ b/aikau/src/test/resources/alfresco/core/PublishPayloadMixinTest.js
@@ -226,6 +226,13 @@ define(["intern!object",
             });
       },
 
+      "Check that BUILD type with strict rules and failing data doens't render": function() {
+         return browser.findAllByCssSelector("#PA_BUILD_FAIL")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The strict BUILD type with invalid data should not have been rendered");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/PublishPayloadMixin.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/PublishPayloadMixin.get.js
@@ -106,6 +106,28 @@ model.jsonModel = {
                   }
                },
                {
+                  id: "PA_BUILD_FAIL",
+                  name: "alfresco/renderers/PublishAction",
+                  config: {
+                     currentItem: {
+                        mixinData5: "mixinValue7"
+                     },
+                     publishTopic: "TOPIC7",
+                     publishPayloadType: "BUILD",
+                     publishPayload: {
+                        itemData: {
+                           alfType: "item",
+                           alfProperty: "mixinData5"
+                        },
+                        missingData: {
+                           alfType: "item",
+                           alfProperty: "not_there",
+                           alfStrict: true
+                        }
+                     }
+                  }
+               },
+               {
                   id: "PROPERTYLINK",
                   name: "alfresco/renderers/PropertyLink",
                   config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-174. It adds the option to make enforce strict existence of data (by setting the "alfStrict" attribute).