### PR TITLE
Updated the unit test list service and page to support pagination

### DIFF
--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -141,7 +141,7 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This function can be used to append the supplied querty parameter name and value onto the 
+       * This function can be used to append the supplied query parameter name and value onto the 
        * supplied URL string which is then returned.
        * 
        * @param {string} url The url to update

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -141,6 +141,27 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * This function can be used to append the supplied querty parameter name and value onto the 
+       * supplied URL string which is then returned.
+       * 
+       * @param {string} url The url to update
+       * @param {string} param The name of the query parameter
+       * @param {string} value The value of the query parameter
+       * @returns {string} The updated URL
+       */
+      addQueryParameter: function alfresco_services_CrudService__addQueryParameter(url, param, value) {
+         if (url.indexOf("?") === -1)
+         {
+            url += "?";
+         }
+         else
+         {
+            url += "&";
+         }
+         return url += param + "=" + value;
+      },
+
+      /**
        * Makes a GET request to the Repository using the 'url' attribute provided in the payload passed
        * in the publication on the topic that this function subscribes to. The 'url' is expected to be a
        * Repository WebScript URL and should not include the Repository proxy stem.
@@ -150,6 +171,16 @@ define(["dojo/_base/declare",
        */
       onGetAll: function alfresco_services_CrudService__onGetAll(payload) {
          var url = this.getUrlFromPayload(payload);
+
+         if (payload.pageSize)
+         {
+            url = this.addQueryParameter(url, "pageSize", payload.pageSize);
+         }
+         if (payload.page)
+         {
+            url = this.addQueryParameter(url, "page", payload.page);
+         }
+         
          if (url) {
             this.serviceXhr({
                url: url,

--- a/aikau/src/test/java/org/alfresco/aikau/UnitTestList.java
+++ b/aikau/src/test/java/org/alfresco/aikau/UnitTestList.java
@@ -20,6 +20,7 @@ import org.springframework.extensions.webscripts.WebScriptRequest;
  */
 public class UnitTestList extends DeclarativeWebScript
 {
+   @Override
    protected Map<String, Object> executeImpl(WebScriptRequest req, Status status)
    {
       Path path = getContainer().getRegistry().getFamily("/aikau-unit-tests");
@@ -30,7 +31,7 @@ public class UnitTestList extends DeclarativeWebScript
       {
          try
          {
-             ps = Integer.parseInt(pageSize);
+             ps = Integer.parseInt(pageSize, 10);
          }
          catch (NumberFormatException e)
          {
@@ -43,7 +44,7 @@ public class UnitTestList extends DeclarativeWebScript
       {
          try
          {
-             int p = Integer.parseInt(page);
+             int p = Integer.parseInt(page, 10);
              si = (p - 1) * ps;
          }
          catch (NumberFormatException e)
@@ -54,11 +55,11 @@ public class UnitTestList extends DeclarativeWebScript
         
       List<WebScript> webscripts = Arrays.asList(path.getScripts());
       Collections.sort(webscripts, new UnitTestList.WebScriptComparator());
-      WebScript[] websscriptsArr = new WebScript[webscripts.size()];
-      webscripts.toArray(websscriptsArr);
-      websscriptsArr = Arrays.copyOfRange(websscriptsArr, si, ps + si);
+      WebScript[] webscriptsArr = new WebScript[webscripts.size()];
+      webscripts.toArray(webscriptsArr);
+      webscriptsArr = Arrays.copyOfRange(webscriptsArr, si, ps + si);
       Map<String, Object> model = new HashMap<String, Object>(7, 1.0f);
-      model.put("scripts", websscriptsArr);
+      model.put("scripts", webscriptsArr);
       model.put("totalRecords", webscripts.size());
       model.put("startIndex", si);
       return model;

--- a/aikau/src/test/java/org/alfresco/aikau/UnitTestList.java
+++ b/aikau/src/test/java/org/alfresco/aikau/UnitTestList.java
@@ -1,26 +1,91 @@
 package org.alfresco.aikau;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.extensions.webscripts.DeclarativeWebScript;
 import org.springframework.extensions.webscripts.Path;
 import org.springframework.extensions.webscripts.Status;
+import org.springframework.extensions.webscripts.WebScript;
 import org.springframework.extensions.webscripts.WebScriptException;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 
+/**
+ * A Java controller for a WebScript that retrieves the details of the Aikau unit test
+ * WebScript pages.
+ */
 public class UnitTestList extends DeclarativeWebScript
 {
+   protected Map<String, Object> executeImpl(WebScriptRequest req, Status status)
+   {
+      Path path = getContainer().getRegistry().getFamily("/aikau-unit-tests");
 
-    /* (non-Javadoc)
-     * @see org.springframework.extensions.webscripts.DeclarativeWebScript#executeImpl(org.springframework.extensions.webscripts.WebScriptRequest, org.springframework.extensions.webscripts.Status)
-     */
-    @Override
-    protected Map<String, Object> executeImpl(WebScriptRequest req, Status status)
-    {
-        Path path = getContainer().getRegistry().getFamily("/aikau-unit-tests");
-        Map<String, Object> model = new HashMap<String, Object>(7, 1.0f);
-        model.put("family", path);
-        return model;
-    }
+      int ps = 25;
+      String pageSize = req.getParameter("pageSize");
+      if (pageSize != null)
+      {
+         try
+         {
+             ps = Integer.parseInt(pageSize);
+         }
+         catch (NumberFormatException e)
+         {
+             // No action required
+         }
+      }
+      int si = 0;
+      String page = req.getParameter("page");
+      if (page != null)
+      {
+         try
+         {
+             int p = Integer.parseInt(page);
+             si = (p - 1) * ps;
+         }
+         catch (NumberFormatException e)
+         {
+             // No action required
+         }
+      }
+        
+      List<WebScript> webscripts = Arrays.asList(path.getScripts());
+      Collections.sort(webscripts, new UnitTestList.WebScriptComparator());
+      WebScript[] websscriptsArr = new WebScript[webscripts.size()];
+      webscripts.toArray(websscriptsArr);
+      websscriptsArr = Arrays.copyOfRange(websscriptsArr, si, ps + si);
+      Map<String, Object> model = new HashMap<String, Object>(7, 1.0f);
+      model.put("scripts", websscriptsArr);
+      model.put("totalRecords", webscripts.size());
+      model.put("startIndex", si);
+      return model;
+   }
+
+   private class WebScriptComparator implements Comparator<WebScript>
+   {
+      public int compare(WebScript ws1, WebScript ws2)
+      {
+         int r = 0;
+         if (ws1 == null && ws2 == null)
+         {
+            r = 0;
+         }
+         else if (ws1 != null && ws2 == null)
+         {
+            r = -1;
+         }
+         else if (ws1 == null && ws2 != null)
+         {
+            r = 1;
+         }
+         else
+         {
+            r = ws1.getDescription().getShortName().compareTo(ws2.getDescription().getShortName());
+         }
+         return r;
+      }
+   }
 }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.js
@@ -23,7 +23,13 @@ model.jsonModel = {
             description: "This page provides links to all the Aikau unit test pages.",
             widgets: [
                {
-                  name: "alfresco/lists/AlfList",
+                 name: "alfresco/lists/Paginator",
+                 config: {
+                   documentsPerPage: 25
+                 }
+               },
+               {
+                  name: "alfresco/lists/AlfSortablePaginatedList",
                   config: {
                      loadDataPublishTopic: "ALF_CRUD_GET_ALL",
                      loadDataPublishPayload: {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/UnitTestList.get.json.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/UnitTestList.get.json.ftl
@@ -1,14 +1,19 @@
 
 {
-   "length": ${family.scripts?size},
+   "totalRecords": ${totalRecords},
+   "startIndex": ${startIndex},
    "unitTestPages": [
-      <#list family.scripts as script>
+      <#assign count = 0>
+      <#list scripts as script>
+         <#if script?is_hash>
          <#assign desc = script.description>
+         <#if count != 0>,</#if>
          {
             "shortname": "${desc.shortName!""}",
             "url": "${desc.URIs[0]}",
             "description": "${desc.description!""}"
-         }<#if script_has_next>,</#if>
-         </#list>
+         }<#assign count = count + 1>
+         </#if>
+      </#list>
    ]
 }

--- a/aikau/src/test/resources/testApp/index.jsp
+++ b/aikau/src/test/resources/testApp/index.jsp
@@ -1,0 +1,2 @@
+<%@ page session="false" %>
+<% response.sendRedirect("page/tp/ws/Index"); %>


### PR DESCRIPTION
These changes improve the initial unit test index page implemented for AKU-183 by sorting on WebScript shortname and providing pagination support.