### PR TITLE
AKU-251: Update PreferenceService for favourites

### DIFF
--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -88,31 +88,6 @@ define(["dojo/_base/declare",
       localPreferences: null,
       
       /**
-       * Converts a dot-notation property address into a JavaScript object literal. This is done so that
-       * preferences can be set on the object generated from and address.
-       * 
-       * @instance
-       * @param {string} str The dot-notation property to convert into an object
-       * @param {object} value The value to set at the dot-notation property address
-       * @return {object} The object generated from the dot-notation property.
-       */
-      dotNotationToObject: function alfresco_services_PreferenceService__dotNotationToObject(str, value) {
-         var object = {}, obj = object;
-         if (typeof str === "string")
-         {
-            var properties = str.split("."), property, i, ii;
-            for (i = 0, ii = properties.length - 1; i < ii; i++)
-            {
-               property = properties[i];
-               obj[property] = {};
-               obj = obj[property];
-            }
-            obj[properties[i]] = value !== undefined ? value : null;
-         }
-         return object;
-      },
-
-      /**
        * Retrieves a preference from the [local copy]{@link module:alfresco/services/PreferenceService#localPreferences} rather than 
        * getting them remotely.
        * 
@@ -188,7 +163,8 @@ define(["dojo/_base/declare",
          {
             var name = requestConfig.data.name;
             var value = requestConfig.data.value;
-            var preferences = this.dotNotationToObject(name, null);
+            var preferences = {};
+            lang.setObject(name, value, preferences);
             $.extend(true, preferences, response);
             var values = lang.getObject(name, false, preferences);
             

--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -18,6 +18,10 @@
  */
 
 /**
+ * This service provides access to user preferences as a whole as well as subscribing to specific topics
+ * for setting Document Library preferences (views, sidebar visibility/width, breadcrumb visibility, etc) and
+ * adding and removing documents or folders from a the users favourites list.
+ * 
  * @module alfresco/services/PreferenceService
  * @extends module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreXhr
@@ -172,7 +176,8 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This is the default success callback for XHR requests that will be used if no other is provided.
+       * This is the success callback for retrieving preferences. If a name and value are included then
+       * the preferences will be updated.
        *
        * @instance
        * @param {object} response The object returned from the successful XHR request
@@ -208,6 +213,20 @@ define(["dojo/_base/declare",
                   value: arrValues.join(",")
                });
             }
+         }
+      },
+
+      /**
+       * This is the failure callback for retrieving preferences
+       *
+       * @instance
+       * @param {object} response The object returned from the successful XHR request
+       * @param {object} requestConfig The original configuration passed when the request was made
+       */
+      onPreferenceRetrievalFail: function alfresco_services_PreferenceService__onPreferenceRetrieved(response, requestConfig) {
+         if (requestConfig.data && requestConfig.data.alfTopic)
+         {
+            this.alfPublish(requestConfig.data.alfTopic + "_FAILURE", {});
          }
       },
 

--- a/aikau/src/main/resources/alfresco/services/RatingsService.js
+++ b/aikau/src/main/resources/alfresco/services/RatingsService.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -76,7 +76,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onAddRating: function alfresco_services_RatingsService__onAddRating(payload) {
-         var alfTopic = (payload.alfResponseTopic != null) ? payload.alfResponseTopic : this.addRatingTopic;
+         var alfTopic = payload.alfResponseTopic || this.addRatingTopic;
          var nodeRefUri = lang.getObject("node.jsNode.nodeRef.uri", false, payload);
          if (nodeRefUri)
          {
@@ -100,7 +100,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onRemoveRating: function alfresco_services_RatingsService__onRemoveRating(payload) {
-         var alfTopic = (payload.alfResponseTopic != null) ? payload.alfResponseTopic : this.onRemoveRating;
+         var alfTopic = payload.alfResponseTopic || this.onRemoveRating;
          var nodeRefUri = lang.getObject("node.jsNode.nodeRef.uri", false, payload);
          if (nodeRefUri)
          {

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -357,23 +357,110 @@ function getRepositoryUrl()
  *                                                                                 *
  ***********************************************************************************/
 
-/**
- * Returns a JSON array of the configuration for all the services required by the document library
- */
-function getDocumentLibraryServices() {
-   var services = getHeaderServices();
-   services = services.concat([
-      "alfresco/dialogs/AlfDialogService",
-      "alfresco/services/ActionService",
-      "alfresco/services/ContentService",
-      "alfresco/services/CrudService",
-      "alfresco/services/DocumentService",
-      "alfresco/services/LightboxService",
-      "alfresco/services/QuickShareService",
-      "alfresco/services/RatingsService",
-      "alfresco/services/SearchService",
-      "alfresco/services/TagService"
-   ]);
+function addService(service, existingServices) {
+   // jshint shadow:false
+   for (var i=0; i < existingServices.length; i++)
+   {
+      if (existingServices[i] && 
+          (existingServices[i].name === service || existingServices[i] === service))
+      {
+         return false;
+      }
+   }
+   return true;
+}
+
+function addDocumentLibraryServices(services) {
+   // jshint shadow:false
+   var defaultServices = [
+      {
+         id: "NAVIGATION_SERVICE",
+         name: "alfresco/services/NavigationService"
+      },
+      {
+         id: "DIALOG_SERVICE",
+         name: "alfresco/services/DialogService"
+      },
+      {
+         id: "ACTION_SERVICE",
+         name: "alfresco/services/ActionService"
+      },
+      {
+         id: "CONTENT_SERVICE",
+         name: "alfresco/services/ContentService"
+      },
+      {
+         id: "CRUD_SERVICE",
+         name: "alfresco/services/CrudService"
+      },
+      {
+         id: "DOCUMENT_SERVICE",
+         name: "alfresco/services/DocumentService"
+      },
+      {
+         id: "LIGHTBOX_SERVICE",
+         name: "alfresco/services/LightboxService"
+      },
+      {
+         id: "QUICKSHARE_SERVICE",
+         name: "alfresco/services/QuickShareService"
+      },
+      {
+         id: "RATINGS_SERVICE",
+         name: "alfresco/services/RatingsService"
+      },
+      {
+         id: "SEARCH_SERVICE",
+         name: "alfresco/services/SearchService"
+      },
+      {
+         id: "TAG_SERVICE",
+         name:  "alfresco/services/TagService"
+      },
+      {
+         id: "PREFERENCE_SERVICE",
+         name:  "alfresco/services/PreferenceService"
+      },
+      {
+         id: "NOTIFICATION_SERVICE",
+         name:  "alfresco/services/NotificationService"
+      },
+      {
+         id: "COMMENT_SERVICE",
+         name:  "alfresco/services/CommentService"
+      },
+      {
+         id: "UPLOAD_SERVICE",
+         name:  "alfresco/services/UploadService"
+      },
+      {
+         id: "CREATE_TEMPLATED_CONTENT_SERVICE",
+         name: "alfresco/services/actions/CreateTemplateContentService"
+      },
+      {
+         id: "COPY_AND_MOVE_SERVICE",
+         name: "alfresco/services/actions/CopyMoveService"
+      },
+      {
+         id: "SIMPLE_WORKFLOW_SERVICE",
+         name: "alfresco/services/actions/SimpleWorkflowService"
+      }
+   ];
+     
+   if (services)
+   {
+      for (var i=0; i < defaultServices.length; i++)
+      {
+         if (addService(defaultServices[i].name, services))
+         {
+            services.push(defaultServices[i]);
+         }
+      }
+   }
+   else
+   {
+      services = defaultServices;
+   }
    return services;
 }
 

--- a/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
@@ -44,107 +44,111 @@ define(["intern!object",
          browser.end();
       },
 
-     "Like Test": function () {
+     "Check like PROCESSING image": function () {
          return browser.findByCssSelector(toggleSelector("LIKES", "processing"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #1a - like PROCESSING image displayed incorrectly");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "on"))
+               assert.isFalse(result, "Like PROCESSING image should not be displayed initially");
+            });
+      },
+
+      "Check like ON image": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "on"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #1b - like ON image displayed incorrectly");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "off"))
+               assert.isFalse(result, "Like ON image should not be displayed initially");
+            });
+      },
+
+      "Check like OFF image": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "off"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === true, "Test #1c - like OFF image was not displayed");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "warning"))
+               assert.isTrue(result, "Like OFF image was not displayed");
+            });
+      },
+
+      "Check like WARNING image": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "warning"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #1d - like WARNING image displayed incorrectly");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "count"))
+               assert.isFalse(result, "Like WARNING image should not be displayed initially");
+            });
+      },
+
+      "Check like count": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "count"))
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "4", "Test #1e - like COUNT is incorrect: " + resultText);
-            })
-            .end()
+               assert.equal(resultText, "4", "Like COUNT is incorrect");
+            });
+      },
 
