### PR TITLE
AKU-219: Ensure that nested single use items are re-instated on deletion

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -188,6 +188,7 @@ define(["dojo/_base/declare",
             if (item)
             {
                this._selectedItem = item;
+               this._selectedNode = evt.target.parentNode;
                array.forEach(this.sourceTarget.getAllNodes(), function(node) {
                   domClass.remove(node.firstChild, "selected");
                });
@@ -224,6 +225,7 @@ define(["dojo/_base/declare",
        * Handles requests to provide an item to insert into a [DragAndDropTarget]{@link module:alfresco/dnd/DragAndDropTarget}
        * 
        * @instance
+       * @param {object} payload The payload of the request to add an item.
        */
       onItemToAddRequest: function alfresco_dnd_DragAndDropItems__onItemToAddRequest(payload) {
          if (payload.promise && typeof payload.promise.resolve === "function")
@@ -231,12 +233,31 @@ define(["dojo/_base/declare",
             if (this._selectedItem)
             {
                payload.promise.resolve({
-                  item: lang.clone(this._selectedItem.data)
+                  item: lang.clone(this._selectedItem.data),
+                  addCallback: this.onItemAddedByKeyboard,
+                  addCallbackScope: this
                });
             }
          }
       },
-      
+
+      /**
+       * Handles items being added via the keyboard. This checks to see whether
+       * [items can only be used once]{@link module:alfresco/dnd/DragAndDropItems#useItemsOnce}
+       * and if this is the case it will remove the selected item.
+       *
+       * @instance
+       * @param  {object} item The item selected
+       */
+      onItemAddedByKeyboard: function alfresco_dnd_DragAndDropItems__onItemAddedByKeyboard(/*jshint unused:false*/ item) {
+         if (this.useItemsOnce === true && this._selectedNode)
+         {
+            this.sourceTarget.delItem(this._selectedNode.id);
+            domConstruct.destroy(this._selectedNode);
+            this._selectedNode = null;
+         }
+      },
+
       /**
        * The widgets model to render as a drag-and-drop item.
        *
@@ -263,7 +284,7 @@ define(["dojo/_base/declare",
        */
       creator: function alfresco_dnd_DragAndDropItems__creator(item, hint) {
          // jshint unused: false
-         var node = domConstruct.create("div");         
+         var node = domConstruct.create("div");
          var clonedItem = lang.clone(item);
          this.currentItem = {};
          this.currentItem.title = "";

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -458,8 +458,13 @@ define(["dojo/_base/declare",
          {
             var createdItem = this.creator(resolvedPromise.item);
             this.previewTarget.insertNodes(true, [createdItem.data]);
+            if (typeof resolvedPromise.addCallback === "function")
+            {
+               resolvedPromise.addCallback.call(resolvedPromise.addCallbackScope || this, resolvedPromise.item);
+            }
             this.onItemsUpdated();
          }
+
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/dnd/DroppedNestingItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedNestingItemWrapper.js
@@ -32,8 +32,9 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/on",
-        "dojo/Deferred"], 
-        function(declare, DroppedItemWrapper, Constants, lang, array, on, Deferred) {
+        "dojo/Deferred",
+        "dijit/registry"], 
+        function(declare, DroppedItemWrapper, Constants, lang, array, on, Deferred, registry) {
    
    return declare([DroppedItemWrapper], {
       
@@ -79,6 +80,31 @@ define(["dojo/_base/declare",
                }
             }
          }, this);
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/dnd/DroppedItemWrapper#onItemDelete} to to iterate
+       * over all the nested items an individually delete them to ensure that any items that are configured for
+       * single use only are ultimately returned to the [DragAndDropItems]{@link module:alfresco/dnd/DragAndDropItems}
+       * widget from which they were originally sourced.
+       *
+       * @instance
+       * @param {object} evt The deletion event
+       */
+      onItemDelete: function alfresco_dnd_DroppedNestingItemWrapper__onItemDelete(/* jshint unused:false */ evt) {
+         array.forEach(this._renderedWidgets, function(widget) {
+            if (widget.previewTarget && typeof widget.previewTarget.getAllNodes === "function")
+            {
+               var nodes = widget.previewTarget.getAllNodes.call(widget.previewTarget);
+               array.forEach(nodes, function(node) {
+                  var w = registry.byNode(node);
+                  if (w && typeof w.onItemDelete === "function") {
+                     w.onItemDelete.call(w);
+                  }
+               });
+            }
+         });
+         this.inherited(arguments);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -558,8 +558,8 @@ define(["intern!object",
                });
       },
 
-      "Drag and drop a single use item": function () {
-         return browser.findByCssSelector("#DRAG_PALETTE2 .dojoDndItem .title")
+      "Drag and drop a single use item into a nested target": function () {
+         return browser.findByCssSelector("#dojoUnique1 .title")
             .moveMouseTo()
             .click()
             .pressMouseButton()
@@ -574,8 +574,18 @@ define(["intern!object",
          .end()
          .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
-                  assert.lengthOf(elements, 1, "The dropped item was not found");
+                  assert.lengthOf(elements, 1, "The dropped item was found");
             })
+         .end()
+         .findByCssSelector(".alfresco-dnd-DroppedItemWrapper .alfresco-dnd-DragAndDropTarget .dojoDndTarget")
+            .click()
+         .end()
+         .pressKeys(keys.ENTER)
+         .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+            .then(function(elements) {
+                  assert.lengthOf(elements, 2, "The dropped item was not found");
+            })
+         .end()
          .findAllByCssSelector("#DRAG_PALETTE2 .dojoDndItem")
             .then(function(elements) {
                   assert.lengthOf(elements, 0, "The dragged single use item was not removed from the items list");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/multi-source.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/multi-source.get.js
@@ -10,7 +10,65 @@ model.jsonModel = {
                error: true
             }
          }
-      }
+      },
+      {
+         name: "alfresco/services/DragAndDropModellingService",
+         config: {
+            models: [
+               {
+                  property: "name",
+                  targetValues: ["bob"],
+                  widgetsForConfig: [
+                     // No config
+                  ],
+                  widgetsForDisplay: [
+                     {
+                        name: "alfresco/dnd/DroppedNestingItemWrapper",
+                        config: {
+                           showEditButton: false,
+                           label: "{label}",
+                           value: "{value}",
+                           widgets: [
+                              {
+                                 name: "alfresco/dnd/DragAndDropNestedTarget",
+                                 config: {
+                                    useModellingService: true,
+                                    label: "Widgets",
+                                    targetProperty: "config.widgets"
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  property: "name",
+                  targetValues: ["ted"],
+                  widgetsForConfig: [
+                     // No config
+                  ],
+                  widgetsForDisplay: [
+                     {
+                        name: "alfresco/dnd/DroppedNestingItemWrapper",
+                        config: {
+                           showEditButton: false,
+                           label: "{label}",
+                           value: "{value}",
+                           widgets: [
+                              {
+                                 name: "alfresco/dnd/DroppedItem"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+
+            ]
+         }
+      },
+      "alfresco/services/DialogService"
    ],
    widgets: [
       {
@@ -49,7 +107,8 @@ model.jsonModel = {
                               label: "Data",
                               name: "data",
                               value: null,
-                              acceptTypes: ["widget"]
+                              acceptTypes: ["widget"],
+                              useModellingService: true
                            }
                         }
                      ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-219 to ensure that nested single use items are re-instated when the nesting item is deleted. This also fixes keyboard navigation issues around adding single use items that were detected when fixing this issue.