### PR TITLE
AKU-245: Localize the CrudService messages

### DIFF
--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -82,7 +82,6 @@ define(["dojo/_base/declare",
             message = "crudservice.generic.success.message";
          }
 
-         // TODO: Need a context sensitive, localized message...
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message(message)
          });

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -79,12 +79,12 @@ define(["dojo/_base/declare",
 
          var message = lang.getObject("successMessage", false, originalRequestConfig);
          if (!message) {
-            message = this.message("crudservice.generic.success.message");
+            message = "crudservice.generic.success.message";
          }
 
          // TODO: Need a context sensitive, localized message...
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
-            message: message
+            message: this.message(message)
          });
 
          var noRefresh = lang.getObject("data.noRefresh", false, originalRequestConfig);
@@ -231,9 +231,9 @@ define(["dojo/_base/declare",
             data: this.clonePayload(payload),
             method: "POST",
             alfTopic: payload.alfResponseTopic,
-            successMessage: payload.successMessage,
+            successMessage: this.message(payload.successMessage || "crudservice.generic.success.message"),
             successCallback: this.refreshRequest,
-            failureMessage: payload.failureMessage,
+            failureMessage: this.message(payload.failureMessage || "crudservice.generic.failure.message"),
             failureCallback: this.failureCallback,
             callbackScope: this
          });
@@ -251,9 +251,9 @@ define(["dojo/_base/declare",
             data: this.clonePayload(payload),
             method: "PUT",
             alfTopic: payload.alfResponseTopic,
-            successMessage: payload.successMessage,
+            successMessage: this.message(payload.successMessage || "crudservice.generic.success.message"),
             successCallback: this.refreshRequest,
-            failureMessage: payload.failureMessage,
+            failureMessage: this.message(payload.failureMessage || "crudservice.generic.failure.message"),
             failureCallback: this.failureCallback,
             callbackScope: this
          });
@@ -296,34 +296,34 @@ define(["dojo/_base/declare",
          var responseTopic = this.generateUuid();
          this._deleteHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onDeleteConfirmation), true);
 
-         var title = payload.confirmationTitle || this.message("crudservice.generic.delete.title");
-         var prompt = payload.confirmationPrompt || this.message("crudservice.generic.delete.prompt");
-         var confirmButtonLabel = payload.confirmationButtonLabel || this.message("crudservice.generic.delete.confirmationButtonLabel");
-         var cancelButtonLabel = payload.cancellationButtonLabel || this.message("crudservice.generic.delete.cancellationButtonLabel");
+         var title = payload.confirmationTitle || "crudservice.generic.delete.title";
+         var prompt = payload.confirmationPrompt || "crudservice.generic.delete.prompt";
+         var confirmButtonLabel = payload.confirmationButtonLabel || "crudservice.generic.delete.confirmationButtonLabel";
+         var cancelButtonLabel = payload.cancellationButtonLabel || "crudservice.generic.delete.cancellationButtonLabel";
 
          var dialog = new AlfDialog({
             generatePubSubScope: false,
-            title: title,
-            textContent: prompt,
+            title: this.message(title),
+            textContent: this.message(prompt),
             widgetsButtons: [
                {
                   name: "alfresco/buttons/AlfButton",
                   config: {
-                     label: confirmButtonLabel,
+                     label: this.message(confirmButtonLabel),
                      publishTopic: responseTopic,
                      publishPayload: {
                         url: url,
                         pubSubScope: payload.pubSubScope,
                         responseTopic: payload.responseTopic,
-                        successMessage: payload.successMessage,
-                        failureMessage: payload.failureMessage
+                        successMessage: this.message(payload.successMessage || "crudservice.generic.success.message"),
+                        failureMessage: this.message(payload.failureMessage || "crudservice.generic.failure.message")
                      }
                   }
                },
                {
                   name: "alfresco/buttons/AlfButton",
                   config: {
-                     label: cancelButtonLabel,
+                     label: this.message(cancelButtonLabel),
                      publishTopic: "close"
                   }
                }
@@ -348,9 +348,9 @@ define(["dojo/_base/declare",
             method: "DELETE",
             data: this.clonePayload(payload),
             alfTopic: payload.responseTopic,
-            successMessage: payload.successMessage,
+            successMessage: this.message(payload.successMessage || "crudservice.generic.success.message"),
             successCallback: this.refreshRequest,
-            failureMessage: payload.failureMessage,
+            failureMessage: this.message(payload.failureMessage || "crudservice.generic.failure.message"),
             failureCallback: this.failureCallback,
             callbackScope: this
          });
@@ -388,7 +388,7 @@ define(["dojo/_base/declare",
          // Get the failure message and display a notification
          var message = originalRequestConfig.failureMessage || this.message("crudservice.generic.failure.message");
          this.alfPublish("ALF_DISPLAY_PROMPT", {
-            message: message
+            message: this.message(message)
          });
       }
    });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-245 to ensure that all messages generated by the CrudService get localized. I've not added a unit test for this as it seems superfluous and is likely to be covered by other unit tests (e.g. editing/deleting comments, etc)