### PR TITLE
AKU-244: Sanitize HTML proxy WebScript

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -48,6 +48,13 @@
             <directory>${basedir}/src/main/resources/webscript-libs</directory>
          </resource>
 
+         <resource>
+            <!-- WebScripts go into their own package -->
+            <targetPath>./alfresco/site-webscripts/org/alfresco/aikau</targetPath>
+            <filtering>false</filtering>
+            <directory>${basedir}/src/main/resources/webscripts</directory>
+         </resource>
+
          <!-- ...but everything else goes into a standard path -->
          <resource>
             <targetPath>META-INF/js/lib</targetPath>

--- a/aikau/src/main/resources/alfresco/services/CommentService.js
+++ b/aikau/src/main/resources/alfresco/services/CommentService.js
@@ -73,7 +73,7 @@ define(["dojo/_base/declare",
          {
             startIndex = (payload.page - 1) * pageSize;
          }
-         var url = AlfConstants.PROXY_URI + "api/node/" + payload.nodeRef + "/comments?reverse=" + reverse + "&startIndex=" + startIndex + "&pageSize=" + pageSize;
+         var url = AlfConstants.URL_SERVICECONTEXT + "/sanitize/response?items=items&attribute=content&ws=/api/node/" + payload.nodeRef + "/comments%3Freverse=" + reverse + "%26startIndex=" + startIndex + "%26pageSize=" + pageSize;
          this.serviceXhr({
             url: url,
             alfTopic: payload.alfResponseTopic || null,

--- a/aikau/src/main/resources/webscripts/sanitize-response.get.desc.xml
+++ b/aikau/src/main/resources/webscripts/sanitize-response.get.desc.xml
@@ -1,0 +1,7 @@
+<webscript>
+  <shortname>Sanitize Content</shortname>
+  <description>This WebScript can be used as a proxy to sanitize responses from Repository APIs to ensure the content can be rendered safely in a browser.</description>
+  <url>/sanitize/response</url>
+  <format default="json">argument</format>
+  <authentication>user</authentication>
+</webscript>

--- a/aikau/src/main/resources/webscripts/sanitize-response.get.js
+++ b/aikau/src/main/resources/webscripts/sanitize-response.get.js
@@ -1,7 +1,4 @@
-/* global args */
-/* global remote */
-/* global stringUtils */
-/* global jsonUtils */
+/*global args,remote,stringUtils,jsonUtils*/
 var response = {};
 if (args.ws)
 {
@@ -9,7 +6,6 @@ if (args.ws)
    var json = connector.get(encodeURI(args.ws));
    try
    {
-      // PLEASE NOTE: Very deliberate usage of == in the following line
       if (/*jshint eqeqeq:false*/ json.status == 200)
       {
          var proxyResponse = JSON.parse(json.response);

--- a/aikau/src/main/resources/webscripts/sanitize-response.get.js
+++ b/aikau/src/main/resources/webscripts/sanitize-response.get.js
@@ -1,0 +1,35 @@
+/* global args */
+/* global remote */
+/* global stringUtils */
+/* global jsonUtils */
+var response = {};
+if (args.ws)
+{
+   var connector = remote.connect("alfresco");
+   var json = connector.get(encodeURI(args.ws));
+   try
+   {
+      // PLEASE NOTE: Very deliberate usage of == in the following line
+      if (/*jshint eqeqeq:false*/ json.status == 200)
+      {
+         var proxyResponse = JSON.parse(json.response);
+         var itemsProperty = args.items || "items";
+         var attributeProperty = args.attribute || "content";
+         if (proxyResponse[itemsProperty])
+         {
+            var items = proxyResponse[itemsProperty];
+            for (var i = 0, il = items.length; i < il; i++)
+            {
+               items[i].content = stringUtils.stripUnsafeHTML(items[i][attributeProperty]);
+            }
+            response = proxyResponse; 
+         }
+      }
+   }
+   catch(e)
+   {
+      // No action. Allow empty response to pass through.
+   }
+}
+// PLEASE NOTE: Intentional use of jsonUtils over JSON here...
+model.sanitizedResponse = jsonUtils.toJSONString(response);

--- a/aikau/src/main/resources/webscripts/sanitize-response.get.json.ftl
+++ b/aikau/src/main/resources/webscripts/sanitize-response.get.json.ftl
@@ -1,0 +1,1 @@
+${sanitizedResponse!"{}"}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-244. 

I've created a new proxy WebScript that accepts URIs for Alfresco Repository REST APIs and runs a single property of each item through the stripUnsafeHTML() function. This is currently limited in that it only sanitizes a single attribute attribute and nested attributes can't be used with dot-notation properties.

However, I think we can live with these limitations initially and iterate as the use-cases arise. I've done manual testing to verify it works, but have not provided an automated test because we have no satisfactory way of testing WebScripts at the moment.

The CommentService has been updated to make use of this new proxy WebScript and I have verified that it works as expected.