### PR TITLE
AKU-150: Updated CSS for title bar

### DIFF
--- a/aikau/src/main/resources/alfresco/header/css/Title.css
+++ b/aikau/src/main/resources/alfresco/header/css/Title.css
@@ -19,7 +19,10 @@
       border-bottom: 1px solid #ccc;
       > div {
          background-color: #fafafa;
-         height: 67px;
+
+         .right-widgets {
+            height: 67px;
+         }
       }
    }
 }


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-150. Unfortunately this is an issue where we really should have a Share specific title bar widget (that extends LeftAndRightWidgets) but unfortunately we've somewhat ended up with Share specific styling in the CSS. This definitely fixes the issue, but if I have time later in the sprint I might revisit and add a new title widget for use in Share and other clients. If not I'll raise an issue to address in a future sprint.