### PR TITLE
AKU-278: Add "striped content" widget

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -1,3 +1,17 @@
+// Main palette
+@primaryBG: #fff;
+@primaryFG: #333;
+@headerBG: #0082c8;
+@headerFG: #fff;
+@alternateBG: #ccc;
+@alternateFG: @primaryFG;
+
+// Default/base "theme"
+@headerRowBG: @headerBG;
+@headerRowFG: @headerFG;
+@subheaderBG: @alternateBG;
+@subheaderFG: @alternateFG;
+
 
 @docListBorderColour: #e5e5e5;
 @docListHeaderBgColour: #f5f5f5;

--- a/aikau/src/main/resources/alfresco/layout/StripedContent.js
+++ b/aikau/src/main/resources/alfresco/layout/StripedContent.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A layout control used to provide "stripes" of content, where a full-width background contains a centred, fixed-width area of content.
+ *
+ * @example <caption>Sample configuration:</caption>
+ * {
+ *    name: "alfresco/layout/StripedContent",
+ *    config: {
+ *       contentWidth: "1200px", // Optional: Overrides default of "960px"
+ *       widgets: [
+ *          {
+ *             name: "alfresco/logo/Logo",
+ *             stripeClass: "header" // Optional: Current built-in classes are: "header","sub-header","menu"
+ *          },
+ *          {
+ *             name: "alfresco/html/Label",
+ *             stripeClass: "sub-header",
+ *             config: {
+ *                label: "This is the sub-header",
+ *                additionalCssClasses: "bold"
+ *             }
+ *          },
+ *          {
+ *             name: "alfresco/html/Label",
+ *             stripeClass: "menu",
+ *             config: {
+ *                label: "This is the menu row"
+ *             }
+ *          },
+ *          {
+ *             name: "alfresco/html/Label",
+ *             stripeStyle: "background: #fee; padding: 30px 0;", // Optional
+ *             config: {
+ *                label: "Content goes here..."
+ *             }
+ *          }
+ *       ]
+ *    }
+ * }
+ *
+ * @module alfresco/layout/StripedContent
+ * @extends module:alfresco/core/ProcessWidgets
+ * @author Martin Doyle
+ */
+define(["alfresco/core/ProcessWidgets",
+      "dojo/_base/array",
+      "dojo/_base/declare",
+      "dojo/dom-class",
+      "dojo/dom-construct"
+   ],
+   function(ProcessWidgets, array, declare, domClass, domConstruct) {
+
+      return declare([ProcessWidgets], {
+
+         /**
+          * The base class for the widget
+          *
+          * @instance
+          * @override
+          * @type {string}
+          * @default "alfresco-layout-StripedContent"
+          */
+         baseClass: "alfresco-layout-StripedContent",
+
+         /**
+          * The size of the fixed-content inside the stripe, as a CSS dimension
+          *
+          * @instance
+          * @type {string}
+          * @default "960px"
+          */
+         contentWidth: "960px",
+
+         /**
+          * An array of the CSS files to use with this widget.
+          *
+          * @instance
+          * @override
+          * @type {object[]}
+          * @default [{cssFile:"./css/StripedContent.css"}]
+          */
+         cssRequirements: [{
+            cssFile: "./css/StripedContent.css"
+         }],
+
+         /**
+          * Creates a new DOM node for a widget to use. The DOM node contains a child <div> element
+          * that the widget will be attached to and an outer <div> element that additional CSS classes
+          * can be applied to.
+          *
+          * @instance
+          * @override
+          * @param {object} widgetConfig The widget definition to create the DOM node for
+          * @param {element} rootNode The DOM node to create the new DOM node as a child of
+          * @param {string} rootClassName A string containing one or more space separated CSS classes to set on the DOM node
+          */
+         createWidgetDomNode: function alfresco_core_CoreWidgetProcessing__createWidgetDomNode(widgetConfig, rootNode, /*jshint unused:false*/ rootClassName) {
+
+            // Create the stripe node and a new node for the widget
+            var stripeNode = domConstruct.create("div", {
+                  className: this.baseClass + "__stripe",
+                  style: widgetConfig.stripeStyle || ""
+               }, rootNode),
+               contentNode = domConstruct.create("div", {
+                  className: this.baseClass + "__stripe__content",
+                  style: {
+                     maxWidth: this.contentWidth
+                  }
+               }, stripeNode);
+
+            // Add custom CSS
+            if (widgetConfig.stripeClass) {
+               domClass.add(stripeNode, this.baseClass + "__stripe--" + widgetConfig.stripeClass);
+            }
+
+            // Pass back the widget node
+            return domConstruct.create("div", {}, contentNode);
+         }
+      });
+   });

