### PR TITLE
ServiceStore: Fixes RegExp error and adds search type option (used in MultiSelectInput)

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
@@ -21,7 +21,7 @@
  * This module was written with the express purpose of working with the [ComboBox]{@link module:alfresco/forms/controls/ComboBox}
  * form control. It extends the Dojo JsonRest module to support queries over the Aikau publication/subscription
  * communication layer (rather than by direct XHR request).
- * 
+ *
  * @module alfresco/forms/controls/utilities/ServiceStore
  * @extends external:dojo/store/JsonRest
  * @author Dave Draper
@@ -33,8 +33,9 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/store/util/QueryResults",
-        "dojo/store/util/SimpleQueryEngine"], 
-        function(declare, JsonRest, AlfCore, Deferred, lang, array, QueryResults, SimpleQueryEngine) {
+        "dojo/store/util/SimpleQueryEngine",
+        "dojo/regexp"],
+        function(declare, JsonRest, AlfCore, Deferred, lang, array, QueryResults, SimpleQueryEngine, regexp) {
 
    return declare([JsonRest, AlfCore], {
 
@@ -58,7 +59,7 @@ define(["dojo/_base/declare",
       publishPayload: null,
 
       /**
-       * This is the attribute to use when querying the result data for matching items. This is set to 
+       * This is the attribute to use when querying the result data for matching items. This is set to
        * "name" by default but can be overridden. When used by a [form control]{@link module:alfresco/forms/controls/BaseFormControl}
        * it would be expected that this would be set to be the [name attribute]{@link module:alfresco/forms/controls/BaseFormControl#name}
        * of that form control.
@@ -68,6 +69,16 @@ define(["dojo/_base/declare",
        * @default "name"
        */
       queryAttribute: "name",
+
+      /**
+       * Should the results all start with the search query string.
+       * If set to false, results that contain the string anywhere will match
+       *
+       * @instance
+       * @type {string}
+       * @default true
+       */
+      searchStartsWith: true,
 
       /**
        * If this is configured to be an array of fixed options then the query will be run against
@@ -82,9 +93,9 @@ define(["dojo/_base/declare",
       /**
        * This function is called to retrieve an item from the store. If the store uses fixed options
        * then these are checked and if an XHR request is required then a deferred item will be
-       * returned pending a callback to the 
+       * returned pending a callback to the
        * [onGetOptions function]{@link module:alfresco/forms/controls/utilities/ServiceStore#onGetOptions}.
-       * 
+       *
        * @instance
        * @param {string} id The id of the item to retrieve from the store
        * @param {object} options Options for finding the item
@@ -123,8 +134,8 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This is the callback function that is hitched to the request for 
-       * 
+       * This is the callback function that is hitched to the request for
+       *
        * @instance
        * @param {obejct} dfd The deferred object to resolve.
        * @param {string} resultsProperty A dot-notation address in the payload that should contain the list of options.
@@ -147,9 +158,9 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Iterates over the supplied results array to try and find an item where it's 
+       * Iterates over the supplied results array to try and find an item where it's
        * valueAttribute matches the supplied id.
-       * 
+       *
        * @instance
        * @param {array} results The results to iterate over
        * @param {string} id The id of the item to find
@@ -167,7 +178,7 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This function is used to actually query the results (either from a pub/sub request or 
+       * This function is used to actually query the results (either from a pub/sub request or
        * defined in a fixed list of options).
        *
        * @instance
@@ -179,14 +190,21 @@ define(["dojo/_base/declare",
          var queryAttribute = (this.queryAttribute != null) ? this.queryAttribute : "name";
          var labelAttribute = (this.labelAttribute != null) ? this.labelAttribute : "label";
          var valueAttribute = (this.valueAttribute != null) ? this.valueAttribute : "value";
-         
+
          // Check that all the data is valid, this is done to ensure any data sets that don't contain all the data...
          // This is a workaround for an issue with the Dojo query engine that will break when an item doesn't contain
          // the query attribute...
          array.forEach(results, lang.hitch(this, this.processResult, queryAttribute, labelAttribute, valueAttribute));
 
-         var updatedQuery = {};
-         updatedQuery[this.queryAttribute] = new RegExp("^" + query[this.queryAttribute].toString() + ".*$", "i");
+         var safeQueryString = regexp.escapeString(query[this.queryAttribute].toString()),
+            rePrefix = "",
+            updatedQuery = {};
+
+         if (this.searchStartsWith) {
+            rePrefix = "^"
+         }
+
+         updatedQuery[this.queryAttribute] = new RegExp(rePrefix + safeQueryString + ".*$", "i");
 
          // NOTE: Ignore JSHint warnings on the following 2 lines...
          var queryEngine = SimpleQueryEngine(updatedQuery);
@@ -195,12 +213,12 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Processes the results to check that all the data is valid, this is done to ensure any 
-       * data sets that don't contain all the data are corrected.This is a workaround for an 
+       * Processes the results to check that all the data is valid, this is done to ensure any
+       * data sets that don't contain all the data are corrected.This is a workaround for an
        * issue with the Dojo query engine that will break when an item doesn't contain
        * the query attribute. This function also adds label and value attributes to the item
        * if they're not present.
-       * 
+       *
        * @instance
        * @param {array} options The array to add the processed item to
        * @param {object} config The configuration to use for processing the option
@@ -236,9 +254,9 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Makes a request for data by publishing a request on a specific topic. This returns a 
-       * Deferred object which is resolved by the 
-       * [onQueryOptions]{@link module:alfresco/forms/controls/utilities/ServiceStore#onQueryOptions} 
+       * Makes a request for data by publishing a request on a specific topic. This returns a
+       * Deferred object which is resolved by the
+       * [onQueryOptions]{@link module:alfresco/forms/controls/utilities/ServiceStore#onQueryOptions}
        * function.
        *
        * @instance
@@ -272,7 +290,7 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Overrides the inherited function from the JsonRest store to call either the 
+       * Overrides the inherited function from the JsonRest store to call either the
        * [queryXhrOptions]{@link module:alfresco/forms/controls/utilities/ServiceStore#queryXhrOptions}
        * or [queryFixedOptions]{@link module:alfresco/forms/controls/utilities/ServiceStore#queryFixedOptions}
        * depending upon how this module has been configured.

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/UseServiceStoreMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/UseServiceStoreMixin.js
@@ -23,21 +23,21 @@
  * [FilteringSelect]{@link module:alfresco/forms/controls/FilteringSelect}
  * form controls. It provides functions for creating and working with
  * a [ServiceStore]{@link module:alfresco/forms/controls/utilities/ServiceStore}.
- * 
+ *
  * @module alfresco/forms/controls/utilities/UseServiceStoreMixin
  * @extends external:dojo/store/JsonRest
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
         "dojo/_base/lang",
-        "alfresco/forms/controls/utilities/ServiceStore"], 
+        "alfresco/forms/controls/utilities/ServiceStore"],
         function(declare, lang, ServiceStore) {
 
    return declare([], {
 
       /**
        * Creates and returns a new service store.
-       * 
+       *
        * @instance
        */
       createServiceStore: function alfresco_forms_controls_utilities_UseServiceStoreMixin__createServiceStore() {
@@ -47,6 +47,7 @@ define(["dojo/_base/declare",
          var labelAttribute = lang.getObject("optionsConfig.labelAttribute", false, this);
          var valueAttribute = lang.getObject("optionsConfig.valueAttribute", false, this);
          var fixedOptions = lang.getObject("optionsConfig.fixed", false, this);
+         var searchStartsWith = lang.getObject("optionsConfig.searchStartsWith", true, this);
          var serviceStore = new ServiceStore({
             idProperty: (valueAttribute != null) ? valueAttribute : "value",
             queryAttribute: (queryAttribute != null) ? queryAttribute : "name",
@@ -54,7 +55,8 @@ define(["dojo/_base/declare",
             valueAttribute: (valueAttribute != null) ? valueAttribute : "value",
             publishTopic: publishTopic,
             publishPayload: publishPayload,
-            fixed: fixedOptions
+            fixed: fixedOptions,
+            searchStartsWith: searchStartsWith
          });
          return serviceStore;
       },

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -106,6 +106,30 @@ define([
                });
          },
 
+         "Typing into search box filters results for strings in middle of tag name": function () {
+            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
+               .type("tag12")
+               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
+               .end()
+
+               .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
+               .then(function (elements) {
+                  assert.lengthOf(elements, 1, "Did not filter results for string in middle of tag name");
+               });
+         },
+
+         "Search box correctly filters on special reg exp chars": function () {
+            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
+               .type("(a")
+               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
+               .end()
+
+               .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
+               .then(function (elements) {
+                  assert.lengthOf(elements, 1, "Did not filter results using special reg exp character");
+               });
+         },
+
          "Clicking cross on a chosen item removes it": function() {
             return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__close-button")
                .click()

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -72,7 +72,7 @@ define([
 
             .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
                .then(function(elements) {
-                  assert.lengthOf(elements, 4, "Did not bring up initial results");
+                  assert.lengthOf(elements, 7, "Did not bring up initial results");
                });
          },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -106,20 +106,22 @@ define([
                });
          },
 
-         "Typing into search box filters results for strings in middle of tag name": function () {
+         "Typing into search box filters results for strings in middle of name": function () {
             return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
-               .type("tag12")
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
+               .clearValue()
+               .type("12")
+               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(2)")
                .end()
 
                .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
                .then(function (elements) {
-                  assert.lengthOf(elements, 1, "Did not filter results for string in middle of tag name");
+                  assert.lengthOf(elements, 1, "Did not filter results for string in middle of name" + elements);
                });
          },
 
          "Search box correctly filters on special reg exp chars": function () {
             return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
+               .clearValue()
                .type("(a")
                .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
                .end()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -45,7 +45,8 @@ model.jsonModel = {
                         publishTopic: "ALF_RETRIEVE_CURRENT_TAGS",
                         publishPayload: {
                            resultsProperty: "response.data.items"
-                        }
+                        },
+                        searchStartsWith: false
                      }
                   }
                }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/MultiSelectInputTest/tags.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/MultiSelectInputTest/tags.json
@@ -83,6 +83,60 @@
          },
          "nodeRef": "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478e",
          "selectable": true
+      }, {
+         "type": "cm:category",
+         "parentType": "cm:cmobject",
+         "parentName": "Tags",
+         "isContainer": false,
+         "name": "newtag12new",
+         "title": "",
+         "description": "",
+         "modified": "2014-08-18T10:50:29.877+01:00",
+         "modifier": "admin",
+         "displayPath": "\/categories\/Tags",
+         "userAccess": {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "nodeRef": "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478f",
+         "selectable": true
+      }, {
+         "type": "cm:category",
+         "parentType": "cm:cmobject",
+         "parentName": "Tags",
+         "isContainer": false,
+         "name": "newtag13(a)",
+         "title": "",
+         "description": "",
+         "modified": "2014-08-18T11:43:29.877+01:00",
+         "modifier": "admin",
+         "displayPath": "\/categories\/Tags",
+         "userAccess": {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "nodeRef": "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478g",
+         "selectable": true
+      }, {
+         "type": "cm:category",
+         "parentType": "cm:cmobject",
+         "parentName": "Tags",
+         "isContainer": false,
+         "name": "newtag13(b)",
+         "title": "",
+         "description": "",
+         "modified": "2014-08-18T12:43:29.877+01:00",
+         "modifier": "admin",
+         "displayPath": "\/categories\/Tags",
+         "userAccess": {
+            "create": true,
+            "edit": true,
+            "delete": true
+         },
+         "nodeRef": "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478h",
+         "selectable": true
       }]
    }
 }


### PR DESCRIPTION
Two issues I discussed with @MartinDoyleUK:
1) RegExp string injection is fragile if the string contains any RegExp special chars (e.g. brackets). I've fixed this to escape the string first
2) MultiSelectInput shouldn't require the matching result to start with the search term, so I've added an option to the service store to turn that off.

Tests included.