### PR TITLE
AKU-242: Paginator page size menu configuration

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/ResultsPerPageGroup.js
+++ b/aikau/src/main/resources/alfresco/lists/ResultsPerPageGroup.js
@@ -70,7 +70,7 @@ define(["dojo/_base/declare",
        */
       postMixInProperties: function alfresco_lists_ResultsPerPageGroup__postMixInProperties() {
          this.inherited(arguments);
-         this.alfSubscribe(this.docsPerpageSelectionTopic, lang.hitch(this, "onDocumentsPerPageChange"));
+         this.alfSubscribe(this.docsPerpageSelectionTopic, lang.hitch(this, this.onDocumentsPerPageChange));
          this.alfPublish(this.getPreferenceTopic, {
             preference: "org.alfresco.share.documentList.documentsPerPage",
             callback: this.setDocumentsPerPage,

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelect.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelect.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -87,11 +87,11 @@ define(["dojo/_base/declare",
             // Update the label with the selection...
             if (payload.label)
             {
-               this.set('label', this.message(payload.label));
+               this.set("label", this.message(payload.label));
             }
-            else if (payload.value != null)
+            else if (payload.value || payload.value === "")
             {
-               this.set('label', payload.value.toString()); 
+               this.set("label", payload.value.toString()); 
             }
             
             // Update the icon if there is an icon node, it's supported and there is a new iconClass...

--- a/aikau/src/test/resources/alfresco/CodeCoverageBalancer.js
+++ b/aikau/src/test/resources/alfresco/CodeCoverageBalancer.js
@@ -42,10 +42,6 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end().alfPostCoverageResults(browser);
-      // },
-
       "Balance": function () {
          if(args.doCoverage === "true")
          {

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -41,10 +41,6 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-     
       "Test page selector drop-down label intialization": function () {
          browser = this.remote;
          return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
@@ -53,6 +49,35 @@ define(["intern!object",
             .getVisibleText()
             .then(function(text) {
                assert(text === "1-25 of 243", "Page selector menu label didn't initialize correctly, expected '1-25 of 243' but saw: " + text);
+            });
+      },
+
+      "Test custom configured page selector drop-down label intialization": function () {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
+            .end()
+         .findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR_text")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "1-10 of 243", "Page selector menu label didn't initialize correctly for custom pagination");
+            });
+      },
+
+      "Test custom configured page size selector value": function() {
+         return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "10 per page", "Page size menu label didn't initialize correctly for custom pagination");
+            });
+      },
+
+      "Count custom configured page sizes": function() {
+         return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .click()
+            .end()
+         .findAllByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown .alf-checkable-menu-item")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "The wrong number of custom page sizes was found");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>Paginator Test</shortname>
-  <description>This WebScript defines the Paginator page test</description>
+  <shortname>Paginator</shortname>
+  <description>Shows the Paginator, ResultsPerPageGroup and AlfSortablePaginatedList widgets in both the default and variable page size settings.</description>
   <family>aikau-unit-tests</family>
   <url>/Paginator</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -20,54 +20,134 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         id: "MENU_BAR",
-         name: "alfresco/menus/AlfMenuBar",
+         name: "alfresco/layout/HorizontalWidgets",
          config: {
             widgets: [
                {
-                  id: "PAGINATOR",
-                  name: "alfresco/lists/Paginator",
+                  id: "DEFAULT_CONFIG",
+                  name: "alfresco/layout/ClassicWindow",
                   config: {
-                     hidePageSizeOnWidth: 100
-                  }
-               },
-               {
-                  id: "MENU_BAR_POPUP",
-                  name: "alfresco/menus/AlfMenuBarPopup",
-                  config: {
-                     label: "Popup",
+                     title: "Default page settings",
                      widgets: [
                         {
-                           name: "alfresco/lists/ResultsPerPageGroup"
-                        }
-                     ]
-                  }
-               }
-            ]
-         }
-      },
-      {
-         id: "LIST",
-         name: "alfresco/lists/AlfSortablePaginatedList",
-         config: {
-            useHash: false,
-            widgets: [
-               {
-                  name: "alfresco/lists/views/AlfListView",
-                  config: {
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/layouts/Row",
+                           id: "MENU_BAR",
+                           name: "alfresco/menus/AlfMenuBar",
                            config: {
                               widgets: [
                                  {
-                                    name: "alfresco/lists/views/layouts/Cell",
+                                    id: "PAGINATOR",
+                                    name: "alfresco/lists/Paginator",
+                                    config: {
+                                       hidePageSizeOnWidth: 100
+                                    }
+                                 },
+                                 {
+                                    id: "MENU_BAR_POPUP",
+                                    name: "alfresco/menus/AlfMenuBarPopup",
+                                    config: {
+                                       label: "Popup",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/ResultsPerPageGroup"
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "LIST",
+                           name: "alfresco/lists/AlfSortablePaginatedList",
+                           config: {
+                              useHash: false,
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/AlfListView",
                                     config: {
                                        widgets: [
                                           {
-                                             name: "alfresco/renderers/Property",
+                                             name: "alfresco/lists/views/layouts/Row",
                                              config: {
-                                                propertyToRender: "index"
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      config: {
+                                                         widgets: [
+                                                            {
+                                                               name: "alfresco/renderers/Property",
+                                                               config: {
+                                                                  propertyToRender: "index"
+                                                               }
+                                                            }
+                                                         ]
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "CUSTOM_PAGE_SIZES",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Custom page sizes",
+                     pubSubScope: "CUSTOM_",
+                     widgets: [
+                        {
+                           id: "MENU_BAR",
+                           name: "alfresco/menus/AlfMenuBar",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "CUSTOM_PAGE_SIZE_PAGINATOR",
+                                    name: "alfresco/lists/Paginator",
+                                    config: {
+                                       documentsPerPage: 10,
+                                       hidePageSizeOnWidth: 100,
+                                       pageSizes: [5,10,20]
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "LIST",
+                           name: "alfresco/lists/AlfSortablePaginatedList",
+                           config: {
+                              useHash: false,
+                              currentPageSize: 10,
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/AlfListView",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Row",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      config: {
+                                                         widgets: [
+                                                            {
+                                                               name: "alfresco/renderers/Property",
+                                                               config: {
+                                                                  propertyToRender: "index"
+                                                               }
+                                                            }
+                                                         ]
+                                                      }
+                                                   }
+                                                ]
                                              }
                                           }
                                        ]
@@ -90,9 +170,6 @@ model.jsonModel = {
                "ALF_DOCLIST_DOCUMENTS_LOADED"
             ]
          }
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/tutorial/chapters/Tutorial11.md
+++ b/tutorial/chapters/Tutorial11.md
@@ -106,12 +106,15 @@ Update the page model so that after the group AlfSortablePaginatedList the follo
 {
   name: "alfresco/lists/Paginator",
   config: {
-    documentsPerPage: 5
+    documentsPerPage: 5,
+    pageSizes: [5,10,20]
   }
 }
 ```
 
 The default number of results per page is 25, and it’s unlikely that you’ve created that many groups so in order to see pagination in action we’re overriding the default to only display 5 results in each page of data. If you’re currently only seeing 5 (or fewer) groups in the list then create a couple more so that you can test pagination!
+
+We're also changing the default page sizes configuration (which would normally be 25,50,75 & 100) to a more suitable set for this example. You may also note that the page size selection menu is hidden as the browser window changes size. This is done to preserve screen "real estate" can can be controlled by the `hidePageSizeOnWidth` configuration attribute (which defaults to 1024).
 
 We also need to make some updates to the AlfSortablePaginatedList configuration to map it against the data that it will receive (an alternative approach would be to add a callback in our service that normalizes the response to fit the defaults). Add the following to the configuration:
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-242 and updates the alfresco/lists/Paginator widget to support configurable page sizes. Unit tests, JSDoc and JSHint fixes are included.