### PR TITLE
AKU-193: Fixed double encoding issue with form control options

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -538,12 +538,10 @@ define(["dojo/_base/declare",
          if (typeof callback === "function")
          {
             this.pendingOptions = callback(config);
-            array.forEach(this.pendingOptions, lang.hitch(this, this.processOptionLabel));
          }
          else if (ObjectTypeUtils.isString(callback) && typeof this[callback] === "function")
          {
             this.pendingOptions = this[callback](config);
-            array.forEach(this.pendingOptions, lang.hitch(this, this.processOptionLabel));
          }
          else
          {
@@ -561,7 +559,6 @@ define(["dojo/_base/declare",
          if (ObjectTypeUtils.isArray(fixed))
          {
             this.pendingOptions = fixed;
-            array.forEach(this.pendingOptions, lang.hitch(this, this.processOptionLabel));
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -86,7 +86,7 @@ define(["intern!object",
          return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "One", "Fixed label not set correctly: " + resultText);
+               assert(resultText === "Priv\u00e9", "Fixed label not set correctly: " + resultText);
             });
       },
   

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.properties
@@ -1,2 +1,2 @@
-select.test.fixed.option.one=One
+select.test.fixed.option.one=Priv\u00e9
 select.test.fixed.option.two=Two


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-193. It looks like we were unnecessarily running the options through the message processing more than once which was double encoding localized values.