### PR TITLE
AKU-249: Tag renderer doesn't set correct hash

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/ReadOnlyTag.js
+++ b/aikau/src/main/resources/alfresco/renderers/ReadOnlyTag.js
@@ -94,7 +94,7 @@ define(["dojo/_base/declare",
             publishTopic: this.navigateToPageTopic,
             publishPayload: {
                type: this.hashPath,
-               url: "filter=tag|" + this.tagName
+               url: "tag=" + this.tagName
             }
          });
          link.placeAt(this.tagNode, "last");

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -82,10 +82,10 @@ define(["intern!object",
       },
 
       "Check the link click published the payload as expected (URL)": function() {
-         return browser.findByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "filter=tag|Test1"))
+         return browser.findByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "tag=Test1"))
             .then(
                function(){},
-               function(){assert(false, "Test #1f - The link did not publish the payload with 'url' as 'filter=tag|Test1'");}
+               function(){assert(false, "Test #1f - The link did not publish the payload with 'url' as 'tag=Test1'");}
             );
       },
 


### PR DESCRIPTION
This addresses issue [AKU-249](https://issues.alfresco.com/jira/browse/AKU-249), which requires a change to the payload of the `ReadOnlyTag#postCreate()` method and an update to its test.