-         // Click on LIKE and check the response...
-         .findByCssSelector("#LIKES")
+      "Like the document": function() {
+         return browser.findByCssSelector("#LIKES")
             .click()
-            .end()
+         .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_ADD", "publish", "any"))
             .then(function(elements) {
-               assert(elements.length === 1, "Test #2a - Add rating request not published");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "on"))
+               assert.lengthOf(elements, 1, "Add rating request not published");
+            });
+      },
+
+      "Check ON image is toggled": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "on"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === true, "Test #2b - like ON image not displayed following like");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "off"))
+               assert.isTrue(result, "Like ON image not displayed following like");
+            });
+      },
+
+      "Check OFF image is toggled": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "off"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #2c - like OFF image displayed despite liking");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "count"))
+               assert.isFalse(result, "Like OFF image displayed despite liking");
+            });
+      },
+
+      "Check the like count is incremented": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "count"))
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "5", "Test #2d - like COUNT is incorrect following liking: " + resultText);
-            })
-            .end()
+               assert.equal(resultText, "5", "Like COUNT is incorrect following liking");
+            });
+      },
 
-         // Click on LIKE again and check the response...
-         .findByCssSelector("#LIKES")
+      "Unlike the document": function() {
+         return browser.findByCssSelector("#LIKES")
             .click()
-            .end()
+         .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_REMOVE", "publish", "any"))
             .then(function(elements) {
-               assert(elements.length === 1, "Test #3a - Add rating request not published");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "on"))
+               assert.lengthOf(elements, 1, "Remove rating request not published");
+            });
+      },
+
+      "Check ON image is toggled (on unlike)": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "on"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #3b - like ON image displayed despite removing like");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "off"))
+               assert.isFalse(result, "Like ON image displayed despite removing like");
+            });
+      },
+
+      "Check OFF image is toggled (on unlike)": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "off"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === true, "Test #3c - like OFF image not displayed despite removing like");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "count"))
+               assert.isTrue(result, "Like OFF image not displayed despite removing like");
+            });
+      },
+
+      "Check count is decremented (on unlike)": function() {
+         return browser.findByCssSelector(toggleSelector("LIKES", "count"))
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "4", "Test #3d - like COUNT is incorrect following liking: " + resultText);
-            })
-            .end()
-
-         // Click on the LIKE again to check the simulated failure request...
-         .findByCssSelector("#LIKES")
-            .click()
-            .end()
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_ADD", "publish", "any"))
-            .then(function(elements) {
-               assert(elements.length === 2, "Test #4a - Add rating request not published");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("LIKES", "warning"))
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === true, "Test #4b - like WARNING image not displayed following simulated failure");
+               assert.equal(resultText, "4", "Like COUNT is incorrect after unliking");
             });
       },
 
