### PR TITLE
AKU-216: Support Repo home configuration

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -520,7 +520,7 @@ define(["dojo/_base/declare",
        */
       alfUnsubscribeSaveHandles: function alfresco_core_Core__alfUnsubscribeSaveHandles(handles) {
          array.forEach(handles, function(handle) {
-            if (handle != null)
+            if (handle)
             {
                this.alfUnsubscribe(handle);
             }

--- a/aikau/src/main/resources/alfresco/navigation/Tree.js
+++ b/aikau/src/main/resources/alfresco/navigation/Tree.js
@@ -273,6 +273,11 @@ define(["dojo/_base/declare",
 
          // Assign the clicked item as the currentItem value so that it can be used in payload generation...
          this.currentItem = item;
+         if (!this.currentItem.nodeRef)
+         {
+            this.currentItem.nodeRef = this.rootNode;
+         }
+
          this.publishPayload = lang.clone(this.publishPayload);
          var generatedPayload = this.getGeneratedPayload(true);
          this.alfPublish(this.publishTopic, generatedPayload, this.publishGlobal);

--- a/aikau/src/main/resources/alfresco/pickers/ContainerListPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/ContainerListPicker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,13 +18,11 @@
  */
 
 /**
- * <p>This extends the standard [document list]{@link module:alfresco/documentlibrary/AlfDocumentList} to
- * define a document list specifically for selecting containers (folders) (e.g. for copy and move targets, etc). It was
- * written to be used as part of a [picker]{@link module:alfresco/pickers/Picker}.</p>
- *
+ * 
  * @module alfresco/pickers/ContainerListPicker
  * @extends module:alfresco/pickers/DocumentListPicker
- * @author Dave Draper & David Webster
+ * @author Dave Draper
+ * @author David Webster
  *
  * @todo Fix look and feel to match existing pickers
  * @todo Make folders tree based?
@@ -33,147 +31,147 @@
  */
 define(["dojo/_base/declare",
         "alfresco/pickers/DocumentListPicker"],
-   function(declare, DocumentListPicker) {
+        function(declare, DocumentListPicker) {
 
-      return declare([DocumentListPicker], {
+   return declare([DocumentListPicker], {
 
-         /**
-          * An array of the i18n files to use with this widget.
-          *
-          * @instance
-          * @type {object[]}
-          * @default [{i18nFile: "./i18n/ContainerListPicker.properties"}]
-          */
-         i18nRequirements: [{i18nFile: "./i18n/ContainerListPicker.properties"}],
+      /**
+       * An array of the i18n files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/ContainerListPicker.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/ContainerListPicker.properties"}],
 
-         /**
-          * An array of the CSS files to use with this widget.
-          *
-          * @instance
-          * @type {object[]}
-          * @default [{cssFile:"./css/ContainerListPicker.css"}]
-          */
-         cssRequirements: [
-            {cssFile:"./css/ContainerListPicker.css"},
-            {cssFile:"../core/css/Icons.css"}
-         ],
+      /**
+       * An array of the CSS files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/ContainerListPicker.css"}]
+       */
+      cssRequirements: [
+         {cssFile:"./css/ContainerListPicker.css"},
+         {cssFile:"../core/css/Icons.css"}
+      ],
 
-         /**
-          * Sets some relevant messages to display
-          *
-          * @instance
-          */
-         setDisplayMessages: function alfresco_pickers_PropertyPicker__setDisplayMessages() {
-            this.noViewSelectedMessage = this.message("containerPicker.no.view.message");
-            this.noDataMessage = this.message("containerPicker.no.data.message");
-            this.fetchingDataMessage = this.message("containerPicker.loading.data.message");
-            this.renderingViewMessage = this.message("containerPicker.rendering.data.message");
-            this.fetchingMoreDataMessage = this.message("containerPicker.loading.data.message");
-            this.dataFailureMessage = this.message("containerPicker.data.failure.message");
-         },
+      /**
+       * Sets some relevant messages to display
+       *
+       * @instance
+       */
+      setDisplayMessages: function alfresco_pickers_PropertyPicker__setDisplayMessages() {
+         this.noViewSelectedMessage = this.message("containerPicker.no.view.message");
+         this.noDataMessage = this.message("containerPicker.no.data.message");
+         this.fetchingDataMessage = this.message("containerPicker.loading.data.message");
+         this.renderingViewMessage = this.message("containerPicker.rendering.data.message");
+         this.fetchingMoreDataMessage = this.message("containerPicker.loading.data.message");
+         this.dataFailureMessage = this.message("containerPicker.data.failure.message");
+      },
 
-         /**
-          * Don't show documents
-          *
-          * @instance
-          * @type {boolean}
-          * @default false
-          */
-         showDocuments: false,
+      /**
+       * Don't show documents
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      showDocuments: false,
 
-         /**
-          * Overrides the [inherited function]{@link module:alfresco/lists/AlfList#postCreate} to create the picker
-          * view for selecting documents.
-          *
-          * @instance
-          */
-         postCreate: function alfresco_pickers_ContainerListPicker__postCreate(payload) {
-            var config = [{
-               name: "alfresco/lists/views/AlfListView",
-               config: {
-                  widgetsForHeader: [
-                     {
-                        name: "alfresco/buttons/AlfButton",
-                        id: "ContainerListPickerParentNav",
-                        config: {
-                           label: this.message("containerPicker.button.parentNav.label"),
-                           additionalCssClasses: "ContainerListPickerParentNav",
-                           publishTopic: "ALF_DOCLIST_PARENT_NAV",
-                           showLabel: false,
-                           iconClass: "alf-folder-up-icon",
-                           disableOnInvalidControls: true
-                        }
+      /**
+       * Overrides the [inherited function]{@link module:alfresco/lists/AlfList#postCreate} to create the picker
+       * view for selecting documents.
+       *
+       * @instance
+       */
+      postCreate: function alfresco_pickers_ContainerListPicker__postCreate() {
+         var config = [{
+            name: "alfresco/lists/views/AlfListView",
+            config: {
+               widgetsForHeader: [
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     id: "ContainerListPickerParentNav",
+                     config: {
+                        label: this.message("containerPicker.button.parentNav.label"),
+                        additionalCssClasses: "ContainerListPickerParentNav",
+                        publishTopic: "ALF_DOCLIST_PARENT_NAV",
+                        showLabel: false,
+                        iconClass: "alf-folder-up-icon",
+                        disableOnInvalidControls: true
                      }
-                  ],
-                  widgets: [
-                     {
-                        name: "alfresco/lists/views/layouts/Row",
-                        config: {
-                           renderFilter: [
-                              {
-                                 property: "node.isContainer",
-                                 values: [true]
+                  }
+               ],
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Row",
+                     config: {
+                        renderFilter: [
+                           {
+                              property: "node.isContainer",
+                              values: [true]
+                           }
+                        ],
+                        widgets: [
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 width: "20px",
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/FileType",
+                                       config: {
+                                          size: "small",
+                                          renderAsLink: true,
+                                          publishTopic: "ALF_DOCLIST_NAV"
+                                       }
+                                    }
+                                 ]
                               }
-                           ],
-                           widgets: [
-                              {
-                                 name: "alfresco/lists/views/layouts/Cell",
-                                 config: {
-                                    width: "20px",
-                                    widgets: [
-                                       {
-                                          name: "alfresco/renderers/FileType",
-                                          config: {
-                                             size: "small",
-                                             renderAsLink: true,
-                                             publishTopic: "ALF_DOCLIST_NAV"
-                                          }
+                           },
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/PropertyLink",
+                                       config: {
+                                          propertyToRender: "node.properties.cm:name",
+                                          renderAsLink: true,
+                                          publishTopic: "ALF_DOCLIST_NAV"
                                        }
-                                    ]
-                                 }
-                              },
-                              {
-                                 name: "alfresco/lists/views/layouts/Cell",
-                                 config: {
-                                    widgets: [
-                                       {
-                                          name: "alfresco/renderers/PropertyLink",
-                                          config: {
-                                             propertyToRender: "node.properties.cm:name",
-                                             renderAsLink: true,
-                                             publishTopic: "ALF_DOCLIST_NAV"
-                                          }
-                                       }
-                                    ]
-                                 }
-                              },
-                              {
-                                 name: "alfresco/lists/views/layouts/Cell",
-                                 config: {
-                                    width: "20px",
-                                    widgets: [
-                                       {
-                                          name: "alfresco/renderers/PublishAction",
-                                          config: {
-                                             publishPayloadType: "CURRENT_ITEM",
-                                             renderFilter: [
-                                                {
-                                                   property: "node.permissions.user.CreateChildren",
-                                                   values: [true]
-                                                }
-                                             ]
-                                          }
-                                       }
-                                    ]
-                                 }
+                                    }
+                                 ]
                               }
-                           ]
-                        }
+                           },
+                           {
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 width: "20px",
+                                 widgets: [
+                                    {
+                                       name: "alfresco/renderers/PublishAction",
+                                       config: {
+                                          publishPayloadType: "CURRENT_ITEM",
+                                          renderFilter: [
+                                             {
+                                                property: "node.permissions.user.CreateChildren",
+                                                values: [true]
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
                      }
-                  ]
-               }
-            }];
-            this.processWidgets(config, this.itemsNode);
-         }
-      });
+                  }
+               ]
+            }
+         }];
+         this.processWidgets(config, this.itemsNode);
+      }
    });
+});

--- a/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
@@ -222,7 +222,8 @@ define(["dojo/_base/declare",
                               {
                                  name: "alfresco/navigation/PathTree",
                                  config: {
-                                    showRoot: false,
+                                    showRoot: true,
+                                    rootLabel: "picker.sharedFiles.label",
                                     rootNode: "alfresco://company/shared",
                                     publishTopic: "ALF_ITEM_SELECTED"
                                  }
@@ -243,8 +244,9 @@ define(["dojo/_base/declare",
                               {
                                  name: "alfresco/navigation/PathTree",
                                  config: {
-                                    showRoot: false,
-                                    rootNode: "alfresco://company/home",
+                                    showRoot: true,
+                                    rootLabel: "picker.repository.label",
+                                    rootNode: "{repoNodeRef}",
                                     publishTopic: "ALF_ITEM_SELECTED"
                                  }
                               }
@@ -264,7 +266,8 @@ define(["dojo/_base/declare",
                               {
                                  name: "alfresco/navigation/PathTree",
                                  config: {
-                                    showRoot: false,
+                                    showRoot: true,
+                                    rootLabel: "picker.myFiles.label",
                                     rootNode: "alfresco://user/home",
                                     publishTopic: "ALF_ITEM_SELECTED"
                                  }
@@ -284,10 +287,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default
+       * @default []
        */
-      widgetsForPickedItems: [
-
-      ]
+      widgetsForPickedItems: []
    });
 });

--- a/aikau/src/main/resources/alfresco/pickers/DocumentListPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/DocumentListPicker.js
@@ -132,7 +132,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      postCreate: function alfresco_pickers_DocumentListPicker__postCreate(payload) {
+      postCreate: function alfresco_pickers_DocumentListPicker__postCreate() {
          var config = [{
             name: "alfresco/lists/views/AlfListView",
             config: {
@@ -236,13 +236,12 @@ define(["dojo/_base/declare",
        */
       onFolderClick: function alfresco_pickers_DocumentListPicker__onFolderClick(payload) {
          var targetNode = lang.getObject("item.nodeRef", false, payload) || lang.getObject("node.nodeRef", false, payload) || payload.nodeRef;
-         if (targetNode != null)
+         if (targetNode)
          {
             this.nodeRef = targetNode;
 
             // Make sure we go back to page one when the new list is requested.
             this.resetPaginationData();
-
             this.loadData();
          }
          else
@@ -259,6 +258,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onDocumentClick: function alfresco_pickers_DocumentListPicker__onDocumentClick(payload) {
+         // jshint unused:false
          // No action.
       },
 
@@ -280,14 +280,14 @@ define(["dojo/_base/declare",
          {
             this.alfPublish("ALF_VALID_CONTROL", {});
          }
-
          this.inherited(arguments);
       },
 
       /**
        * Overrides [onDataLoadSuccess]{@link module:alfresco/documentlibrary/AlfList#onDataLoadSuccess} to skip children.
        *
-       * @param payload
+       * @instance
+       * @param {object} payload
        */
       onDataLoadSuccess: function alfresco_pickers_DocumentListPicker__onDataLoadSuccess(payload) {
          var parentType = lang.getObject("response.metadata.parent.type", false, payload);
@@ -336,10 +336,8 @@ define(["dojo/_base/declare",
        * displayed in the picker.
        *
        * @instance
-       * @type {object}
+       * @type {array}
        */
-      widgets: [
-
-      ]
+      widgets: []
    });
 });

--- a/aikau/src/main/resources/alfresco/pickers/Picker.js
+++ b/aikau/src/main/resources/alfresco/pickers/Picker.js
@@ -121,6 +121,17 @@ define(["dojo/_base/declare",
       generatePubSubScope: true,
 
       /**
+       * This should be set to the NodeRef to be used to represent the root of the Repository. By default
+       * this is "alfresco://company/home" but can be configured to be any other value. This value is used
+       * as the root location for the Repository root picker.
+       *
+       * @instance
+       * @type {string}
+       * @default "alfresco://company/home"
+       */
+      repoNodeRef: "alfresco://company/home",
+
+      /**
        *
        *
        * @instance
@@ -142,7 +153,9 @@ define(["dojo/_base/declare",
 
          if (this.widgetsForRootPicker !== null)
          {
-            this.processWidgets(lang.clone(this.widgetsForRootPicker), this.subPickersNode);
+            var clonedWidgetsForRootPicker = lang.clone(this.widgetsForRootPicker);
+            this.processObject(["processInstanceTokens"], clonedWidgetsForRootPicker);
+            this.processWidgets(clonedWidgetsForRootPicker, this.subPickersNode);
             if (this.subPickersLabel) {
                this.subPickersLabelNode.innerHTML = this.message(this.subPickersLabel);
             }
@@ -333,7 +346,7 @@ define(["dojo/_base/declare",
                               {
                                  name: "alfresco/pickers/DocumentListPicker",
                                  config: {
-                                    nodeRef: "alfresco://company/home",
+                                    nodeRef: "{repoNodeRef}",
                                     path: "/"
                                  }
                               }

--- a/aikau/src/main/resources/alfresco/pickers/SingleItemPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/SingleItemPicker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -23,7 +23,8 @@
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreWidgetProcessing
- * @author Dave Draper & David Webster
+ * @author Dave Draper
+ * @author David Webster
  */
 define(["dojo/_base/declare",
         "dijit/_WidgetBase",
@@ -58,11 +59,10 @@ define(["dojo/_base/declare",
 
       /**
        *
-       *
        * @instance
        */
       postCreate: function alfresco_pickers_SingleItemPicker__postCreate() {
-         if (this.requestItemsTopic != null)
+         if (this.requestItemsTopic)
          {
             var pubSubScope = this.generateUuid();
             var requestTopic = pubSubScope + "ALF_SINGLE_PICKER_ITEMS_REQUEST";
@@ -91,7 +91,7 @@ define(["dojo/_base/declare",
       onItemsLoadSuccess: function alfresco_pickers_SingleItemPicker__onItemsLoadSuccess(payload) {
          this.alfLog("log", "Items loaded", payload);
 
-         if (payload == null || payload.response == null)
+         if (!payload || !payload.response)
          {
             this.alfLog("warn", "The response for a request for SingleItemPicker items did not contain a 'response' attribute", payload, this);
          }
@@ -126,9 +126,8 @@ define(["dojo/_base/declare",
        * @param {number} index The index of the item to add
        * @todo Hard coded to site data. See comment in method description about generalising code.
        */
-      addItemWidgetConfig: function alfresco_pickers_SingleItemPicker__addItemWidgetConfig(widgets, item, index) {
+      addItemWidgetConfig: function alfresco_pickers_SingleItemPicker__addItemWidgetConfig(widgets, item, /*jshint unused:false*/ index) {
          var siteNodeRef = NodeUtils.processNodeRef(item.node.substring(item.node.indexOf("workspace"))).nodeRef;
-
 
          // Generate the widget model for the sub-picker...
          // We're going to clone the defined "widgetsForSubPicker" configuration to prevent
@@ -139,7 +138,6 @@ define(["dojo/_base/declare",
             siteNodeRef: siteNodeRef
          };
          this.processObject(["processCurrentItemTokens"], widgetsForSubPicker);
-
 
          var config = {
             name: "alfresco/menus/AlfMenuBarItem",
@@ -158,7 +156,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       *
        *
        * @instance
        */
@@ -193,7 +190,6 @@ define(["dojo/_base/declare",
          // TODO: Implement item selected function. This is only relevant for hardcoded options
          //       HOWEVER, maybe the menu item should publish a topic that this subscribes to so that this can
          //       be a more useful override??
-
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -102,35 +102,6 @@ define(["dojo/_base/declare",
       rootNode: null,
 
       /**
-       * Used by callbacks from picker dialogs to store the picked target.
-       *
-       * @instance
-       * @type {string}
-       * @default null
-       */
-      copyMoveTarget: null,
-
-      /**
-       * URL to call to copy a document
-       *
-       * @instance
-       * @type {string}
-       * @default
-       * @TODO the call to this should be in the document service.
-       */
-      copyAPI: "slingshot/doclib/action/copy-to/node/",
-
-      /**
-       * URL to call to move a document
-       *
-       * @instance
-       * @type {string}
-       * @default
-       * @TODO the call to this should be in the document service.
-       */
-      moveAPI: "slingshot/doclib/action/move-to/node/",
-
-      /**
        * Sets up the subscriptions for the Action Service
        *
        * @instance
@@ -232,8 +203,8 @@ define(["dojo/_base/declare",
       handleSingleDocAction: function alfresco_services_ActionService__handleSingleDocAction(payload) {
          this.alfLog("log", "Single document action request:", payload);
          if (payload &&
-             payload.document != null &&
-             payload.action != null)
+             payload.document &&
+             payload.action)
          {
             if (typeof payload.action === "string")
             {
@@ -268,7 +239,10 @@ define(["dojo/_base/declare",
             var documents = [];
             for (var nodeRef in this.currentlySelectedDocuments)
             {
-               documents.push(this.currentlySelectedDocuments[nodeRef])
+               if (this.currentlySelectedDocuments.hasOwnProperty(nodeRef))
+               {
+                  documents.push(this.currentlySelectedDocuments[nodeRef]);
+               }
             }
             this[payload.action].call(this, payload, documents);
          }
@@ -303,10 +277,10 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the document selected
        */
       onDocumentSelected: function alfresco_services_ActionService__onDocumentSelected(payload) {
-         if (payload && payload.value && payload.value.nodeRef != null)
+         if (payload && payload.value && payload.value.nodeRef)
          {
             this.currentlySelectedDocuments[payload.value.nodeRef] = payload.value;
-            if (this.selectionTimeout != null)
+            if (this.selectionTimeout)
             {
                clearTimeout(this.selectionTimeout);
             }
@@ -334,10 +308,10 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the document selected
        */
       onDocumentDeselected: function alfresco_services_ActionService__onDocumentDeselected(payload) {
-         if (payload && payload.value && payload.value.nodeRef != null)
+         if (payload && payload.value && payload.value.nodeRef)
          {
             delete this.currentlySelectedDocuments[payload.value.nodeRef];
-            if (this.selectionTimeout != null)
+            if (this.selectionTimeout)
             {
                clearTimeout(this.selectionTimeout);
             }
@@ -354,7 +328,10 @@ define(["dojo/_base/declare",
          var a = [];
          for (var key in this.currentlySelectedDocuments)
          {
-            a.push(this.currentlySelectedDocuments[key]);
+            if (this.currentlySelectedDocuments.hasOwnProperty(key))
+            {
+               a.push(this.currentlySelectedDocuments[key]);
+            }
          }
          return a;
       },
@@ -414,7 +391,7 @@ define(["dojo/_base/declare",
                {
                   if (!ArrayUtils.arrayContains(file.node.aspects, commonAspects[j]))
                   {
-                     ArrayUtils.arrayRemove(commonAspects, commonAspects[j])
+                     ArrayUtils.arrayRemove(commonAspects, commonAspects[j]);
                   }
                }
             }
@@ -424,7 +401,7 @@ define(["dojo/_base/declare",
             {
                if (!ArrayUtils.arrayContains(allAspects, file.node.aspects[j]))
                {
-                  allAspects.push(file.node.aspects[j])
+                  allAspects.push(file.node.aspects[j]);
                }
             }
          }
@@ -525,12 +502,12 @@ define(["dojo/_base/declare",
        */
       createPageLinkContent: function alfresco_services_ActionService__createPageLinkContent(payload, document) {
          var url = payload.params.page;
-         if (document != null)
+         if (document)
          {
             // TODO: Need to check other substitution points...
             url = lang.replace(url, document);
          }
-         else if (this._currentNode != null)
+         else if (this._currentNode)
          {
             url = lang.replace(url, { nodeRef: this._currentNode.parent.nodeRef});
          }
@@ -563,7 +540,7 @@ define(["dojo/_base/declare",
          var url = lang.replace(payload.params.href, this.getActionUrls(document, this.siteId, this.repositoryUrl, this.replicationUrlMapping));
          var indexOfTarget = url.indexOf("\" target=\"_blank");
          var target = "CURRENT";
-         if (indexOfTarget != -1)
+         if (indexOfTarget !== -1)
          {
             url = url.substring(0, indexOfTarget);
             target = "NEW";
@@ -583,7 +560,7 @@ define(["dojo/_base/declare",
        * @param {object} document The document to perform the action on.
        */
       createJavaScriptContent: function alfresco_services_ActionService__createJavaScriptContent(payload, document) {
-         if (document == null)
+         if (!document)
          {
             var node = lang.clone(this._currentNode.parent);
             document = {
@@ -632,7 +609,7 @@ define(["dojo/_base/declare",
          // 1. Get the data.
          // 2. Create a form dialog containing fields for all the properties
 
-         if (document == null || document.nodeRef == null)
+         if (!document || !document.nodeRef)
          {
             this.alfLog("warn", "A request was made to edit the properties of a document but no document or 'nodeRef' attribute was provided", document, this);
          }
@@ -654,6 +631,7 @@ define(["dojo/_base/declare",
        */
       onActionDetailsSuccess: function alfresco_services_ActionService__onActionDetailsSuccess(payload) {
          // TODO: this needs to use the external forms processor in order to cope with custom models with forms defined.
+         // jshint unused:false
          this.alfLog("Error", "This method hasn't been implemented yet.");
       },
 
@@ -667,6 +645,7 @@ define(["dojo/_base/declare",
        * @param {object} document The document to upload a new version for.
        */
       onActionUploadNewVersion: function alfresco_services_ActionService__onActionUploadNewVersion(payload, document) {
+         // jshint unused:false
          // Call dialog service to open dialog with upload widget in.
          this.alfPublish("ALF_SHOW_UPLOADER", payload);
       },
@@ -689,6 +668,7 @@ define(["dojo/_base/declare",
        * @param payload
        */
       onActionCancelEditingSuccess: function alfresco_services_ActionService_onActionCancelEditingSuccess(payload) {
+         // jshint unused:false
          this.alfPublish(this.reloadDataTopic, {});
       },
 
@@ -700,7 +680,7 @@ define(["dojo/_base/declare",
        * @param {object} document The document to edit.
        */
       onActionEditInline: function alfresco_services_ActionService__onActionEditInline(payload, document) {
-         if (document == null || document.nodeRef == null)
+         if (!document || !document.nodeRef)
          {
             this.alfLog("warn", "A request was made to edit the properties of a document but no document or 'nodeRef' attribute was provided", document, this);
          }
@@ -832,9 +812,7 @@ define(["dojo/_base/declare",
          // Document might be an array.
          document = (lang.isArray(document))? document[0] : document;
 
-         if (document != null &&
-             document.node != null &&
-             document.node.nodeRef != null)
+         if (document && document.node && document.node.nodeRef)
          {
             var data = {
                nodeRef: document.node.nodeRef
@@ -867,10 +845,10 @@ define(["dojo/_base/declare",
       onActionEditOfflineSuccess: function alfresco_services_ActionService__onActionEditOfflineSuccess(response, originalRequestConfig) {
          this.alfLog("log", "Edit offline request success", response, originalRequestConfig);
 
-         if (response != null &&
-             response.results != null &&
+         if (response &&
+             response.results &&
              response.results.length > 0 &&
-             response.results[0].downloadUrl != null)
+             response.results[0].downloadUrl)
          {
             this.displayMessage(this.message("message.edit-offline.success", {"0": response.results[0].id}));
             this.alfPublish(this.navigateToPageTopic, {
@@ -907,7 +885,11 @@ define(["dojo/_base/declare",
        * @param {object} documents The documents edit offline.
        */
       onActionCopyTo: function alfresco_services_ActionService__onActionCopyTo(payload, documents) {
-         this.createCopyMoveDialog(payload, documents); // config not needed as it defaults to copy.
+         this.alfPublish("ALF_COPY_OR_MOVE_REQUEST", {
+            documents: documents,
+            copy: true,
+            singleItemMode: true
+         });
       },
 
       /**
@@ -918,140 +900,13 @@ define(["dojo/_base/declare",
        * @param {object} documents The document edit offline.
        */
       onActionMoveTo: function alfresco_services_ActionService__onActionMoveTo(payload, documents) {
-         this.createCopyMoveDialog(payload, documents, {
-            urlPrefix: this.moveAPI,
+         this.alfPublish("ALF_COPY_OR_MOVE_REQUEST", {
+            documents: documents,
+            copy: false,
             dialogTitle: "services.ActionService.moveTo.title",
             confirmButtonLabel: "services.ActionService.moveTo.ok",
             singleItemMode: true
          });
-      },
-
-      /**
-       * Create a typeDef for the createCopyMoveDialogConfig type used by {@link alfresco/services/ActionService:createCopyMoveDialog}
-       *
-       * @typedef {Object} createCopyMoveDialogConfig
-       * @property [urlPrefix] {String} - The URL prefix for the action
-       * @property [dialogTitle] {string} - The title for the dialog
-       * @property [confirmButtonLabel] {String} - The label for the confirmation button
-       * @property [singleItemMode] {Bool} - {@link alfresco/pickers/PickedItems:singleItemMode}
-       */
-
-      /**
-       * This function handles the creation of dialogs for both copy and move actions because
-       * they are identical apart from the config object (which can be optionally passed in).
-       * It defaults to copy mode if missing.
-       *
-       * @instance
-       * @param {object} payload The action payload
-       * @param {object} documents The documents selected for copy or move
-       * @param {createCopyMoveDialogConfig} [config] The config object.
-       */
-      createCopyMoveDialog: function alfresco_services_ActionService__createCopyMoveDialog(payload, documents, config) {
-
-         config = config || {};
-
-         var urlPrefix = config.urlPrefix || this.copyAPI, // Default to copy API.
-            dialogTitle = config.dialogTitle || "services.ActionService.copyTo.title", // Default to copy title
-            confirmButtonLabel = config.confirmButtonLabel || "services.ActionService.copyTo.ok", // Default to copy confirmation
-            singleItemMode = config.singleItemMode || false; // Default to allow multiple selections
-
-         var responseTopic = this.generateUuid() + "_ALF_MOVE_LOCATION_PICKED",
-            nodes = NodeUtils.nodeRefArray(documents),
-            publishPayload = {
-               nodes: nodes,
-               documents: documents
-            };
-
-         var fileName = (nodes.length === 1)? documents[0].fileName : this.message("services.ActionService.copyMoveTo.multipleFiles");
-
-         this._actionHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onCopyMoveLocationSelected, urlPrefix), true);
-         this.alfPublish("ALF_CREATE_DIALOG_REQUEST", {
-            dialogTitle: this.message(dialogTitle, { 0: fileName}),
-            handleOverflow: false,
-            widgetsContent: [
-               {
-                  name: "alfresco/pickers/ContainerPicker",
-                  config: {
-                     singleItemMode: singleItemMode,
-                     generatePubSubScope: true
-                  }
-               }
-            ],
-            widgetsButtons: [
-               {
-                  name: "alfresco/buttons/AlfButton",
-                  config: {
-                     label: confirmButtonLabel,
-                     publishTopic: responseTopic,
-                     publishPayload: publishPayload,
-                     disableOnInvalidControls: true,
-                     validTopic: "ALF_PICKER_VALID",
-                     invalidTopic: "ALF_PICKER_INVALID"
-                  }
-               },
-               {
-                  name: "alfresco/buttons/AlfButton",
-                  config: {
-                     label: "picker.cancel.label",
-                     publishTopic: "NO_OP"
-                  }
-               }
-            ]
-         }, true);
-      },
-
-      /**
-       * Handles the actual copy call - triggered once the location has been selected by
-       * [onActionCopyTo]{@link module:alfresco/services/ActionsService#onActionCopyTo}
-       *
-       * @instance
-       * @param payload
-       */
-      onCopyMoveLocationSelected: function alfresco_services_ActionService__onCopyMoveLocationSelected(urlPrefix, payload) {
-         this.alfUnsubscribeSaveHandles([this._actionCopyHandle]);
-
-         // Get the locations to copy to and the documents to them...
-         var locations = lang.getObject("dialogContent.0.pickedItemsWidget.currentData.items", false, payload);
-         var documents = lang.getObject("documents", false, payload);
-         if (locations == null || locations.length === 0)
-         {
-            this.alfLog("error", "copyMoveTarget not specified");
-         }
-         else if (documents == null || documents.length === 0)
-         {
-            this.alfLog("error", "Documents to copy not specified.");
-         }
-         else
-         {
-            // TODO: The closure should be moved to an instance function...
-            array.forEach(locations, function(location, index) {
-               var nodeRefs = NodeUtils.nodeRefArray(documents),
-                           responseTopic = this.generateUuid(),
-                           subscriptionHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onActionCopyToSuccess), true);
-
-               this.serviceXhr({
-                  alfTopic: responseTopic,
-                  subscriptionHandle: subscriptionHandle,
-                  url: AlfConstants.PROXY_URI + urlPrefix + location.nodeRef.replace("://", "/"),
-                  method: "POST",
-                  data: {
-                     nodeRefs: nodeRefs,
-                     parentId: location
-                  }
-               });
-            }, this);
-         }
-      },
-
-      /**
-       * What should we do when the copy action succeeds?
-       *
-       * @instance
-       * @param payload
-       */
-      onActionCopyToSuccess: function alfresco_services_ActionService__onActionCopyToSuccess(payload) {
-         // TODO: Not all success is success. Need to check response.overallSuccess rather than just response status.
-         this.onActionCompleteSuccess(arguments);
       },
 
       /**
@@ -1171,6 +1026,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onActionDeleteSuccess: function alfresco_services_ActionService__onActionDeleteSuccess(payload) {
+         // jshint unused:false
          this.onActionCompleteSuccess(arguments);
       },
 
@@ -1182,7 +1038,7 @@ define(["dojo/_base/declare",
        */
       onActionCompleteSuccess: function alfresco_services_ActionService__onActionCompleteSuccess(payload) {
          var subscriptionHandle = lang.getObject("requestConfig.subscriptionHandle", false, payload);
-         if (subscriptionHandle != null)
+         if (subscriptionHandle)
          {
             this.alfUnsubscribe(subscriptionHandle);
          }
@@ -1259,7 +1115,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload
        */
-      onSyncLocation: function alfresco_services_ActionService__onSyncLocation(payload) {
+      onSyncLocation: function alfresco_services_ActionService__onSyncLocation(/*jshint unused:false*/ payload) {
          var node = lang.clone(this._currentNode.parent);
          var record = {
             nodeRef: node.nodeRef,
@@ -1273,7 +1129,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload
        */
-      onUnsyncLocation: function alfresco_services_ActionService__onUnsyncLocation(payload) {
+      onUnsyncLocation: function alfresco_services_ActionService__onUnsyncLocation(/*jshint unused:false*/ payload) {
          var node = lang.clone(this._currentNode.parent);
          var record = {
             nodeRef: node.nodeRef,
@@ -1294,18 +1150,16 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onMoveDocuments: function alfresco_services_ActionService__onMoveDocuments(payload) {
-
-         if (payload &&
-             payload.sourceNodeRefs != null)
+         if (payload && payload.sourceNodeRefs)
          {
             var url = null;
-            if (payload.targetNodeRefUri != null)
+            if (payload.targetNodeRefUri)
             {
                url = AlfConstants.PROXY_URI + "slingshot/doclib/action/move-to/node/" + payload.targetNodeRefUri;
             }
-            else if (payload.targetPath != null)
+            else if (payload.targetPath)
             {
-               if (this.rootNode != null)
+               if (this.rootNode)
                {
                   var currentLocation = new JsNode(this.rootNode).nodeRef.uri;
                   url = AlfConstants.PROXY_URI + "slingshot/doclib/action/move-to/node/" + currentLocation + payload.targetPath;
@@ -1315,7 +1169,7 @@ define(["dojo/_base/declare",
                   url = AlfConstants.PROXY_URI + "slingshot/doclib/action/move-to/site/" + this.siteId + "/" + this.containerId  + "/" + payload.targetPath;
                }
             }
-            if (url != null)
+            if (url)
             {
                var dataObj = {
                   nodeRefs: payload.sourceNodeRefs,
@@ -1341,6 +1195,7 @@ define(["dojo/_base/declare",
        * @param {object} originalRequestConfig
        */
       onMoveDocumentsSuccess: function alfresco_services_ActionService__onMoveDocumentsSuccess(response, originalRequestConfig) {
+         // jshint unused:false
          // TODO: Display a success message.
          this.alfPublish(this.reloadDataTopic, {});
       },
@@ -1351,6 +1206,7 @@ define(["dojo/_base/declare",
        * @param {object} originalRequestConfig
        */
       onMoveDocumentsFailure: function alfresco_services_ActionService__onMoveDocumentsSuccess(response, originalRequestConfig) {
+         // jshint unused:false
          // TODO: Publish an error message.
       },
 

--- a/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
@@ -1,0 +1,282 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This service handles requests to copy or move nodes from one location to another. It does this by displaying
+ * a [Dialog]{@link module:alfresco/dialogs/AlfDialog} containing a [ContainerPicker]{@link module:alfresco/pickers/ContainerPicker}.
+ * The [Dialog]{@link module:alfresco/dialogs/AlfDialog} is created via the [DialogService]{@link module:alfresco/services/DialogService}
+ * so it is imperative that is also included on the page (or an alternative service that handles the same publications).
+ *
+ * @module alfresco/services/actions/CopyMoveService
+ * @extends module:alfresco/core/Core
+ * @mixes module:alfresco/core/CoreXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "alfresco/core/CoreXhr",
+        "service/constants/Default",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "alfresco/core/NodeUtils"],
+        function(declare, AlfCore, AlfCoreXhr, AlfConstants, lang, array, NodeUtils) {
+
+   return declare([AlfCore, AlfCoreXhr], {
+
+      /**
+       * An array of the i18n files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/CopyMoveService.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/CopyMoveService.properties"}],
+
+      /**
+       * This should be set to the NodeRef to be used to represent the root of the Repository. By default
+       * this is "alfresco://company/home" but can be configured to be any other value. When used in Alfresco
+       * Share this should be set to the configured value of <root-node>
+       *
+       * @instance
+       * @type {string}
+       * @default "alfresco://company/home"
+       */
+      repoNodeRef: "alfresco://company/home",
+
+      /**
+       * URL to call to copy a document
+       *
+       * @instance
+       * @type {string}
+       * @default "slingshot/doclib/action/copy-to/node/"
+       */
+      copyAPI: "slingshot/doclib/action/copy-to/node/",
+
+      /**
+       * URL to call to move a document
+       *
+       * @instance
+       * @type {string}
+       * @default "slingshot/doclib/action/move-to/node/"
+       */
+      moveAPI: "slingshot/doclib/action/move-to/node/",
+
+      /**
+       * Sets up the service using the configuration provided. 
+       *
+       * @instance
+       * @param {array} args Constructor arguments
+       */
+      constructor: function alfresco_services_actions_CopyMoveService__constructor(args) {
+         lang.mixin(this, args);
+         this.alfSubscribe("ALF_COPY_OR_MOVE_REQUEST", lang.hitch(this, this.createCopyMoveDialog));
+      },
+
+      /**
+       * Create a typeDef for the createCopyMoveDialogConfig type used by {@link alfresco/services/ActionService:createCopyMoveDialog}
+       *
+       * @typedef {Object} createCopyMoveDialogConfig
+       * @property [urlPrefix] {String} - The URL prefix for the action
+       * @property [dialogTitle] {string} - The title for the dialog
+       * @property [confirmButtonLabel] {String} - The label for the confirmation button
+       * @property [singleItemMode] {Bool} - {@link alfresco/pickers/PickedItems:singleItemMode}
+       */
+      
+      /* This function handles the creation of dialogs for both copy and move actions because
+       * they are identical apart from the config object (which can be optionally passed in).
+       * It defaults to copy mode if missing.
+       *
+       * @instance
+       * @param {object} payload The action payload
+       * @param {object} documents The documents selected for copy or move
+       * @param {createCopyMoveDialogConfig} [config] The config object.
+       */
+      createCopyMoveDialog: function alfresco_services_ActionService__createCopyMoveDialog(payload) {
+         var documents = payload.documents || [];
+
+         var urlPrefix = payload.copy ? this.copyAPI : this.moveAPI, // Default to copy API.
+             dialogTitle = payload.dialogTitle || "services.ActionService.copyTo.title", // Default to copy title
+             confirmButtonLabel = payload.confirmButtonLabel || "services.ActionService.copyTo.ok", // Default to copy confirmation
+             singleItemMode = payload.singleItemMode !== false;
+
+         var responseTopic = this.generateUuid() + "_ALF_MOVE_LOCATION_PICKED",
+            nodes = NodeUtils.nodeRefArray(documents),
+            publishPayload = {
+               nodes: nodes,
+               documents: documents
+            };
+
+         var fileName = (nodes.length === 1)? documents[0].fileName : this.message("services.ActionService.copyMoveTo.multipleFiles");
+         this._actionHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onCopyMoveLocationSelected, urlPrefix, payload.copy), true);
+         this.alfPublish("ALF_CREATE_DIALOG_REQUEST", {
+            dialogTitle: this.message(dialogTitle, { 0: fileName}),
+            handleOverflow: false,
+            widgetsContent: [
+               {
+                  name: "alfresco/pickers/ContainerPicker",
+                  config: {
+                     singleItemMode: singleItemMode,
+                     generatePubSubScope: true,
+                     repoNodeRef: this.repoNodeRef || "alfresco://company/home"
+                  }
+               }
+            ],
+            widgetsButtons: [
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: confirmButtonLabel,
+                     publishTopic: responseTopic,
+                     publishPayload: publishPayload,
+                     disableOnInvalidControls: true,
+                     validTopic: "ALF_PICKER_VALID",
+                     invalidTopic: "ALF_PICKER_INVALID"
+                  }
+               },
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "picker.cancel.label",
+                     publishTopic: "NO_OP"
+                  }
+               }
+            ]
+         }, true);
+      },
+
+      /**
+       * Handles the actual copy or move XHR call
+       *
+       * @instance
+       * @param {string} urlPrefix The specific URL prefix to use for the action (e.g. either move or copy)
+       * @param {boolean} copy A boolean indicating if this is a copy action or not
+       * @param {object} payload The payload from confirmation of the action dialog
+       */
+      onCopyMoveLocationSelected: function alfresco_services_ActionService__onCopyMoveLocationSelected(urlPrefix, copy, payload) {
+         this.alfUnsubscribeSaveHandles([this._actionCopyHandle]);
+
+         // Get the locations to copy to and the documents to them...
+         var locations = lang.getObject("dialogContent.0.pickedItemsWidget.currentData.items", false, payload);
+         var documents = lang.getObject("documents", false, payload);
+         if (!locations || locations.length === 0)
+         {
+            this.alfLog("error", "copyMoveTarget not specified");
+         }
+         else if (!documents || documents.length === 0)
+         {
+            this.alfLog("error", "Documents to copy not specified.");
+         }
+         else
+         {
+            var nodeRefs = NodeUtils.nodeRefArray(documents);
+            array.forEach(locations, lang.hitch(this, this.performAction, nodeRefs, urlPrefix, copy));
+         }
+      },
+
+      /**
+       * Makes an XHR call to move or copy the selected documents to the location provided.
+       * 
+       * @param {array} nodeRefs An array of the nodes to move or copy
+       * @param {string} urlPrefix The prefix to use in the action URL
+       * @param {boolean} copy A boolean indicating if this is a copy action or not
+       * @param {array} location  The location to move or copy the documents to
+       */
+      performAction: function alfresco_services_actions_CopyMoveService__performAction(nodeRefs, urlPrefix, copy, location) {
+         var responseTopic = this.generateUuid();
+         var successSubscription = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onActionSuccess), true);
+         var failureSubscription = this.alfSubscribe(responseTopic + "_FAILURE", lang.hitch(this, this.onActionFailure), true);
+         this.serviceXhr({
+            alfTopic: responseTopic,
+            subscriptionHandles: [successSubscription,failureSubscription],
+            copy: copy,
+            url: AlfConstants.PROXY_URI + urlPrefix + location.nodeRef.replace("://", "/"),
+            method: "POST",
+            data: {
+               nodeRefs: nodeRefs,
+               parentId: location
+            }
+         });
+      },
+
+      /**
+       * Handles successful actions in one of two ways. When an attempt is made to move or copy more than one node
+       * it is possible that only some of the nodes will be moved/copied successfuly. If all the nodes were moved or
+       * copied successfully then a simple notification is displayed indicating a successful action was completed, however
+       * if a partial success was reported then a prompt is displayed listing the nodes that could not be copied or moved.
+       *
+       * @instance
+       * @param payload
+       */
+      onActionSuccess: function alfresco_services_ActionService__onActionSuccess(payload) {
+         // jshint unused:false
+         var subscriptionHandles = lang.getObject("requestConfig.subscriptionHandles", false, payload);
+         if (subscriptionHandles)
+         {
+            this.alfUnsubscribeSaveHandles(subscriptionHandles);
+         }
+         if (payload.response.overallSuccess === true)
+         {
+            this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+               message: payload.requestConfig.copy ? this.message("copyMoveService.copy.completeSuccess") : this.message("copyMoveService.move.completeSuccess")
+            });
+         }
+         else
+         {
+            var failures = "";
+            array.forEach(payload.response.results, function(result) {
+               if (!result.success)
+               {
+                  failures += result.id + ", ";
+               }
+            });
+            if (failures.length > 2)
+            {
+               failures = failures.substring(0, failures.length - 2);
+            }
+            var messageKey = payload.requestConfig.copy ? "copyMoveService.copy.partialSuccess" : "copyMoveService.move.partialSuccess";
+            var message = this.message(messageKey, {
+               0: failures
+            });
+            this.alfPublish("ALF_DISPLAY_PROMPT", {
+               message: message
+            });
+         }
+         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+      },
+
+      /**
+       * Handles failed actions by displaying a notification indicating that the action was not successful.
+       *
+       * @instance
+       * @param payload
+       */
+      onActionFailure: function alfresco_services_ActionService__onActionFailure(payload) {
+         // jshint unused:false
+         // TODO: Not all success is success. Need to check response.overallSuccess rather than just response status.
+         var subscriptionHandles = lang.getObject("requestConfig.subscriptionHandles", false, payload);
+         if (subscriptionHandles)
+         {
+            this.alfUnsubscribeSaveHandles(subscriptionHandles);
+         }
+         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+            message: payload.requestConfig.copy ? this.message("copyMoveService.copy.failure") : this.message("copyMoveService.move.failure")
+         });
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/actions/i18n/CopyMoveService.properties
+++ b/aikau/src/main/resources/alfresco/services/actions/i18n/CopyMoveService.properties
@@ -1,0 +1,17 @@
+## Copy To Dialog
+# {0} = file name (or see below)
+services.ActionService.copyTo.title=Copy {0} to...
+services.ActionService.moveTo.title=Move {0} to...
+# used in place of {0} to indicate more than one file.
+services.ActionService.copyMoveTo.multipleFiles=files
+
+# The confirmation button label for the copy/move dialog:
+services.ActionService.copyTo.ok=Copy
+services.ActionService.moveTo.ok=Move
+
+copyMoveService.copy.completeSuccess=The copy operation completed successfully
+copyMoveService.copy.partialSuccess=The copy operation was partially successful, the following items could not be copied: {0}
+copyMoveService.move.completeSuccess=The move operation completed successfully
+copyMoveService.move.partialSuccess=The move operation was partially successful, the following items could not be moved: {0}
+copyMoveService.copy.failure=It was not possible to complete the copy action
+copyMoveService.move.failure=It was not possible to complete the move action

--- a/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
@@ -40,10 +40,6 @@ define(["intern!object",
          browser.end();
       },
       
-      // teardown: function() {
-      //    browser.end().alfPostCoverageResults(browser);
-      // },
-      
       "Test picker dialog can be displayed": function () {
          return browser.findByCssSelector("#FOLDER_PICKER .alfresco-layout-VerticalWidgets > span > span > span")
             .click()

--- a/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Copy/Move tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/CopyMoveService", "Copy/Move tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Test dialog title of copy via ActionService": function() {
+         return browser.findByCssSelector("#COPY1_label")
+            .click()
+         .end()
+         .findByCssSelector(".dijitDialogTitle")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Copy File 1 to...", "Copy dialog title not set correctly");
+            });
+      },
+
+      "Test Shared Files location shows root node": function() {
+         return browser.findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:first-child .dijitMenuItem:nth-child(4)")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "The Shared Files sub-picker was not shown");
+            })
+         .end()
+         .findAllByCssSelector(".alfresco-navigation-Tree .dijitTreeLabel")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Only one tree node was expected");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Shared Files", "The tree node did not have the expected label");
+            })
+            .click();
+      },
+
+      "Test that the copy confirmation button has correct label": function() {
+         return browser.findByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonText")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Copy", "The confirmation button on the copy dialog was incorrect");
+            })
+            .click()
+         .end();
+      },
+
+      "Test that a notification of complete success is displayed": function() {
+         return browser.findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "The copy operation completed successfully"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The copy success message was not found");
+            });
+      },
+
+      "Test that the copy request was successful": function() {
+         return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_DOCLIST_RELOAD_DATA", "publish", "last"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Only expected one reload publication to indicate success");
+            });
+      },
+
+      "Test dialog title of move via ActionService": function() {
+         return browser.sleep(500) // Give the previous dialog a chance to close
+            .findByCssSelector("#MOVE1_label")
+            .click()
+         .end()
+         .findByCssSelector(".dijitDialogTitle")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Move File 1 to...", "Move dialog title not set correctly");
+            });
+      },
+
+      "Test My Files location shows root node": function() {
+         return browser.findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:first-child .dijitMenuItem:nth-child(6)")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "The My Files sub-picker was not shown");
+            })
+         .end()
+         .findAllByCssSelector(".alfresco-navigation-Tree .dijitTreeLabel")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Only one tree node was expected");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "My Files", "The tree node did not have the expected label");
+            })
+            .click();
+      },
+
+      "Test the partial success promot": function() {
+         return browser.findByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonText")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Move", "The confirmation button on the move dialog was incorrect");
+            })
+            .click()
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_PROMPT", "message", "The move operation was partially successful, the following items could not be moved: File2, File3"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The copy success message was not found");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   registerSuite({
+      name: "Copy/Move tests (overrides and failures)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/CopyMoveService?repoNodeRef=some://fake/node&copyAPI=fail/", "Copy/Move tests (overrides and failures)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Test Repository location shows root node": function() {
+         return browser.findByCssSelector("#COPY1_label")
+            .click()
+         .end()
+         .findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:first-child .dijitMenuItem:nth-child(5)")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "The Repository sub-picker was not shown");
+            })
+         .end()
+         .findAllByCssSelector(".alfresco-navigation-Tree .dijitTreeLabel")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Only one tree node was expected");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Repository", "The tree node did not have the expected label");
+            })
+            .click()
+         .end()
+         .findByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonText")
+            .click();
+      },
+
+      "Test the repository root override is applied": function() {
+         return browser.findByCssSelector(".mx-row:nth-child(1) .mx-url")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text.indexOf("libraryRoot=some%3A%2F%2Ffake%2Fnode") !== -1, "The configured root node was not used: ", text);
+            });
+      },
+
+      "Test that the custom copyAPI was used": function() {
+         return browser.findByCssSelector(".mx-row:nth-child(2) .mx-url")
+            .getVisibleText()
+            .then(function(text) {
+               assert(text.indexOf("/aikau/proxy/alfresco/fail/some/fake/node") !== -1, "The custom copy API was not used");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/dnd/ModelCreationServiceTest"
+      "src/test/resources/alfresco/services/actions/CopyMoveTest"
    ],
 
    /**
@@ -175,6 +175,7 @@ define({
       "src/test/resources/alfresco/services/SiteServiceTest",
       "src/test/resources/alfresco/services/UserServiceTest",
 
+      "src/test/resources/alfresco/services/actions/CopyMoveTest",
       "src/test/resources/alfresco/services/actions/ManageAspectsTest",
 
       "src/test/resources/alfresco/upload/UploadTest"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ContainerPicker.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ContainerPicker.get.js
@@ -28,9 +28,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Copy/Move Service</shortname>
+  <description>Displays buttons that call the CopyMoveService to launch copy/move dialogs</description>
+  <family>aikau-unit-tests</family>
+  <url>/CopyMoveService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.js
@@ -1,0 +1,75 @@
+// jshint undef:false
+model.jsonModel = {
+   services: [
+      {
+            name: "alfresco/services/LoggingService",
+            config: {
+               loggingPreferences: {
+                  enabled: true,
+                  all: true
+               }
+            }
+      },
+      "alfresco/services/DialogService",
+      "alfresco/services/ActionService",
+      "alfresco/services/DocumentService",
+      "alfresco/services/SiteService",
+      {
+         name: "alfresco/services/actions/CopyMoveService",
+         config: {
+            repoNodeRef: page.url.args["repoNodeRef"] || "alfresco://company/home",
+            copyAPI: page.url.args["copyAPI"] ||"slingshot/doclib/action/copy-to/node/"
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "COPY1",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Copy (via ActionService)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: {
+                  type: "javascript",
+                  params: {
+                     "function": "onActionCopyTo"
+                  }
+               },
+               document: {
+                  nodeRef: "workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                  displayName: "Some Node Title",
+                  fileName: "File 1"
+               }
+            }
+         }
+      },
+      {
+         id: "MOVE1",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Move (via ActionService)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: {
+                  type: "javascript",
+                  params: {
+                     "function": "onActionMoveTo"
+                  }
+               },
+               document: {
+                  nodeRef: "workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                  displayName: "Some Node Title",
+                  fileName: "File 1"
+               }
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/CopyMoveServiceMockXhr"
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
-  <shortname>Manage Aspects Test</shortname>
+  <shortname>Manage Aspects</shortname>
+  <description>Displays buttons that use the ManageAspects service to display aspect management dialogs.</description>
   <family>aikau-unit-tests</family>
   <url>/ManageAspects</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
@@ -125,9 +125,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CopyMoveServiceMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CopyMoveServiceMockXhr.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/CopyMoveServiceMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr",
+        "dojo/text!./responseTemplates/CopyMoveService/Copy.json",
+        "dojo/text!./responseTemplates/CopyMoveService/Move.json"], 
+        function(declare, MockXhr, Copy, Move) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_CopyMoveServiceMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("POST",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/action/copy-to/node/alfresco/company/shared",
+                                    [200,
+                                    {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":2563},
+                                     Copy]);
+            this.server.respondWith("POST",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/action/move-to/node/alfresco/user/home",
+                                    [200,
+                                    {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":2563},
+                                     Move]);
+            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/CopyMoveService/Copy.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/CopyMoveService/Copy.json
@@ -1,0 +1,16 @@
+{
+   "totalResults": 1,
+   "overallSuccess": true,
+   "successCount": 1,
+   "failureCount": 0,
+   "results":
+   [
+      {
+         "id": "Meeting Notes 2011-01-27.doc",
+         "action": "copyFile",
+         "nodeRef": "workspace:\/\/SpacesStore\/3f3ecd27-87fd-4bf9-bddf-a79d6cb999e4",
+         "type": "document",
+         "success": true
+      }
+   ]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/CopyMoveService/Move.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/CopyMoveService/Move.json
@@ -1,0 +1,30 @@
+{
+   "totalResults": 3,
+   "overallSuccess": false,
+   "successCount": 1,
+   "failureCount": 2,
+   "results":
+   [
+      {
+         "id": "File1",
+         "action": "moveFile",
+         "nodeRef": "workspace:\/\/SpacesStore\/3f3ecd27-87fd-4bf9-bddf-a79d6cb999e4",
+         "type": "document",
+         "success": true
+      },
+      {
+         "id": "File2",
+         "action": "moveFile",
+         "nodeRef": "workspace:\/\/SpacesStore\/3f3ecd27-87fd-4bf9-bddf-a79d6cb999e4",
+         "type": "document",
+         "success": false
+      },
+      {
+         "id": "File3",
+         "action": "moveFile",
+         "nodeRef": "workspace:\/\/SpacesStore\/3f3ecd27-87fd-4bf9-bddf-a79d6cb999e4",
+         "type": "document",
+         "success": false
+      }
+   ]
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-216 but also extracts the existing code from the ActionService so that it can be used independently and adds in unit tests that were previously missing.