### PR TITLE
AKU-230: Correction to InlineProperty renderOnNewLine fix

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -2,6 +2,11 @@
    &:hover .editIcon {
       opacity: 1;
    }
+   &.alfresco-renderers-Property {
+      .alfresco-renderers-Property.block {
+         display: inline-block;
+      }
+   }
    .inlineEditValue {
       cursor: pointer;
       line-height: 20px;


### PR DESCRIPTION
This PR corrects the previous fix for https://issues.alfresco.com/jira/browse/AKU-230