### PR TITLE
AKU-238: MultiSelectInput options are partially hidden if included in dialog

### DIFF
--- a/aikau/src/grunt/testing.js
+++ b/aikau/src/grunt/testing.js
@@ -11,10 +11,10 @@ module.exports = function(grunt) {
    grunt.registerTask("dt", ["intern:local"]);
 
    // Register test tasks for local/vagrant/SauceLabs/grid respectively
-   grunt.registerTask("test_local", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "intern:local"]);
-   grunt.registerTask("test", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "intern:dev"]);
-   grunt.registerTask("test_sl", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "intern:sl"]);
-   grunt.registerTask("test_grid", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "intern:grid"]);
+   grunt.registerTask("test_local", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:local"]);
+   grunt.registerTask("test", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:dev"]);
+   grunt.registerTask("test_sl", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:sl"]);
+   grunt.registerTask("test_grid", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:grid"]);
 
    // Watch for changes and retest
    grunt.registerTask("watchDev", ["watch:dev"]);

--- a/aikau/src/grunt/watch.js
+++ b/aikau/src/grunt/watch.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
    grunt.config.merge({
       watch: {
          dev: {
-            files: [alfConfig.files.app, alfConfig.files.testApp, alfConfig.files.testFramework],
+            files: [alfConfig.files.app, alfConfig.files.testApp, alfConfig.files.testFramework, "!" + alfConfig.requireEverything.widget],
             tasks: ["updateTest"],
             options: {
                livereload: true

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -170,7 +170,7 @@ define([
           * Collection of choice objects
           *
           * @instance
-          * @type {Choice[]}
+          * @type {module:alfresco/forms/controls/MultiSelect#Choice[]}
           */
          _choices: null,
 
@@ -178,7 +178,7 @@ define([
           * The currently focused result item
           *
           * @instance
-          * @type {Result}
+          * @type {module:alfresco/forms/controls/MultiSelect#Result}
           */
          _focusedResult: null,
 
@@ -246,7 +246,7 @@ define([
           * The currently selected choice object
           *
           * @instance
-          * @type {Choice}
+          * @type {module:alfresco/forms/controls/MultiSelect#Choice}
           */
          _selectedChoice: null,
 

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -856,7 +856,7 @@ define([
           * @param {object} evt Dojo-normalised event object
           */
          _onSearchKeypress: function alfresco_forms_controls_MultiSelect___onSearchKeypress(evt) {
-            /*jshint maxcomplexity:21*/
+            /*jshint maxcomplexity:false*/
             var cursorPosBeforeKeypress = this._getCursorPositionWithinTextbox(),
                modifiersPressed = evt.ctrlKey || evt.altKey || evt.shiftKey || evt.metaKey;
             if (!modifiersPressed) {
@@ -892,7 +892,7 @@ define([
                      evt.preventDefault();
                      break;
                   case keys.LEFT_ARROW:
-                     if (!cursorPosBeforeKeypress) {
+                     if (cursorPosBeforeKeypress === 0) {
                         this._selectChoice(-1);
                      }
                      break;
@@ -902,14 +902,18 @@ define([
                         evt.preventDefault();
                      }
                      break;
-                  case keys.DELETE:
                   case keys.BACKSPACE:
+                     if (cursorPosBeforeKeypress === 0 && this._choices.length) {
+                        this._selectChoice(-1);
+                        this._deleteSelectedChoice();
+                        evt.preventDefault();
+                        break;
+                     }
+                     /* falls through */
+                  case keys.DELETE:
                      if (this._selectedChoice) {
                         this._deleteSelectedChoice();
                         evt.preventDefault();
-                     } else if (!cursorPosBeforeKeypress && this._choices.length) {
-                        this._selectChoice(-1);
-                        this._deleteSelectedChoice();
                      }
                      break;
                   default:

--- a/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
@@ -172,3 +172,11 @@
       }
    }
 }
+
+.alfresco-dialog-AlfDialog.dijitDialog {
+   .alfresco-forms-controls-MultiSelect {
+      &__search-box {
+         border: 0;
+      }
+   }
+}

--- a/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
@@ -80,14 +80,12 @@
       background: @list-background-color;
       box-shadow: @standard-box-shadow;
       display: none;
-      left: -1px;
       list-style: none;
       margin: 0;
       overflow: hidden;
       padding: 0;
       position: absolute;
-      right: -1px;
-      top: 100%;
+      z-index: 1000;
       > * {
          border: solid @standard-border-color;
          border-width: 1px 1px 0;
@@ -98,78 +96,76 @@
          text-overflow: ellipsis;
          white-space: nowrap;
       }
-   }
-   &__result-loading, &__result-error, &__result-no-results {
-      border-width: 1px;
-      display: none;
-   }
-   &__result-no-results {
-      color: @de-emphasized-font-color;
-   }
-   &__result-error {
-      color: #c00;
-      font-family: @bold-font;
-      font-weight: 700;
-      white-space: normal;
-   }
-   &__result {
-      border-top-color: #ccc;
-      cursor: pointer;
-      &__highlighted-label {
+      &__loading-message, &__error-message, &__no-results-message {
+         border-width: 1px;
+         display: none;
+      }
+      &__no-results-message {
+         color: @de-emphasized-font-color;
+      }
+      &__error-message {
+         color: #c00;
          font-family: @bold-font;
          font-weight: 700;
-         text-decoration: underline;
+         white-space: normal;
       }
-      &:first-child {
-         border-top-color: @standard-border-color;
+      &__result {
+         border-top-color: #ccc;
+         cursor: pointer;
+         &__highlighted-label {
+            font-family: @bold-font;
+            font-weight: 700;
+            text-decoration: underline;
+         }
+         &:first-child {
+            border-top-color: @standard-border-color;
+         }
+         &:last-child {
+            border-bottom-width: 1px;
+         }
+         &--focused {
+            background: #06a;
+            color: @highlighted-font-color;
+         }
+         &--already-chosen {
+            background: @list-background-color;
+            color: @de-emphasized-font-color;
+            cursor: default;
+         }
       }
-      &:last-child {
-         border-bottom-width: 1px;
+      &--visible {
+         display: block;
       }
-      &--focused {
-         background: #06a;
-         color: @highlighted-font-color;
+      &--error {
+         .alfresco-forms-controls-MultiSelect {
+            &__results__error-message {
+               border-color: #c00;
+               display: block;
+            }
+         }
       }
-      &--already-chosen {
-         background: @list-background-color;
-         color: @de-emphasized-font-color;
-         cursor: default;
+      &--loading {
+         .alfresco-forms-controls-MultiSelect {
+            &__results__loading-message {
+               display: block;
+            }
+         }
       }
+      &--empty {
+         .alfresco-forms-controls-MultiSelect {
+            &__results__no-results-message {
+               display: block;
+            }
+         }
+      }
+   }
+   &--has-error {
+      border-color: #c00;
+      outline: 1px solid #faa;
    }
    &--focused {
       border-color: #09c;
       outline: 1px solid #0cf;
-   }
-   &--show-results {
-      .alfresco-forms-controls-MultiSelect {
-         &__results {
-            display: block;
-         }
-      }
-   }
-   &--show-error {
-      border-color: #c00;
-      outline: 1px solid #faa;
-      .alfresco-forms-controls-MultiSelect {
-         &__result-error {
-            border-color: #c00;
-            display: block;
-         }
-      }
-   }
-   &--show-loading {
-      .alfresco-forms-controls-MultiSelect {
-         &__result-loading {
-            display: block;
-         }
-      }
-   }
-   &--show-empty {
-      .alfresco-forms-controls-MultiSelect {
-         &__result-no-results {
-            display: block;
-         }
-      }
    }
 }
 

--- a/aikau/src/main/resources/alfresco/forms/controls/templates/MultiSelect.html
+++ b/aikau/src/main/resources/alfresco/forms/controls/templates/MultiSelect.html
@@ -3,8 +3,4 @@
    <div class="${rootClass}__container" data-dojo-attach-point="labelsContainer">
       <input class="${rootClass}__search-box" data-dojo-attach-point="searchBox" data-dojo-attach-event="keypress:_onSearchKeypress,keyup:_onSearchKeyup" type="text" />
    </div>
-   <ul class="${rootClass}__results" data-dojo-attach-point="resultsDropdown"><li
-      class="${rootClass}__result-loading" data-dojo-attach-point="loadingMessage">${loadingMessage}</li><li
-      class="${rootClass}__result-no-results" data-dojo-attach-point="noResultsMessage"></li><li
-      class="${rootClass}__result-error" data-dojo-attach-point="errorMessage"></li></ul>
 </div>

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -181,6 +181,9 @@ define(["intern/dojo/node!fs",
             filter.type && selectorBits.push("[data-aikau-log-type=\"" + filter.type + "\"]"); // Type is "..."
             filter.topic && selectorBits.push("[data-aikau-log-topic$=\"" + filter.topic + "\"]"); // Topic ends with "..."
             filter.object && selectorBits.push("[data-aikau-log-object=\"" + filter.object + "\"]"); // Object is "..."
+            if (filter.debug) {
+               console.log("Log entry selector: \"" + selectorBits.join("") + "\"");
+            }
             return browser.executeAsync(function(entriesSelector, pos, callback) {
                var entries = document.querySelectorAll(entriesSelector),
                   dataObjs = [],

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -175,7 +175,32 @@ define(["intern/dojo/node!fs",
                   fs.writeFile(screenshotPath, screenshot.toString("binary"), "binary");
                });
          };
-         
+         command.session.getLogEntries = function(filter) {
+            filter = filter || {};
+            var selectorBits = [".alfresco_logging_DebugLog__entry"];
+            filter.type && selectorBits.push("[data-aikau-log-type=\"" + filter.type + "\"]"); // Type is "..."
+            filter.topic && selectorBits.push("[data-aikau-log-topic$=\"" + filter.topic + "\"]"); // Topic ends with "..."
+            filter.object && selectorBits.push("[data-aikau-log-object=\"" + filter.object + "\"]"); // Object is "..."
+            return browser.executeAsync(function(entriesSelector, pos, callback) {
+               var entries = document.querySelectorAll(entriesSelector),
+                  dataObjs = [],
+                  entry,
+                  dataAttr;
+               for (var i = 0, j = entries.length; i < j; i++) {
+                  entry = entries[i];
+                  dataAttr = entry.getAttribute("data-aikau-log-data");
+                  dataObjs.push(JSON.parse(dataAttr));
+               }
+               if (pos === "first") {
+                  callback(dataObjs.shift());
+               } else if (pos === "last") {
+                  callback(dataObjs.pop());
+               } else {
+                  callback(dataObjs);
+               }
+            }, [selectorBits.join(""), filter.pos]);
+         };
+
          return command;
       },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -44,20 +44,20 @@ define([
          },
 
          "Preset values are rendered by control": function() {
-            return browser.findAllByCssSelector(".alfresco-forms-controls-MultiSelect__choice")
+            return browser.findAllByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice")
                .then(function(elements) {
                   assert.lengthOf(elements, 2, "Did not render two preset values for control");
                })
                .end()
 
-            .findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+            .findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "tag1", "Did not display first tag label correctly");
                })
                .end()
 
-            .findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+            .findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "tag11", "Did not display second tag label correctly");
@@ -70,24 +70,24 @@ define([
                .pressKeys(keys.TAB)
                .end()
 
-            .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
                .then(function(elements) {
                   assert.lengthOf(elements, 7, "Did not bring up initial results");
                });
          },
 
          "Selecting item in dropdown chooses that item": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
                .click()
                .end()
 
-            .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__choice")
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice")
                .then(function(elements) {
                   assert.lengthOf(elements, 3, "Did not add new choice to control");
                })
                .end()
 
-            .findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
+            .findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "tag2", "Did not add selected tag at end of choices");
@@ -95,87 +95,119 @@ define([
          },
 
          "Typing into search box filters results": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
                .type("tag2")
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
                .end()
 
-            .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "Did not filter results");
                });
          },
 
-         "Typing into search box filters results for strings in middle of name": function () {
-            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
+         "Typing into search box filters results for strings in middle of name": function() {
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
                .clearValue()
                .type("12")
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(2)")
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(2)")
                .end()
 
-               .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
-               .then(function (elements) {
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .then(function(elements) {
                   assert.lengthOf(elements, 1, "Did not filter results for string in middle of name" + elements);
                });
          },
 
-         "Search box correctly filters on special reg exp chars": function () {
-            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__search-box")
+         "Search box correctly filters on special reg exp chars": function() {
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
                .clearValue()
                .type("(a")
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__result:nth-child(5)")
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
                .end()
 
-               .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__result")
-               .then(function (elements) {
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .then(function(elements) {
                   assert.lengthOf(elements, 1, "Did not filter results using special reg exp character");
                });
          },
 
          "Clicking cross on a chosen item removes it": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__close-button")
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__close-button")
                .click()
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
                .end()
 
-            .findAllByCssSelector(".alfresco-forms-controls-MultiSelect__choice")
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice")
                .then(function(elements) {
                   assert.lengthOf(elements, 2, "Did not remove choice");
                });
          },
 
          "Submitting form submits correct values from control": function() {
-            return browser.findByCssSelector("#FORM1 .confirmationButton .dijitButtonNode")
+            return browser.findByCssSelector("#FORM1 .confirmationButton")
                .click()
                .end()
 
-            .then(pollUntil(function() {
-                  /*jshint browser:true*/
-                  var topicData = document.querySelectorAll(".sl-topic[data-publish-topic=FORM_POST] + td.sl-data"),
-                     lastTopic = topicData && topicData[topicData.length - 1],
-                     dataContent = lastTopic && (lastTopic.textContent || lastTopic.innerText);
-                  return dataContent || null;
-               }, 5000))
-               .then(function(dataContent) {
-                  assert.include(dataContent, "labeltag1valueworkspace", "Failed to submit control value of tag1");
-                  assert.include(dataContent, "labeltag2valueworkspace", "Failed to submit control value of tag2");
-               }, function(err) {
-                  assert.fail(null, null, "Failed to submit control values [" + err.name + "]: " + err);
+            .getLogEntries({
+                  topic: "FORM_POST",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.isDefined(payload, "Could not find form submission");
+                  if (payload) {
+                     assert.deepPropertyVal(payload, "tags.0.name", "tag1", "Failed to submit tag1 name");
+                     assert.deepPropertyVal(payload, "tags.0.value", "workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "Failed to submit tag1 value");
+                     assert.deepPropertyVal(payload, "tags.1.name", "tag2", "Failed to submit tag2 name");
+                     assert.deepPropertyVal(payload, "tags.1.value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value");
+                  }
                });
          },
 
          "Deleting all items disables confirmation button": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
                .click()
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
-            .end()
-            .findByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
                .click()
-               .waitForDeletedByCssSelector(".alfresco-forms-controls-MultiSelect__choice:nth-child(1)")
-            .end()
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1)")
+               .end()
+
             .findAllByCssSelector("#FORM1 .confirmationButton.dijitDisabled")
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "The confirmation button was not disabled when all the items were removed");
+               });
+         },
+
+         "Opening MultiSelect in dialog still displays dropdown properly": function() {
+            return browser.findByCssSelector("#CREATE_FORM_DIALOG")
+               .click()
+               .end()
+
+            .findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+               .isDisplayed()
+               .then(function(isDisplayed) {
+                  assert.isTrue(isDisplayed, "Unable to see result in dropdown");
+               });
+         },
+
+         "Dialog MultiSelect submits correct data": function() {
+            return browser.findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+               .click()
+               .end()
+
+            .getLogEntries({
+                  topic: "DIALOG_POST",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.isDefined(payload, "Could not find dialog submission");
+                  if (payload) {
+                     assert.deepPropertyVal(payload, "tags.0.name", "tag2", "Failed to submit tag2 name from dialog");
+                     assert.deepPropertyVal(payload, "tags.0.value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value from dialog");
+                  }
                });
          },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -150,11 +150,12 @@ define([
                .end()
 
             .getLogEntries({
+                  type: "PUBLISH",
                   topic: "FORM_POST",
                   pos: "last"
                })
                .then(function(payload) {
-                  assert.isDefined(payload, "Could not find form submission");
+                  assert.isNotNull(payload, "Could not find form submission");
                   if (payload) {
                      assert.deepPropertyVal(payload, "tags.0.name", "tag1", "Failed to submit tag1 name");
                      assert.deepPropertyVal(payload, "tags.0.value", "workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "Failed to submit tag1 value");
@@ -198,12 +199,17 @@ define([
                .click()
                .end()
 
+            .findByCssSelector("#DIALOG_WITH_MULTISELECT .footer .confirmationButton .dijitButtonNode")
+               .click()
+               .end()
+
             .getLogEntries({
+                  type: "PUBLISH",
                   topic: "DIALOG_POST",
                   pos: "last"
                })
                .then(function(payload) {
-                  assert.isDefined(payload, "Could not find dialog submission");
+                  assert.isNotNull(payload, "Could not find dialog submission");
                   if (payload) {
                      assert.deepPropertyVal(payload, "tags.0.name", "tag2", "Failed to submit tag2 name from dialog");
                      assert.deepPropertyVal(payload, "tags.0.value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value from dialog");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -11,9 +11,45 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/TagService"
+      "alfresco/services/TagService",
+      "alfresco/services/DialogService"
    ],
    widgets: [
+      {
+         id: "CREATE_FORM_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create dialog with MultiSelect",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "DIALOG_WITH_MULTISELECT",
+               dialogTitle: "Dialog With MultiSelect",
+               formSubmissionTopic: "DIALOG_POST",
+               widgets: [
+                  {
+                     id: "MULTISELECT_IN_DIALOG",
+                     name: "alfresco/forms/controls/MultiSelectInput",
+                     config: {
+                        label: "Tags",
+                        name: "tags",
+                        width: "400px",
+                        optionsConfig: {
+                           queryAttribute: "name",
+                           valueAttribute: "nodeRef",
+                           labelAttribute: "name",
+                           pubSubScope: "DIALOG_",
+                           publishTopic: "ALF_RETRIEVE_CURRENT_TAGS",
+                           publishPayload: {
+                              resultsProperty: "response.data.items"
+                           },
+                           searchStartsWith: false
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      },
       {
          name: "alfresco/buttons/AlfButton",
          id: "FOCUS_HELPER_BUTTON",
@@ -60,7 +96,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/MultiSelectInputMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
@@ -29,10 +29,11 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/MockXhr.html",
         "alfresco/core/Core",
         "dojo/_base/lang",
+        "dojo/dom-class",
         "dojo/dom-construct",
         "dojo/aspect",
         "dojo/Deferred"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, lang, domConstruct, aspect, Deferred) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, lang, domClass, domConstruct, aspect, Deferred) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
 
@@ -43,7 +44,7 @@ define(["dojo/_base/declare",
        * @type {object[]}
        * @default [{cssFile:"./css/MockXhr.css"}]
        */
-   cssRequirements: [{cssFile:"./css/MockXhr.css"}],
+      cssRequirements: [{cssFile:"./css/MockXhr.css"}],
 
       /**
        * The HTML template to use for the widget.
@@ -189,6 +190,15 @@ define(["dojo/_base/declare",
             // Add a new row to the log
             responseNode.innerHTML = responseHtml;
          });
+      },
+
+      /**
+       * Toggle the body visibility for the log
+       *
+       * @instance
+       */
+      _toggleBody: function alfresco_testing_MockXhr___toggleBody() {
+         domClass.toggle(this.domNode, "alfresco-testing-MockXhr--hide-body");
       }
    });
 });

--- a/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
@@ -25,11 +25,12 @@
       border: none;
    }
    caption {
+      background: #ccc;
       border-bottom: none;
+      cursor: pointer;
       font-size: 1.1em;
       font-weight: 700;
       text-align: left;
-      background: #ccc;
    }
    .mx-response {
       position: relative;
@@ -68,6 +69,15 @@
          .mx-response__info {
             display: block;
          }
+      }
+   }
+   &--hide-body {
+      opacity: .3;
+      caption {
+         border-bottom: 1px solid #808080;
+      }
+      .mx-tbody, .mx-thead {
+         display: none;
       }
    }
 }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
@@ -1,7 +1,7 @@
 <div class="alfresco-testing-MockXhr" data-dojo-attach-point="containerNode">
    <table class="log">
-      <caption>MockXhr Log</caption>
-      <thead>
+      <caption data-dojo-attach-event="onclick:_toggleBody">MockXhr Log (toggle visibility)</caption>
+      <thead class="mx-thead">
          <tr>
             <th class="mx-method">Method</th>
             <th class="mx-url">URL</th>
@@ -9,7 +9,7 @@
             <th class="mx-response">Response</th>
          </tr>
       </thead>
-      <tbody data-dojo-attach-point="logNode">
+      <tbody class="mx-tbody" data-dojo-attach-point="logNode">
       </tbody>
    </table>
 </div>


### PR DESCRIPTION
This addresses issue [AKU-238](https://issues.alfresco.com/jira/browse/AKU-238), which highlights that MultiSelect options are hidden when the control is inside a dialog. It has been fixed by moving the dropdown to be a body-level element with a higher-than-Dojo z-index (1000).
This pull request also includes updates to TestCommon, specifically a new session method to make querying the pub/sub log simpler, as well as minor tweaks to the Grunt config and the MockXHR log.