### PR TITLE
AKU-274: Odd styling in alfresco/forms/controls/Select

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/Select.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Select.js
@@ -41,6 +41,23 @@ define(["alfresco/forms/controls/BaseFormControl",
       cssRequirements: [{cssFile:"./css/Select.css"}],
 
       /**
+       * Adds a new option to the wrapped widget.
+       *
+       * @instance
+       * @override
+       * @param {object} option The option to add
+       * @param {number} index The index of the option to add
+       */
+      addOption: function alfresco_forms_controls_Select__addOption(option, /*jshint unused:false*/ index) {
+         // Dijit Select widget does not support empty values! https://bugs.dojotoolkit.org/ticket/9973
+         if (option.value === "") {
+            this.alfLog("error", "Attempted to add option with empty value", option);
+         } else {
+            this.inherited(arguments);
+         }
+      },
+
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_Select__getWidgetConfig() {
@@ -55,7 +72,7 @@ define(["alfresco/forms/controls/BaseFormControl",
       /**
        * @instance
        */
-      createFormControl: function alfresco_forms_controls_Select__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_Select__createFormControl(config) {
          var select = new Select(config);
 
          // Handle adding classes to control...
@@ -76,7 +93,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {object} option The option configuration
        * @param {number} index The index of the option
        */
-      processOptionLabel: function alfresco_forms_controls_BaseFormControl__processOptionLabel(option, index) {
+      processOptionLabel: function alfresco_forms_controls_BaseFormControl__processOptionLabel(option, /*jshint unused:false*/ index) {
          this.inherited(arguments);
          if (option.label)
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/css/Select.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/Select.css
@@ -34,5 +34,5 @@
 }
 
 .claro .dijitMenu .dijitSelectSelectedOption * {
-   color: #ababab;
+   font-family: @bold-font;
 }

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -190,13 +190,11 @@ define(["alfresco/core/ObjectTypeUtils",
                   innerHTML: "Payload"
                }, entryNode);
                domConstruct.create("span", {
-                  className: this.rootClass + "__entry__data__collapsed",
-                  innerHTML: simpleData
-               }, dataNode);
+                  className: this.rootClass + "__entry__data__collapsed"
+               }, dataNode).appendChild(document.createTextNode(simpleData));
                domConstruct.create("span", {
-                  className: this.rootClass + "__entry__data__full",
-                  innerHTML: formattedData
-               }, dataNode);
+                  className: this.rootClass + "__entry__data__full"
+               }, dataNode).appendChild(document.createTextNode(formattedData));
                on(entryNode, "click", lang.hitch(this, function() {
                   this._toggleCollapsed(dataNode);
                }));

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -167,8 +167,8 @@ define(["intern/dojo/node!fs",
                      .toUpperCase() + namePart.substr(1)
                      .toLowerCase() : namePart.toUpperCase();
                })
-               .join("_");
-            var screenshotName = safeBrowserName + "-" + testName + "-" + command.session.screenieIndex++ +".png",
+               .join("_"),
+               screenshotName = safeBrowserName + "-" + testName + "-" + command.session.screenieIndex++ +".png",
                screenshotPath = "src/test/screenshots/" + screenshotName;
             return browser.takeScreenshot()
                .then(function(screenshot) {

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -18,14 +18,14 @@
  */
 
 /**
- * 
+ *
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!assert",
-        "require",
+        "intern/chai!assert", 
+        "require", 
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function(registerSuite, assert, require, TestCommon) {
 
    // Get the options labels using:
    //    #FIXED_INVALID_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel
@@ -45,80 +45,84 @@ define(["intern!object",
 
       setup: function() {
          browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Select", "Select Menu Tests").end();
+         return TestCommon.loadTestWebScript(this.remote, "/Select", "Select Form Control Tests").end();
       },
 
       beforeEach: function() {
          browser.end();
       },
 
-      "Test Label Rendering": function () {
-         return TestCommon.loadTestWebScript(this.remote, "/Select", "Select Form Control Tests").findByCssSelector("#FIXED_INVALID_CHANGES_TO .label")
+      "Test Label Rendering": function() {
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .label")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "Fixed Options", "The label was not rendered correctly: " + resultText);
+               assert.equal(resultText, "Fixed Options", "The label was not rendered correctly");
             });
       },
-      
+
       "Test initial value of fixed config": function() {
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO span[role=option]")
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO span[role=option]")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "Two", "The initial value was not represented correctly: " + resultText);
+               assert.equal(resultText, "Two", "The initial value was not represented correctly");
             });
       },
-      
+
       "Test fixed options count": function() {
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
             .then(function(elements) {
-               assert(elements.length === 3, "Three fixed options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 3, "Incorrect number of fixed options found");
             });
       },
-  
+
       "Test fixed option label rendering": function() {
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "Priv\u00e9", "Fixed label not set correctly: " + resultText);
+               assert.equal(resultText, "Priv\u00e9", "Fixed label not set correctly");
             });
       },
-  
+
       "Test fixed option label set from value": function() {
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(3) td.dijitMenuItemLabel")
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(3) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "NO LABEL", "Fixed label not set correctly from value: " + resultText);
+               assert.equal(resultText, "NO LABEL", "Fixed label not set correctly from value");
             });
       },
 
       "Test initial value of pub sub option": function() {
          return browser.findByCssSelector(".confirmationButton > span")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector(TestCommon.pubDataCssSelector("UNIT_TEST_FORM_POST", "updated1", "Value2_1"))
             .then(function(elements) {
                assert.lengthOf(elements, 1, "The value was not re-selected in the second set of options");
             });
       },
-   
+
       "Test pub/sub options generated": function() {
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown .dijitMenuItemLabel")
             .then(function(elements) {
                assert.lengthOf(elements, 3, "The wrong number of options were generated");
             });
       },
-  
+
       "Test updated label set by pub/sub": function() {
-         return this.remote.findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+         return browser.findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "Update1_1", "Updated label not set correctly by pub/sub");
@@ -129,24 +133,28 @@ define(["intern!object",
          // The options should have been provided once (the mock service increments the options)...
          return browser.findByCssSelector("#HAS_CHANGES_TO_CONTROL")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "Update1_3", "Updated label not set correctly by pub/sub: " + resultText);
+               assert.equal(resultText, "Update1_3", "Updated label not set correctly by pub/sub");
             });
       },
-  
+
       "Test update topics processed": function() {
-         return this.remote.findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
+         return browser.findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#REQUEST_GLOBAL_UPDATE_label")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(text) {
@@ -157,7 +165,8 @@ define(["intern!object",
       "Test value of pub sub option after options update": function() {
          return browser.findByCssSelector(".confirmationButton > span")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector(TestCommon.pubDataCssSelector("UNIT_TEST_FORM_POST", "updated1", "Value2_1"))
             .then(function(elements) {
                assert.lengthOf(elements, 2, "The value was not re-selected in the second set of options");
@@ -166,69 +175,78 @@ define(["intern!object",
 
       "Test pub/sub options generated from field change": function() {
          // Check that pub/sub options generated from field changes are correct (should be on 3rd request based on values being set)...
-         return this.remote.findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
+         return browser.findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
             .then(function(elements) {
-               assert(elements.length === 2, "Two options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 2, "Incorrect number of options found");
             });
       },
- 
+
       "Test update topic scoping": function() {
          // Clicking the 2nd button should have no effect (as it's the scoped topic published globally)...
-         return this.remote.findByCssSelector("#REQUEST_SCOPED_UPDATE_GLOBALLY_label")
+         return browser.findByCssSelector("#REQUEST_SCOPED_UPDATE_GLOBALLY_label")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "Update1_2", "Updated label not unexpectedly updated: " + resultText);
+               assert.equal(resultText, "Update1_2", "Updated label not unexpectedly updated");
             });
       },
-   
+
       "Test label updated  from external publication": function() {
          // Clicking the 3rd button should perform an update...
-         return this.remote.findByCssSelector("#REQUEST_SCOPED_UPDATE_label")
+         return browser.findByCssSelector("#REQUEST_SCOPED_UPDATE_label")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "Update1_3", "Updated label not set correctly by external update: " + resultText);
+               assert.equal(resultText, "Update1_3", "Updated label not set correctly by external update");
             });
       },
-   
+
       "Test changing field triggers update": function() {
          // Change a field to check an update is made...
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
+         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert(resultText === "Update1_4", "Updated label not set correctly by pub/sub: " + resultText);
+               assert.equal(resultText, "Update1_4", "Updated label not set correctly by pub/sub");
             });
       },
-   
+
       "Test XSS attack fails": function() {
          // Change a field to check an update is made...
-         return browser.then(function(){
+         return browser.then(function() {
             var notHacked = browser.execute("!window.hackedLabel && !window.hackedValue");
             assert(notHacked, "XSS prevention failed - script executed in label or value of option");
          });
@@ -239,12 +257,12 @@ define(["intern!object",
          // Create the form dialog...
          return browser.findByCssSelector("#CREATE_FORM_DIALOG_label")
             .click()
-         .end()
+            .end()
 
          // Open the opens...
          .findByCssSelector("#SELECT_IN_DIALOG .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
 
          // Count that there are some...
          .findAllByCssSelector("#SELECT_IN_DIALOG_CONTROL_dropdown .dijitMenuItemLabel")
@@ -256,7 +274,8 @@ define(["intern!object",
       "Test pub/sub options value": function() {
          return browser.findByCssSelector("#DIALOG_WITH_SELECT .confirmationButton > span")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector(TestCommon.pubDataCssSelector("DIALOG_POST", "selected", "DO2"))
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Options value was not initialized correctly");

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/documentlibrary/PaginationTest"
+      "src/test/resources/alfresco/forms/controls/SelectTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
@@ -51,6 +51,7 @@ model.jsonModel = {
                         fixed: [
                            {label:"select.test.fixed.option.one",value:"1"},
                            {label:"select.test.fixed.option.two",value:"2"},
+                           {label:"No value",value:""},
                            {value:"NO LABEL"},
                            {INVALID:"DATA"}
                         ]


### PR DESCRIPTION
This addresses issue [AKU-274](https://issues.alfresco.com/jira/browse/AKU-274), which talks about odd styling of the Select control in a specific circumstance. The problem is twofold, both aesthetic (selected styling was grey text, now changed to bold) and functional (options with empty values are unsupported by the underlying Dojo control, now prevented). Also includes a small tweak to prevent XSS scripting tests from breaking the DebugLog and very minor refactor inside TestCommon.