### PR TITLE
AKU-163: Update AlfHashList to map hash vars to load data payload

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -57,6 +57,17 @@ define(["dojo/_base/declare",
       hashVarsForUpdate: [],
 
       /**
+       * Indicates whether or not the [hashVarsForUpdate]{@link module:alfresco/lists/AlfHashList#hashVarsForUpdate}
+       * that are present in the current hash should be mapped directly into the 
+       * [loadDataPublishPayload]{@link module:alfresco/lists/AlfList#loadDataPublishPayload}.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      mapHashVarsToPayload: false,
+
+      /**
        * Determines whether or not a locally stored hash value should be maintained and re-used in the event of 
        * a hash not being found in the URL. This was added to support the scenario where a user might leave and 
        * then return to a page having lost the hash (e.g. actions on search).
@@ -155,6 +166,32 @@ define(["dojo/_base/declare",
             else
             {
                this.loadData();
+            }
+         }
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#updateLoadDataPayload} to map
+       * the [hashVarsForUpdate]{@link module:alfresco/lists/AlfHashList#hashVarsForUpdate} values into the
+       * [loadDataPublishPayload]{@link module:alfresco/lists/AlfList#loadDataPublishPayload} if 
+       * [mapHashVarsToPayload]{@link module:alfresco/lists/AlfHashList#mapHashVarsToPayload}
+       * is set to true.
+       *
+       * @instance
+       * @param {object} payload The payload to update
+       */
+      updateLoadDataPayload: function alfresco_lists_AlfHashList__updateLoadDataPayload(payload) {
+         this.inherited(arguments);
+         if (this.mapHashVarsToPayload)
+         {
+            var hashString = hash();
+            var currHash = ioQuery.queryToObject(hashString);
+            for(var i=0; i < this.hashVarsForUpdate.length; i++)
+            {
+               if(this.hashVarsForUpdate[i] in currHash)
+               {
+                  payload[this.hashVarsForUpdate[i]] = currHash[this.hashVarsForUpdate[i]];
+               }
             }
          }
       },

--- a/aikau/src/test/resources/alfresco/lists/AlfHashListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfHashListTest.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "AlfHashList Tests",
+      
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AlfHashList#var1=initial", "AlfHashList Tests").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+      
+      "Test initial load request": function() {
+         return browser.findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_RETRIEVE_DOCUMENTS_REQUEST", "var1", "initial"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Found the initial data request");
+            });
+      },
+
+      "Set hash var that won't trigger reload": function() {
+         return browser.findByCssSelector("#SET_HASH1_label")
+            .click()
+         .end()
+         // Check that the hash change topic is last, not a request to load data...
+         .findByCssSelector(TestCommon.topicSelector("ALF_HASH_CHANGED", "publish", "last"))
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_HASH_CHANGED", "var3", "test3"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The hash was not updated correctly");
+            });
+      },
+
+      "Set hash var that will trigger reload": function() {
+         return browser.findByCssSelector("#SET_HASH2_label")
+            .click()
+         .end()
+         .findByCssSelector(TestCommon.topicSelector("ALF_RETRIEVE_DOCUMENTS_REQUEST", "publish", "last"))
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_RETRIEVE_DOCUMENTS_REQUEST", "var1", "test1"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The request did not include the mapped hash data for 'var1'");
+            })
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_RETRIEVE_DOCUMENTS_REQUEST", "var2", "test2"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The request did not include the mapped hash data for 'var2'");
+            })
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_RETRIEVE_DOCUMENTS_REQUEST", "var3", "test3"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The request should not have included hash data for 'var3'");
+            })
+         .end();
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/actions/CopyMoveTest"
+      "src/test/resources/alfresco/lists/AlfHashListTest"
    ],
 
    /**
@@ -117,8 +117,9 @@ define({
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
       "src/test/resources/alfresco/layout/TwisterTest",
 
-      "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
+      "src/test/resources/alfresco/lists/AlfHashListTest",
       "src/test/resources/alfresco/lists/FilteredListTest",
+      "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
       "src/test/resources/alfresco/lists/views/layouts/RowTest",
 
       "src/test/resources/alfresco/logo/LogoTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfHashList</shortname>
+  <description>Shows an AlfHashList which is a list that can request new data as the browser URL hash changes and use values from the hash to control the items that are returned</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfHashList</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.js
@@ -1,0 +1,87 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets: [
+      {
+         id: "SET_HASH1",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set hash (shouldn't trigger load)",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "var3=test3",
+               type: "HASH"
+            }
+         }
+      },
+      {
+         id: "SET_HASH2",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set hash (should trigger load)",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "var1=test1&var2=test2&var3=test3",
+               type: "HASH"
+            }
+         }
+      },
+      {
+         id: "HASHLIST1",
+         name: "alfresco/lists/AlfHashList",
+         config: {
+            useHash: true,
+            hashVarsForUpdate: [
+               "var1",
+               "var2"
+            ],
+            mapHashVarsToPayload: true,
+            widgets: [
+               {
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     additionalCssClasses: "bordered",
+                     noItemsMessage: "No results",
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       additionalCssClasses: "mediumpad",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-163.

I've added a new configuration attribute to AlfHashList called "mapHashVarsToPayload" which is configured to be true (the default is false for backwards compatibility) then any keys defined in the "hashVarsForUpdate" array that are found in the changed URL hash will automatically be added to the load data payload.