### PR TITLE
AKU-183: Unit test page list page

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -13,6 +13,7 @@
    <description>Aikau is a meta-framework for Alfresco specific UI development</description>
 
    <build>
+
       <!-- Everything gets place into the META-INF folder of the JAR because Surf (the expected platform for Aikau)
            will be able to access resources from that location via the /res/ path -->
       <resources>
@@ -74,26 +75,40 @@
 
       <plugins>
 
-        <plugin>
+         <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.8</version>
             <executions>
-                <execution>
-                    <id>duplicate-english-messages</id>
-                    <phase>generate-resources</phase>
-                    <goals>
-                        <goal>run</goal>
-                    </goals>
+               <execution>
+                  <id>duplicate-english-messages</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                     <goal>run</goal>
+                  </goals>
+                  <configuration>
+                     <target>
+                        <copy todir="${project.build.outputDirectory}/META-INF/js/aikau/${project.version}">
+                           <fileset dir="${basedir}/src/main/resources" includes="alfresco/**/*.properties" />
+                           <mapper from="^([^_]*).properties$" to="\1_en.properties" type="regexp" />
+                        </copy>
+                     </target>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>copy-webscript-beans</id>
+                  <phase>process-test-classes</phase>
+                  <goals>
+                     <goal>run</goal>
+                  </goals>
+                  <configuration>
+                     <target>
+                        <copy todir="${project.build.testOutputDirectory}/testApp/WEB-INF/classes">
+                           <fileset dir="${project.build.testOutputDirectory}" includes="**/*.class" />
+                        </copy>
+                      </target>
+                  </configuration>
                 </execution>
             </executions>
-            <configuration>
-                <target>
-                    <copy todir="${project.build.outputDirectory}/META-INF/js/aikau/${project.version}">
-                        <fileset dir="${basedir}/src/main/resources" includes="alfresco/**/*.properties" />
-                        <mapper from="^([^_]*).properties$" to="\1_en.properties" type="regexp" />
-                    </copy>
-                </target>
-            </configuration>
         </plugin>
 
         <plugin>

--- a/aikau/src/test/java/org/alfresco/aikau/UnitTestList.java
+++ b/aikau/src/test/java/org/alfresco/aikau/UnitTestList.java
@@ -1,0 +1,26 @@
+package org.alfresco.aikau;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.extensions.webscripts.DeclarativeWebScript;
+import org.springframework.extensions.webscripts.Path;
+import org.springframework.extensions.webscripts.Status;
+import org.springframework.extensions.webscripts.WebScriptException;
+import org.springframework.extensions.webscripts.WebScriptRequest;
+
+public class UnitTestList extends DeclarativeWebScript
+{
+
+    /* (non-Javadoc)
+     * @see org.springframework.extensions.webscripts.DeclarativeWebScript#executeImpl(org.springframework.extensions.webscripts.WebScriptRequest, org.springframework.extensions.webscripts.Status)
+     */
+    @Override
+    protected Map<String, Object> executeImpl(WebScriptRequest req, Status status)
+    {
+        Path path = getContainer().getRegistry().getFamily("/aikau-unit-tests");
+        Map<String, Object> model = new HashMap<String, Object>(7, 1.0f);
+        model.put("family", path);
+        return model;
+    }
+}

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Unit Test Index Page</shortname>
+  <description>The provides links to all the other unit test pages</description>
+  <family>aikau-unit-tests</family>
+  <url>/Index</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.js
@@ -1,0 +1,107 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService",
+      "alfresco/services/CrudService"
+   ],
+   widgets: [
+      {
+         id: "TDAC",
+         name: "alfresco/layout/TitleDescriptionAndContent",
+         config: {
+            title: "Aikau Unit Tests",
+            description: "This page provides links to all the Aikau unit test pages.",
+            widgets: [
+               {
+                  name: "alfresco/lists/AlfList",
+                  config: {
+                     loadDataPublishTopic: "ALF_CRUD_GET_ALL",
+                     loadDataPublishPayload: {
+                       url: "unitTestList",
+                       urlType: "SHARE"
+                     },
+                     itemsProperty: "unitTestPages",
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/AlfListView",
+                           config: {
+                              additionalCssClasses: "bordered",
+                              widgetsForHeader: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/HeaderCell",
+                                    config: {
+                                       label: "Name"
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/HeaderCell",
+                                    config: {
+                                       label: "Description"
+                                    }
+                                 }
+                              ],
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Row",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                additionalCssClasses: "mediumpad",
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/renderers/PropertyLink",
+                                                      config: {
+                                                         propertyToRender: "shortname",
+                                                         useCurrentItemAsPayload: false,
+                                                         publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                                                         publishPayloadType: "PROCESS",
+                                                         publishPayloadModifiers: ["processCurrentItemTokens"],
+                                                         publishPayload: {
+                                                            type: "SHARE_PAGE_RELATIVE",
+                                                            url: "tp/ws{url}"
+                                                         }
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          },
+                                          {
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                additionalCssClasses: "mediumpad",
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/renderers/Property",
+                                                      config: {
+                                                         propertyToRender: "description"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/UnitTestList.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/UnitTestList.get.desc.xml
@@ -1,0 +1,5 @@
+<webscript>
+  <shortname>List Unit Tests</shortname>
+  <url>/unitTestList</url>
+  <format default="json">argument</format>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/UnitTestList.get.json.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/UnitTestList.get.json.ftl
@@ -1,0 +1,14 @@
+
+{
+   "length": ${family.scripts?size},
+   "unitTestPages": [
+      <#list family.scripts as script>
+         <#assign desc = script.description>
+         {
+            "shortname": "${desc.shortName!""}",
+            "url": "${desc.URIs[0]}",
+            "description": "${desc.description!""}"
+         }<#if script_has_next>,</#if>
+         </#list>
+   ]
+}

--- a/aikau/src/test/resources/testApp/WEB-INF/config/web-application-config.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/config/web-application-config.xml
@@ -102,4 +102,7 @@
          </list>
       </property>
    </bean>
+
+   <bean id="webscript.alfresco.UnitTestList.get" class="org.alfresco.aikau.UnitTestList" parent="webscript" scope="prototype" />
+   
 </beans>


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-183. Rather than manually creating a page that would require updating, I've taken the approach of creating a Java backed WebScript to retrieve all the unit test WebScripts in the "/aikau-unit-tests" family.

Currently this new WebScript isn't supporting sorting or pagination, and many of the test page WebScripts will need to have their shortname and description fields updated. These are all outside of the scope of this issue though and can be addressed iteratively going forwards