### PR TITLE
AKU-280: MultiSelect should handle long items better

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -20,7 +20,10 @@
 // TODO: Add ARIA
 
 /**
- * An input control that allows multiple-selection of defined items
+ * An input control that allows multiple-selection of defined items. Note that, when
+ * specifying the labelAttribute, queryAttribute and valueAttribute in the optionsConfig
+ * as per the below example, the queryAttribute is used to search on and the
+ * labelAttribute is used to display, so they would normally be the same value.
  *
  * @example <caption>Sample configuration:</caption>
  * {
@@ -30,14 +33,22 @@
  *       label: "My multi-select input",
  *       name: "form_field_name",
  *       width: "400px",
+ *       choiceCanWrap: false, // Whether chosen items' text can wrap over multiple lines (defaults to true)
+ *       choiceMaxWidth: "50%", // The maximum width of chosen items (defaults to 100%)
  *       optionsConfig: {
- *          labelAttribute: "name",  // Defaults to label
- *          queryAttribute: "name",  // Defaults to name
- *          valueAttribute: "value", // Defaults to value
+ *          labelAttribute: "name",  // What's displayed in the dropdown and choice (defaults to label)
+ *          queryAttribute: "name",  // The attribute that's used when filtering the dropdown (defaults to name)
+ *          valueAttribute: "value", // The actual submitted value for each chosen item (defaults to value)
  *          publishTopic: "ALF_RETRIEVE_MULTISELECT_INFO",
  *          publishPayload: {
  *             resultsProperty: "response.data.items"
- *          }
+ *          },
+ *          labelFormat: { // Optional label format strings (all default to item[this.store.labelAttribute] if not specified)
+ *             choice: "${value}",
+ *             result: "${label}",
+ *             full: "${value} - ${label}"
+ *          },
+ *          searchStartsWith: false // Whether the query attribute should start with the search string (defaults to true)
  *       }
  *    }
  * }
@@ -49,6 +60,7 @@
  */
 define([
       "alfresco/core/Core",
+      "alfresco/core/ObjectProcessingMixin",
       "alfresco/core/ObjectTypeUtils",
       "dijit/_FocusMixin",
       "dijit/_TemplatedMixin",
@@ -66,10 +78,10 @@ define([
       "dojo/when",
       "dojo/text!./templates/MultiSelect.html"
    ],
-   function(Core, ObjectTypeUtils, _FocusMixin, _TemplatedMixin, _WidgetBase, array, declare, lang, Deferred,
-      domConstruct, domGeom, domStyle, domClass, keys, on, when, template) {
+   function(Core, ObjectProcessingMixin, ObjectTypeUtils, _FocusMixin, _TemplatedMixin, _WidgetBase, array,
+      declare, lang, Deferred, domConstruct, domGeom, domStyle, domClass, keys, on, when, template) {
 
-      return declare([_WidgetBase, _TemplatedMixin, _FocusMixin, Core], {
+      return declare([_WidgetBase, _TemplatedMixin, _FocusMixin, Core, ObjectProcessingMixin], {
 
          /**
           * The Choice object (referenced in other JSDoc comments)
@@ -82,7 +94,6 @@ define([
           * @property {object} selectListener A remove handle for the choice selection listener
           * @property {object} closeListener A remove handle for the close-button listener
           * @property {object} item The store item
-          * @property {string} label The label for this choice
           * @property {string} value The value of this choice
           */
 
@@ -93,9 +104,36 @@ define([
           * @typedef {object} Result
           * @property {object} domNode The main domNode for the result
           * @property {object} item The store item
-          * @property {string} label The label for this choice
           * @property {string} value The value of this choice
           */
+
+         /**
+          * The Label object (referenced in other JSDoc comments)
+          *
+          * @instance
+          * @typedef {object} Label
+          * @property {string} choice The version of the label used for chosen items
+          * @property {string} result The version of the label used for items in the results dropdown
+          * @property {string} full The full version of the label, used as the title attribute for choices and results
+          */
+
+         /**
+          * Whether choices' text can wrap
+          *
+          * @instance
+          * @type {boolean}
+          * @default true
+          */
+         choiceCanWrap: true,
+
+         /**
+          * The maximum width of choices within the control as a CSS string
+          *
+          * @instance
+          * @type {string}
+          * @default "100%"
+          */
+         choiceMaxWidth: "100%",
 
          /**
           * An array of the CSS files to use with this widget.
@@ -118,6 +156,15 @@ define([
          i18nRequirements: [{
             i18nFile: "./i18n/MultiSelect.properties"
          }],
+
+         /**
+          * An object that defines the formats of the labels. See main module example for example.
+          *
+          * @type {object} A format string for each of the three label strings
+          * @see {module:alfresco/forms/controls/MultiSelect#Label}
+          * @default undefined
+          */
+         labelFormat: undefined,
 
          /**
           * The root class of this widget
@@ -143,6 +190,14 @@ define([
           * @type {object[]}
           */
          value: null,
+
+         /**
+          * The width of the control, specified as a CSS value (optional)
+          *
+          * @instance
+          * @type {string}
+          */
+         width: null,
 
          /**
           * A cache of the current search value
@@ -314,6 +369,9 @@ define([
          postCreate: function alfresco_forms_controls_MultiSelect__postCreate() {
             this.inherited(arguments);
             this.own(on(this.domNode, "click", lang.hitch(this, this._onControlClick)));
+            if (!this.choiceCanWrap) {
+               domClass.add(this.domNode, this.rootClass + "--choices-nowrap");
+            }
             this._preventWidgetDropdownDisconnects();
             this.value = [];
          },
@@ -337,7 +395,8 @@ define([
          setValue: function alfresco_forms_controls_MultiSelect__setValue(newValueParam) {
 
             // Setup helper vars
-            var labelAttrName = this.store.labelAttribute,
+            var nameAttrName = this.store.nameAttribute,
+               labelAttrName = this.store.labelAttribute,
                valueAttrName = this.store.valueAttribute,
                newValuesArray = newValueParam;
             if (!ObjectTypeUtils.isArray(newValuesArray)) {
@@ -365,9 +424,12 @@ define([
                   nextItem = nextNewValue;
                }
 
-               // Add a temporary label if not present
+               // Add a temporary name and label property if not present
+               if (!nextItem.hasOwnProperty(nameAttrName)) {
+                  nextItem[nameAttrName] = nextItem[valueAttrName];
+               }
                if (!nextItem.hasOwnProperty(labelAttrName)) {
-                  nextItem[labelAttrName] = nextItem[valueAttrName];
+                  nextItem[labelAttrName] = nextItem[nameAttrName];
                }
 
                // Put the new item into the items map
@@ -382,11 +444,7 @@ define([
             }, this);
 
             // Add the choices to the control and kick off the label retrieval if necessary
-            array.forEach(chosenItems, function(nextItem) {
-               var label = nextItem[labelAttrName],
-                  value = nextItem[valueAttrName];
-               this._addChoice(label, value);
-            }, this);
+            array.forEach(chosenItems, this._addChoice, this);
             this._updateItemsFromStore();
             this._updateResultsDropdown();
 
@@ -398,10 +456,13 @@ define([
           * Add the specified result item to the choices
           *
           * @instance
-          * @param    {string} label The label of the chosen item
-          * @param    {string} value The value of the chosen item
+          * @param    {object} item The item to choose
           */
-         _addChoice: function alfresco_forms_controls_MultiSelect___addChoice(label, value) {
+         _addChoice: function alfresco_forms_controls_MultiSelect___addChoice(item) {
+
+            // Get the label and value
+            var labelObj = this._getLabel(item),
+               value = item[this.store.valueAttribute];
 
             // Add to the control's value property
             var storeItem = this._storeItems[value];
@@ -410,7 +471,10 @@ define([
             // Construct and attach the DOM nodes
             var choiceClass = this.rootClass + "__choice",
                choiceNode = domConstruct.create("div", {
-                  className: choiceClass
+                  className: choiceClass,
+                  style: {
+                     maxWidth: this.choiceMaxWidth
+                  }
                }, this.searchBox, "before"),
                contentNode = domConstruct.create("span", {
                   className: choiceClass + "__content"
@@ -432,14 +496,14 @@ define([
                selectListener: selectListener,
                closeListener: closeListener,
                item: storeItem,
-               label: label,
                value: value
             });
             this._choices.push(choiceObject);
 
             // Add the label and value
             contentNode.setAttribute(this._valueHtmlAttribute, value);
-            contentNode.appendChild(document.createTextNode(label));
+            contentNode.setAttribute("title", labelObj.full);
+            contentNode.appendChild(document.createTextNode(labelObj.choice));
          },
 
          /**
@@ -457,7 +521,7 @@ define([
             }
 
             // Add the choice
-            this._addChoice(focusedResult.label, focusedResult.value);
+            this._addChoice(focusedResult.item);
 
             // Update the control
             this._resetSearchBox();
@@ -506,23 +570,41 @@ define([
           * Create a document fragment of a label, highlighted with the current search term
           *
           * @instance
-          * @param    {string} label The label
+          * @param    {string} resultLabel The label
           * @returns  {object} A document fragment of the highlighted label
           */
-         _createHighlightedLabel: function alfresco_forms_controls_MultiSelect___createHighlightedLabel(label) {
-            var labelParts = label.split(this._currentSearchValue),
-               labelFrag = document.createDocumentFragment();
-            array.forEach(labelParts, function(labelPart, partIndex) {
-               var highlightSpan;
-               if (partIndex) {
-                  highlightSpan = domConstruct.create("span", {
-                     className: this.rootClass + "__result__highlighted-label"
-                  }, labelFrag);
-                  highlightSpan.appendChild(document.createTextNode(this._currentSearchValue));
-               }
-               labelFrag.appendChild(document.createTextNode(labelPart));
-            }, this);
-            return labelFrag;
+         _createHighlightedResultLabel: function alfresco_forms_controls_MultiSelect___createHighlightedResultLabel(resultLabel) {
+
+            // Create variables
+            var resultLabelFrag = document.createDocumentFragment();
+
+            // Do we have a current search value
+            if (!this._currentSearchValue) {
+
+               // No highlighting
+               resultLabelFrag.appendChild(document.createTextNode(resultLabel));
+
+            } else {
+
+               // Run the regex against the label
+               var searchRegex = this.store.createSearchRegex(this._currentSearchValue, true),
+                  searchResults = searchRegex.exec(resultLabel),
+                  matchedText = searchResults[0],
+                  matchedIndex = searchResults.index,
+                  beforeMatch = resultLabel.substr(0, matchedIndex),
+                  afterMatch = resultLabel.substr(matchedIndex + matchedText.length);
+
+               // Populate the fragment
+               beforeMatch && resultLabelFrag.appendChild(document.createTextNode(beforeMatch));
+               domConstruct.create("span", {
+                  className: this.rootClass + "__results__result__highlighted-label"
+               }, resultLabelFrag).appendChild(document.createTextNode(matchedText));
+               afterMatch && resultLabelFrag.appendChild(document.createTextNode(afterMatch));
+
+            }
+
+            // Pass back the match
+            return resultLabelFrag;
          },
 
          /**
@@ -603,6 +685,30 @@ define([
          },
 
          /**
+          * Build the label for an item. By default, this simply returns item[labelAttribute]
+          * (where labelAttribute is defined in the store config) for both short and full values.
+          *
+          * @instance
+          * @param    {item} item The item whose label to retrieve
+          * @returns {module:alfresco/forms/controls/MultiSelect#Label}
+          */
+         _getLabel: function alfresco_forms_controls_MultiSelect___getLabel(item) {
+
+            // Setup the label format strings
+            var choice = (this.labelFormat && this.labelFormat.choice) || item[this.store.labelAttribute],
+               result = (this.labelFormat && this.labelFormat.result) || item[this.store.labelAttribute],
+               full = (this.labelFormat && this.labelFormat.full) || item[this.store.labelAttribute],
+               labelObj = {
+                  "choice": this.processTokens(choice, item),
+                  "result": this.processTokens(result, item),
+                  "full": this.processTokens(full, item)
+               };
+
+            // Setup and return the label object
+            return labelObj;
+         },
+
+         /**
           * Go to the next result in the dropdown, or the first one if none selected (ignores already-chosen items)
           *
           * @instance
@@ -669,13 +775,11 @@ define([
          _handleSearchSuccess: function alfresco_forms_controls_MultiSelect___handleSearchSuccess(responseItems) {
             this._hideLoadingMessage();
             this._results = array.map(responseItems, function(nextItem) {
-               var label = nextItem[this.store.labelAttribute],
-                  value = nextItem[this.store.valueAttribute];
+               var value = nextItem[this.store.valueAttribute];
                this._storeItems[value] = nextItem;
                return {
                   domNode: null,
                   item: nextItem,
-                  label: label,
                   value: value
                };
             }, this);
@@ -1208,6 +1312,7 @@ define([
                      return nextChoice.value === nextResult.value;
                   }),
                   itemNode = this._nodes.resultsDropdown.childNodes[index + 3],
+                  labelObj = this._getLabel(nextResult.item),
                   clickListener,
                   mouseoverListener;
 
@@ -1218,19 +1323,15 @@ define([
                   }, this._nodes.resultsDropdown);
                }
 
-               // Update the value if necessary
-               if (itemNode.getAttribute(this._valueHtmlAttribute) !== nextResult.value) {
-                  itemNode.setAttribute(this._valueHtmlAttribute, nextResult.value);
-               }
+               // Update the value and title
+               itemNode.setAttribute(this._valueHtmlAttribute, nextResult.value);
+               itemNode.setAttribute("title", labelObj.full);
 
                // Recreate the label
-               var newLabel = this._createHighlightedLabel(nextResult.label);
-               if (itemNode.innerHTML !== newLabel.outerHTML) {
-                  while (itemNode.hasChildNodes()) {
-                     itemNode.removeChild(itemNode.firstChild);
-                  }
-                  itemNode.appendChild(newLabel);
-               }
+               var labelFrag = this._createHighlightedResultLabel(labelObj.result),
+                  tempLabelHolder = domConstruct.create("span");
+               domConstruct.empty(itemNode);
+               itemNode.appendChild(labelFrag);
 
                // Setup event listeners
                clickListener = on(itemNode, "mousedown", lang.hitch(this, this._onResultMousedown));
@@ -1276,11 +1377,12 @@ define([
                   // Run through the choices, updating their labels
                   array.forEach(this._choices, function(nextChoice) {
                      var contentNode = nextChoice.contentNode,
-                        realLabel = nextChoice.item[this.store.labelAttribute];
+                        labelObj = this._getLabel(nextChoice.item);
                      while (contentNode.hasChildNodes()) {
                         contentNode.removeChild(contentNode.firstChild);
                      }
-                     contentNode.appendChild(document.createTextNode(realLabel));
+                     contentNode.appendChild(document.createTextNode(labelObj.choice));
+                     contentNode.setAttribute("title", labelObj.full);
                   }, this);
 
                }),

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
@@ -42,12 +42,28 @@ define([
           * @instance
           */
          getWidgetConfig: function alfresco_forms_controls_MultiSelectInput__getWidgetConfig() {
-            return {
+
+            // Setup the widget config
+            var widgetConfig = {
                id: this.id + "_CONTROL",
                name: this.name,
                width: this.width,
-               value: this.value
+               value: this.value,
+               choiceCanWrap: this.optionsConfig.choiceCanWrap,
+               choiceMaxWidth: this.optionsConfig.choiceMaxWidth,
+               labelFormat: this.optionsConfig.labelFormat
             };
+
+            // Don't want to pass through undefined values (will override defaults)
+            if (!widgetConfig.choiceCanWrap && widgetConfig.choiceCanWrap !== false) {
+               delete widgetConfig.choiceCanWrap;
+            }
+            if (!widgetConfig.choiceMaxWidth) {
+               delete widgetConfig.choiceMaxWidth;
+            }
+
+            // Pass back the config
+            return widgetConfig;
          },
 
          /**

--- a/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
@@ -18,9 +18,14 @@
       margin: 0 5px 5px 0;
       padding: 0 20px 0 3px;
       position: relative;
+      vertical-align: top;
       &__content {
          color: #333;
+         display: inline-block;
          line-height: 22px;
+         max-width: 100%;
+         overflow: hidden;
+         text-overflow: ellipsis;
       }
       &__close-button {
          color: #aaa;
@@ -71,6 +76,7 @@
       margin: 0 0 5px 0;
       max-width: 100%;
       padding: 0;
+      vertical-align: baseline;
       width: 50px;
       &:focus {
          outline: 0;
@@ -166,6 +172,11 @@
    &--focused {
       border-color: #09c;
       outline: 1px solid #0cf;
+   }
+   &--choices-nowrap {
+      .alfresco-forms-controls-MultiSelect__choice__content {
+         white-space: nowrap;
+      }
    }
 }
 

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -25,10 +25,9 @@ define([
       "intern/chai!assert",
       "require",
       "alfresco/TestCommon",
-      "intern/dojo/node!leadfoot/keys",
-      "intern/dojo/node!leadfoot/helpers/pollUntil"
+      "intern/dojo/node!leadfoot/keys"
    ],
-   function(registerSuite, assert, require, TestCommon, keys, pollUntil) {
+   function(registerSuite, assert, require, TestCommon, keys) {
 
       var browser;
       registerSuite({
@@ -73,6 +72,23 @@ define([
             .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
                .then(function(elements) {
                   assert.lengthOf(elements, 7, "Did not bring up initial results");
+               });
+         },
+
+         "Selecting already-chosen item in dropdown does not choose item again": function() {
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
+               .click()
+               .pressKeys(keys.ESCAPE)
+               .end()
+
+            .findById("FOCUS_HELPER_BUTTON")
+               .click()
+               .pressKeys(keys.TAB)
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Added already-selected choice to control");
                });
          },
 
@@ -208,6 +224,43 @@ define([
             .findAllByCssSelector("#FORM1 .confirmationButton.dijitDisabled")
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "The confirmation button was not disabled when all the items were removed");
+               });
+         },
+
+         "Custom label format is used for choices": function() {
+            return browser.findByCssSelector("#MULTISELECT_2_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Those that belong to the emperor", "Did not display custom label format (type=choice) for choice");
+               })
+               .getAttribute("title")
+               .then(function(title) {
+                  assert.equal(title, "ID=CAT_01, Name=Those that belong to the emperor", "Did not display custom label format (type=full) for choice");
+               });
+         },
+
+         "Custom label format is used for results": function() {
+            return browser.findByCssSelector("#MULTISELECT_2_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
+               .type("the")
+               .waitForDeletedByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+               .end()
+
+            .findByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "CAT_01: Those that belong to the emperor", "Did not display custom label format (type=result) for result");
+               })
+               .getAttribute("title")
+               .then(function(title) {
+                  assert.equal(title, "ID=CAT_01, Name=Those that belong to the emperor", "Did not display custom label format (type=full) for result");
+               });
+         },
+
+         "Choices do not exceed max width": function() {
+            return browser.findByCssSelector("#MULTISELECT_2_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getSize()
+               .then(function(size) {
+                  assert(size.width < 151, "Choice was not restricted to under 150px as requested");
                });
          },
 

--- a/aikau/src/test/resources/reporters/AikauReporter.js
+++ b/aikau/src/test/resources/reporters/AikauReporter.js
@@ -178,9 +178,14 @@ define([], function() {
          console.log("");
          console.log("Took " + timeTaken + " to run " + counts.total + " tests in " + environmentNames.length + " environments: \"" + environmentNames.join("\", \"") + "\"");
 
+         // Calculate total success percent (but don't let it be 100% if there are any errors/failures)
+         var totalSuccesses = counts.passed + counts.skipped;
+            successPercent = Math.round(totalSuccesses / counts.total * 1000) / 10;
+         successPercent = successPercent === 100 ? (totalSuccesses === counts.total ? 100 : 99.9) : successPercent;
+
          // Calculate stats for the test-run
          var stats = {
-               "Success rate": Math.round((counts.passed + counts.skipped) / counts.total * 1000) / 10 + "%",
+               "Success rate": successPercent + "%",
                "Total passed": counts.passed,
                "Total skipped": counts.skipped,
                "Total failed": collections.failures.length,

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -12,6 +12,7 @@ model.jsonModel = {
          }
       },
       "alfresco/services/TagService",
+      "aikauTesting/mockservices/MultiSelectMockService",
       "alfresco/services/DialogService"
    ],
    widgets: [
@@ -41,8 +42,7 @@ model.jsonModel = {
                            publishTopic: "ALF_RETRIEVE_CURRENT_TAGS",
                            publishPayload: {
                               resultsProperty: "response.data.items"
-                           },
-                           searchStartsWith: false
+                           }
                         }
                      }
                   }
@@ -86,6 +86,39 @@ model.jsonModel = {
                      },
                      requirementConfig: {
                         initialValue: true
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "FORM2",
+         name: "alfresco/forms/Form",
+         config: {
+            okButtonPublishTopic: "FORM2_POST",
+            scopeFormControls: false,
+            value: {
+               categories: ["CAT_01", "CAT_10"]
+            },
+            widgets: [
+               {
+                  id: "MULTISELECT_2",
+                  name: "alfresco/forms/controls/MultiSelectInput",
+                  config: {
+                     label: "Celestial categories",
+                     name: "categories",
+                     width: "310px",
+                     optionsConfig: {
+                        choiceCanWrap: true,
+                        choiceMaxWidth: "150px",
+                        publishTopic: "ALF_RETRIEVE_CELESTIAL_CATEGORIES",
+                        labelFormat: {
+                           choice: "{label}",
+                           result: "{value}: {label}",
+                           full: "ID={value}, Name={label}"
+                        },
+                        searchStartsWith: false
                      }
                   }
                }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/MultiSelectMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/MultiSelectMockService.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/MultiSelectMockService
+ * @extends module:alfresco/core/Core
+ * @author Martin Doyle
+ */
+define(["alfresco/core/Core",
+      "dojo/_base/array",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(AlfCore, array, declare, lang) {
+
+      return declare([AlfCore], {
+
+         /**
+          * Mock list of items with long labels
+          * (Taken from the "Celestial Emporium of Benevolent Knowledge")
+          *
+          * @type {object[]}
+          */
+         _celestialCategories: [{
+            name: "Those that belong to the emperor",
+            label: "Those that belong to the emperor",
+            value: "CAT_01"
+         }, {
+            name: "Embalmed ones",
+            label: "Embalmed ones",
+            value: "CAT_02"
+         }, {
+            name: "Those that are trained",
+            label: "Those that are trained",
+            value: "CAT_03"
+         }, {
+            name: "Suckling pigs",
+            label: "Suckling pigs",
+            value: "CAT_04"
+         }, {
+            name: "Mermaids (or Sirens)",
+            label: "Mermaids (or Sirens)",
+            value: "CAT_05"
+         }, {
+            name: "Fabulous ones",
+            label: "Fabulous ones",
+            value: "CAT_06"
+         }, {
+            name: "Stray dogs",
+            label: "Stray dogs",
+            value: "CAT_07"
+         }, {
+            name: "Those that are included in this classification",
+            label: "Those that are included in this classification",
+            value: "CAT_08"
+         }, {
+            name: "Those that tremble as if they were mad",
+            label: "Those that tremble as if they were mad",
+            value: "CAT_09"
+         }, {
+            name: "Innumerable ones",
+            label: "Innumerable ones",
+            value: "CAT_10"
+         }, {
+            name: "Those drawn with a very fine camel hair brush",
+            label: "Those drawn with a very fine camel hair brush",
+            value: "CAT_11"
+         }, {
+            name: "Et cetera",
+            label: "Et cetera",
+            value: "CAT_12"
+         }, {
+            name: "Those that have just broken the flower vase",
+            label: "Those that have just broken the flower vase",
+            value: "CAT_13"
+         }, {
+            name: "Those that, at a distance, resemble flies",
+            label: "Those that, at a distance, resemble flies",
+            value: "CAT_14"
+         }],
+
+         /**
+          * Constructor
+          *
+          * @instance
+          * @param {array} args The constructor arguments.
+          */
+         constructor: function alfresco_testing_mockservices_MultiSelectMockService__constructor(args) {
+            declare.safeMixin(this, args);
+            this.alfSubscribe("ALF_RETRIEVE_CELESTIAL_CATEGORIES", lang.hitch(this, this._getCelestialCategories));
+         },
+
+         /**
+          * Handle comment creation
+          *
+          * @instance
+          * @param    {object} payload The publish payload
+          */
+         _getCelestialCategories: function alfresco_testing_mockservices_MultiSelectMockService___getCelestialCategories(payload) {
+            this.alfPublish(payload.alfResponseTopic || payload.responseTopic, {
+               response: this._celestialCategories
+            });
+         }
+      });
+   });


### PR DESCRIPTION
This addresses issue [AKU-280](https://issues.alfresco.com/jira/browse/AKU-280) by offering three new configuration options:

`choiceCanWrap`: Defaults to true, but can be set to false to prevent the text within choices from wrapping to the next line. Any overflow will be hidden by an ellipsis
`choiceMaxWidth`: The maximum width of choices. This defaults to 100%, but can take any CSS max-width value
`labelFormat`: Allows specification of custom label formats by permitting format strings, where item properties can be wrapped in curly-braces. Can specify some or all of `choice`, `result` and `full` for displaying in the chosen items, the results dropdown or the title attribute of both respectively.

This also makes some modifications to the ServiceStore (bug-fix, function externalisation and JSHint corrections) and updates all of the MultiSelect tests to accommodate the new features. There's also a small tweak to the AikauReporter.