### PR TITLE
AKU-277: MultiSelect keyboard navigation not working

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -1001,7 +1001,7 @@ define([
           *
           * @instance
           */
-         _preventWidgetDropdownDisconnects: function alfresco_forms_controls_MultiSelect___preventWidgetDropdownDisconnects(){
+         _preventWidgetDropdownDisconnects: function alfresco_forms_controls_MultiSelect___preventWidgetDropdownDisconnects() {
 
             // When we're in a dialog, we want to hide the results. There is never going to be a situation
             // (assumption) where a dialog moving is going to cause a problem if we hide the results dropdown
@@ -1012,8 +1012,8 @@ define([
             // moving, so we'll go up the tree trying to find any, and then listen for their scroll events and
             // again hide the dropdown when it happens
             var nextParent = this.domNode;
-            while((nextParent = nextParent.parentNode) && nextParent.tagName !== "body") {
-               if(nextParent.scrollHeight > nextParent.offsetHeight) {
+            while ((nextParent = nextParent.parentNode) && nextParent.tagName !== "body") {
+               if (nextParent.scrollHeight > nextParent.offsetHeight) {
                   this.own(on(nextParent, "scroll", lang.hitch(this, this._hideResultsDropdown)));
                }
             }
@@ -1036,7 +1036,7 @@ define([
           * @returns  {boolean} The results dropdown's visibility
           */
          _resultsDropdownIsVisible: function alfresco_forms_controls_MultiSelect___resultsDropdownIsVisible() {
-            return domClass.contains(this.domNode, this.rootClass + "--show-results");
+            return domClass.contains(this._nodes.resultsDropdown, this.rootClass + "__results--visible");
          },
 
          /**

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -169,8 +169,33 @@ define([
                });
          },
 
+         "Keyboard can navigate and select items in dropdown": function() {
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
+               .type("new")
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+               .pressKeys([keys.ARROW_DOWN, keys.ARROW_DOWN, keys.ARROW_UP, keys.ENTER])
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "Did not add new choice to control");
+               })
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "newtag13(a)", "Did not add selected tag at end of choices");
+               });
+         },
+
          "Deleting all items disables confirmation button": function() {
             return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
+               .click()
+               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
                .click()
                .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
                .end()

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/SelectTest"
+      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
@@ -1,4 +1,4 @@
-<div class="alfresco-testing-MockXhr" data-dojo-attach-point="containerNode">
+<div class="alfresco-testing-MockXhr alfresco-testing-MockXhr--hide-body" data-dojo-attach-point="containerNode">
    <table class="log">
       <caption data-dojo-attach-event="onclick:_toggleBody">MockXhr Log (toggle visibility)</caption>
       <thead class="mx-thead">


### PR DESCRIPTION
This addresses issue [AKU-277](https://issues.alfresco.com/jira/browse/AKU-277), which notes a regression in the keyboard navigation of the MultiSelect. This was due to a leftover reference from the old widget DOM model and has been updated accordingly. A test has been added to ensure any future regression would be detected. Also a small tweak to default the MockXHR log to collapsed, in order for test "screenies" to be more useful.