### PR TITLE
AKU-232: ActionService update and test

### DIFF
--- a/aikau/src/main/resources/alfresco/core/JsNode.js
+++ b/aikau/src/main/resources/alfresco/core/JsNode.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -80,7 +80,7 @@ define(["dojo/_base/declare",
             lang.mixin(this.node, args);
             this.nodeJson = dojoJson.stringify(this.node);
          }
-         if (this.node != null)
+         if (this.node)
          {
             this.nodeRef = NodeUtils.processNodeRef(this.node.nodeRef);
             this.properties = this.node.properties || {};
@@ -118,7 +118,7 @@ define(["dojo/_base/declare",
                   }
                   this.properties[index.replace(/:/g, "_")] = this.properties[index];
                }
-            };
+            }
          }
       },
 
@@ -244,7 +244,7 @@ define(["dojo/_base/declare",
        */
       constructor: function alfresco_core_JsNode__constructor(args) {
          var primaryJsNode = new JsNode(args);
-         if (primaryJsNode.node != null && primaryJsNode.node.linkedNode != null)
+         if (primaryJsNode.node && primaryJsNode.node.linkedNode)
          {
             primaryJsNode.linkedNode = new JsNode(primaryJsNode.linkedNode);
          }

--- a/aikau/src/main/resources/alfresco/core/NodeUtils.js
+++ b/aikau/src/main/resources/alfresco/core/NodeUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -20,12 +20,12 @@
 /**
  *
  * @module alfresco/core/NodeUtils
- * @author Dave Draper & David Webster
+ * @author Dave Draper
+ * @author David Webster
  */
 define(["dojo/_base/lang",
         "dojo/_base/array"],
         function(lang, array) {
-
    return {
 
       /**
@@ -38,7 +38,6 @@ define(["dojo/_base/lang",
       processNodeRef: function alfresco_core_NodeUtils__processNodeRef(nodeRefInput) {
          try
          {
-
             // Split the nodeRef and rebuild from composite parts, for clarity and to support input of uri node refs.
             var arr = nodeRefInput.replace(":/", "").split("/"),
                storeType = arr[0],
@@ -75,7 +74,6 @@ define(["dojo/_base/lang",
        * @returns {Array} nodeRefArray
        */
       nodeRefArray: function alfresco_core_NodeUtils__nodeRefArray(nodes) {
-
          if (!lang.isArray(nodes))
          {
             this.alfLog("error", "expected an array of nodes, but didn't receive one");
@@ -86,7 +84,6 @@ define(["dojo/_base/lang",
                return node.nodeRef;
             }
          });
-
          return nodeRefArray;
       },
 
@@ -97,9 +94,8 @@ define(["dojo/_base/lang",
        * @returns {String} comma separated list of nodeRefs
        */
       nodeRefsString: function alfresco_core_NodeUtils_nodeRefString(nodes) {
-
          // Use nodeRefArray to extract the nodeRefs from the object.
-         return this.nodeRefArray(nodes).join(',');
+         return this.nodeRefArray(nodes).join(",");
       },
 
       /**
@@ -128,7 +124,7 @@ define(["dojo/_base/lang",
             {
                for (var i = 1, j = record.length, sameParent = true; i < j && sameParent; i++)
                {
-                  sameParent = (record[i].parent.nodeRef == record[i - 1].parent.nodeRef);
+                  sameParent = (record[i].parent.nodeRef === record[i - 1].parent.nodeRef);
                }
 
                nodeRef = sameParent ? record[0].parent.nodeRef : this.doclistMetadata.container;
@@ -138,7 +134,6 @@ define(["dojo/_base/lang",
          {
             nodeRef = lang.getObject("record.parent.nodeRef", false, this);
          }
-
          return nodeRef;
       }
    };

--- a/aikau/src/main/resources/alfresco/renderers/SmallThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/SmallThumbnail.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -54,7 +54,7 @@ define(["dojo/_base/declare",
        * @param {string} renditionName
        * @returns {string}
        */
-      generateThumbnailUrl: function alfresco_renderers_SmallThumbnail__generateThumbnailUrl(renditionName) {
+      generateThumbnailUrl: function alfresco_renderers_SmallThumbnail__generateThumbnailUrl(/*jshint unused:false*/renditionName) {
          var url,
              jsNode = this.currentItem.jsNode;
          if (jsNode.isContainer || (jsNode.isLink && jsNode.linkedNode.isContainer))

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -919,115 +919,81 @@ define(["dojo/_base/declare",
        * @param {object} documents The document edit offline.
        */
       onActionDelete: function alfresco_services_ActionService__onActionDelete(payload, documents) {
-
-         var responseTopic = this.generateUuid();
-         this._actionDeleteHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onActionDeleteConfirmation), true);
-
-         var dialog = new AlfDialog({
-            generatePubSubScope: false,
-            title: this.message("delete-dialog.title"),
-            widgetsContent: [
-               {
-                  name: "alfresco/lists/views/AlfListView",
-                  config: {
-                     additionalCssClasses: "no-highlight",
-                     currentData: {
-                        items: documents
-                     },
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/layouts/Row",
-                           config: {
-                              widgets: [
-                                 {
-                                    name: "alfresco/lists/views/layouts/Cell",
-                                    config: {
-                                       widgets: [
-                                          {
-                                             name: "alfresco/renderers/SmallThumbnail"
-                                          }
-                                       ]
-                                    }
-                                 },
-                                 {
-                                    name: "alfresco/lists/views/layouts/Cell",
-                                    config: {
-                                       widgets: [
-                                          {
-                                             name: "alfresco/renderers/Property",
-                                             config: {
-                                                propertyToRender: "node.properties.cm:name"
-                                             }
-                                          }
-                                       ]
-                                    }
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  }
-               }
-            ],
-            widgetsButtons: [
-               {
-                  name: "alfresco/buttons/AlfButton",
-                  config: {
-                     label: this.message("services.ActionService.button.ok"),
-                     publishTopic: responseTopic,
-                     publishPayload: {
-                        nodes: documents,
-                        completionTopic: payload.completionTopic
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/buttons/AlfButton",
-                  config: {
-                     label: this.message("services.ActionService.button.cancel"),
-                     publishTopic: "close"
-                  }
-               }
-            ]
+         this.alfPublish("ALF_DELETE_CONTENT_REQUEST", {
+            nodes: documents || [payload.document]
          });
-         dialog.show();
-      },
 
-      /**
-       * This function is called when the user confirms that they wish to delete a document
-       *
-       * @instance
-       * @param {object} payload An object containing the details of the document(s) to be deleted.
-       */
-      onActionDeleteConfirmation: function alfresco_services_ActionService__onActionDeleteConfirmation(payload) {
-         this.alfUnsubscribeSaveHandles([this._actionDeleteHandle]);
+         // var responseTopic = this.generateUuid();
+         // this._actionDeleteHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onActionDeleteConfirmation), true);
 
-         var nodeRefs = array.map(payload.nodes, function(item) {
-            return item.nodeRef;
-         });
-         var responseTopic = this.generateUuid();
-         var subscriptionHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onActionDeleteSuccess), true);
-
-         this.serviceXhr({
-            alfTopic: responseTopic,
-            subscriptionHandle: subscriptionHandle,
-            url: AlfConstants.PROXY_URI + "slingshot/doclib/action/files?alf_method=delete",
-            method: "POST",
-            data: {
-               nodeRefs: nodeRefs
-            }
-         });
-      },
-
-      /**
-       * This action will be called when documents are successfully deleted
-       *
-       * @instance
-       * @param {object} payload
-       */
-      onActionDeleteSuccess: function alfresco_services_ActionService__onActionDeleteSuccess(payload) {
-         // jshint unused:false
-         this.onActionCompleteSuccess(arguments);
+         // var dialog = new AlfDialog({
+         //    generatePubSubScope: false,
+         //    title: this.message("delete-dialog.title"),
+         //    widgetsContent: [
+         //       {
+         //          name: "alfresco/lists/views/AlfListView",
+         //          config: {
+         //             additionalCssClasses: "no-highlight",
+         //             currentData: {
+         //                items: documents
+         //             },
+         //             widgets: [
+         //                {
+         //                   name: "alfresco/lists/views/layouts/Row",
+         //                   config: {
+         //                      widgets: [
+         //                         {
+         //                            name: "alfresco/lists/views/layouts/Cell",
+         //                            config: {
+         //                               widgets: [
+         //                                  {
+         //                                     name: "alfresco/renderers/SmallThumbnail"
+         //                                  }
+         //                               ]
+         //                            }
+         //                         },
+         //                         {
+         //                            name: "alfresco/lists/views/layouts/Cell",
+         //                            config: {
+         //                               widgets: [
+         //                                  {
+         //                                     name: "alfresco/renderers/Property",
+         //                                     config: {
+         //                                        propertyToRender: "node.properties.cm:name"
+         //                                     }
+         //                                  }
+         //                               ]
+         //                            }
+         //                         }
+         //                      ]
+         //                   }
+         //                }
+         //             ]
+         //          }
+         //       }
+         //    ],
+         //    widgetsButtons: [
+         //       {
+         //          name: "alfresco/buttons/AlfButton",
+         //          config: {
+         //             label: this.message("services.ActionService.button.ok"),
+         //             publishTopic: responseTopic,
+         //             publishPayload: {
+         //                nodes: documents,
+         //                completionTopic: payload.completionTopic
+         //             }
+         //          }
+         //       },
+         //       {
+         //          name: "alfresco/buttons/AlfButton",
+         //          config: {
+         //             label: this.message("services.ActionService.button.cancel"),
+         //             publishTopic: "close"
+         //          }
+         //       }
+         //    ]
+         // });
+         // dialog.show();
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/i18n/ActionService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/ActionService.properties
@@ -57,9 +57,6 @@ tip.insitu-tag=Tag
 ## File Upload (upload new version)
 label.filter-description=Same type as {0}
 
-## Delete Dialog
-delete-dialog.title=Confirm Delete
-
 ## Edit Details Dialog
 edit-details.title=Edit Properties: {0}
 edit-details.label.edit-metadata=All Properties...

--- a/aikau/src/main/resources/alfresco/services/i18n/ContentService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/ContentService.properties
@@ -1,0 +1,11 @@
+## Upload
+contentService.uploader.dialog.title=Select files to upload
+contentService.uploader.dialog.confirmation=Upload
+contentService.uploader.dialog.cancellation=Cancel
+contentService.uploader.dialog.fileSelect.label=Select files to upload...
+
+## Delete
+contentService.delete.dialog.title=Confirm Delete
+contentService.delete.confirmation=Delete
+contentService.delete.cancellation=Cancel
+contentService.delete.success.message=Delete successful

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "ContentService Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/ContentService", "ContentService Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Delete node (basic data)": function() {
+         return browser.findByCssSelector("#DELETE_CONTENT_1_label")
+            .click()
+         .end()
+         .findByCssSelector(".dijitDialogTitle")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The confirmation dialog was not displayed");
+            });
+      },
+
+      "Check dialog title (basic data)": function() {
+         return browser.findByCssSelector(".dijitDialogTitle")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Confirm Delete", "The confirmation dialog title was wrong");
+            });
+      },
+
+      "Count displayed items for deletion": function() {
+         return browser.findAllByCssSelector(".dialog-body .alfresco-renderers-Property .value")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Unexpected number of items to delete");
+            });
+      },
+
+      "Check display name for item to delete": function() {
+         return browser.findByCssSelector(".dialog-body .alfresco-renderers-Property .value")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Some Node Title", "The item display name was wrong");
+            });
+      },
+
+      "Confirm delete (basic data)": function() {
+         return browser.findByCssSelector(".footer .alfresco-buttons-AlfButton:first-child .dijitButtonText")
+            .click()
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "Delete successful"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Could not find success notification");
+            });
+      },
+
+      "Delete node (doclib data)": function() {
+         return browser.sleep(500).findByCssSelector("#DELETE_CONTENT_2_label")
+            .click()
+         .end()
+         .findByCssSelector(".dialog-body .alfresco-renderers-Property .value")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Some Node", "The item property name was not displayed");
+            });
+      },
+
+      "Confirm delete (doclib data)": function() {
+         return browser.findByCssSelector(".footer .alfresco-buttons-AlfButton:first-child .dijitButtonText")
+            .click()
+         .end()
+         .sleep(500)
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "Delete successful"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Could not find success notification");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -174,6 +174,7 @@ define({
       "src/test/resources/alfresco/search/FacetFiltersTest",
       "src/test/resources/alfresco/search/SearchSuggestionsTest",
 
+      "src/test/resources/alfresco/services/ContentServiceTest",
       "src/test/resources/alfresco/services/CrudServiceTest",
       "src/test/resources/alfresco/services/DialogServiceTest",
       "src/test/resources/alfresco/services/NotificationServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Content Service</shortname>
+  <description>Displays buttons that use the ContentService service to create, update, delete and upload content.</description>
+  <family>aikau-unit-tests</family>
+  <url>/ContentService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
@@ -1,0 +1,68 @@
+model.jsonModel = {
+   services: [
+      {
+            name: "alfresco/services/LoggingService",
+            config: {
+               loggingPreferences: {
+                  enabled: true,
+                  all: true
+               }
+            }
+      },
+      "alfresco/services/DialogService",
+      "alfresco/services/ActionService",
+      "alfresco/services/ContentService"
+   ],
+   widgets: [
+      {
+         id: "DELETE_CONTENT_1",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Delete Content",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: {
+                  type: "javascript",
+                  params: {
+                     "function": "onActionDelete"
+                  }
+               },
+               document: {
+                  nodeRef: "workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                  displayName: "Some Node Title"
+               }
+            }
+         }
+      },
+      {
+         id: "DELETE_CONTENT_2",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Delete Content (different node data)",
+            publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: {
+                  type: "javascript",
+                  params: {
+                     "function": "onActionDelete"
+                  }
+               },
+               document: {
+                  node: {
+                     nodeRef: "workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                     properties: {
+                        "cm:name": "Some Node"
+                     }
+                  }
+               }
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/CreateContentMockXhr"
+      },
+      {
+         name: "alfresco/logging/SubscriptionLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CreateContentMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CreateContentMockXhr.js
@@ -38,6 +38,11 @@ define(["dojo/_base/declare",
       setupServer: function alfresco_testing_CreateContentMockXhr__setupServer() {
          try
          {
+            this.server.respondWith("POST",
+                                    "/aikau/proxy/alfresco/slingshot/doclib/action/files?alf_method=delete",
+                                    [200,
+                                    {"Content-Type":"application/json;charset=UTF-8"},
+                                     ""]);
             this.server.respondWith("GET",
                                     /\/aikau\/proxy\/alfresco\/slingshot\/doclib\/node-templates/,
                                     [200,


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-232. I'm continuing to move actions out of the ActionService and into more appropriate services so that they can be easily called outside of the Document Library. I've made the fix originally required for the issue and added a unit test that was missing for the delete action (and a few JShint fixes along the way).