### PR TITLE
AKU-243: Added sorting and pagination to CommentsList

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSitesList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSitesList.js
@@ -134,7 +134,7 @@ define(["dojo/_base/declare",
          // With the pagination items mapped to what the documentList expects
          this.alfPublish(this.documentsLoadedTopic, {
             documents: this._currentData.items,
-            totalDocuments: pagination.totalItems,
+            totalRecords: pagination.totalItems,
             startIndex: pagination.skipCount
          });
 

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
@@ -213,7 +213,7 @@ define(["alfresco/lists/views/layouts/Row",
             },
             name: "alfresco/renderers/Comments",
             config: {
-               subscriptionTopic: "ALF_COMMENTS_LOADED",
+               subscriptionTopic: "ALF_GET_COMMENTS_SUCCESS",
                publishTopic: "ALF_REVEAL_COMMENTS",
                publishPayload: {}
             }

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1029,7 +1029,7 @@ define(["dojo/_base/declare",
 
          this.alfPublish(this.documentsLoadedTopic, {
             documents: this.currentData.items,
-            totalDocuments: this.totalRecords,
+            totalRecords: this.totalRecords,
             startIndex: this.startIndex
          });
       },

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -99,7 +99,7 @@ define(["dojo/_base/declare",
        * @type {number} 
        * @default null
        */
-      totalDocuments: null,
+      totalRecords: null,
       
       /**
        * Used to keep track of the total number of pages in the current data set
@@ -213,6 +213,24 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * The property in the response that indicates the starting index of overall data to request.
+       *
+       * @instance
+       * @type {string}
+       * @default "startIndex"
+       */
+      startIndexProperty: "startIndex",
+
+      /**
+       * The property in the response that indicates the total number of results available.
+       *
+       * @instance
+       * @type {string}
+       * @default "totalRecords"
+       */
+      totalResultsProperty: "totalRecords",
+
+      /**
        * This function processes the loaded document data to set the appropriate data in the paginator
        * widgets.
        *
@@ -221,21 +239,45 @@ define(["dojo/_base/declare",
        */
       processLoadedDocuments: function alfresco_lists_Paginator__processLoadedDocuments(payload) {
          // jshint maxcomplexity:false,unused:false,maxstatements:false
-         if (payload && payload.totalDocuments !== null && payload.startIndex !== null)
+         var totalRecords = lang.getObject(this.totalResultsProperty, false, payload);
+         var startIndex = lang.getObject(this.startIndexProperty, false, payload);
+         if (payload && totalRecords !== null && startIndex !== null)
          {
-            if (payload.totalDocuments === 0)
+            if (totalRecords === 0)
             {
                // Hide pagination controls when there are no results...
-               domClass.add(this.domNode, "hidden");
+               // domClass.add(this.domNode, "hidden");
+               if (this.pageSelector)
+               {
+                  domClass.add(this.pageSelector.domNode, "hidden");
+               }
+               domClass.add(this.pageBack.domNode, "hidden");
+               domClass.add(this.pageMarker.domNode, "hidden");
+               domClass.add(this.pageForward.domNode, "hidden");
+               if (this.resultsPerPageGroup)
+               {
+                  domClass.add(this.resultsPerPageGroup.domNode, "hidden");
+               }
             }
             else
             {
                // Make sure the pagination controls aren't hidden...
-               domClass.remove(this.domNode, "hidden");
+               // domClass.remove(this.domNode, "hidden");
+               if (this.pageSelector)
+               {
+                  domClass.remove(this.pageSelector.domNode, "hidden");
+               }
+               domClass.remove(this.pageBack.domNode, "hidden");
+               domClass.remove(this.pageMarker.domNode, "hidden");
+               domClass.remove(this.pageForward.domNode, "hidden");
+               if (this.resultsPerPageGroup)
+               {
+                  domClass.remove(this.resultsPerPageGroup.domNode, "hidden");
+               }
                
-               this.totalDocuments = payload.totalDocuments;
-               this.totalPages = Math.ceil(payload.totalDocuments/this.documentsPerPage);
-               this.currentPage = ((payload.startIndex - (payload.startIndex % this.documentsPerPage))/this.documentsPerPage) + 1;
+               this.totalRecords = totalRecords;
+               this.totalPages = Math.ceil(totalRecords/this.documentsPerPage);
+               this.currentPage = ((startIndex - (startIndex % this.documentsPerPage))/this.documentsPerPage) + 1;
 
                // Update the page back action to disable if on the first page...
                if (this.pageBack)
@@ -283,10 +325,10 @@ define(["dojo/_base/declare",
                      else
                      {
                         // ...for the last page just count up to the last document
-                        pageEnd = this.totalDocuments;
+                        pageEnd = this.totalRecords;
                      }
                      
-                     var label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalDocuments});
+                     var label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords});
                      var menuItem = new AlfCheckableMenuItem({
                         label: label,
                         value: i+1,
@@ -410,6 +452,30 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Since this widget is an implementation of an [AlfMenuBar]{@link module:alfresco/menus/AlfMenuBar} it is 
+       * perfectly reasonable to add additional menu widgets (such as [menu items]{@link module:alfresco/menus/AlfMenuBarItem}
+       * or [drop-down menus]{@link module:alfresco/menus/AlfMenuBarPopup}) before the main pagination controls. This
+       * can be configured to be an array of such menu widgets to be displayed.
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      widgetsBefore: null,
+
+      /**
+       * Since this widget is an implementation of an [AlfMenuBar]{@link module:alfresco/menus/AlfMenuBar} it is 
+       * perfectly reasonable to add additional menu widgets (such as [menu items]{@link module:alfresco/menus/AlfMenuBarItem}
+       * or [drop-down menus]{@link module:alfresco/menus/AlfMenuBarPopup}) after the main pagination controls. This
+       * can be configured to be an array of such menu widgets to be displayed.
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      widgetsAfter: null,
+
+      /**
        * <p>Calls the [createPageSizeMenuItem function]{@link module:alfresco/lists/Paginator#createPageSizeMenuItem} 
        * for each item in the [pageSizes array]{@link module:alfresco/lists/Paginator#pageSizes} to build the page
        * size selection menu. If a [pageSizes array]{@link module:alfresco/lists/Paginator#pageSizes} has not been
@@ -496,6 +562,10 @@ define(["dojo/_base/declare",
                }
             });
          }
+
+         // Prepend and append any widgets requested to go before or after the pagination controls...
+         this.widgets = (this.widgetsBefore || []).concat(this.widgets, (this.widgetsAfter || []));
+
          this.inherited(arguments);
       },
       
@@ -514,13 +584,15 @@ define(["dojo/_base/declare",
          // postCreate function...
          if (this.compactMode === false)
          {
-            var popupChildren = this._menuBar.getChildren()[0].popup.getChildren();
+            this.pageSelector = registry.byId(this.id + "_PAGE_SELECTOR");
+            var popupChildren = this.pageSelector.popup.getChildren();
             this.pageSelectorGroup = popupChildren[popupChildren.length-1];
          }
          
          this.pageBack = registry.byId(this.id + "_PAGE_BACK");
          this.pageForward = registry.byId(this.id + "_PAGE_FORWARD");
          this.pageMarker = registry.byId(this.id + "_PAGE_MARKER");
+         this.resultsPerPageGroup = registry.byId(this.id + "_RESULTS_PER_PAGE_SELECTOR");
 
          // Check to see if any document data was provided before widget instantiation completed and
          // if so process it with the now available widgets...

--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -232,7 +232,10 @@ define(["dojo/_base/declare",
          // Clicking on the check cell will result in the menu item being marked as selected
          // but we want to ensure that this is not the case so always remove the class that
          // indicates selection...
-         domClass.remove(this.checkCell.parentNode, "dijitMenuItemSelected");
+         if (this.checkCell && this.checkCell.parentNode)
+         {
+            domClass.remove(this.checkCell.parentNode, "dijitMenuItemSelected");
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/Comments.js
+++ b/aikau/src/main/resources/alfresco/renderers/Comments.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,6 +18,14 @@
  */
 
 /**
+ * This renderer can be used to both display a count of comments on a particular node as well as providing
+ * a link to where comments can be added, edited or deleted. The link can either be to particular page
+ * or alternatively can be used with a [VerticalReveal]{@link module:alfresco/layout/VerticalReveal},
+ * the [DialogService]{@link module:alfresco/services/DialogService} or some other widget or service to 
+ * display a [Comments List]{@link module:alfresco/renderers/CommentsList}. For example the 
+ * standard Document Library [Detailed View]{@link module:alfresco/documentlibrary/views/AlfDetailedView}
+ * uses the [VerticalReveal]{@link module:alfresco/layout/VerticalReveal} approach to allow inline commenting.
+ * 
  * @module alfresco/renderers/Comments
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
@@ -126,7 +134,7 @@ define(["dojo/_base/declare",
          
          // By default this will generate a link to details page for the current Node. However,
          // if a publishTopic is provided then it will publish on topic is provided
-         if (this.publishTopic == null)
+         if (!this.publishTopic)
          {
             // Get the URL for making a comment...
             // TODO: This should be replaced by publishing an action to allow greater control over how comments are made
@@ -146,7 +154,7 @@ define(["dojo/_base/declare",
          
          // Get the count of comments if there are any...
          this.commentCount = lang.getObject(this.commentCountProperty, false, this.currentItem);
-         if (this.commentCount == null)
+         if (!this.commentCount)
          {
             this.commentCount = 0;
          }
@@ -167,13 +175,13 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_renderers_Comments__postCreate() {
-         if (this.commentCount != null)
+         if (this.commentCount || this.commentCount === 0)
          {
             domClass.remove(this.countNode, "hidden");
          }
          this.makeAnchor(this.targetUrl, this.targetUrlType);
 
-         if (this.subscriptionTopic != null)
+         if (this.subscriptionTopic)
          {
             this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.onCommentCountUpdate));
          }
@@ -188,9 +196,9 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "totalDocuments"
+       * @default "totalRecords"
        */
-      publicationCountProperty: "totalDocuments",
+      publicationCountProperty: "totalRecords",
 
       /**
        * Called whenever the [subscriptionTopic]{@link module:alfresco/renderers/Comments#subscriptionTopic}
@@ -202,7 +210,7 @@ define(["dojo/_base/declare",
        */
       onCommentCountUpdate: function alfresco_renderers_Comments__onCommentCountUpdate(payload) {
          var updatedCount = lang.getObject(this.publicationCountProperty, false, payload);
-         if (updatedCount != null)
+         if (updatedCount || updatedCount === 0)
          {
             this.countNode.innerHTML = updatedCount;
          }
@@ -216,8 +224,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onCommentClick: function alfresco_renderers_Comments__onCommentClick(evt) {
-         if (this.publishTopic != null)
+      onCommentClick: function alfresco_renderers_Comments__onCommentClick(/*jshint unused:false*/ evt) {
+         if (this.publishTopic)
          {
             // Clone the configured payload to avoid collisions with other instances...
             this.publishPayload = lang.clone(this.publishPayload);

--- a/aikau/src/main/resources/alfresco/renderers/EditableComment.js
+++ b/aikau/src/main/resources/alfresco/renderers/EditableComment.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,7 +18,12 @@
  */
 
 /**
- * This is a BETA quality widget and not guaranteed for production use. 
+ * This renderer should be used to show an individual comment that can be switched into an edit mode that
+ * shows a [TinyMCE editor]{@link module:alfresco/forms/controls/TinyMCE} for updating the comment. Note that
+ * the widget does not take responsibility for which users have the ability to toggle between read and edit 
+ * modes. It does not provide the controls to switch modes so the other controls for toggling mode should be
+ * rendered based on the current user permissions. Examples of this approach can be found in the 
+ * [CommentsList renderer]{@link module:alfresco/renderers/CommentsList}.
  *
  * @module alfresco/renderers/EditableComment
  * @extends external:dijit/_WidgetBase
@@ -253,8 +258,6 @@ define(["dojo/_base/declare",
       postParam: "content",
 
       /**
-       * TODO: Localize!!!
-       * 
        * @instance
        * @type {string}
        * @default "Save"

--- a/aikau/src/main/resources/alfresco/services/CommentService.js
+++ b/aikau/src/main/resources/alfresco/services/CommentService.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>This service is used to retrieve comments from an Alfresco Repository and has been created to 
+ * primarily service the [CommentsList]{@link module:alfresco/renderers/CommentsList}. It is required
+ * in order to normalise the JSON response returned on the comments API. The 
+ * [CrudService]{@link module:alfresco/renderers/CrudService} is currently used to service create, update and
+ * delete comment requests, but this service may be updated in the future to handle those operations directly.</p>
+ * 
+ * @module alfresco/services/CommentService
+ * @extends module:alfresco/core/Core
+ * @mixes module:alfresco/core/CoreXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "alfresco/core/CoreXhr",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "service/constants/Default"],
+        function(declare, AlfCore, CoreXhr, lang, array, AlfConstants) {
+   
+   return declare([AlfCore, CoreXhr], {
+      
+      /**
+       * An array of the i18n files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/CommentService.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/CommentService.properties"}],
+      
+      /**
+       * Sets up the subscriptions for the CommentService
+       * 
+       * @instance 
+       * @param {array} args The constructor arguments.
+       */
+      constructor: function alfresco_services_CommentService__constructor(args) {
+         lang.mixin(this, args);
+         this.alfSubscribe("ALF_GET_COMMENTS", lang.hitch(this, this.onGetComments));
+      },
+      
+      /**
+       * 
+       * 
+       * @instance
+       * @param {object} payload
+       */
+      onGetComments: function alfresco_services_CommentService__onGetComments(payload) {
+         var reverse = payload.sortAscending === true;
+         var pageSize = payload.pageSize || 10;
+         var startIndex = 0;
+         if (payload.page)
+         {
+            startIndex = (payload.page - 1) * pageSize;
+         }
+         var url = AlfConstants.PROXY_URI + "api/node/" + payload.nodeRef + "/comments?reverse=" + reverse + "&startIndex=" + startIndex + "&pageSize=" + pageSize;
+         this.serviceXhr({
+            url: url,
+            alfTopic: payload.alfResponseTopic || null,
+            method: "GET",
+            successCallback: this.onCommentsRetrieved,
+            callbackScope: this
+         });
+      },
+
+      /**
+       * This is the success callback function that is used when retrieving comments. It updates each comment object to
+       * ensure that it contains a "displayName" attribute which can be used for the 
+       * [imageTitleProperty]{@link module:alfresco/renderers/Thumbnail#imageTitleProperty} of a 
+       * [AvatarThumbnail]{@link module:alfresco/renderers/AvatarThumbnail}.
+       *
+       * @instance
+       * @param {object} response The object returned from the successful XHR request
+       * @param {object} requestConfig The original configuration passed when the request was made
+       */
+      onCommentsRetrieved: function alfresco_services_CommentService__onCommentsRetrieved(response, requestConfig) {
+         array.forEach(response.items, lang.hitch(this, this.updateComment));
+         response.totalRecords = response.total;
+         if (requestConfig.alfTopic)
+         {
+            this.alfPublish(requestConfig.alfTopic + "_SUCCESS", response);
+         }
+      },
+
+      /**
+       * The comments API does not include the display name for the comment author. Instead it provides the 
+       * first and last names as two separate attributes. This function updates a comment to create a displayName
+       * attribute that is the combination of the first and last name attributes.
+       *
+       * @instance
+       * @param {object} comment The comment to update
+       */
+      updateComment: function alfresco_services_CommentService__updateComment(comment) {
+         if (comment && comment.author)
+         {
+            comment.author.displayName = comment.author.firstName + " " + comment.author.lastName;
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -179,6 +179,11 @@ define(["dojo/_base/declare",
          {
             url = this.addQueryParameter(url, "page", payload.page);
          }
+         if (payload.page && payload.pageSize)
+         {
+            var startIndex = (payload.page - 1) * payload.pageSize;
+            url = this.addQueryParameter(url, "startIndex", startIndex);
+         }
          if (payload.dataFilters)
          {
             // TODO: iterate over filters and add each as a request parameter...

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -52,7 +52,7 @@ define(["intern!object",
             .type("one")
          .end()
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalDocuments", "1"))
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "1"))
          .end()
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
          .then(function(elements) {
@@ -65,7 +65,7 @@ define(["intern!object",
             .type(keys.BACKSPACE)
             .type(keys.BACKSPACE)
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalDocuments", "3"))
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "3"))
          .end()
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
          .then(function(elements) {
@@ -80,7 +80,7 @@ define(["intern!object",
          .findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL_popup1")
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalDocuments", "4"))
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "4"))
          .end()
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
          .then(function(elements) {
@@ -93,7 +93,7 @@ define(["intern!object",
             .type("t")
          .end()
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalDocuments", "2"))
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "2"))
          .end()
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
          .then(function(elements) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/galleryViewTest.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/galleryViewTest.get.js
@@ -125,7 +125,7 @@ model.jsonModel = {
                         rules: [
                            {
                               topic: "ALF_DOCLIST_DOCUMENTS_LOADED",
-                              attribute: "totalDocuments",
+                              attribute: "totalRecords",
                               isNot: ["0"]
                            }
                         ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/CommentsList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/CommentsList.get.js
@@ -1,6 +1,7 @@
 /*jshint maxlen:1000*/
 model.jsonModel = {
-   services: [{
+   services: [
+      {
          name: "alfresco/services/LoggingService",
          config: {
             loggingPreferences: {
@@ -13,27 +14,28 @@ model.jsonModel = {
       "alfresco/services/DialogService",
       "aikauTesting/mockservices/CommentsListMockService"
    ],
-   widgets: [{
-      name: "alfresco/renderers/CommentsList",
-      id: "COMMENT_LIST",
-      config: {
-         pubSubScope: "COMMENTS1_",
-         currentItem: {
-            node: {
-               nodeRef: "workspace://SpacesStore/4fd42b12-361a-4e02-a1da-9131e6fa074d"
-            },
-            parent: {
-               permissions: {
-                  user: {
-                     CreateChildren: true
+   widgets: [
+      {
+         name: "alfresco/renderers/CommentsList",
+         id: "COMMENT_LIST",
+         config: {
+            pubSubScope: "COMMENTS1_",
+            currentItem: {
+               node: {
+                  nodeRef: "workspace://SpacesStore/4fd42b12-361a-4e02-a1da-9131e6fa074d"
+               },
+               parent: {
+                  permissions: {
+                     user: {
+                        CreateChildren: true
+                     }
                   }
                }
             }
          }
+      }, 
+      {
+         name: "alfresco/logging/DebugLog"
       }
-   }, {
-      name: "alfresco/logging/DebugLog"
-   }, {
-      name: "aikauTesting/TestCoverageResults"
-   }]
+   ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-243. I've made some updates to try and make some of the configuration attributes be consistently named. I've fixed some JSHint issues along the way and added better JSDoc where appropriate and updated the unit test to cover the main features of the CommentsList and its associated widgets.