--- a/aikau/src/main/resources/alfresco/layout/css/StripedContent.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StripedContent.css
@@ -1,0 +1,24 @@
+.alfresco-layout-StripedContent {
+   &__stripe {
+      &__content {
+         margin: 0 auto;
+         overflow: hidden;
+      }
+      &--header {
+         background-color: #0082c8;
+         box-shadow: inset 0 0 2px 0 rgba(0,0,0,.75);
+         color: #fff;
+      }
+      &--sub-header {
+         background-color: #ccc;
+         font-family: @bold-font;
+         font-weight: 700;
+         padding: 15px 0;
+      }
+      &--menu {
+         border: solid #aaa;
+         border-width: 1px 0;
+         padding: 10px 0;
+      }
+   }
+}

--- a/aikau/src/main/resources/alfresco/layout/css/StripedContent.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StripedContent.css
@@ -5,12 +5,13 @@
          overflow: hidden;
       }
       &--header {
-         background-color: #0082c8;
+         background: @headerRowBG;
          box-shadow: inset 0 0 2px 0 rgba(0,0,0,.75);
-         color: #fff;
+         color: @headerRowFG;
       }
       &--sub-header {
-         background-color: #ccc;
+         background: @subheaderBG;
+         color: @subheaderFG;
          font-family: @bold-font;
          font-weight: 700;
          padding: 15px 0;

--- a/aikau/src/test/resources/alfresco/layout/StripedContentTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StripedContentTest.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a unit test for the StripedContent widget
+ *
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, TestCommon) {
+
+      var browser;
+      registerSuite({
+         name: "StripedContent tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/StripedContent", "StripedContent Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Content is rendered on load": function() {
+            return browser.findByCssSelector(".alfresco-layout-StripedContent")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.include(text, "This is the sub-header", "Sub-header content not rendered on page-load");
+                  assert.include(text, "This is the menu row", "Menu row content not rendered on page-load");
+                  assert.include(text, "Content goes here...", "Main content row not rendered on page-load");
+               });
+         },
+
+         "Logo is rendered on load": function() {
+            return browser.findByCssSelector(".alfresco-logo-Logo")
+               .isDisplayed()
+               .then(function(isDisplayed) {
+                  assert(isDisplayed, "Logo was not visible");
+               });
+         },
+
+         "Elements all rendered in correct order": function() {
+            var lastTop = 0;
+            return browser.findByCssSelector(".alfresco-logo-Logo")
+               .getPosition()
+               .then(function(pos) {
+                  assert(lastTop < (lastTop = pos.y), "Logo was not below top of page");
+               })
+               .end()
+
+            .findAllByCssSelector(".alfresco-html-Label")
+               .then(function(elements) {
+                  elements[0].getPosition()
+                     .then(function(pos) {
+                        assert(lastTop < (lastTop = pos.y), "Sub-header was not below logo");
+                     });
+
+                  elements[1].getPosition()
+                     .then(function(pos) {
+                        assert(lastTop < (lastTop = pos.y), "Menu row was not below sub-header");
+                     });
+
+                  return elements[2].getPosition()
+                     .then(function(pos) {
+                        assert(lastTop < (lastTop = pos.y), "Main content was not below menu row");
+                     });
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
+      "src/test/resources/alfresco/layout/StripedContentTest"
    ],
 
    /**
@@ -117,6 +117,7 @@ define({
       "src/test/resources/alfresco/layout/AlfTabContainerTest",
       "src/test/resources/alfresco/layout/BasicLayoutTest",
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
+      "src/test/resources/alfresco/layout/StripedContentTest",
       "src/test/resources/alfresco/layout/TwisterTest",
       "src/test/resources/alfresco/layout/VerticalRevealTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StripedContent.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StripedContent.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>StripedContent Test</shortname>
+  <description>Demonstrates the StripedContent widget with four sample stripes</description>
+  <family>aikau-unit-tests</family>
+  <url>/StripedContent</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StripedContent.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StripedContent.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StripedContent.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StripedContent.get.js
@@ -1,0 +1,52 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/StripedContent",
+         config: {
+            contentWidth: "950px",
+            widgets: [
+               {
+                  name: "alfresco/logo/Logo",
+                  stripeClass: "header"
+               },
+               {
+                  name: "alfresco/html/Label",
+                  stripeClass: "sub-header",
+                  config: {
+                     label: "This is the sub-header",
+                     additionalCssClasses: "bold"
+                  }
+               },
+               {
+                  name: "alfresco/html/Label",
+                  stripeClass: "menu",
+                  config: {
+                     label: "This is the menu row"
+                  }
+               },
+               {
+                  name: "alfresco/html/Label",
+                  stripeStyle: "background: #fee; padding: 30px 0;",
+                  config: {
+                     label: "Content goes here..."
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses issue [AKU-278](https://issues.alfresco.com/jira/browse/AKU-278) which is a feature request for a new style of layout widget called "striped content", which is a stylable, full-width container with a centred, fixed-width content.