@@ -165,89 +169,87 @@ define(["intern!object",
          browser.end();
       },
 
-     "Favourite Test": function () {
+     "Check initial PROCESSING image": function () {
          return browser.findByCssSelector(toggleSelector("FAVOURITES", "processing"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #1a - favourite PROCESSING image displayed incorrectly");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "on"))
+               assert.isFalse(result, "Favourite PROCESSING image should not be displayed initially");
+            });
+      },
+
+      "Check initial ON image": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "on"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #1b - favourite ON image displayed incorrectly");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "off"))
+               assert.isFalse(result, "Favourite ON image should not be displayed initially");
+            });
+      },
+
+      "Check initial OFF image": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "off"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === true, "Test #1c - favourite OFF image was not displayed");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "warning"))
+               assert.isTrue(result, "Favourite OFF image was not displayed");
+            });
+      },
+
+      "Check initial WARNING image": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "warning"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === false, "Test #1d - favourite WARNING image displayed incorrectly");
-            })
-            .end()
-         
-         // Click on FAVOURITE and check the response...
-         .findByCssSelector("#FAVOURITES")
+               assert.isFalse(result, "Favourite WARNING image should not be displayed initially");
+            });
+      },
+
+      "Favourite a document": function() {
+         return browser.findByCssSelector("#FAVOURITES")
             .click()
-            .end()
+         .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE", "publish", "any"))
             .then(function(elements) {
-               assert(elements.length === 1, "Test #2a - Add favourite request not published");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "on"))
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === true, "Test #2b - favourite ON image not displayed following favourite");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "off"))
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "Test #2c - favourite OFF image displayed despite liking");
-            })
-            .end()
+               assert.lengthOf(elements, 1, "Add favourite request not published");
+            });
+      },
 
