### PR TITLE
AKU-230: Ensure renderOnNewLine works properly for InlineEditProperty

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -15,6 +15,9 @@
    .alfresco-renderers-Property {
       margin-left: 0;
    }
+   .alfresco-renderers-Property.block {
+      display: inline-block;
+   }
    .editIcon {
       cursor: pointer;
       display: inline-block;

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -67,6 +67,22 @@ define(["intern!object",
             });
       },
 
+      "Render on new line configuration doesn't effect icon": function() {
+         var valueX;
+         return browser.findByCssSelector("#INLINE_EDIT .inlineEditValue")
+            .getPosition()
+            .then(function(p) {
+               valueX = p.x;
+            })
+         .end()
+         .findByCssSelector("#INLINE_EDIT .editIcon")
+            .getPosition()
+            .then(function(p) {
+               assert.notEqual(valueX, p.x, "The value and icon should NOT be starting at the same X co-ordinate");
+            })
+         .end();
+      },
+
       "Icon appears on focus": function() {
          return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
             .then(function(element) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>InlineEditProperty Test</shortname>
-  <description>This WebScript defines the InlineEditProperty page test</description>
+  <shortname>InlineEditProperty Renderer</shortname>
+  <description>Shows 2 different variations on inline editing of properties, one InlineEditProperty and InlineEditSelect. These are configured in the same cell but use the renderOnNewLine configuration attribute to ensure they are not rendered on a single line.</description>
   <family>aikau-unit-tests</family>
   <url>/InlineEditProperty</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
@@ -53,16 +53,10 @@ model.jsonModel = {
                                              ruleFailValue: "",
                                              is: ["New"]
                                           }
-                                       ]
+                                       ],
+                                       renderOnNewLine: true
                                     }
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           name: "alfresco/lists/views/layouts/Cell",
-                           config: {
-                              widgets: [
+                                 },
                                  {
                                     id: "INLINE_SELECT",
                                     name: "alfresco/renderers/InlineEditSelect",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-230 and ensures that the InlineEditProperty renderer can use the renderOnNewLine configuration without corrupting the location of the edit icon