### PR TITLE
AKU-3: Update config to allow Selenium Grid testing

### DIFF
--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -26,32 +26,13 @@
  */
 define(["intern/dojo/node!fs",
         "intern/dojo/node!http",
+        "intern/dojo/node!os",
         "config/Config",
         "intern/dojo/node!leadfoot/helpers/pollUntil",
         "intern/lib/args",
         "intern/chai!assert"],
-        function(fs, http, Config, pollUntil, args, assert) {
+        function(fs, http, os, Config, pollUntil, args, assert) {
    return {
-
-      /**
-       * Path configurations.
-       */
-      paths: {
-         bootstrapPath: "/share/page/tp/ws/unit-test-bootstrap",
-         moduleDeploymentPath: "/share/page/modules/deploy"
-      },
-
-      /**
-       * This is the URL to use to bootstrap tests. It is composed of the paths.bootstrapPath and the
-       * Config.urls.bootstrapBaseUrl which is provided in the config package.
-       *
-       * @instance
-       * @type {string}
-       * @default Config.url.bootstrapBaseUrl + this.paths.bootstrapPath
-       */
-      bootstrapUrl: function bootstrapUrl(){
-         return Config.urls.bootstrapBaseUrl + this.paths.bootstrapPath;
-      },
 
       /**
        * Generates the URL to use for loading unit test WebScripts
@@ -61,20 +42,13 @@ define(["intern/dojo/node!fs",
        * @param {string} webScriptPrefix Optional prefix to the test page.
        */
       testWebScriptURL: function (webScriptURL, webScriptPrefix) {
+         if (!Config.urls.unitTestAppBaseUrl) {
+            var testServer = "http://" + this._getLocalIP() + ":8089";
+            Config.urls.unitTestAppBaseUrl = testServer;
+            // console.log("Using test-server URL: " + testServer);
+         }
          var prefix = webScriptPrefix || "/tp/ws";
          return Config.urls.unitTestAppBaseUrl + "/aikau/page" + prefix + webScriptURL;
-      },
-
-      /**
-       * This is the URL to use to access the module deployment screen. It is composed of the
-       * paths.moduleDeploymentPath and the Config.urls.bootstrapBaseUrl which is provided in the config package.
-       *
-       * @instance
-       * @type {string}
-       * @default Config.url.bootstrapBaseUrl + this.paths.moduleDeploymentPath
-       */
-      moduleDeploymentUrl: function moduleDeploymentUrl(){
-         return Config.urls.moduleDeploymentBaseUrl + this.paths.moduleDeploymentPath;
       },
 
       /**
@@ -152,11 +126,6 @@ define(["intern/dojo/node!fs",
          this._applyTimeouts(browser);
          this._maxWindow(browser);
          this._cancelModifierKeys(browser);
-         // if(testName && browser.environmentType.browserName)
-         // {
-         //    console.log(">> Starting '" + testName + "' on " + browser.environmentType.browserName);
-         //    console.log("   Test URL: " + this.testWebScriptURL(testWebScriptURL, testWebScriptPrefix));
-         // }
          var command = browser.get(this.testWebScriptURL(testWebScriptURL, testWebScriptPrefix))
             .then(pollUntil(
                function() {
@@ -168,7 +137,7 @@ define(["intern/dojo/node!fs",
                function (element) {
                },
                function (error) {
-                  // console.log(">> Test page for '" + testName + "'  failed to load, trying again...");
+                  // Failed to load, trying again...
                   browser.refresh();
                })
             .then(pollUntil(
@@ -179,10 +148,10 @@ define(["intern/dojo/node!fs",
                }, [], 10000, 1000))
             .then(
                function (element) {
-                  // console.log(">> Test page for '" + testName + "' loaded successfully");
+                  // Loaded successfully
                },
                function (error) {
-                  // console.log(">> Test page for '" + testName + "'  failed to load after two attempts");
+                  // Failed to load after two attempts
                   assert.fail(null, null, "Test page could not be loaded");
                })
             .end();
@@ -222,6 +191,38 @@ define(["intern/dojo/node!fs",
          browser.setFindTimeout(Config.timeout.find);
          browser.setPageLoadTimeout(Config.timeout.pageLoad);
          browser.setExecuteAsyncTimeout(Config.timeout.executeAsync);
+      },
+
+      /**
+       * Get the local machine IP address (for us from other machines on the network). Specifically,
+       * it will pass back the first IPv4, external IP address whose name begins with an "e".
+       * 
+       * [MJD 2015-03-30] Hopefully this will be robust enough (examples seen = en0,en1,eth0,ethernet0)
+       *
+       * @instance
+       * @protected
+       * @returns  {string} The local IP address
+       */
+      _getLocalIP: function() {
+         var networkInterfaces = os.networkInterfaces(),
+            validNameRegex = /^e[a-z]+[0-9]$/i,
+            ipAddress = null;
+         Object.keys(networkInterfaces).every(function(interfaceName) {
+            if (validNameRegex.test(interfaceName)) {
+               networkInterfaces[interfaceName].every(function(interface) {
+                  if (interface.family === "IPv4" && !interface.internal) {
+                     ipAddress = interface.address;
+                     return false;
+                  }
+                  return true;
+               });
+            }
+            if (ipAddress) {
+               return false;
+            }
+            return true;
+         });
+         return ipAddress;
       },
 
       /**

--- a/aikau/src/test/resources/config/grid/Config.js
+++ b/aikau/src/test/resources/config/grid/Config.js
@@ -32,9 +32,7 @@ define({
     * @type {object}
     */
    urls: {
-      bootstrapBaseUrl: "http://localhost:8081",
-      moduleDeploymentBaseUrl: "http://admin:admin@localhost:8081",
-      unitTestAppBaseUrl: "http://localhost:8089"
+      unitTestAppBaseUrl: null
    },
 
    /**

--- a/aikau/src/test/resources/config/loc/Config.js
+++ b/aikau/src/test/resources/config/loc/Config.js
@@ -32,8 +32,6 @@ define({
     * @type {object}
     */
    urls: {
-      bootstrapBaseUrl: "http://localhost:8081",
-      moduleDeploymentBaseUrl: "http://admin:admin@localhost:8081",
       unitTestAppBaseUrl: "http://localhost:8089"
    },
 

--- a/aikau/src/test/resources/config/sl/Config.js
+++ b/aikau/src/test/resources/config/sl/Config.js
@@ -32,8 +32,6 @@ define({
     * @type {object}
     */
    urls: {
-      bootstrapBaseUrl: "http://localhost:8081",
-      moduleDeploymentBaseUrl: "http://admin:admin@localhost:8081",
       unitTestAppBaseUrl: "http://localhost:8089"
    },
 

--- a/aikau/src/test/resources/config/vm/Config.js
+++ b/aikau/src/test/resources/config/vm/Config.js
@@ -32,8 +32,6 @@ define({
     * @type {object}
     */
    urls: {
-      bootstrapBaseUrl: "http://192.168.56.1:8081",
-      moduleDeploymentBaseUrl: "http://admin:admin@192.168.56.1:8081",
       unitTestAppBaseUrl: "http://192.168.56.1:8089"
    },
 

--- a/aikau/src/test/resources/intern_grid.js
+++ b/aikau/src/test/resources/intern_grid.js
@@ -1,75 +1,86 @@
 // Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
-define(["./config/Suites"], 
-       function (Suites) {
-   return {
+define(["./config/Suites"],
+   function(Suites) {
+      return {
 
-      // The port on which the instrumenting proxy will listen
-      proxyPort: 9000,
+         // The port on which the instrumenting proxy will listen
+         proxyPort: 9000,
 
-      // A fully qualified URL to the Intern proxy
-      proxyUrl: 'http://localhost:9000/',
+         // A fully qualified URL to the Intern proxy
+         proxyUrl: "http://localhost:9000/",
 
-      // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
-      // specified browser environments in the `environments` array below as well. See
-      // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
-      // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
-      // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
-      // automatically
-      capabilities: {
-         'selenium-version': '2.43.0'
-      },
+         // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
+         // specified browser environments in the `environments` array below as well. See
+         // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
+         // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
+         // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
+         // automatically
+         capabilities: {
+            "selenium-version": "2.45.0"
+         },
 
-      // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
-      // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
-      // capabilities options specified for an environment will be copied as-is
-      environments: [
-         { browserName: 'chrome' },
-         { browserName: 'firefox' }
-//         ,
-//         { browserName: 'internet explorer' }
-      ],
+         // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+         // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+         // capabilities options specified for an environment will be copied as-is
+         environments: [{
+            browserName: "chrome",
+            chromeOptions: {
+               excludeSwitches: ["ignore-certificate-errors"]
+            }
+         }, {
+            browserName: "firefox"
+         }, {
+            browserName: "internet explorer"
+         }],
 
-      // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-      maxConcurrency: 1,
+         // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+         maxConcurrency: 1,
 
-      // Whether or not to start Sauce Connect before running tests
-      useSauceConnect: false,
+         // Whether or not to start Sauce Connect before running tests
+         useSauceConnect: false,
 
-      // Connection information for the remote WebDriver service. If using Sauce Labs, keep your username and password
-      // in the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables unless you are sure you will NEVER be
-      // publishing this configuration file somewhere
-      tunnelOptions: {
-         hostname: 'localhost',
-         port: 4444
-      },
+         // Connection information for the remote WebDriver service. If using Sauce Labs, keep your username and password
+         // in the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables unless you are sure you will NEVER be
+         // publishing this configuration file somewhere
+         tunnelOptions: {
+            hostname: "pqat03.alfresco.com",
+            port: 4449
+         },
 
-      // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
-      // used here
-      loader: {
-         // Packages that should be registered with the loader in each testing environment
-         // Note: the config package is specifically for grid machine (grid)
-         packages: [
-            { name: 'alfresco', location: './src/test/resources/alfresco' },
-            { name: 'config', location: './src/test/resources/config/grid' }
+         // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
+         // used here
+         loader: {
+            // Packages that should be registered with the loader in each testing environment
+            // Note: the config package is specifically for grid machine (grid)
+            packages: [{
+               name: "alfresco",
+               location: "./src/test/resources/alfresco"
+            }, {
+               name: "config",
+               location: "./src/test/resources/config/grid"
+            }, {
+               name: "reporters",
+               location: "./src/test/resources/reporters"
+            }]
+         },
+
+         // Non-functional test suite(s) to run in each browser
+         suites: Suites.nonFunctionalSuites,
+
+         // Functional test suite(s) to run in each browser once non-functional tests are completed
+         functionalSuites: Suites.gridFunctionalSuites(),
+
+         // A regular expression matching URLs to files that should not be included in code coverage analysis
+         excludeInstrumentation: /^(?:tests|node_modules)\//,
+
+         // An array of code coverage reporters to invoke
+         reporters: [
+            // "console",
+            // "runner",
+            "reporters/AikauReporter"
          ]
-      },
 
-      // Non-functional test suite(s) to run in each browser
-      suites: Suites.nonFunctionalSuites,
-
-      // Functional test suite(s) to run in each browser once non-functional tests are completed
-      functionalSuites: Suites.gridFunctionalSuites(),
-
-      // A regular expression matching URLs to files that should not be included in code coverage analysis
-      excludeInstrumentation: /^(?:tests|node_modules)\//,
-   
-      // An array of code coverage reporters to invoke
-      reporters: [
-         'console',
-         'runner'
-      ]
-
-   };
-});
+      };
+   });

--- a/aikau/src/test/resources/intern_local.js
+++ b/aikau/src/test/resources/intern_local.js
@@ -1,79 +1,84 @@
 // Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
-define(["./config/Suites"], 
-       function (Suites) {
-   return {
+define(["./config/Suites"],
+   function(Suites) {
+      return {
 
-      // The port on which the instrumenting proxy will listen
-      proxyPort: 9000,
+         // The port on which the instrumenting proxy will listen
+         proxyPort: 9000,
 
-      // A fully qualified URL to the Intern proxy
-      proxyUrl: 'http://localhost:9000/',
+         // A fully qualified URL to the Intern proxy
+         proxyUrl: "http://localhost:9000/",
 
-      // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
-      // specified browser environments in the `environments` array below as well. See
-      // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
-      // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
-      // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
-      // automatically
-      capabilities: {
-         'selenium-version': '2.44.0'
-      },
+         // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
+         // specified browser environments in the `environments` array below as well. See
+         // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
+         // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
+         // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
+         // automatically
+         capabilities: {
+            "selenium-version": "2.45.0"
+         },
 
-      // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
-      // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
-      // capabilities options specified for an environment will be copied as-is
-      environments: [
-         {
-            browserName: 'chrome',
+         // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+         // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+         // capabilities options specified for an environment will be copied as-is
+         environments: [{
+            browserName: "chrome",
             chromeOptions: {
-               excludeSwitches: ['ignore-certificate-errors']
+               excludeSwitches: ["ignore-certificate-errors"]
             }
-         }//,
-         // { browserName: 'firefox' }//,
-         // { browserName: 'ie' }
-      ],
+         }, {
+            browserName: "firefox"
+         // }, {
+         //    browserName: "ie"
+         }],
 
-      // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-      maxConcurrency: 1,
+         // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+         maxConcurrency: 1,
 
-      // Dig Dug tunnel handler
-      tunnel: 'NullTunnel',
+         // Dig Dug tunnel handler
+         tunnel: "NullTunnel",
 
-      // Dig Dug tunnel options
-      tunnelOptions: {
-         hostname: 'localhost',
-         port: 4444
-      },
+         // Dig Dug tunnel options
+         tunnelOptions: {
+            hostname: "localhost",
+            port: 4444
+         },
 
-      // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
-      // used here
-      loader: {
-         // Packages that should be registered with the loader in each testing environment
-	      // Note: the config package is specifically for local (loc)
-         packages: [
-            { name: 'alfresco', location: './src/test/resources/alfresco' },
-            { name: 'config', location: './src/test/resources/config/loc' },
-            { name: 'reporters', location: './src/test/resources/reporters'}
+         // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
+         // used here
+         loader: {
+            // Packages that should be registered with the loader in each testing environment
+            // Note: the config package is specifically for local (loc)
+            packages: [{
+               name: "alfresco",
+               location: "./src/test/resources/alfresco"
+            }, {
+               name: "config",
+               location: "./src/test/resources/config/loc"
+            }, {
+               name: "reporters",
+               location: "./src/test/resources/reporters"
+            }]
+         },
+
+         // Non-functional test suite(s) to run in each browser
+         suites: Suites.nonFunctionalSuites,
+
+         // Functional test suite(s) to run in each browser once non-functional tests are completed
+         functionalSuites: Suites.localFunctionalSuites(),
+
+         // A regular expression matching URLs to files that should not be included in code coverage analysis
+         excludeInstrumentation: /^(?:tests|node_modules)\//,
+
+         // An array of code coverage reporters to invoke
+         reporters: [
+            // "console",
+            // "runner",
+            "reporters/AikauReporter"
          ]
-      },
 
-      // Non-functional test suite(s) to run in each browser
-      suites: Suites.nonFunctionalSuites,
-
-      // Functional test suite(s) to run in each browser once non-functional tests are completed
-      functionalSuites: Suites.localFunctionalSuites(),
-
-      // A regular expression matching URLs to files that should not be included in code coverage analysis
-      excludeInstrumentation: /^(?:tests|node_modules)\//,
-   
-      // An array of code coverage reporters to invoke
-      reporters: [
-         // 'console',
-         // 'runner',
-         'reporters/TestSummary'
-      ]
-
-   };
-});
+      };
+   });


### PR DESCRIPTION
This addresses issue https://issues.alfresco.com/jira/browse/AKU-3 which requires support for Selenium Grid testing our unit tests. The intern config for the grid has been updated, redundant properties have been removed from all testing code (e.g. bootstrapBaseUrl and moduleDeploymentBaseUrl), and the AikauReporter has been updated to handle Grid errors/output.