-         // Click on FAVOURITE again and check the response...
-         .findByCssSelector("#FAVOURITES")
+      "Check ON image toggled (add favourite)": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "on"))
+            .isDisplayed()
+            .then(function(result) {
+               assert.isTrue(result, "Favourite ON image not displayed following favourite");
+            });
+      },
+
+      "Check OFF image toggled (add favourite)": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "off"))
+            .isDisplayed()
+            .then(function(result) {
+               assert.isFalse(result, "Favourite OFF image displayed despite favourite");
+            });
+      },
+
+      "Remove favourite": function() {
+         return browser.findByCssSelector("#FAVOURITES")
             .click()
-            .end()
+         .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE", "publish", "any"))
             .then(function(elements) {
-               assert(elements.length === 1, "Test #3a - Remove favourite request not published");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "on"))
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "Test #3b - favourite ON image displayed despite removing favourite");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "off"))
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === true, "Test #3c - favourite OFF image not displayed despite removing favourite");
-            })
-            .end()
+               assert.lengthOf(elements, 1, "Remove favourite request not published");
+            });
+      },
 
-         // Click on the FAVOURITE again to check the simulated failure request...
-         .findByCssSelector("#FAVOURITES")
-            .click()
-            .end()
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE", "publish", "any"))
-            .then(function(elements) {
-               assert(elements.length === 2, "Test #4a - Add favourite request not published");
-            })
-            .end()
-         .findByCssSelector(toggleSelector("FAVOURITES", "warning"))
+      "Check ON image toggled (remove favourite)": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "on"))
             .isDisplayed()
             .then(function(result) {
-               assert(result === true, "Test #4b - favourite WARNING image not displayed following simulated failure");
+               assert.isFalse(result, false, "Favourite ON image displayed despite removing favourite");
+            });
+      },
+
+      "Check OFF image toggled (remove favourite)": function() {
+         return browser.findByCssSelector(toggleSelector("FAVOURITES", "off"))
+            .isDisplayed()
+            .then(function(result) {
+               assert.isTrue(result, "Favourite OFF image not displayed despite removing favourite");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>SocialRenderers Test</shortname>
-  <description>This WebScript defines the SocialRenderers page test</description>
+  <shortname>Social renderers</shortname>
+  <description>Shows the favourite, like, comment and quick share renderers</description>
   <family>aikau-unit-tests</family>
   <url>/SocialRenderers</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
@@ -79,9 +79,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
@@ -9,7 +9,8 @@ model.jsonModel = {
             }
          }
       },
-      "aikauTesting/mockservices/SocialTestService",
+      "alfresco/services/PreferenceService",
+      "alfresco/services/RatingsService",
       "alfresco/services/ErrorReporter"
    ],
    widgets:[
@@ -20,6 +21,10 @@ model.jsonModel = {
             currentData: {
                items: [
                   {
+                     nodeRef: "some://dummy/nodeRef",
+                     node: {
+                        nodeRef: "some://dummy/nodeRef"
+                     },
                      name: "Test 1",
                      liked: false,
                      likeCount: 4,
@@ -76,6 +81,9 @@ model.jsonModel = {
             ]
             
          }
+      },
+      {
+         name: "aikauTesting/mockservices/SocialMockXhr"
       },
       {
          name: "alfresco/logging/SubscriptionLog"

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
@@ -33,7 +33,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      setupServer: function alfresco_testing_SitesPaginationMockXhr__setupServer() {
+      setupServer: function alfresco_testing_SocialMockXhr__setupServer() {
          try
          {
             this.server.respondWith("POST",

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @module aikauTesting/SocialMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr"], 
+        function(declare, MockXhr) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_SitesPaginationMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("POST",
+                                    /\/proxy\/alfresco\/api\/node\/(.*)\/ratings/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     "{\"data\":{\"ratingsCount\":5}}"]);
+            this.server.respondWith("DELETE",
+                                    /\/proxy\/alfresco\/api\/node\/(.*)\/ratings/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     "{\"data\":{\"ratingsCount\":4}}"]);
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/api/people/guest/preferences",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     "{}"]);
+            this.server.respondWith("POST",
+                                    "/aikau/proxy/alfresco/api/people/guest/preferences",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     "{}"]);
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});


### PR DESCRIPTION
This PR addresses AKU-251 (and in part AKU-254) to support the adding and removal of favourites on an Aikau client that is independent of Share. Existing YUI/Share code dependencies have been removed and ported into the Aikau code base. The unit tests have been updated to include tests for both the PreferenceService and RatingsService and the doclib.lib.js has been updated to make it easier to get the list of services required for using the Document Library.