### PR TITLE
AKU-180: Pdf Preview Faults test

### DIFF
--- a/aikau/src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest.js
+++ b/aikau/src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest.js
@@ -202,7 +202,6 @@ define(["intern!object",
          return browser.findByCssSelector(".alfresco-dialog-AlfDialog")
             .isDisplayed()
             .then(function(displayed) {
-               TestCommon.log(testname,"Checking dialog is displayed");
                expect(displayed).to.equal(true, "Dialog should be displayed");
             });
       },
@@ -222,12 +221,11 @@ define(["intern!object",
             .click()
          .end()
 
-         .sleep(500)
+         .sleep(1000) // Allow time for the dialog to close and re-open
 
-         .findByCssSelector(".alfresco-dialog-AlfDialog")
-            .isDisplayed()
-            .then(function(displayed) {
-               expect(displayed).to.equal(true, "Dialog should be displayed");
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_CREATE_FORM_DIALOG_REQUEST", "publish", "any"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Another request for a dialog should have been made");
             });
       },
 
@@ -246,12 +244,11 @@ define(["intern!object",
             .click()
          .end()
 
-         .sleep(500)
+         .sleep(1000) // Allow time for the dialog to close and re-open
 
-         .findByCssSelector(".alfresco-dialog-AlfDialog")
-            .isDisplayed()
-            .then(function(displayed) {
-               expect(displayed).to.equal(true, "Dialog should be displayed");
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_CREATE_FORM_DIALOG_REQUEST", "publish", "any"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "Another request for a dialog should have been made");
             });
       },
 
@@ -270,7 +267,7 @@ define(["intern!object",
             .click()
          .end()
 
-         .sleep(500)
+         .sleep(1000) // Allow for successful password to be applied
 
          .findByCssSelector(".previewer > .controls")
             .isDisplayed()


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-180. I think that I've established that the cause of the intermittent failures was that the test was written in such a way that it relies on a specific time (500ms) being the correct delay between a faulty password being submitted and the password dialog being recreated. 

I've tried to improve this test by counting the number of request for dialogs to be created rather than whether or not the dialog is displayed at the precise moment its selected.