### PR TITLE
AKU-177: Inline comments scoping

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedView.js
@@ -67,7 +67,10 @@ define(["dojo/_base/declare",
        * @type {object[]}
        */
       widgets: [{
-         name: "alfresco/documentlibrary/views/AlfDetailedViewItem"
+         name: "alfresco/documentlibrary/views/AlfDetailedViewItem",
+         config: {
+            generatePubSubScope: true
+         }
       }]
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/VerticalReveal.js
+++ b/aikau/src/main/resources/alfresco/layout/VerticalReveal.js
@@ -131,7 +131,13 @@ define(["alfresco/core/ProcessWidgets",
             this.processWidgets(this.widgets, this.containerNode);
             this._processedWidgetsToReveal = true;
          }
-         domClass.toggle(this.contentNode, "reveal");
+         var maxHeight = domStyle.get(this.contentNode, "maxHeight"),
+            isExpanded = !isNaN(maxHeight) && maxHeight > 0;
+         if (isExpanded) {
+            domStyle.set(this.contentNode, "maxHeight", 0);
+         } else {
+            domStyle.set(this.contentNode, "maxHeight", this.contentNode.scrollHeight + "px");
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/css/VerticalReveal.css
+++ b/aikau/src/main/resources/alfresco/layout/css/VerticalReveal.css
@@ -1,23 +1,15 @@
 .alfresco-layout-VerticalReveal {
-   
-}
-
-.alfresco-layout-VerticalReveal > div.toggle.hidden {
-   display: none;
-}
-
-.alfresco-layout-VerticalReveal > div.content {
-   max-height: 0;
-   overflow: hidden;
-   transition: max-height 1s ease;
-}
-
-.alfresco-layout-VerticalReveal > div.content > div {
-   border: 1px solid #ccc;
-   padding: 5px;
-   margin: 5px;
-}
-
-.alfresco-layout-VerticalReveal > div.content.reveal {
-   max-height: 1000px;
+   > .toggle.hidden {
+      display: none;
+   }
+   > .content {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height .7s cubic-bezier(0,.5,0,1);
+      > div {
+         border: 1px solid #ccc;
+         margin: 5px;
+         padding: 5px;
+      }
+   }
 }

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
@@ -62,8 +62,8 @@ define(["intern!object",
       "Version only appears on hover": function() {
          return browser.findByCssSelector(".detail-item__version .value")
             .isDisplayed()
-            .then(function(versionDisplayed) {
-               assert.isFalse(versionDisplayed, "Version information visible without hovering");
+            .then(function(displayed) {
+               assert.isFalse(displayed, "Version information visible without hovering");
             })
             .end()
 
@@ -73,8 +73,8 @@ define(["intern!object",
 
          .findByCssSelector(".detail-item__version .value")
             .isDisplayed()
-            .then(function(versionDisplayed) {
-               assert.isTrue(versionDisplayed, "Version information not visible when hovering");
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Version information not visible when hovering");
             })
             .end()
 
@@ -84,8 +84,8 @@ define(["intern!object",
 
          .findByCssSelector(".detail-item__version .value")
             .isDisplayed()
-            .then(function(versionDisplayed) {
-               assert.isFalse(versionDisplayed, "Version information visible when no longer hovering");
+            .then(function(displayed) {
+               assert.isFalse(displayed, "Version information visible when no longer hovering");
             });
       },
 
@@ -183,6 +183,25 @@ define(["intern!object",
          .findAllByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(3) .detail-item__size, .alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(4) .detail-item__size")
             .then(function(elements) {
                assert.lengthOf(elements, 2, "Size widgets not created for correct items");
+            });
+      },
+
+      "Clicking the comments link only opens the comments for that item": function() {
+         return browser.findByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(1) .comment-link")
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(1) .detail-item__commentsReveal > .content")
+            .getSize()
+            .then(function(size) {
+               assert.notEqual(size.height, 0, "Comments not expanded for chosen item");
+            })
+            .end()
+
+         .findByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(2) .detail-item__commentsReveal > .content")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, 0, "Comments expanded for incorrect item");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/layout/VerticalRevealTest.js
+++ b/aikau/src/test/resources/alfresco/layout/VerticalRevealTest.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a unit test for the VerticalReveal widget
+ *
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, require, TestCommon) {
+
+      var browser;
+      registerSuite({
+         name: "VerticalReveal tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/VerticalReveal", "VerticalReveal Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Content is hidden on load": function() {
+            return browser.findAllByCssSelector(".alfresco-layout-VerticalReveal .content")
+               .getSize()
+               .then(function(size) {
+                  var contentHeight = (size && size.height) || 0;
+                  assert.equal(contentHeight, 0, "Content was visible at page-load");
+               });
+         },
+
+         "Content is displayed when toggled": function() {
+            return browser.findById("TOGGLE_LOGO")
+               .click()
+               .sleep(1000)
+               .end()
+
+            .screenie() // Allow visual checking of content appearing
+
+            .findByCssSelector(".alfresco-layout-VerticalReveal .content")
+               .getSize()
+               .then(function(size) {
+                  assert(size.height > 0, "Content was not revealed on button click");
+               });
+         },
+
+         "Content is hidden when toggled again": function() {
+            return browser.findById("TOGGLE_LOGO")
+               .click()
+               .sleep(1000)
+               .end()
+
+            .screenie() // Allow visual checking of content hiding
+
+            .findByCssSelector(".alfresco-layout-VerticalReveal .content")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 0, "Content was not hidden on second button click");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/logo/LogoTest"
+      "src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest"
    ],
 
    /**

--- a/aikau/src/test/resources/reporters/AikauReporter.js
+++ b/aikau/src/test/resources/reporters/AikauReporter.js
@@ -219,8 +219,22 @@ define([], function() {
                   console.log("- " + item.state.test);
                   console.log("  \"" + item.message + "\"");
                } else {
-                  // This should be a stacktrace
-                  console.log("- " + item.message);
+                  // This should be a stacktrace ... if it is, format specially
+                  var alfrescoTestPath = "test/resources/alfresco",
+                     resultMessage = item.message,
+                     isStacktrace = resultMessage.indexOf(alfrescoTestPath) !== -1,
+                     stacktraceLines;
+                  if (isStacktrace) {
+                     stacktraceLines = resultMessage.split("\n");
+                     resultMessage = stacktraceLines.map(function(line, lineIndex) {
+                        if (lineIndex && line.indexOf(alfrescoTestPath) === -1) {
+                           return ANSI_COLORS.Dim + line + ANSI_COLORS.Reset;
+                        } else {
+                           return line;
+                        }
+                     }).join("\n");
+                  }
+                  console.log("- " + resultMessage);
                }
             });
          });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/VerticalReveal.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/VerticalReveal.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>VerticalReveal Test</shortname>
+  <description>This WebScript defines the VerticalReveal test page</description>
+  <family>aikau-unit-tests</family>
+  <url>/VerticalReveal</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/VerticalReveal.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/VerticalReveal.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/VerticalReveal.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/VerticalReveal.get.js
@@ -1,0 +1,37 @@
+model.jsonModel = {
+   services: [{
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/ActionService",
+      "alfresco/services/NavigationService",
+      "alfresco/services/SearchService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [{
+      name: "alfresco/buttons/AlfButton",
+      id: "TOGGLE_LOGO",
+      config: {
+         label: "Toggle logo display",
+         publishTopic: "ALF_REVEAL_LOGO"
+      }
+   }, {
+      name: "alfresco/layout/VerticalReveal",
+      config: {
+         subscriptionTopic: "ALF_REVEAL_LOGO",
+         widgets: [{
+            name: "alfresco/logo/Logo",
+            id: "ALFRESCO_LOGO"
+         }]
+      }
+   }, {
+      name: "alfresco/logging/SubscriptionLog"
+   }, {
+      name: "aikauTesting/TestCoverageResults"
+   }]
+};


### PR DESCRIPTION
This addresses issue https://issues.alfresco.com/jira/browse/AKU-177 which is about making sure only one comments list opens on the page at once in the AlfDetailedView widget. It also contains a tweak to the VerticalReveal behaviour, and a new test for that widget.