### PR TITLE
AKU-248: Selecting a filter doesn't reset page to 1

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -138,6 +138,7 @@ define(["dojo/_base/declare",
             {
                var currHash = ioQuery.queryToObject(hash());
                currHash.path = payload.path;
+               currHash.currentPage = 1;
                delete currHash.filter;
                delete currHash.category;
                delete currHash.tag;
@@ -148,6 +149,7 @@ define(["dojo/_base/declare",
             }
             else
             {
+               this.currentPage = 1;
                this.currentFilter = {
                   path: payload.path
                };
@@ -174,6 +176,7 @@ define(["dojo/_base/declare",
             {
                var currHash = ioQuery.queryToObject(hash());
                currHash.category = payload.path;
+               currHash.currentPage = 1;
                delete currHash.filter;
                delete currHash.path;
                delete currHash.tag;
@@ -184,6 +187,7 @@ define(["dojo/_base/declare",
             }
             else
             {
+               this.currentPage = 1;
                this.currentFilter = {
                   category: payload.path
                };
@@ -210,6 +214,7 @@ define(["dojo/_base/declare",
             {
                var currHash = ioQuery.queryToObject(hash());
                currHash.filter = payload.value;
+               currHash.currentPage = 1;
                delete currHash.category;
                delete currHash.path;
                delete currHash.tag;
@@ -220,9 +225,11 @@ define(["dojo/_base/declare",
             }
             else
             {
+               this.currentPage = 1;
                this.currentFilter = {
                   filter: payload.value
                };
+               this.loadData();
             }
          }
          else
@@ -245,6 +252,7 @@ define(["dojo/_base/declare",
             {
                var currHash = ioQuery.queryToObject(hash());
                currHash.tag = payload.value;
+               currHash.currentPage = 1;
                delete currHash.category;
                delete currHash.path;
                delete currHash.filter;
@@ -255,9 +263,11 @@ define(["dojo/_base/declare",
             }
             else
             {
+               this.currentPage = 1;
                this.currentFilter = {
                   tag: payload.value
                };
+               this.loadData();
             }
          }
          else
@@ -334,6 +344,9 @@ define(["dojo/_base/declare",
       onHashChanged: function alfresco_documentlibrary_AlfDocumentList__onHashChanged(payload) {
          if(this.doHashVarUpdate(payload))
          {
+            if (payload.currentPage) {
+               this.currentPage = payload.currentPage;
+            }
             this.currentFilter = payload;
             if (this._readyToLoad) this.loadData();
          }

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -323,6 +323,10 @@ define(["alfresco/core/ObjectTypeUtils",
             return safeData;
          },
 
+         _onClearButtonClick: function alfresco_logging_DebugLog___onClearButtonClick(){
+            domConstruct.empty(this.logNode);
+         },
+
          /**
           * Toggle the collapsed state of a data item
           *

--- a/aikau/src/main/resources/alfresco/logging/css/DebugLog.css
+++ b/aikau/src/main/resources/alfresco/logging/css/DebugLog.css
@@ -1,6 +1,23 @@
 .alfresco_logging_DebugLog {
    margin: 25px 0;
+   &__header, &__clear-button {
+      line-height: 24px;
+      font-size: 16px;
+      display: inline-block;
+      margin: 0 10px 10px 0;
+   }
+   &__header {
+      font-weight: 700;
+      font-family: @bold-font;
+   }
+   &__clear-button {
+      background: #fff;
+      color: #333;
+      padding: 0 10px;
+      border: 1px solid #333;
+   }
    &__log {
+      display: block;
       list-style: none;
       margin: 0;
       max-width: 100%;

--- a/aikau/src/main/resources/alfresco/logging/templates/DebugLog.html
+++ b/aikau/src/main/resources/alfresco/logging/templates/DebugLog.html
@@ -1,4 +1,5 @@
 <div class="${rootClass}">
-   <h3>Subscription Log</h3>
+   <h3 class="${rootClass}__header">Subscription Log</h3>
+   <button class="${rootClass}__clear-button" data-dojo-attach-event="click:_onClearButtonClick">Clear</button>
    <ul class="${rootClass}__log" data-dojo-attach-point="logNode"></ul>
 </div>

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -21,14 +21,14 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
-        "intern/chai!assert",
-        "require",
+        "intern/chai!expect", 
+        "intern/chai!assert", 
+        "require", 
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function(registerSuite, expect, assert, require, TestCommon) {
 
    var browser;
-   // var pause = 500;
+
    registerSuite({
       name: "Pagination Tests",
 
@@ -41,10 +41,10 @@ define(["intern!object",
          browser.end();
       },
 
-      "Test page selector drop-down label intialization": function () {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
+      "Test page selector drop-down label intialization": function() {
+         return browser.findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
             .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -52,10 +52,10 @@ define(["intern!object",
             });
       },
 
-      "Test custom configured page selector drop-down label intialization": function () {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
+      "Test custom configured page selector drop-down label intialization": function() {
+         return browser.findByCssSelector(TestCommon.topicSelector("ALF_WIDGETS_READY", "publish", "any"))
             .end()
+
          .findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -73,8 +73,9 @@ define(["intern!object",
 
       "Count custom configured page sizes": function() {
          return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-               .click()
+            .click()
             .end()
+
          .findAllByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown .alf-checkable-menu-item")
             .then(function(elements) {
                assert.lengthOf(elements, 3, "The wrong number of custom page sizes was found");
@@ -82,21 +83,21 @@ define(["intern!object",
       },
 
       "Test prevous page button is disabled on page load": function() {
-         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+         return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 1, "The previous page button should be disabled");
             });
       },
 
       "Test next page button is enabled on page load": function() {
-         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+         return browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 0, "The next page button should be enabled");
             });
       },
 
       "Test items loaded correctly (check first row of 25 items)": function() {
-         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
+         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
             .getVisibleText()
             .then(function(text) {
                assert(text === "1", "First displayed row should be 1, saw: " + text);
@@ -104,26 +105,24 @@ define(["intern!object",
       },
 
       "Test items loaded correctly (check last row of 25 items)": function() {
-         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(25) span.value")
+         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(25) span.value")
             .getVisibleText()
             .then(function(text) {
                assert(text === "25", "First displayed row should be 25, saw: " + text);
             });
       },
 
-      "Test 50 items per page selection update page selector drop-down label": function () {
+      "Test 50 items per page selection update page selector drop-down label": function() {
          // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
          // Switch to 50 results per page...
-         return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            // .sleep(100)
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(2) td:nth-child(3)")
             .click()
-         .end()
-         // sped up - hopefully at some point in the future we can remove this sleep!         
-         // .sleep(pause)
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+            .end()
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
                assert(text === "1-50 of 243", "Page selector label not updated correctly after switching to 50 items per page: " + text);
@@ -131,24 +130,24 @@ define(["intern!object",
       },
 
       "Test previous page button is still disabled (after increasing page size)": function() {
-         this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+         browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 1, "The previous page button should still be disabled");
             });
       },
 
       "Test next page button is still enabled (after increasing page size)": function() {
-         this.remote.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+         browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 0, "The next page button should still be enabled");
             });
       },
 
-      "Test clicking next page updates page selector drop-down label": function () {
-         return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+      "Test clicking next page updates page selector drop-down label": function() {
+         return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
-            // .sleep(pause)
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -156,25 +155,25 @@ define(["intern!object",
             });
       },
 
-      "Test clicking next page enables previous page button": function () {
-         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+      "Test clicking next page enables previous page button": function() {
+         return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 0, "The previous page button should now be enabled");
             });
       },
 
       "Test next page button is still enabled (after using next page button)": function() {
-         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+         return browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 0, "The next page button should still be enabled");
             });
       },
 
       "Test previous page button updates page selector drop-down label": function() {
-         return this.remote.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
+         return browser.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
             .click()
-            // .sleep(pause)
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -183,21 +182,23 @@ define(["intern!object",
       },
 
       "Test previous page button is disabled (after previous page action)": function() {
-         return this.remote.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+         return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 1, "The previous page button should now be disabled");
             });
       },
 
-      "Test page selection updates page selector label correctly": function () {
+      "Test page selection updates page selector label correctly": function() {
          // Select the 4th page, because there are 5 pages and we want to click next page to check that
          // using the next page button will disable the next page button when the last page is reached...
-         return this.remote.findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
@@ -206,10 +207,10 @@ define(["intern!object",
       },
 
       "Test next page button (to last page) disables next page button": function() {
-         return this.remote.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+         return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
             .click()
-            // .sleep(pause)
-         .end()
+            .end()
+
          .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
             .then(function(elements) {
                assert(elements.length === 1, "The next page button should be disabled when next paging to the last page");
@@ -221,20 +222,21 @@ define(["intern!object",
          // a page of data that won't exist... instead, we should load a smaller page number to 
          // accommodate the larger page size.
          // Select 100 items per page and the page number should go from 5 to 3...
-         return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            // .sleep(100)
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
             .click()
-         .end()
-         // .sleep(pause)
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
                assert(text === "201-243 of 243", "Page selector label not correct, expected '201-243 of 243' but saw: " + text);
             })
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
             .getVisibleText()
             .then(function(text) {
@@ -243,7 +245,7 @@ define(["intern!object",
       },
 
       "Test items loaded correctly for incomplete page(check first row of 100 items": function() {
-         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
+         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
             .getVisibleText()
             .then(function(text) {
                assert(text === "201", "First displayed row should be 201, saw: " + text);
@@ -251,18 +253,19 @@ define(["intern!object",
       },
 
       "Test items loaded correctly (check last row of 100 items": function() {
-         return this.remote.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(43) span.value")
+         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(43) span.value")
             .getVisibleText()
             .then(function(text) {
                assert(text === "243", "First displayed row should be 243, saw: " + text);
             });
       },
 
-      "Test Results Per Page Group": function () {
+      "Test Results Per Page Group": function() {
          // This tests the external results per page menu, to ensure it picks up changes correctly...
-         return this.remote.findByCssSelector("#MENU_BAR_POPUP_text")
+         return browser.findByCssSelector("#MENU_BAR_POPUP_text")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(4) td.alf-selected-icon")
             .then(function(elements) {
                assert(elements.length === 1, "Results per page widget check box not highlighted correctly");
@@ -274,20 +277,21 @@ define(["intern!object",
          // appropriate page for the smaller page size. Although we're on the last page (201-243) for
          // 100 items per page, we want to jump to the penultimate page for 25 items per page (201-225)
          // as this is the most appropriate page for where we were.
-         return this.remote.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
             .click()
-            // .sleep(100)
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(1) td:nth-child(3)")
             .click()
-         .end()
-         // .sleep(pause)
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
             .getVisibleText()
             .then(function(text) {
                assert(text === "201-225 of 243", "Page selector label not correct, expected '201-225 of 243' but saw: " + text);
             })
-         .end()
+            .end()
+
          .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
             .getVisibleText()
             .then(function(text) {
@@ -295,8 +299,107 @@ define(["intern!object",
             });
       },
 
+      "Starting page is initialised and working (useHash=false)": function() {
+         return checkPage("CUSTOM_", 1)()
+            .then(gotoNextPage("CUSTOM_"))
+            .then(checkPage("CUSTOM_", 2));
+      },
+
+      "Changing filter changes to page 1 (useHash=false)": function() {
+         return clickButton("CHANGE_FILTER")
+            .then(checkPage("CUSTOM_", 1))
+            .then(gotoNextPage("CUSTOM_"));
+      },
+
+      "Changing tag changes to page 1 (useHash=false)": function() {
+         return clickButton("CHANGE_TAG")
+            .then(checkPage("CUSTOM_", 1))
+            .then(gotoNextPage("CUSTOM_"));
+      },
+
+      "Changing category changes to page 1 (useHash=false)": function() {
+         return clickButton("CHANGE_CATEGORY")
+            .then(checkPage("CUSTOM_", 1))
+            .then(gotoNextPage("CUSTOM_"));
+      },
+
+      "Changing path changes to page 1 (useHash=false)": function() {
+         return clickButton("CHANGE_PATH")
+            .then(checkPage("CUSTOM_", 1))
+            .then(gotoNextPage("CUSTOM_"));
+      },
+
+      "Starting page is initialised and working (useHash=true)": function() {
+         return checkPage("HASH_CUSTOM_", 1)()
+            .then(gotoNextPage("HASH_CUSTOM_"))
+            .then(checkPage("HASH_CUSTOM_", 2));
+      },
+
+      "Changing filter changes to page 1 (useHash=true)": function() {
+         return clickButton("HASH_CHANGE_FILTER")
+            .then(checkPage("HASH_CUSTOM_", 1))
+            .then(gotoNextPage("HASH_CUSTOM_"));
+      },
+
+      "Changing tag changes to page 1 (useHash=true)": function() {
+         return clickButton("HASH_CHANGE_TAG")
+            .then(checkPage("HASH_CUSTOM_", 1))
+            .then(gotoNextPage("HASH_CUSTOM_"));
+      },
+
+      "Changing category changes to page 1 (useHash=true)": function() {
+         return clickButton("HASH_CHANGE_CATEGORY")
+            .then(checkPage("HASH_CUSTOM_", 1))
+            .then(gotoNextPage("HASH_CUSTOM_"));
+      },
+
+      "Changing path changes to page 1 (useHash=true)": function() {
+         return clickButton("HASH_CHANGE_PATH")
+            .then(checkPage("HASH_CUSTOM_", 1))
+            .then(gotoNextPage("HASH_CUSTOM_"));
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });
+
+   /********************/
+   /* Helper functions */
+   /********************/
+   function clickButton(buttonId) {
+      return browser.findByCssSelector("[widgetid=\"" + buttonId + "\"] .dijitButtonNode")
+         .click()
+         .sleep(500)
+         .end();
+   }
+
+   function gotoNextPage(scope) {
+      return function() {
+         return browser.end()
+            .findById(scope + "PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+            .click()
+            .end();
+      };
+   }
+
+   function checkPage(scope, pageNum) {
+      var firstItem = ((pageNum - 1) * 10) + 1;
+      return function() {
+         return browser.end()
+            .findById(scope + "PAGE_SIZE_PAGINATOR_PAGE_MARKER")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "" + pageNum, "Should be displaying that page number is " + pageNum);
+            })
+            .end()
+
+         .findByCssSelector("#" + scope + "PAGE_SIZES .alfresco-lists-views-layouts-Row:first-child")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "" + firstItem, "Should be displaying results from page " + pageNum);
+            })
+            .end();
+      };
+   }
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/ActionServiceTest"
+      "src/test/resources/alfresco/documentlibrary/PaginationTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -16,7 +16,8 @@ model.jsonModel = {
          config: {
             loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
          }
-      }
+      },
+      "alfresco/services/NavigationService"
    ],
    widgets: [
       {
@@ -96,52 +97,247 @@ model.jsonModel = {
                   }
                },
                {
-                  id: "CUSTOM_PAGE_SIZES",
-                  name: "alfresco/layout/ClassicWindow",
+                  name: "alfresco/layout/VerticalWidgets",
                   config: {
-                     title: "Custom page sizes",
-                     pubSubScope: "CUSTOM_",
                      widgets: [
                         {
-                           id: "MENU_BAR",
-                           name: "alfresco/menus/AlfMenuBar",
+                           name: "alfresco/layout/LeftAndRight",
                            config: {
                               widgets: [
                                  {
-                                    id: "CUSTOM_PAGE_SIZE_PAGINATOR",
-                                    name: "alfresco/lists/Paginator",
+                                    id: "CHANGE_FILTER",
+                                    name: "alfresco/buttons/AlfButton",
                                     config: {
-                                       documentsPerPage: 10,
-                                       hidePageSizeOnWidth: 100,
-                                       pageSizes: [5,10,20]
+                                       label: "Change Filter",
+                                       pubSubScope: "CUSTOM_",
+                                       publishTopic: "ALF_DOCLIST_FILTER_SELECTION",
+                                       publishPayload: {
+                                          value: "myfilter"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "CHANGE_PATH",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Path",
+                                       pubSubScope: "CUSTOM_",
+                                       publishTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
+                                       publishPayload: {
+                                          path: "mypath"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "CHANGE_TAG",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Tag",
+                                       pubSubScope: "CUSTOM_",
+                                       publishTopic: "ALF_DOCUMENTLIST_TAG_CHANGED",
+                                       publishPayload: {
+                                          tag: "mytag"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "CHANGE_CATEGORY",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Category",
+                                       pubSubScope: "CUSTOM_",
+                                       publishTopic: "ALF_DOCUMENTLIST_CATEGORY_CHANGED",
+                                       publishPayload: {
+                                          category: "mycategory"
+                                       }
                                     }
                                  }
                               ]
                            }
                         },
                         {
-                           id: "LIST",
-                           name: "alfresco/lists/AlfSortablePaginatedList",
+                           id: "CUSTOM_PAGE_SIZES",
+                           name: "alfresco/layout/ClassicWindow",
                            config: {
-                              useHash: false,
-                              currentPageSize: 10,
+                              title: "Custom page sizes",
+                              pubSubScope: "CUSTOM_",
                               widgets: [
                                  {
-                                    name: "alfresco/lists/views/AlfListView",
+                                    id: "MENU_BAR",
+                                    name: "alfresco/menus/AlfMenuBar",
                                     config: {
                                        widgets: [
                                           {
-                                             name: "alfresco/lists/views/layouts/Row",
+                                             id: "CUSTOM_PAGE_SIZE_PAGINATOR",
+                                             name: "alfresco/lists/Paginator",
+                                             config: {
+                                                useHash: false,
+                                                documentsPerPage: 10,
+                                                hidePageSizeOnWidth: 100,
+                                                pageSizes: [5,10,20]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "LIST",
+                                    name: "alfresco/documentlibrary/AlfDocumentList",
+                                    config: {
+                                       useHash: false,
+                                       currentPageSize: 10,
+                                       hashVarsForUpdate: [
+                                          "path",
+                                          "filter",
+                                          "tag",
+                                          "category"
+                                       ],
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/AlfListView",
                                              config: {
                                                 widgets: [
                                                    {
-                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      name: "alfresco/lists/views/layouts/Row",
                                                       config: {
                                                          widgets: [
                                                             {
-                                                               name: "alfresco/renderers/Property",
+                                                               name: "alfresco/lists/views/layouts/Cell",
                                                                config: {
-                                                                  propertyToRender: "index"
+                                                                  widgets: [
+                                                                     {
+                                                                        name: "alfresco/renderers/Property",
+                                                                        config: {
+                                                                           propertyToRender: "index"
+                                                                        }
+                                                                     }
+                                                                  ]
+                                                               }
+                                                            }
+                                                         ]
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/layout/LeftAndRight",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "HASH_CHANGE_FILTER",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Filter",
+                                       pubSubScope: "HASH_CUSTOM_",
+                                       publishTopic: "ALF_DOCLIST_FILTER_SELECTION",
+                                       publishPayload: {
+                                          value: "myfilter"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "HASH_CHANGE_PATH",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Path",
+                                       pubSubScope: "HASH_CUSTOM_",
+                                       publishTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
+                                       publishPayload: {
+                                          path: "mypath"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "HASH_CHANGE_TAG",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Tag",
+                                       pubSubScope: "HASH_CUSTOM_",
+                                       publishTopic: "ALF_DOCUMENTLIST_TAG_CHANGED",
+                                       publishPayload: {
+                                          value: "mytag"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "HASH_CHANGE_CATEGORY",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Change Category",
+                                       pubSubScope: "HASH_CUSTOM_",
+                                       publishTopic: "ALF_DOCUMENTLIST_CATEGORY_CHANGED",
+                                       publishPayload: {
+                                          path: "mycategory"
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "HASH_CUSTOM_PAGE_SIZES",
+                           name: "alfresco/layout/ClassicWindow",
+                           config: {
+                              title: "Custom page sizes",
+                              pubSubScope: "HASH_CUSTOM_",
+                              widgets: [
+                                 {
+                                    id: "HASH_MENU_BAR",
+                                    name: "alfresco/menus/AlfMenuBar",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "HASH_CUSTOM_PAGE_SIZE_PAGINATOR",
+                                             name: "alfresco/lists/Paginator",
+                                             config: {
+                                                useHash: false,
+                                                documentsPerPage: 10,
+                                                hidePageSizeOnWidth: 100,
+                                                pageSizes: [5,10,20]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "HASH_LIST",
+                                    name: "alfresco/documentlibrary/AlfDocumentList",
+                                    config: {
+                                       useHash: true,
+                                       currentPageSize: 10,
+                                       hashVarsForUpdate: [
+                                          "path",
+                                          "filter",
+                                          "tag",
+                                          "category"
+                                       ],
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/AlfListView",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/lists/views/layouts/Row",
+                                                      config: {
+                                                         widgets: [
+                                                            {
+                                                               name: "alfresco/lists/views/layouts/Cell",
+                                                               config: {
+                                                                  widgets: [
+                                                                     {
+                                                                        name: "alfresco/renderers/Property",
+                                                                        config: {
+                                                                           propertyToRender: "index"
+                                                                        }
+                                                                     }
+                                                                  ]
                                                                }
                                                             }
                                                          ]
@@ -156,10 +352,9 @@ model.jsonModel = {
                               ]
                            }
                         }
-                     ]
-                  }
+                  ]
                }
-            ]
+            }]
          }
       },
       {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -136,7 +136,7 @@ model.jsonModel = {
                                        pubSubScope: "CUSTOM_",
                                        publishTopic: "ALF_DOCUMENTLIST_TAG_CHANGED",
                                        publishPayload: {
-                                          tag: "mytag"
+                                          value: "mytag"
                                        }
                                     }
                                  },
@@ -148,7 +148,7 @@ model.jsonModel = {
                                        pubSubScope: "CUSTOM_",
                                        publishTopic: "ALF_DOCUMENTLIST_CATEGORY_CHANGED",
                                        publishPayload: {
-                                          category: "mycategory"
+                                          path: "mycategory"
                                        }
                                     }
                                  }


### PR DESCRIPTION
This addresses issue [AKU-248](https://issues.alfresco.com/jira/browse/AKU-248) which requires that changing a filter, category, tag or path on a paginated list should reset the list to page 1. It also adds a clear button to the DebugLog.