### PR TITLE
AKU-247: Selected items drop-down not enabled when options are selected

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -29,9 +29,8 @@
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarPopup",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "dojo/_base/lang",
-        "dojo/dom-class"], 
-        function(declare, AlfMenuBarPopup, _AlfDocumentListTopicMixin, lang, domClass) {
+        "dojo/_base/lang"], 
+        function(declare, AlfMenuBarPopup, _AlfDocumentListTopicMixin, lang) {
    
    return declare([AlfMenuBarPopup, _AlfDocumentListTopicMixin], {
       
@@ -118,10 +117,10 @@ define(["dojo/_base/declare",
          if (payload && payload.value)
          {
             var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
-            if (itemKey != null)
+            if (itemKey)
             {
                this.currentlySelectedItems[itemKey] = payload.value;
-               if (this.selectionTimeout != null)
+               if (this.selectionTimeout)
                {
                   clearTimeout(this.selectionTimeout);
                }
@@ -146,9 +145,11 @@ define(["dojo/_base/declare",
          var selectedItems = [];
          for (var key in this.currentlySelectedItems)
          {
-            selectedItems.push(this.currentlySelectedItems[key]);
+            if (this.currentlySelectedItems.hasOwnProperty(key)) {
+               selectedItems.push(this.currentlySelectedItems[key]);
+            }
          }
-         this.set('disabled', (selectedItems.length === 0));
+         this.set("disabled", (selectedItems.length === 0));
          this.publishSelectedItems(selectedItems);
          this.selectionTimeout = null;
       },
@@ -176,10 +177,10 @@ define(["dojo/_base/declare",
          if (payload && payload.value)
          {
             var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
-            if (itemKey != null)
+            if (itemKey)
             {
                delete this.currentlySelectedItems[itemKey];
-               if (this.selectionTimeout != null)
+               if (this.selectionTimeout)
                {
                   clearTimeout(this.selectionTimeout);
                }
@@ -199,9 +200,9 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload This is not expected to contain any usable data.
        */
-      onItemSelectionCleared: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onItemSelectionCleared(payload) {
+      onItemSelectionCleared: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onItemSelectionCleared(/*jshint unused:false*/ payload) {
          this.currentlySelectedItems = {};
-         if (this.selectionTimeout != null)
+         if (this.selectionTimeout)
          {
             clearTimeout(this.selectionTimeout);
          }
@@ -216,7 +217,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the selected files.
        */
       onFilesSelected: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onFilesSelected(payload) {
-         this.set('disabled', (payload && payload.selectedFiles && payload.selectedFiles.length === 0));
+         this.set("disabled", (payload && payload.selectedFiles && payload.selectedFiles.length === 0));
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -213,11 +213,6 @@ define(["alfresco/core/ObjectTypeUtils",
           */
          _createSafeData: function alfresco_logging_DebugLog___createSafeData(data) {
 
-            // Return early if it's already falsy
-            if (!data || typeof data !== "object") {
-               return data;
-            }
-
             // Setup variables
             var maxChildren = this.payloadConfig.maxChildren,
                maxDepth = this.payloadConfig.maxDepth,
@@ -227,86 +222,100 @@ define(["alfresco/core/ObjectTypeUtils",
             var safeData = (function makeSafe(unsafe, ancestors) {
                /*jshint maxcomplexity:false,maxstatements:false*/
 
-               // If this is an array, deal with it immediately
-               if (ObjectTypeUtils.isArray(unsafe)) {
-                  return array.map(unsafe, lang.hitch(this, function(unsafeChild) {
-                     return makeSafe(unsafeChild, ancestors.concat(unsafe));
+               // Setup return value
+               var safeValue = {};
+
+               // Deal with data appropriately
+               if (!unsafe || typeof unsafe !== "object") {
+
+                  // Falsy values and non-objects are already safe
+                  safeValue = unsafe;
+
+               } else if (ObjectTypeUtils.isArray(unsafe)) {
+
+                  // Arrays are safe in themselves, but make their items safe
+                  safeValue = array.map(unsafe, lang.hitch(this, function(unsafeChild) {
+                     return makeSafe(unsafeChild, ancestors);
                   }));
-               }
 
-               // Setup variables
-               var keys = Object.keys(unsafe),
-                  safe = {},
-                  key,
-                  value;
+               } else if (unsafe.nodeType === Node.ELEMENT_NODE) {
 
-               // Run through the keys
-               for (var i = 0; i < keys.length; i++) {
-
-                  // Variables
-                  key = keys[i];
-                  try {
-                     value = unsafe[key];
-                  } catch (e) {
-                     value = "Error: " + e.message;
-                     console.debug("Errored on " + key + " property on object: ", safe);
+                  // Display information about which element this is
+                  safeValue = unsafe.tagName.toLowerCase();
+                  if (unsafe.id) {
+                     safeValue += "#" + unsafe.id;
+                  }
+                  if (unsafe.className) {
+                     safeValue += "." + unsafe.className.split(" ").join(".");
                   }
 
-                  // Check against max children
-                  if (maxChildren !== -1 && i === maxChildren) {
-                     safe["MAXIMUM CHILDREN"] = "Maximum child-property count reached";
-                     break;
-                  }
+               } else if (unsafe.nodeType === Node.TEXT_NODE) {
 
-                  // Ensure key isn't explicitly excluded
-                  if (excludedKeys.indexOf(key) !== -1) {
-                     safe[key] = "[key excluded]";
-                     continue;
-                  }
+                  // Text nodes are just strings
+                  safeValue = unsafe.textContent;
+
+               } else if (unsafe.nodeType) {
+
+                  // Un-handled node type
+                  safeValue = "[" + unsafe.nodeName + "]";
+
+               } else if (unsafe._attachPoints) {
 
                   // Ignore widgets
-                  if (value && value._attachPoints) {
-                     safe[key] = "[widget]";
-                     continue;
-                  }
+                  safeValue = "[widget]";
 
-                  // We only really care about objects
-                  if (value && typeof value === "object") {
+               } else if (ancestors.indexOf(unsafe) !== -1) {
 
-                     // Handle object appropriately
-                     if (value.nodeType === Node.ELEMENT_NODE) {
-                        safe[key] = value.tagName.toLowerCase();
-                        if (value.id) {
-                           safe[key] += "#" + value.id;
-                        }
-                        if (value.className) {
-                           safe[key] += "." + value.className.split(" ").join(".");
-                        }
-                     } else if (value.nodeType === Node.TEXT_NODE) {
-                        safe[key] = value.textContent;
-                     } else if (value.nodeType) {
-                        safe[key] = "[" + value.nodeName + "]";
-                     } else if (ancestors.indexOf(value) !== -1) {
-                        safe[key] = "[recursive object";
-                        safe[key] += value.id ? " id=" + value.id + "]" : "]";
-                     } else if (maxDepth !== -1 && ancestors.length === maxDepth) {
-                        safe[key] = "[object beyond max-depth]";
-                     } else {
-                        safe[key] = makeSafe(value, ancestors.concat(unsafe));
+                  // Recursion avoidance!
+                  safeValue = "[recursive object";
+                  safeValue += unsafe.id ? " id=" + unsafe.id + "]" : "]";
+
+               } else if (maxDepth !== -1 && ancestors.length === maxDepth) {
+
+                  // Handle max-depth exceptions
+                  safeValue = "[object beyond max-depth]";
+
+               } else {
+
+                  // A normal object, so recurse through its properties
+                  var keys = Object.keys(unsafe),
+                     key,
+                     value;
+                  for (var i = 0; i < keys.length; i++) {
+
+                     // Variables
+                     key = keys[i];
+                     try {
+                        value = unsafe[key];
+                     } catch (e) {
+                        value = "Error (see console for details): " + e.message;
+                        console.warn("Unable to access '" + key + "' property on object: ", unsafe);
                      }
 
-                  } else {
-                     safe[key] = value;
-                  }
+                     // Check against max children
+                     if (maxChildren !== -1 && i === maxChildren) {
+                        safeValue["MAXIMUM CHILDREN"] = "Maximum child-property count reached";
+                        break;
+                     }
 
-                  // Get rid of "proper" linebreaks
-                  if (typeof safe[key] === "string") {
-                     safe[key] = safe[key].replace(/\r/g, "").replace(/\n/g, "\\n");
+                     // Ensure key isn't explicitly excluded
+                     if (excludedKeys.indexOf(key) !== -1) {
+                        safeValue[key] = "[key excluded]";
+                        continue;
+                     }
+
+                     // Make the value safe before adding to the return object
+                     safeValue[key] = makeSafe(value, ancestors.concat(unsafe));
                   }
+               }
+
+               // If we end up with a string, make the linebreaks safe
+               if (typeof safeValue === "string") {
+                  safeValue = safeValue.replace(/\r/g, "").replace(/\n/g, "\\n");
                }
 
                // Pass back the safe object
-               return safe;
+               return safeValue;
 
             })(data, []);
 

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -276,9 +276,10 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the document selected
        */
       onDocumentSelected: function alfresco_services_ActionService__onDocumentSelected(payload) {
-         if (payload && payload.value && payload.value.nodeRef)
+         var payloadNoderef = payload && payload.value && payload.value.node && payload.value.node.nodeRef;
+         if (payloadNoderef)
          {
-            this.currentlySelectedDocuments[payload.value.nodeRef] = payload.value;
+            this.currentlySelectedDocuments[payloadNoderef] = payload.value;
             if (this.selectionTimeout)
             {
                clearTimeout(this.selectionTimeout);
@@ -307,9 +308,10 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the document selected
        */
       onDocumentDeselected: function alfresco_services_ActionService__onDocumentDeselected(payload) {
-         if (payload && payload.value && payload.value.nodeRef)
+         var payloadNoderef = payload && payload.value && payload.value.node && payload.value.node.nodeRef;
+         if (payloadNoderef)
          {
-            delete this.currentlySelectedDocuments[payload.value.nodeRef];
+            delete this.currentlySelectedDocuments[payloadNoderef];
             if (this.selectionTimeout)
             {
                clearTimeout(this.selectionTimeout);

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -344,6 +344,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       onSelectedFilesChanged: function alfresco_services_ActionService__onSelectedFilesChanged() {
+         /*jshint maxcomplexity:false*/
          var files = this.getSelectedDocumentArray(), fileTypes = [], file,
              fileType, userAccess = {}, fileAccess, index,
              commonAspects = [], allAspects = [],
@@ -425,6 +426,7 @@ define(["dojo/_base/declare",
        * @param {object} document The document to perform the action on (only applicable to actions of type "javascript")
        */
       processActionObject: function alfresco_services_ActionService__processActionObject(action, document) {
+         /*jshint maxcomplexity:false*/
          if (action && action.type)
          {
             if (action.type === "pagelink")

--- a/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, require, TestCommon) {
+
+      var browser;
+
+      registerSuite({
+
+         name: "ActionService Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ActionService", "ActionService Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Selecting a document changes the selected documents appropriately": function() {
+            return browser.findByCssSelector("[widgetid=\"DOCUMENT_SELECTED_BUTTON\"] .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "ALF_SELECTED_FILES_CHANGED",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.isNotNull(payload, "Selected files change not published");
+                  if (payload) {
+                     assert.lengthOf(payload.selectedFiles, 1, "Should have one node selected");
+                     assert.deepPropertyVal(payload, "selectedFiles[0].node.nodeRef", "workspace://SpacesStore/b0037179-f105-4858-9d8f-44bfb0f67d8a", "Incorrect node selected");
+                  }
+               });
+         },
+
+         "Deselecting a document changes the selected documents appropriately": function() {
+            return browser.findByCssSelector("[widgetid=\"DOCUMENT_DESELECTED_BUTTON\"] .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "ALF_SELECTED_FILES_CHANGED",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.isNotNull(payload, "Selected files change not published");
+                  if (payload) {
+                     assert.lengthOf(payload.selectedFiles, 0, "Should not have a current selected node");
+                  }
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/CommentsListTest"
+      "src/test/resources/alfresco/services/ActionServiceTest"
    ],
 
    /**
@@ -174,6 +174,7 @@ define({
       "src/test/resources/alfresco/search/FacetFiltersTest",
       "src/test/resources/alfresco/search/SearchSuggestionsTest",
 
+      "src/test/resources/alfresco/services/ActionServiceTest",
       "src/test/resources/alfresco/services/ContentServiceTest",
       "src/test/resources/alfresco/services/CrudServiceTest",
       "src/test/resources/alfresco/services/DialogServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ActionService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ActionService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Action Service</shortname>
+  <description>Displays buttons that exercise the ActionService service.</description>
+  <family>aikau-unit-tests</family>
+  <url>/ActionService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ActionService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ActionService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ActionService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ActionService.get.js
@@ -1,0 +1,114 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/ActionService"
+   ],
+   widgets: [
+      {
+         id: "DOCUMENT_SELECTED_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Publish document selected event",
+            publishTopic: "ALF_DOCLIST_DOCUMENT_SELECTED",
+            publishPayload: {
+               value: {
+                  node: getTestNode()
+               }
+            }
+         }
+      },
+      {
+         id: "DOCUMENT_DESELECTED_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Publish document de-selected event",
+            publishTopic: "ALF_DOCLIST_DOCUMENT_DESELECTED",
+            publishPayload: {
+               value: {
+                  node: getTestNode()
+               }
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};
+
+// Put this into a function (use hoisting to keep code tidy), to avoid repetition
+function getTestNode() {
+   return {
+      "isLink": false,
+      "aspects": ["cm:auditable", "cm:thumbnailModification", "sys:referenceable", "cm:titled", "rn:renditioned", "cm:author", "cm:taggable", "sys:localized", "cm:generalclassifiable", "app:inlineeditable"],
+      "properties": {
+         "cm:modified": {
+            "value": "Wed Mar 11 13:47:09 GMT 2015",
+            "iso8601": "2015-03-11T13:47:09.072Z"
+         },
+         "cm:taggable": null,
+         "cm:categories": [{
+            "name": "British English",
+            "path": "\/Languages\/English",
+            "nodeRef": "workspace:\/\/SpacesStore\/bdd65b2d-8b03-45f0-89fe-701723df1afa"
+         }],
+         "cm:content": null,
+         "sys:node-uuid": null,
+         "app:editInline": "true",
+         "cm:name": "Another document",
+         "cm:lastThumbnailModification": ["pdf:1426081599646", "doclib:1426081635555"],
+         "sys:store-protocol": null,
+         "sys:locale": null,
+         "sys:node-dbid": null,
+         "cm:description": "",
+         "cm:creator": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "cm:created": {
+            "value": "Wed Mar 11 13:46:38 GMT 2015",
+            "iso8601": "2015-03-11T13:46:38.088Z"
+         },
+         "cm:title": "",
+         "cm:author": "",
+         "cm:modifier": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "sys:store-identifier": null
+      },
+      "type": "cm:content",
+      "isLocked": false,
+      "size": 12,
+      "mimetypeDisplayName": "Plain Text",
+      "mimetype": "text\/plain",
+      "encoding": "UTF-8",
+      "permissions": {
+         "roles": ["ALLOWED;GROUP_site_site5_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_site_site5_SiteCollaborator;SiteCollaborator;INHERITED", "ALLOWED;GROUP_site_site5_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site5_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED"],
+         "inherited": true,
+         "user": {
+            "ChangePermissions": true,
+            "CancelCheckOut": false,
+            "CreateChildren": true,
+            "Write": true,
+            "Delete": true,
+            "Unlock": false
+         }
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/b0037179-f105-4858-9d8f-44bfb0f67d8a",
+      "isContainer": false,
+      "contentURL": "\/slingshot\/node\/content\/workspace\/SpacesStore\/b0037179-f105-4858-9d8f-44bfb0f67d8a\/Another%20document"
+   };
+}


### PR DESCRIPTION
This addresses issue [AKU-248](https://issues.alfresco.com/jira/browse/AKU-247) where an incorrect property path was meaning that selection changes were not being published, and adds tests for the appropriate methods in the ActionService. There are also some fixes to the DebugLog and the TestCommon method that uses it.