### PR TITLE
AKU-176: Ensure that form dialog honours contentWidth and contentHeight

### DIFF
--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -339,6 +339,8 @@ define(["dojo/_base/declare",
             parentPubSubScope: config.parentPubSubScope,
             additionalCssClasses: config.additionalCssClasses ? config.additionalCssClasses : "",
             suppressCloseClasses: suppressCloseClasses,
+            contentWidth: config.contentWidth ? config.contentWidth : null,
+            contentHeight: config.contentHeight ? config.contentHeight : null,
             widgetsContent: [formConfig],
             widgetsButtons: [
                   {

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -147,6 +147,24 @@ define(["intern!object",
             });
       },
 
+      "Check that form dialog dimensions can be set": function() {
+         return closeAllDialogs()
+            .then(function() {
+               return browser.findById("CREATE_FORM_DIALOG")
+                  .click()
+               .end()
+               .findByCssSelector("#FD2 .dialog-body")
+                  .getComputedStyle("width")
+                     .then(function(width) {
+                        assert.equal(width, "700px", "Width was not set correctly");
+                     })
+                  .getComputedStyle("height")
+                     .then(function(height) {
+                        assert.equal(height, "300px", "Height was not set correctly");
+                     });
+            });
+      },
+
       "Dialog is closed when dialogCloseTopic is set": function() {
          return closeAllDialogs()
             .then(function() {
@@ -195,6 +213,23 @@ define(["intern!object",
             });
       },
 
+      "Check that non-form dialog dimensions can be set": function() {
+         return closeAllDialogs()
+            .then(function() {
+               return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
+                  .click()
+               .end()
+               .findByCssSelector("#OUTER_DIALOG .dialog-body")
+                  .getComputedStyle("width")
+                     .then(function(width) {
+                        assert.equal(width, "600px", "Width was not set correctly");
+                     })
+                  .getComputedStyle("height")
+                     .then(function(height) {
+                        assert.equal(height, "400px", "Height was not set correctly");
+                     });
+            });
+      },
 
       "Can launch dialog within dialog": function() {
          return closeAllDialogs()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -56,6 +56,8 @@ model.jsonModel = {
                formSubmissionPayloadMixin: {
                   bonusData: "test"
                },
+               contentWidth: "700px",
+               contentHeight: "300px",
                widgets: [
                   {
                      id: "TB2",
@@ -78,6 +80,8 @@ model.jsonModel = {
             publishPayload: {
                dialogTitle: "Outer dialog",
                dialogId: "OUTER_DIALOG",
+               contentWidth: "600px",
+               contentHeight: "400px",
                widgetsContent: [
                   {
                      name: "alfresco/buttons/AlfButton",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-176 which reports that only non-form dialogs were honouring the contentWidth and contentHeight payload configuration. This has been fixed and the unit test updated to verify and prevent future regressions.