### PR TITLE
AKU-235: Update archetype pom.xml to use 5.0.d

### DIFF
--- a/aikau-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/aikau-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,12 +29,12 @@
       <dependency>
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf</artifactId>
-         <version>5.1-SNAPSHOT</version>
+         <version>5.0.d</version>
       </dependency>
       <dependency>
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf-api</artifactId>
-         <version>5.1-SNAPSHOT</version>
+         <version>5.0.d</version>
       </dependency>
       <dependency>
          <groupId>org.tuckey</groupId>


### PR DESCRIPTION
This should have been included in the previous PR for https://issues.alfresco.com/jira/browse/AKU-235