### PR TITLE
Fix SocialRenderersTest

### DIFF
--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
@@ -9,67 +9,74 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/PreferenceService",
       "alfresco/services/RatingsService",
       "alfresco/services/ErrorReporter"
    ],
    widgets:[
       {
-         name: "alfresco/lists/views/AlfListView",
+         name: "aikauTesting/WaitForMockXhrService",
          config: {
-            id: "LIST",
-            currentData: {
-               items: [
-                  {
-                     nodeRef: "some://dummy/nodeRef",
-                     node: {
-                        nodeRef: "some://dummy/nodeRef"
-                     },
-                     name: "Test 1",
-                     liked: false,
-                     likeCount: 4,
-                     favourite: false,
-                     shareId: null,
-                     commentCount: 6
-                  }
-               ]
-            },
-            widgets:[
+            services: ["alfresco/services/PreferenceService"],
+            widgets: [
                {
-                  name: "alfresco/lists/views/layouts/Row",
+                  name: "alfresco/lists/views/AlfListView",
                   config: {
-                     widgets: [
+                     id: "LIST",
+                     currentData: {
+                        items: [
+                           {
+                              nodeRef: "some://dummy/nodeRef",
+                              node: {
+                                 nodeRef: "some://dummy/nodeRef"
+                              },
+                              name: "Test 1",
+                              liked: false,
+                              likeCount: 4,
+                              favourite: false,
+                              shareId: null,
+                              commentCount: 6
+                           }
+                        ]
+                     },
+                     widgets:[
                         {
-                           name: "alfresco/lists/views/layouts/Cell",
+                           name: "alfresco/lists/views/layouts/Row",
                            config: {
                               widgets: [
                                  {
-                                    id: "LIKES",
-                                    name: "alfresco/renderers/Like",
+                                    name: "alfresco/lists/views/layouts/Cell",
                                     config: {
-                                       propertyToRender: "liked",
-                                       likeCountProperty: "likeCount"
-                                    }
-                                 },
-                                 {
-                                    id: "FAVOURITES",
-                                    name: "alfresco/renderers/Favourite",
-                                    config: {
-                                       propertyToRender: "favourite"
-                                    }
-                                 },
-                                 {
-                                    id: "COMMENTS",
-                                    name: "alfresco/renderers/Comments",
-                                    config: {
-                                       commentCountProperty: "commentCount"
-                                    }
-                                 },
-                                 {
-                                    id: "QUICKSHARE",
-                                    name: "alfresco/renderers/QuickShare",
-                                    config: {
-                                       propertyToRender: "shareId"
+                                       widgets: [
+                                          {
+                                             id: "LIKES",
+                                             name: "alfresco/renderers/Like",
+                                             config: {
+                                                propertyToRender: "liked",
+                                                likeCountProperty: "likeCount"
+                                             }
+                                          },
+                                          {
+                                             id: "FAVOURITES",
+                                             name: "alfresco/renderers/Favourite",
+                                             config: {
+                                                propertyToRender: "favourite"
+                                             }
+                                          },
+                                          {
+                                             id: "COMMENTS",
+                                             name: "alfresco/renderers/Comments",
+                                             config: {
+                                                commentCountProperty: "commentCount"
+                                             }
+                                          },
+                                          {
+                                             id: "QUICKSHARE",
+                                             name: "alfresco/renderers/QuickShare",
+                                             config: {
+                                                propertyToRender: "shareId"
+                                             }
+                                          }
+                                       ]
                                     }
                                  }
                               ]
@@ -79,7 +86,6 @@ model.jsonModel = {
                   }
                }
             ]
-            
          }
       },
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/WaitForMockXhrService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/WaitForMockXhrService.js
@@ -24,8 +24,9 @@
  */
 define(["dojo/_base/declare",
         "alfresco/core/ProcessWidgets",
-        "dojo/_base/lang"], 
-        function(declare, ProcessWidgets, lang) {
+        "dojo/_base/lang",
+        "dojo/_base/array"], 
+        function(declare, ProcessWidgets, lang, array) {
    
    return declare([ProcessWidgets], {
       
@@ -35,7 +36,41 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_testing_WaitForMockXhrService__postCreate() {
-         this.alfSubscribe("ALF_MOCK_XHR_SERVICE_READY", lang.hitch(this, this.processWidgets, this.widgets, this.containerNode));
+         this.alfSubscribe("ALF_MOCK_XHR_SERVICE_READY", lang.hitch(this, this.onMockXhrServiceReady));
+      },
+
+      /**
+       * Load any services and widgets once the mock XHR service is ready to handle requests that
+       * make XHR requests.
+       * 
+       * @instance
+       */
+      onMockXhrServiceReady: function alfresco_testing_WaitForMockXhrService__onMockXhrServiceReady() {
+         if (this.services)
+         {
+            array.forEach(this.services, function(service) {
+               var dep = null,
+                   serviceConfig = {};
+               if (typeof service === "string")
+               {
+                  dep = service;
+               }
+               else if (typeof service === "object" && service.name)
+               {
+                  dep = service.name;
+                  serviceConfig = service.config || {};
+               }
+               var requires = [dep];
+               require(requires, function(ServiceType) {
+                  var s = new ServiceType(serviceConfig);
+                  return s;
+               });
+            });
+         }
+         if (this.widgets)
+         {
+            this.processWidgets(this.widgets, this.containerNode);
+         }
       }
    });
 });

--- a/aikau/src/test/resources/testApp/js/aikau/testing/WaitForMockXhrService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/WaitForMockXhrService.js
@@ -62,8 +62,8 @@ define(["dojo/_base/declare",
                }
                var requires = [dep];
                require(requires, function(ServiceType) {
-                  var s = new ServiceType(serviceConfig);
-                  return s;
+                  // jshint nonew:false
+                  new ServiceType(serviceConfig);
                });
             });
          }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
@@ -61,6 +61,7 @@ define(["dojo/_base/declare",
          {
             this.alfLog("error", "The following error occurred setting up the mock server", e);
          }
+         this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
       }
    });
 });


### PR DESCRIPTION
Updates to improve ensuring that mock XHR services are setup before creating widgets and services for the test.

In this case we need to create the PreferenceService once the mock XHR service is ready to accept the request that it immediately makes to get the user preferences.