### PR TITLE
AKU-246: Resolve dialog size issues

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -53,9 +53,11 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dojo/dom-geometry",
         "dojo/html",
-        "dojo/aspect"], 
+        "dojo/aspect",
+        "jquery",
+        "alfresco/layout/SimplePanel"], 
         function(declare, Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin, lang, sniff, array,
-                 domConstruct, domClass, domStyle, domGeom, html, aspect) {
+                 domConstruct, domClass, domStyle, domGeom, html, aspect, $) {
    
    return declare([Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin], {
       
@@ -203,9 +205,24 @@ define(["dojo/_base/declare",
 
          if (this.widgetsContent)
          {
+            // Workout a maximum height for the dialog as it should always fit in the window...
+            var docHeight = $(document).height(),
+                clientHeight = $(window).height();
+            var h = (docHeight < clientHeight) ? docHeight : clientHeight;
+
             // Add widget content to the container node...
-            var widgetsNode = domConstruct.create("div", {}, this.bodyNode, "last");
-            this.processWidgets(this.widgetsContent, widgetsNode);
+            var widgetsNode = domConstruct.create("div", {
+               style: "max-height:" + (h - 200) + "px"
+            }, this.bodyNode, "last");
+            var bodyModel = [{
+               name: "alfresco/layout/SimplePanel",
+               assignTo: "_dialogPanel",
+               config: {
+                  height: this.contentHeight,
+                  widgets: this.widgetsContent
+               }
+            }];
+            this.processWidgets(bodyModel, widgetsNode);
          }
          else if (this.textContent)
          {
@@ -322,7 +339,16 @@ define(["dojo/_base/declare",
                {
                   button.publishPayload = {};
                }
-               button.publishPayload.dialogContent = widgets;
+               // The dialog content is expected to be found in the SimplePanel that is the main content
+               // widget. It's array of processed widgets represent the dialog content that should be worked with
+               if (widgets && widgets[0] && widgets[0]._processedWidgets)
+               {
+                  button.publishPayload.dialogContent = widgets[0]._processedWidgets;
+               }
+               else
+               {
+                  button.publishPayload.dialogContent = [];
+               }
                button.publishPayload.dialogRef = this; // Add a reference to the dialog itself so that it can be destroyed
             });
          }

--- a/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
@@ -26,8 +26,9 @@ define(["alfresco/forms/controls/BaseFormControl",
         "alfresco/forms/controls/utilities/TextBoxValueChangeMixin",
         "dojo/_base/declare",
         "dojo/_base/lang",
-        "dijit/form/NumberSpinner"], 
-        function(BaseFormControl, TextBoxValueChangeMixin, declare, lang, NumberSpinner) {
+        "dijit/form/NumberSpinner",
+        "alfresco/core/ObjectTypeUtils"], 
+        function(BaseFormControl, TextBoxValueChangeMixin, declare, lang, NumberSpinner, ObjectTypeUtils) {
    
    return declare([BaseFormControl, TextBoxValueChangeMixin], {
       
@@ -115,7 +116,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        */
       configureValidation: function alfresco_forms_controls_NumberSpinner__configureValidation() {
-         if (!this.validationConfig)
+         if (!this.validationConfig || ObjectTypeUtils.isObject(this.validationConfig))
          {
             this.validationConfig = [];
          }

--- a/aikau/src/main/resources/alfresco/layout/SimplePanel.js
+++ b/aikau/src/main/resources/alfresco/layout/SimplePanel.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This layout widget provides a simple way in which content can have a constrained 
+ * [height]{@link module:alfresco/layout/SimplePanel#height} and 
+ * [width]{@link module:alfresco/layout/SimplePanel#width}.
+ *
+ * @example <caption>Example configuration:</caption>
+ * {
+ *   name: "alfresco/layout/SimplePanel",
+ *     config: {
+ *        height: "100px",
+ *        width: "100px",
+ *        handleOverflow: true,
+ *        widgets: [
+ *           {
+ *              name: "alfresco/logo/Logo"
+ *           }
+ *        ]
+ *     }
+ *  }
+ *  
+ * @module alfresco/layout/SimplePanel
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "dijit/_WidgetBase", 
+        "dijit/_TemplatedMixin",
+        "dojo/text!./templates/SimplePanel.html",
+        "alfresco/core/Core",
+        "alfresco/core/CoreWidgetProcessing",
+        "dojo/dom-class",
+        "dojo/dom-style"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, domClass, domStyle) {
+   
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
+      
+      /**
+       * The HTML template to use for the widget.
+       * @instance
+       * @type {string}
+       */
+      templateString: template,
+      
+      /**
+       * The height of the panel.
+       * 
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      height: null,
+
+      /**
+       * The width of the panel.
+       * 
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      width: null,
+
+      /**
+       * Controls whether or not scroll bars will be displayed as the content of the panel
+       * grows beyond its dimensions. Defaults to true, if the widgets within the panel
+       * manage their own overflow then this should be set to false.
+       *
+       * @instance
+       * @type {boolean}
+       * @default true
+       */
+      handleOverflow: true,
+
+      /**
+       * Processes the widgets into the content node.
+       * 
+       * @instance
+       */
+      postCreate: function alfresco_layout_SimplePanel__postCreate() {
+         domClass.add(this.domNode, this.additionalCssClasses || "");
+         if (this.handleOverflow === false)
+         {
+            domStyle.set(this.domNode, "overflow", "hidden");
+         }
+         this.height && domStyle.set(this.domNode, "height", this.height);
+         this.width && domStyle.set(this.domNode, "width", this.width);
+         if (this.widgets)
+         {
+            this.processWidgets(this.widgets, this.domNode);
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/layout/templates/SimplePanel.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/SimplePanel.html
@@ -1,0 +1,1 @@
+<div class="alfresco-layout-SimplePanel"></div>

--- a/aikau/src/main/resources/alfresco/services/LoggingService.js
+++ b/aikau/src/main/resources/alfresco/services/LoggingService.js
@@ -161,6 +161,10 @@ define(["dojo/_base/declare",
                preference: this.loggingPreferencesId + "." + payload.value,
                value: (payload.selected === true)
             });
+            if (!this.loggingPreferences)
+            {
+               this.loggingPreferences = {};
+            }
             this.loggingPreferences[payload.value] = (payload.selected === true);
             this.handleSubscription();
          }

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -800,12 +800,15 @@ define(["dojo/_base/declare",
        * @return {object} A reference to the widget used for displaying progress.
        */
       getUploadDisplayWidget: function alfresco_services_UploadService__getUploadDisplayWidget() {
-         if (this.progressDialog !== null && 
-             this.progressDialog !== undefined && 
-             this.progressDialog.uploadDisplayWidget !== null && 
-             this.progressDialog.uploadDisplayWidget !== undefined)
+         if (this.progressDialog && 
+             this.progressDialog._dialogPanel && 
+             this.progressDialog._dialogPanel.uploadDisplayWidget)
          {
-            this.uploadDisplayWidget = this.progressDialog.uploadDisplayWidget;
+            this.uploadDisplayWidget = this.progressDialog._dialogPanel.uploadDisplayWidget;
+         }
+         else
+         {
+            this.alfLog("warn", "Could not find 'uploadDisplayWidget' in dialog content", this);
          }
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-273 to ensure that dialog body grows sensibly when content is progressively revealed. A max height is set based on the size of the view port and scroll bars are added when the content height exceeds it. There's still some further improvements that we can iterate on here in the future (such as repositioning) but this should be enough to satisfy the bug fix.