### PR TITLE
Dialog display updates

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -181,7 +181,7 @@ define(["dojo/_base/declare",
             this.creatingButtons = true;
             this.buttonsNode = domConstruct.create("div", {
                "class" : "footer"
-            }, this.containerNode.parentNode, "last");
+            }, this.containerNode, "last");
             this.processWidgets(this.widgetsButtons, this.buttonsNode);
             this.creatingButtons = false;
          }

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -173,6 +173,13 @@ define(["dojo/_base/declare",
             height: this.contentHeight ? this.contentHeight: null
          });
 
+         if (sniff("ie") === 8 || sniff("ie") === 9)
+         {
+            // Add specific classes for IE8 and 9 to undo the CSS calculations and selectors
+            // that make the footer always visible (because they don't support CSS calc)...
+            domClass.add(this.domNode, "iefooter");
+         }
+
          // It is important to create the buttons BEFORE creating the main body. This is especially important
          // for when the buttons will respond to initial setup events from a form placed inside the body (e.g.
          // so that the buttons are disabled initially if required)

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -42,6 +42,12 @@
    height: ~"calc(100% - 50px)";
 }
 
+.alfresco-dialog-AlfDialog.iefooter .dialog-body {
+   padding: 12px;
+   overflow: hidden;
+   height: auto;
+}
+
 .alfresco-dialog-AlfDialog.no-padding .dialog-body {
    padding: 0px;
 }
@@ -86,7 +92,12 @@
    padding: 8px 0;
    width: 100%;
    position: absolute;
-   bottom: 0px;
+   bottom: 0;
+}
+
+.alfresco-dialog-AlfDialog.iefooter .footer {
+   position: inherit;
+   bottom: inherit;
 }
 
 .alfresco-dialog-AlfDialog.no-padding .footer {

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -38,7 +38,8 @@
 
 .alfresco-dialog-AlfDialog .dialog-body {
    padding: 12px;
-   overflow: hidden;
+   overflow: auto;
+   height: ~"calc(100% - 50px)";
 }
 
 .alfresco-dialog-AlfDialog.no-padding .dialog-body {
@@ -84,6 +85,8 @@
    text-align: center;
    padding: 8px 0;
    width: 100%;
+   position: absolute;
+   bottom: 0px;
 }
 
 .alfresco-dialog-AlfDialog.no-padding .footer {


### PR DESCRIPTION
Ensure that footer is always displayed on the dialog and overflow is handled appropriately. This undoes the change made in #112 (which prevented the tab key from getting to the dialog buttons) but addresses the issue of making the footer always visible through CSS.