### PR TITLE
AKU-262: Breadcrumb updates

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -107,6 +107,12 @@ color: @de-emphasized-font-color;
 @standard-box-shadow: 0.33px 2px 8px rgba(0, 0, 0, 0.3);
 @inset-box-shadow: 1px 1px 3px @standard-button-border-color inset;
 
+// Breadcrumbs
+@breadcrumb-font-color: @general-font-color;
+@breadcrumb-background-color: white;
+@breadcrumb-border-color: @standard-border-color;
+@breadcrumb-hover-color: #eee;
+
 // Generic colours for displaying collections of items
 @collectionColour1: #f1e695;
 @collectionColour2: #f4af72;

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumb.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumb.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -78,41 +78,32 @@ define(["dojo/_base/declare",
       path: null,
       
       /**
-       * The target URL for the breadcrumb
+       * This is the topic that will be published when the breadcrumb is clicked.
+       *
        * @instance
        * @type {string}
-       * @default null 
+       * @default null
        */
-      targetUrl: null,
-      
+      publishTopic: null,
+
       /**
-       * The URL type to use for target URLs. Can be overridden as necessary.
-       * 
+       * This is the payload that will be published when the breadcrumb is clicked.
+       *
        * @instance
-       * @type {string}
-       * @default "SHARE_PAGE_RELATIVE"
+       * @type {object}
+       * @default null
        */
-      targetUrlType: "SHARE_PAGE_RELATIVE",
-      
-      /**
-       * The URL location to use for target URLs. Can be overridden as necessary.
-       * 
-       * @instance
-       * @type {string}
-       * @default "CURRENT"
-       */
-      targetUrlLocation: "CURRENT",
+      publishPayload: null,
       
       /**
        * Implements the Dojo widget lifecycle method to set the label of the widget
        * @instance
        */
       postCreate: function alfresco_documentlibrary_AlfBreadcrumbTrail__postCreate() {
-         if (this.label != null)
+         if (this.label)
          {
             this.breadcrumbNode.innerHTML = this.encodeHTML(this.message(this.label));
          }
-         this.addNodeDropTarget(this.domNode);
       },
       
       /**
@@ -122,20 +113,10 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onClick: function alfresco_documentlibrary_AlfBreadcrumb(evt) {
-         if (this.targetUrl != null)
+      onClick: function alfresco_documentlibrary_AlfBreadcrumb(/* jshint unused:false */ evt) {
+         if (this.publishTopic)
          {
-            // If a URL has been provided then clicking will navigate to that URL (this is typically the 
-            // action for the last breadcrumb in the trail)...
-            this.alfPublish("ALF_NAVIGATE_TO_PAGE", { url: this.targetUrl,
-                                                      type: this.targetUrlType,
-                                                      target: this.targetUrlLocation});
-         }
-         else
-         {
-            this.alfPublish("ALF_NAVIGATE_TO_PAGE", { url: "path=" + this.path,
-                                                      type: "HASH",
-                                                      target: this.targetUrlLocation});
+            this.alfPublish(this.publishTopic, this.publishPayload, (this.publishGlobal !== undefined && this.publishGlobal === true));
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumb.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumb.js
@@ -116,7 +116,7 @@ define(["dojo/_base/declare",
       onClick: function alfresco_documentlibrary_AlfBreadcrumb(/* jshint unused:false */ evt) {
          if (this.publishTopic)
          {
-            this.alfPublish(this.publishTopic, this.publishPayload, (this.publishGlobal !== undefined && this.publishGlobal === true));
+            this.alfPublish(this.publishTopic, this.publishPayload, (this.publishGlobal === true));
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,14 +18,28 @@
  */
 
 /**
- * Used to represent the path or filter that is currently being displayed. When a path is being rendered
- * each element in the path is rendered by an individual [AlfBreadcrumb]{@link module:alfresco/documentlibrary/AlfBreadcrumb}
+ * <p>This widget can be used to render breadcrumb trails. It can be used either to render a fixed set of breadcrumbs (e.g.
+ * where you might want to render some information about a fixed location of a page) or it can be used to render path
+ * based data. When rendering path based data it is possible to get the path from the
+ * [browser URL hash]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#useHash} of from explicitly configured
+ * [path publishing topics]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#pathChangeTopic}. When rendering
+ * a path based breadcrumb trail it is expected that the last item in the trail  represents the
+ * current location and clicking it can either navigate the user to another page (in which case you should set the
+ * [lastBreadcrumbPublishTopic]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#lastBreadcrumbPublishTopic} and other associated
+ * attributes). Clicking on any other breadcrumb in the trail is expected to simply publish information about the selected
+ * path.<p>
+ * 
+ * <p>Each element in the trail is rendered by the [AlfBreadcrumb]{@link module:alfresco/documentlibrary/AlfBreadcrumb}
+ * widget. This module should be extended and the 
+ * [renderBreadcrumb]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#lastBreadcrumbPublishTopic#renderBreadcrumb} function
+ * overridden if an alternative widget needs to be used.</p>
  * 
  * @module alfresco/documentlibrary/AlfBreadcrumbTrail
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -34,15 +48,16 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/AlfBreadcrumbTrail.html",
         "alfresco/core/Core",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
+        "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/documentlibrary/AlfBreadcrumb",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
-        "dojo/dom-class",
-        "dojo/on"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template,  AlfCore, _AlfDocumentListTopicMixin, AlfBreadcrumb, lang, array, domConstruct, domClass, on) {
+        "dojo/dom-class"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template,  AlfCore, _AlfDocumentListTopicMixin, _PublishPayloadMixin,
+                 AlfBreadcrumb, lang, array, domConstruct, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _AlfDocumentListTopicMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _PublishPayloadMixin, _AlfDocumentListTopicMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -97,27 +112,149 @@ define(["dojo/_base/declare",
       showRootLabel: true,
          
       /**
+       * A path to use as a breadcrumb trail. This is a simple alternative to defining invidual breadcrumbs
+       * but gives less flexibility over what clicking on the breadcrumbs do.
+       *
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      currentPath: null,
+
+      /**
+       * Indicates whether the browser URL hash will be used to provide the breadcrumb trail. If this is
+       * set to true then the breadcrumb trail will be re-rendered as the hash changes.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      useHash: false,
+
+      /**
+       * The topic to subscribe to for listening to changes to the path. This is only used when 
+       * [useHash]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#useHash} is set to false.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      pathChangeTopic: null,
+
+      /**
+       * This indicates that the final breadcrumb in the trail  is 
+       * 
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      lastBreadcrumbIsCurrentNode: false,
+
+      /**
+       * This is the topic that is published when the final breadcrumb in the trail is clicked.
+       *
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      lastBreadcrumbPublishTopic: null,
+
+      /**
+       * This is the payload that is published when the final breadcrumb in the trail is clicked.
+       *
+       * @instance
+       * @type {object}
+       * @default null
+       */
+      lastBreadcrumbPublishPayload: null,
+
+      /**
+       * This is the type of payload that is published when the final breadcrumb in the trail is clicked. 
+       * By default it will use the 
+       * [lastBreadcrumbPublishPayload]{@link module:alfresco/documentlibrary/AlfBreadCrumbTrail#lastBreadcrumbPublishPayload} 
+       * exactly as it is configured.
+       *
+       * @instance
+       * @type {string}
+       * @default "CONFIGURED"
+       */
+      lastBreadcrumbPublishPayloadType: "CONFIGURED",
+
+      /**
+       * Indicate whether or not the "currentItem" object will be mixed into the 
+       * [lastBreadcrumbPublishPayload]{@link module:alfresco/documentlibrary/AlfBreadCrumbTrail#lastBreadcrumbPublishPayload}.
+       * By default this is set to false because it is not expected that there will typically be a "currentItem" object set.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      lastBreadcrumbPublishPayloadItemMixin: false,
+
+      /**
+       * An array of the modifying functions that will be applied to the 
+       * [lastBreadcrumbPublishPayload]{@link module:alfresco/documentlibrary/AlfBreadCrumbTrail#lastBreadcrumbPublishPayload}
+       * if the 
+       * [lastBreadcrumbPublishPayloadType]{@link module:alfresco/documentlibrary/AlfBreadCrumbTrail#lastBreadcrumbPublishPayloadType}
+       * is configured to be "PROCESS".
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      lastBreadcrumbPublishPayloadModifiers: null,
+
+      /**
+       * An array of fixed breadcrumbs to render. Each breadcrumb needs to have a "label" attribute and can
+       * also optionally include "publishTopic" and "publishPayload" attributes if clicking on the breadcrumb
+       * should have an action.
+       * 
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      breadcrumbs: null,
+
+      /**
        * Implements the Dojo widget lifecycle function to subscribe to the relevant topics that
        * provide information on path and filter changes. 
        * 
        * @instance
        */
       postCreate: function alfresco_documentlibrary_AlfBreadcrumbTrail__postCreate() {
-         this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.handleCurrentNodeChange));
-         this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged));
+
          this.alfSubscribe(this.showPathTopic, lang.hitch(this, this.onShowBreadcrumb));
          this.alfSubscribe(this.filterSelectionTopic, lang.hitch(this, this.onFilterSelection));
          this.alfSubscribe("ALF_DOCUMENTLIST_CATEGORY_CHANGED", lang.hitch(this, this.onFilterSelection));
          this.alfSubscribe("ALF_DOCUMENTLIST_TAG_CHANGED", lang.hitch(this, this.onFilterSelection));
 
-         if (this.currentPath != null)
+         if (this.breadcrumbs)
          {
-            this.renderBreadcrumbTrail();
+            // Render a fixed breadcrumb trail...
+            array.forEach(this.breadcrumbs, lang.hitch(this, this.renderBreadcrumb));
          }
-         var currentFolderNodeRef = lang.getObject("_currentNode.parent.nodeRef", false, this);
-         if (currentFolderNodeRef != null)
+         else
          {
-            this._currentFolderUrl = "folder-details?nodeRef=" + currentFolderNodeRef;
+            // When the "lastBreadcrumb" represents the current node (e.g. when the breadcrumb trail represents
+            // a location in a Document Library for example) then it is necessary to subscribe to changes
+            // of the current node...
+            if (this.lastBreadcrumbIsCurrentNode === true)
+            {
+               this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.onCurrentNodeChange));
+            }
+
+            if (this.useHash === true)
+            {
+               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged));
+            }
+            else if (this.pathChangeTopic)
+            {
+               this.alfSubscribe(this.pathChangeTopic, lang.hitch(this, this.onPathChanged));
+            }
+            if (this.currentPath)
+            {
+               this.renderPathBreadcrumbTrail();
+            }
          }
       },
 
@@ -128,18 +265,7 @@ define(["dojo/_base/declare",
        * @type {object}
        * @default null
        */
-      _currentNode: null,
-      
-      /**
-       *  A URL to the current folder. This will get set when the 
-       * current node changes. It will be set so that breadcrumb links to the current folder can display
-       * the folder details rather than just changing the DocumentList filter.
-       * 
-       * @instance
-       * @type {string}
-       * @default null
-       */
-      _currentFolderUrl: null,
+      currentNode: null,
       
       /**
        * This handles publications on the [metadataChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#metadataChangeTopic}
@@ -149,31 +275,17 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload 
        */
-      handleCurrentNodeChange: function alfresco_documentlibrary_AlfBreadcrumbTrail__handleCurrentNodeChange(payload) {
+      onCurrentNodeChange: function alfresco_documentlibrary_AlfBreadcrumbTrail__onCurrentNodeChange(payload) {
          if (payload && payload.node)
          {
-            this._currentNode = payload.node;
-            if (payload.node.parent && payload.node.parent.nodeRef)
-            {
-               this._currentFolderUrl = "folder-details?nodeRef=" + payload.node.parent.nodeRef;
-               this.renderBreadcrumbTrail();
-            }
+            this.currentNode = payload.node;
+            this.renderPathBreadcrumbTrail();
          }
          else
          {
             this.alfLog("error", "A request was made to update the current NodeRef, but no 'node' property was provided in the payload: ", payload);
          }
       },
-      
-      /**
-       * The path to display. This can be set on instantiation to indicate the initial path to display but will
-       * be updated each time the path is changed. 
-       * 
-       * @instance
-       * @type {string}
-       * @default ""
-       */
-      currentPath: "",
       
       /**
        * This handles publications on the [hashChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#hashChangeTopic}
@@ -186,13 +298,27 @@ define(["dojo/_base/declare",
        */
       onPathChanged: function alfresco_documentlibrary_AlfBreadcrumbTrail__onPathChanged(payload) {
          this.alfLog("log", "Detected path change", payload);
-         if (payload && payload.path != null)
+         if (payload && payload.path)
          {
             this.currentPath = payload.path;
-            this.renderBreadcrumbTrail();
+            this.renderPathBreadcrumbTrail();
          }
       },
      
+      /**
+       * Renders a breadcrumb.
+       * 
+       * @param {object} breadcrumb The configuration for the breadcrumb
+       * @param {number} index The index of the breadcrumb
+       */
+      renderBreadcrumb: function alfresco_documentlibrary_AlfBreadcrumbTrail__renderBreadcrumb(breadcrumb, /*jshint unused:false*/ index) {
+         if (breadcrumb.label)
+         {
+            var bc = new AlfBreadcrumb(breadcrumb);
+            domConstruct.place(bc.domNode, this.containerNode, "last");
+         }
+      },
+
       /**
        * Renders an individual [AlfBreadcrumb]{@link module:alfresco/documentlibrary/AlfBreadcrumb} in the breadcrumb trail.
        * 
@@ -200,31 +326,37 @@ define(["dojo/_base/declare",
        * @param {string} folderName The name of the folder to render
        * @param {integer} index The index of the folder in array of breadcrumbs
        */
-      renderBreadcrumb: function alfresco_documentlibrary_AlfBreadcrumbTrail__renderBreadcrumb(paths, folderName, index) {
-         // Construct the new path that the breadcrumb should link to...
+      renderPathBreadcrumb: function alfresco_documentlibrary_AlfBreadcrumbTrail__renderPathBreadcrumb(paths, folderName, index) {
          var path = paths.slice(0, index+1).join("/");
-         
-         // Create the breadcrumb...
-         
-         var breadcrumb = new AlfBreadcrumb({label: folderName,
-                                             path: path});
-         domConstruct.place(breadcrumb.domNode, this.containerNode, "last");
-         
-         // Create a breadcrumb separator if required...
+         var config = {
+            label: folderName,
+            path: path
+         };
          if (index < paths.length -1)
          {
-            var breadcrumbSeparator = domConstruct.create("span", { innerHTML: "&nbsp;" });
-            domClass.add(breadcrumbSeparator, "alf-folder-separator");
-            domConstruct.place(breadcrumbSeparator, this.containerNode);
-         }
-         else
-         {
-            // For the last breadcrumb - set a target URL for the last folder...
-            if (this._currentFolderUrl)
+            if (this.useHash === true)
             {
-               breadcrumb.targetUrl = this._currentFolderUrl;
+               config.publishTopic = "ALF_NAVIGATE_TO_PAGE";
+               config.publishPayload = {
+                  url: "path=" + (path || "/"),
+                  type: "HASH",
+                  target: "CURRENT"
+               };
+            }
+            else
+            {
+               config.publishTopic = this.pathChangeTopic;
+               config.publishPayload = {
+                  path: (path || "/")
+               };
             }
          }
+         else if (this.lastBreadcrumbPublishTopic)
+         {
+            config.publishTopic = this.lastBreadcrumbPublishTopic;
+            config.publishPayload = this.generatePayload(this.lastBreadcrumbPublishPayload, this.currentItem, null, this.lastBreadcrumbPublishPayloadType, this.lastBreadcrumbPublishPayloadItemMixin, this.lastBreadcrumbPublishPayloadModifiers);
+         }
+         this.renderBreadcrumb(config);
       },
       
       /**
@@ -233,41 +365,47 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      renderBreadcrumbTrail: function alfresco_documentlibrary_AlfBreadcrumbTrail__renderBreadcrumbTrail() {
-         
-         // Empty the current breadcrumb trail...
-         domConstruct.empty(this.containerNode);
-         
-         // Build an array of the breadcrumbs...
-         var paths = this.currentPath.split("/");
-         if (this.currentPath === "/")
+      renderPathBreadcrumbTrail: function alfresco_documentlibrary_AlfBreadcrumbTrail__renderPathBreadcrumbTrail() {
+         if (this.currentPath)
          {
-            paths = ["/"];
-         }
-         if (paths[paths.length-1] == "")
-         {
-            paths.pop();
-         }
-         
-         var displayPaths = paths.concat();
-         displayPaths[0] = this.message(this.rootLabel);
-         
-         if (!this.showRootLabel)
-         {
-            // Remove the root element so that it doesn't show...
-            displayPaths.shift();
-            paths.shift();
-         }
-         
-         array.forEach(displayPaths, lang.hitch(this, "renderBreadcrumb", paths));
-         
-         if (this.hide) 
-         {
-            domClass.add(this.domNode, "hidden");
-         }
-         else
-         {
-            domClass.remove(this.domNode, "hidden");
+            domConstruct.empty(this.containerNode);
+
+            if (this.currentPath[0] !== "/")
+            {
+               this.currentPath = "/" + this.currentPath;
+            }
+            var paths = this.currentPath.split("/");
+            if (this.currentPath === "/")
+            {
+               paths = ["/"];
+            }
+            if (paths[paths.length-1] === "")
+            {
+               paths.pop();
+            }
+
+            var displayPaths = paths.concat();
+            if (this.rootLabel)
+            {
+               displayPaths[0] = this.message(this.rootLabel);
+            }
+
+            if (!this.showRootLabel)
+            {
+               displayPaths.shift();
+               paths.shift();
+            }
+            
+            array.forEach(displayPaths, lang.hitch(this, this.renderPathBreadcrumb, paths));
+            
+            if (this.hide) 
+            {
+               domClass.add(this.domNode, "hidden");
+            }
+            else
+            {
+               domClass.remove(this.domNode, "hidden");
+            }
          }
       },
       
@@ -279,7 +417,7 @@ define(["dojo/_base/declare",
        * @param {object} payload Must contain a "selected" attribute which should map to whether or not the trail is shown or not. 
        */
       onShowBreadcrumb: function alfresco_documentlibrary_AlfBreadcrumbTrail__onShowBreadcrumb(payload) {
-         if (payload && payload.selected != null)
+         if (payload && (payload.selected || payload.selected === false))
          {
             this.hide = !payload.selected;
             if (this.hide) 
@@ -301,8 +439,9 @@ define(["dojo/_base/declare",
        */
       onFilterSelection: function alfresco_documentlibrary_AlfBreadcrumbTrail__onFilterSelection(payload) {
          // Empty the current breadcrumb trail...
-         if (payload != null && payload.description != null)
+         if (payload && payload.description)
          {
+            // TODO: Make this work with the CSS
             domConstruct.empty(this.containerNode);
             domConstruct.create("div", {
                innerHTML: payload.description

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -199,7 +199,7 @@ define(["dojo/_base/declare",
        * is configured to be "PROCESS".
        *
        * @instance
-       * @type {array}
+       * @type {string[]}
        * @default null
        */
       lastBreadcrumbPublishPayloadModifiers: null,
@@ -210,7 +210,7 @@ define(["dojo/_base/declare",
        * should have an action.
        * 
        * @instance
-       * @type {array}
+       * @type {object[]}
        * @default null
        */
       breadcrumbs: null,
@@ -315,7 +315,7 @@ define(["dojo/_base/declare",
          if (breadcrumb.label)
          {
             var bc = new AlfBreadcrumb(breadcrumb);
-            domConstruct.place(bc.domNode, this.containerNode, "last");
+            bc.placeAt(this.containerNode);
          }
       },
 
@@ -441,11 +441,10 @@ define(["dojo/_base/declare",
          // Empty the current breadcrumb trail...
          if (payload && payload.description)
          {
-            // TODO: Make this work with the CSS
             domConstruct.empty(this.containerNode);
-            domConstruct.create("div", {
-               innerHTML: payload.description
-            }, this.containerNode);
+            this.renderBreadcrumb({
+               label: payload.description
+            });
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
@@ -1,41 +1,55 @@
-.alfresco-documentlibrary-AlfBreadcrumb {
+/* CSS for this was adapted from https://css-tricks.com/triangle-breadcrumbs/ */
+.alfresco-documentlibrary-AlfBreadcrumb { 
+   float: left; 
+}
+.alfresco-documentlibrary-AlfBreadcrumb a {
+   text-decoration: none; 
+   padding: 5px 0 5px 50px;
+   background: @breadcrumb-background-color;
+   position: relative; 
+   display: block;
+   float: left;
    cursor: pointer;
-   position: relative;
-   display: inline-block;
 }
 
-.alfresco-documentlibrary-AlfBreadcrumb.Focused.dijitFocused {
-   background-color: #f0f0f0;
-   outline: 0;
-}
-
-.alfresco-documentlibrary-AlfBreadcrumb.dndHighlight .breadcrumb
-{
-   background-color: #dceaf4;
-   outline: 2px solid #4F94C9;
-}
-
-.alfresco-documentlibrary-AlfBreadcrumb .breadcrumb:hover
-{
-   background-color: #f0f0f0;
-}
-
-.alfresco-documentlibrary-AlfBreadcrumb span.droppable
-{
-   background: url(./images/drop-arrow-left-small.png) no-repeat;
-   display: none;
-   height: 14px;
+.alfresco-documentlibrary-AlfBreadcrumb a:after { 
+   content: " ";
+   display: block;
+   width: 0;
+   height: 0;
+   border-top: 50px solid transparent;
+   border-bottom: 50px solid transparent;
+   border-left: 30px solid @breadcrumb-background-color;
    position: absolute;
-   width: 33px;
+   top: 50%;
+   margin-top: -50px;
+   left: 100%;
+   z-index: 2;
+}
+
+.alfresco-documentlibrary-AlfBreadcrumb a:before { 
+   content: " ";
+   display: block;
+   width: 0; 
+   height: 0;
+   border-top: 50px solid transparent;
+   border-bottom: 50px solid transparent;
+   border-left: 30px solid @breadcrumb-border-color;
+   position: absolute;
+   top: 50%;
+   margin-top: -50px;
+   margin-left: 1px;
+   left: 100%;
    z-index: 1;
-   margin-left: 30px;
-   top: -5px;
-   left: -10px;
 }
 
-/* Drag and Drop */
-
-.alfresco-documentlibrary-AlfBreadcrumb.dndHighlight span.droppable
-{
-   display: block !important;
+.alfresco-documentlibrary-AlfBreadcrumb:first-child a {
+   padding-left: 10px;
 }
+
+.alfresco-documentlibrary-AlfBreadcrumb a:focus {
+   outline: none;
+}
+
+.alfresco-documentlibrary-AlfBreadcrumb a:hover { background: @breadcrumb-hover-color; }
+.alfresco-documentlibrary-AlfBreadcrumb a:hover:after { border-left-color: @breadcrumb-hover-color !important; }

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumbTrail.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumbTrail.css
@@ -1,20 +1,20 @@
 .alfresco-documentlibrary-AlfBreadcrumbTrail {
    margin-bottom: @standard-line-height;
    margin-top: @standard-line-height;
-   margin-left: @standard-column-width;
    font-family: @bold-font;
-   color: @general-font-color;
+   color: @breadcrumb-font-color;
    font-size: @normal-font-size;
+   border: 1px solid @standard-border-color;
 }
 
 .alfresco-documentlibrary-AlfBreadcrumbTrail.hidden {
    display: none;
 }
 
-.alfresco-share .alfresco-documentlibrary-AlfBreadcrumbTrail .alf-folder-separator {
-   background: url("./images/folder-separator.png") no-repeat scroll 0 center transparent;
-   margin-left: 10px;
-   padding: 0 10px;
-   height: 20px;
-   width: 20px;
+.alfresco-documentlibrary-AlfBreadcrumbTrail ul { 
+   list-style: none; 
+   overflow: hidden; 
+   padding-left: 0;
+   margin-top: 0;
+   margin-bottom: 0;
 }

--- a/aikau/src/main/resources/alfresco/documentlibrary/templates/AlfBreadcrumb.html
+++ b/aikau/src/main/resources/alfresco/documentlibrary/templates/AlfBreadcrumb.html
@@ -1,4 +1,4 @@
-<span class="alfresco-documentlibrary-AlfBreadcrumb">
-   <span class="breadcrumb" data-dojo-attach-point="breadcrumbNode" data-dojo-attach-event="ondijitclick:onClick" tabIndex="0"></span>
-   <span class="droppable hidden" data-dojo-attach-point="droppableNode"></span>
-</span>
+<li class="alfresco-documentlibrary-AlfBreadcrumb">
+   <a class="breadcrumb" data-dojo-attach-point="breadcrumbNode" data-dojo-attach-event="ondijitclick:onClick" tabIndex="0"></a>
+   <!--<span class="droppable hidden" data-dojo-attach-point="droppableNode"></span> -->
+</li>

--- a/aikau/src/main/resources/alfresco/documentlibrary/templates/AlfBreadcrumbTrail.html
+++ b/aikau/src/main/resources/alfresco/documentlibrary/templates/AlfBreadcrumbTrail.html
@@ -1,1 +1,3 @@
-<div class="alfresco-documentlibrary-AlfBreadcrumbTrail" data-dojo-attach-point="containerNode" tabIndex="-1"></div>
+<div class="alfresco-documentlibrary-AlfBreadcrumbTrail" tabIndex="-1">
+   <ul data-dojo-attach-point="containerNode"></ul>
+</div>

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -24,9 +24,8 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/lists/views/AlfListView",
-        "service/constants/Default"], 
-        function(declare, AlfDocumentListView, AlfConstants) {
+        "alfresco/lists/views/AlfListView"], 
+        function(declare, AlfDocumentListView) {
    
    return declare([AlfDocumentListView], {
       
@@ -228,7 +227,7 @@ define(["dojo/_base/declare",
                                  useCurrentItemAsPayload: false,
                                  publishPayload: {
                                     url: "user/{node.properties.cm:creator.userName}/profile",
-                                    type: "SHARE_PAGE_RELATIVE",
+                                    type: "PAGE_RELATIVE",
                                     target: "CURRENT"
                                  }
                               }
@@ -267,7 +266,7 @@ define(["dojo/_base/declare",
                                  useCurrentItemAsPayload: false,
                                  publishPayload: {
                                     url: "user/{node.properties.cm:creator.userName}/profile",
-                                    type: "SHARE_PAGE_RELATIVE",
+                                    type: "PAGE_RELATIVE",
                                     target: "CURRENT"
                                  }
                               }

--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -819,7 +819,7 @@ define(["dojo/_base/declare",
                   var url = this.generateSearchPageLink(terms);
                   this.alfPublish("ALF_NAVIGATE_TO_PAGE", { 
                      url: url,
-                     type: "SHARE_PAGE_RELATIVE",
+                     type: "PAGE_RELATIVE",
                      target: "CURRENT"
                   });
                }

--- a/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
@@ -30,7 +30,7 @@
  * in mind that if using both attributes then the gap between 2 widgets will be the <b>combination</b> of both values).</p>
  * <p><b>PLEASE NOTE: Resize operations are not currently handled - this will be addressed in the future</b></p>
  * <p><pre>{
- *    "name": "alfresco/layout/VerticalWidgets",
+ *    "name": "alfresco/layout/HorizontalWidgets",
  *    "config": {
  *       "widgetMarginLeft": 10,
  *       "widgetMarginRight": 10

--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -95,22 +95,22 @@ define(["dojo/_base/declare",
 
       // TODO: It might be nice to retrieve this from the NavigationService itself??
       /**
-       * Indicates how the target URL should be handled. This defaults to "SHARE_PAGE_RELATIVE" which means that the URL
+       * Indicates how the target URL should be handled. This defaults to "PAGE_RELATIVE" which means that the URL
        * will be appended to the 'AlfConstants.URL_PAGECONTEXT' Global JavaScript constant. This can be overridden
        * on instantiation to indicate that another URL type, such as "FULL_PATH" should be used.
        *
        * @instance
        * @type {string}
-       * @default "SHARE_PAGE_RELATIVE"
+       * @default "PAGE_RELATIVE"
        */
-      targetUrlType: "SHARE_PAGE_RELATIVE",
+      targetUrlType: "PAGE_RELATIVE",
 
       /**
        * Indicates whether or not the URL should be opened in the current window/tab or in a new window.
        *
        * @instance
        * @type {string}
-       * @default "SHARE_PAGE_RELATIVE"
+       * @default "PAGE_RELATIVE"
        */
       targetUrlLocation: "CURRENT",
 

--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -39,8 +39,9 @@ define(["dojo/_base/declare",
        * @return {object} The generated payload
        */
       generateSearchLinkPayload: function alfresco_renderers__SearchResultLinkMixin__generateSearchLinkPayload() {
+         // jshint maxcomplexity:false
          var payload = {
-            type: "SHARE_PAGE_RELATIVE",
+            type: "PAGE_RELATIVE",
             target: "CURRENT",
             url: null
          };
@@ -53,95 +54,67 @@ define(["dojo/_base/declare",
                
                var path = lang.getObject("path", false, this.currentItem),
                name = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/documentlibrary?path=" + path + "/" + name;
                }
-               else if (path != null)
+               else if (path)
                {
-                  path = '/' + path.split('/').slice(2).join('/');
+                  path = "/" + path.split("/").slice(2).join("/");
                   payload.url = "repository?path=" + path + "/" + name;
                }
                break;
 
             case "wikipage":
-
                var title = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/wiki-page?title=" + title;
                }
                break;
 
             case "blogpost":
-
                var postid = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/blog-postview?postId=" + postid;
                }
                break;
 
             case "forumpost":
-
                var topicid = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/discussions-topicview?topicId=" + topicid;
                }
                break;
 
             case "link":
-
                var linkid = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/links-view?linkId=" + linkid;
                }
                break;
 
             case "datalist":
-
                var listid = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/data-lists?list=" + listid;
                }
                break;
 
             case "calendarevent":
-
-               //var eventdate = lang.getObject("name", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
-                  //payload.url = "site/" + site + "/calendar?date=" + eventdate; //2014-06-04
-                  payload.url = "site/" + site + "/calendar";
-               }
-               break;
-
-            case "datalist":
-
-               var listid = lang.getObject("name", false, this.currentItem);
-               if (site != null)
-               {
-                  payload.url = "site/" + site + "/data-lists?list=" + listid;
-               }
-               break;
-
-            case "calendarevent":
-
-               //var eventdate = lang.getObject("name", false, this.currentItem);
-               if (site != null)
-               {
-                  //payload.url = "site/" + site + "/calendar?date=" + eventdate; //2014-06-04
                   payload.url = "site/" + site + "/calendar";
                }
                break;
 
             default:
-
                var nodeRef = lang.getObject("nodeRef", false, this.currentItem);
-               if (site != null)
+               if (site)
                {
                   payload.url = "site/" + site + "/document-details?nodeRef=" + nodeRef;
                }

--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -201,7 +201,7 @@ define(["dojo/_base/declare",
             publishPayloadModifiers: ["processCurrentItemTokens"],
             publishPayload: {
                url: "user/{modifiedByUser}/profile",
-               type: "SHARE_PAGE_RELATIVE"
+               type: "PAGE_RELATIVE"
             }
          }, this.dateNode);
 
@@ -242,7 +242,7 @@ define(["dojo/_base/declare",
                publishPayloadModifiers: ["processCurrentItemTokens"],
                publishPayload: {
                   url: "site/{site.shortName}/dashboard",
-                  type: "SHARE_PAGE_RELATIVE"
+                  type: "PAGE_RELATIVE"
                }
             }, this.siteNode);
          }
@@ -271,7 +271,7 @@ define(["dojo/_base/declare",
                publishPayloadModifiers: ["processCurrentItemTokens"],
                publishPayload: {
                   url: repo ? "repository?path={pathLink}" : "site/{site.shortName}/documentlibrary?path={pathLink}",
-                  type: "SHARE_PAGE_RELATIVE"
+                  type: "PAGE_RELATIVE"
                }
             }, this.pathNode);
          }

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -66,8 +66,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe(this.navigateToPageTopic, lang.hitch(this, this.navigateToPage));
          this.alfSubscribe(this.reloadPageTopic, lang.hitch(this, this.reloadPage));
          this.alfSubscribe(this.postToPageTopic, lang.hitch(this, this.postToPage));
-
-         if (this.subscriptions != null)
+         if (this.subscriptions)
          {
             array.forEach(this.subscriptions, lang.hitch(this, "setupNavigationSubscriptions"));
          }
@@ -80,9 +79,7 @@ define(["dojo/_base/declare",
        * @param {object} subscription The subscription to configure
        */
       setupNavigationSubscriptions: function alfresco_services_NavigationService__setupNavigationSubscriptions(subscription) {
-         if (subscription != null &&
-             subscription.topic != null &&
-             subscription.url != null)
+         if (subscription && subscription.topic && subscription.url)
          {
             this.alfSubscribe(subscription.topic, lang.hitch(this, "navigateToPage", subscription));
          }
@@ -102,7 +99,8 @@ define(["dojo/_base/declare",
        * @todo explain what data can contain...
        */
       navigateToPage: function alfresco_services_NavigationService__navigateToPage(data) {
-         if (data.type != this.hashPath && (typeof data.url == "undefined" || data.url == null || data.url === ""))
+         // jshint maxcomplexity:false
+         if (data.type !== this.hashPath && !data.url)
          {
             this.alfLog("error", "A page navigation request was made without a target URL defined as a 'url' attribute", data);
          }
@@ -110,13 +108,9 @@ define(["dojo/_base/declare",
          {
             this.alfLog("log", "Page navigation request received:", data);
             var url;
-            if (typeof data.type == "undefined" ||
-                data.type == null ||
-                data.type === "" ||
-                data.type == this.sharePageRelativePath)
+            if (!data.type || data.type === this.sharePageRelativePath || data.type === this.pageRelativePath)
             {
                var siteStem = "site/" + data.site + "/";
-
                url = data.url;
 
                // Cater for site urls that are sent from a non-site context.
@@ -126,28 +120,25 @@ define(["dojo/_base/declare",
                }
                url = AlfConstants.URL_PAGECONTEXT + url;
             }
-            else if (data.type == this.contextRelativePath)
+            else if (data.type === this.contextRelativePath)
             {
                url = AlfConstants.URL_CONTEXT + data.url;
             }
-            else if (data.type == this.fullPath)
+            else if (data.type === this.fullPath)
             {
                url = data.url;
             }
 
             // Determine the location of the URL...
-            if (data.type == this.hashPath)
+            if (data.type === this.hashPath)
             {
                hash(data.url);
             }
-            else if (typeof data.target == "undefined" ||
-                data.target == null ||
-                data.target === "" ||
-                data.target == this.currentTarget)
+            else if (!data.target ||data.target === this.currentTarget)
             {
                window.location = url;
             }
-            else if (data.target == this.newTarget)
+            else if (data.target === this.newTarget)
             {
                window.open(url);
             }

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -479,7 +479,7 @@ define(["dojo/_base/declare",
                      publishTopic: "ALF_NAVIGATE_TO_PAGE",
                      publishPayload: {
                         url: "user/" + originalRequestConfig.user + "/dashboard",
-                        type: "SHARE_PAGE_RELATIVE",
+                        type: "PAGE_RELATIVE",
                         target: "CURRENT"
                      }
                   }
@@ -723,7 +723,7 @@ define(["dojo/_base/declare",
       leaveSiteSuccess: function alfresco_services_SiteService__leaveSiteSuccess(response, requestConfig) {
          this.alfPublish("ALF_NAVIGATE_TO_PAGE", {
             url: "user/" + requestConfig.user + "/dashboard",
-            type: "SHARE_PAGE_RELATIVE",
+            type: "PAGE_RELATIVE",
             target: "CURRENT"
          });
       },

--- a/aikau/src/main/resources/alfresco/services/_NavigationServiceTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_NavigationServiceTopicMixin.js
@@ -67,8 +67,19 @@ define(["dojo/_base/declare"],
        * @instance
        * @type {string}
        * @default "SHARE_PAGE_RELATIVE"
+       * @deprecated Since 1.0.17 - Use [pageRelativePath]{@link module:alfresco/services/_NavigationServiceTopicMixin#pageRelativePath} instead.
        */
       sharePageRelativePath: "SHARE_PAGE_RELATIVE",
+
+      /**
+       * This value is used to indicate that the supplied URL is relative to the application Page context (e.g. /<application-context>/page)
+       *
+       * @instance
+       * @type {string}
+       * @default "PAGE_RELATIVE"
+       * @deprecated Since 1.0.17 - Use 
+       */
+      pageRelativePath: "PAGE_RELATIVE",
 
       /**
        * This value is used to indicate that the supplied URL is relative to the application context (e.g. /share)

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -1192,7 +1192,17 @@ function getDocLib(siteId, containerId, rootNode, rootLabel, rawData) {
                         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
                         config: {
                            hide: docLibPrefrences.hideBreadcrumbTrail,
-                           rootLabel: rootLabel
+                           rootLabel: rootLabel,
+                           lastBreadcrumbIsCurrentNode: true,
+                           useHash: true,
+                           lastBreadcrumbPublishTopic: "ALF_NAVIGATE_TO_PAGE",
+                           lastBreadcrumbPublishPayload: {
+                              url: "folder-details?nodeRef={currentNode.parent.nodeRef}",
+                              type: "PAGE_RELATIVE",
+                              target: "CURRENT"
+                           },
+                           lastBreadcrumbPublishPayloadType: "PROCESS",
+                           lastBreadcrumbPublishPayloadModifiers: ["processInstanceTokens"]
                         }
                      },
                      getDocLibList(siteId, containerId, rootNode, rawData)

--- a/aikau/src/test/resources/alfresco/core/PublishPayloadMixinTest.js
+++ b/aikau/src/test/resources/alfresco/core/PublishPayloadMixinTest.js
@@ -234,7 +234,7 @@ define(["intern!object",
       },
 
       "Check that PROPERTYLINK type payload was correct": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "SHARE_PAGE_RELATIVE"))
+         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "PAGE_RELATIVE"))
             .then(function(elements) {
                assert.lengthOf(elements, 1, "PROPERTYLINK type payload failure");
             });
@@ -260,7 +260,7 @@ define(["intern!object",
       },
 
       "Check that DATELINK type payload was correct": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "SHARE_PAGE_RELATIVE"))
+         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "PAGE_RELATIVE"))
             .then(function(elements) {
                assert.lengthOf(elements, 1, "DATELINK type payload failure");
             });

--- a/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
@@ -40,45 +40,69 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-       
-      "Counting breadcrumbs...": function () {
+      "Counting fixed breadcrumbs...": function () {
          // Test 1...
          // Check the path is initially displayed...
-         return browser.findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+         return browser.findAllByCssSelector("#FIXED_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
             .then(function(elements) {
                assert.lengthOf(elements, 4, "An unexpected number of breadcrumbs were found");
             });
       },
 
-      "Checking root breadcrumb text...": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) > .breadcrumb")
+      "Counting path breadcrumbs...": function () {
+         // Test 1...
+         // Check the path is initially displayed...
+         return browser.findAllByCssSelector("#PATH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "An unexpected number of breadcrumbs were found");
+            });
+      },
+
+      "Click a path breadcrumb": function() {
+         return browser.findByCssSelector("#PATH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) > .breadcrumb")
+            .click()
+         .end()
+         .findAllByCssSelector("#PATH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Breadcrumb path not updated");
+            });
+      },
+
+      "Counting hash breadcrumbs...": function () {
+         // Test 1...
+         // Check the path is initially displayed...
+         return browser.findAllByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "An unexpected number of breadcrumbs were found");
+            });
+      },
+
+      "Checking root hash breadcrumb text...": function() {
+         return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(1) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
                assert(text === "HOME", "Incorrect root text found: " + text);
             });
       },
 
-      "Checking 2nd breadcrumb text": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(4) > .breadcrumb")
+      "Checking 2nd hash breadcrumb text": function() {
+         return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
                assert(text === "some", "Incorrect breadcrumb text found: " + text);
             });
       },
 
-      "Checking 3rd breadcrumb text": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(6) > .breadcrumb")
+      "Checking 3rd hash breadcrumb text": function() {
+         return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(3) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
                assert(text === "imaginary", "Incorrect breadcrumb text found: " + text);
             });
       },
 
-      "Checking 4th breadcrumb text": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(8) > .breadcrumb")
+      "Checking 4th hash breadcrumb text": function() {
+         return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(4) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
               assert(text === "path", "Incorrect breadcrumb text found: " + text);
@@ -89,7 +113,7 @@ define(["intern!object",
          return browser.findByCssSelector("#HIDE_PATH_label")
             .click()
             .end()
-         .findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumbTrail")
+         .findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail")
             .isDisplayed()
             .then(function(result) {
                assert(result === false, "The breadcrumb trail wasn't hidden");
@@ -100,7 +124,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SHOW_PATH_label")
             .click()
             .end()
-         .findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumbTrail")
+         .findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail")
             .isDisplayed()
             .then(function(result) {
                assert(result === true, "The breadcrumb trail wasn't displayed");
@@ -111,14 +135,14 @@ define(["intern!object",
          return browser.findByCssSelector("#FILTER_SELECTION_label")
             .click()
             .end()
-         .findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+         .findAllByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
             .then(function(elements) {
                assert(elements.length === 0, "Setting filter didn't remove breadcrumbs");
             });
       },
 
       "Check that filter is displayed correctly": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumbTrail > div")
+         return browser.findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail > ul > div")
             .getVisibleText()
             .then(function(text) {
                assert(text === "Simulated Filter", "Filter wasn't displayed correctly");
@@ -129,30 +153,30 @@ define(["intern!object",
          return browser.findByCssSelector("#SET_HASH_label")
             .click()
             .end()
-         .findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+         .findAllByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
             .then(function(elements) {
                assert(elements.length === 3, "An unexpected number of breadcrumbs were found: " + elements.length);
             });
       },
 
-      "Check breadcrumb root label": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(3) > .breadcrumb")
+      "Check hash breadcrumb root label": function() {
+         return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
                assert(text === "different", "Incorrect root text found: " + text);
             });
       },
 
-      "Check breadcrumb label": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(5) > .breadcrumb")
+      "Check hash breadcrumb label": function() {
+         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(3) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
                assert(text === "path", "Incorrect breadcrumb text found: " + text);
             });
       },
 
-      "Check breadcrumb navigation request publishes": function() {
-         return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(5) > .breadcrumb")
+      "Check hash breadcrumb navigation request publishes": function() {
+         return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) > .breadcrumb")
             .click()
             .end()
 
@@ -162,18 +186,18 @@ define(["intern!object",
             });
       },
 
-      "Check breadcrumb navigation payload": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "url", "path=/different/path"))
+      "Check hash breadcrumb navigation payload": function() {
+         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "url", "path=/different"))
             .then(function(elements) {
                assert(elements.length === 1, "Navigation payload not correct");
             });
       },
 
-      "Check leaf breadcrumb navigation payload": function() {
+      "Check hash final breadcrumb navigation payload": function() {
          return browser.findByCssSelector("#CHANGE_NODEREF_label")
             .click()
             .end()
-         .findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(5) > .breadcrumb")
+         .findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(3) > .breadcrumb")
             .click()
             .end()
          .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "url", "folder-details?nodeRef=some://fake/nodeRef"))

--- a/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
@@ -137,15 +137,15 @@ define(["intern!object",
             .end()
          .findAllByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
             .then(function(elements) {
-               assert(elements.length === 0, "Setting filter didn't remove breadcrumbs");
+               assert(elements.length === 1, "Setting filter didn't remove breadcrumbs");
             });
       },
 
       "Check that filter is displayed correctly": function() {
-         return browser.findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail > ul > div")
+         return browser.findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail > ul > li > a")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "Simulated Filter", "Filter wasn't displayed correctly");
+               assert.equal(text, "Simulated Filter", "Filter wasn't displayed correctly");
             });
       },
 
@@ -163,7 +163,7 @@ define(["intern!object",
          return browser.findByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "different", "Incorrect root text found: " + text);
+               assert.equal(text, "different", "Incorrect root text found");
             });
       },
 
@@ -171,7 +171,7 @@ define(["intern!object",
          return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:nth-child(3) > .breadcrumb")
             .getVisibleText()
             .then(function(text) {
-               assert(text === "path", "Incorrect breadcrumb text found: " + text);
+               assert.equal(text, "path", "Incorrect breadcrumb text found");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/DateLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateLinkTest.js
@@ -72,10 +72,10 @@ define(["intern!object",
       },
 
       "Check the date click published the payload as expected (1)": function() {
-         return browser.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "SHARE_PAGE_RELATIVE"))
+         return browser.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "PAGE_RELATIVE"))
             .then(
                function(){},
-               function(){assert(false, "The datelink did not publish the payload with 'type' as 'SHARE_PAGE_RELATIVE'");}
+               function(){assert(false, "The datelink did not publish the payload with 'type' as 'PAGE_RELATIVE'");}
             );
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/SearchResultPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SearchResultPropertyLinkTest.js
@@ -48,19 +48,19 @@ define(["intern!object",
             });
       },
 
-      "Check that 'SHARE_PAGE_RELATIVE' is set as the type": function() {
+      "Check that 'PAGE_RELATIVE' is set as the type": function() {
          return browser.pressKeys(keys.TAB)
          .pressKeys(keys.RETURN)
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "SHARE_PAGE_RELATIVE"))
+         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "PAGE_RELATIVE"))
             .then(function(elements) {
-               assert(elements.length === 1, "'SHARE_PAGE_RELATIVE' was not set as the navigation type");
+               assert(elements.length === 1, "'PAGE_RELATIVE' was not set as the navigation type");
             });
       },
 
       "Check that 'CURRENT' is set as the target": function() {
          return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "target", "CURRENT"))
             .then(function(elements) {
-               assert(elements.length === 1, "'SHARE_PAGE_RELATIVE' was not set as the navigation target");
+               assert(elements.length === 1, "'PAGE_RELATIVE' was not set as the navigation target");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/TestIndex.get.js
@@ -92,7 +92,7 @@ model.jsonModel = {
                                                          publishPayloadType: "PROCESS",
                                                          publishPayloadModifiers: ["processCurrentItemTokens"],
                                                          publishPayload: {
-                                                            type: "SHARE_PAGE_RELATIVE",
+                                                            type: "PAGE_RELATIVE",
                                                             url: "tp/ws{url}"
                                                          }
                                                       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/PublishPayloadMixin.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/PublishPayloadMixin.get.js
@@ -156,7 +156,7 @@ model.jsonModel = {
                      publishPayloadModifiers: ["processCurrentItemTokens"],
                      publishPayload: {
                         url: "site/{site.shortName}/dashboard",
-                        type: "SHARE_PAGE_RELATIVE"
+                        type: "PAGE_RELATIVE"
                      }
                   }
                },
@@ -177,7 +177,7 @@ model.jsonModel = {
                      publishPayloadModifiers: ["processCurrentItemTokens"],
                      publishPayload: {
                         url: "user/{modifiedByUser}/profile",
-                        type: "SHARE_PAGE_RELATIVE"
+                        type: "PAGE_RELATIVE"
                      }
                   }
                }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>BreadcrumbTrail Test</shortname>
-  <description>This WebScript defines the BreadcrumbTrail page test</description>
+  <shortname>AlfBreadcrumbTrail</shortname>
+  <description>Demonstrates the different ways in which a breadcrumb trail can be used.</description>
   <family>aikau-unit-tests</family>
   <url>/BreadcrumbTrail</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
@@ -15,6 +15,55 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         id: "FIXED_BREADCRUMBS",
+         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+         config: {
+            breadcrumbs: [
+               {
+                  label: "Small"
+               },
+               {
+                  label: "Crumb"
+               },
+               {
+                  label: "Of"
+               },
+               {
+                  label: "Comfort"
+               }
+            ]
+         }
+      },
+      {
+         id: "PATH_BREADCRUMBS",
+         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+         config: {
+            showRootLabel: false,
+            pathChangeTopic: "CHANGE_PATH",
+            currentPath: "/the/road/less/travelled"
+         }
+      },
+      {
+         id: "HASH_BREADCRUMBS",
+         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+         config: {
+            lastBreadcrumbIsCurrentNode: true,
+            useHash: true,
+            rootLabel: "HOME",
+            lastBreadcrumbPublishTopic: "ALF_NAVIGATE_TO_PAGE",
+            lastBreadcrumbPublishPayload: {
+               url: "folder-details?nodeRef={currentNode.parent.nodeRef}",
+               type: "PAGE_RELATIVE",
+               target: "CURRENT"
+            },
+            lastBreadcrumbPublishPayloadType: "PROCESS",
+            lastBreadcrumbPublishPayloadModifiers: ["processInstanceTokens"],
+            currentPath: "/some/imaginary/path",
+            currentNode: {
+            }
+         }
+      },
+      {
          id: "CHANGE_NODEREF",
          name: "alfresco/buttons/AlfButton",
          config: {
@@ -74,19 +123,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
-         config: {
-            rootLabel: "HOME",
-            currentPath: "/some/imaginary/path",
-            _currentNode: {
-            }
-         }
-      },
-      {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/DateLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/DateLink.get.js
@@ -27,11 +27,10 @@ model.jsonModel = {
             publishPayloadType: "CONFIGURED",
             publishPayload: {
                url: "/1/2/3/4/5",
-               type: "SHARE_PAGE_RELATIVE"
+               type: "PAGE_RELATIVE"
             },
             publishGlobal: true,
-            publishToParent: true,
-            useCurrentItemAsPayload: false
+            publishToParent: true
          }
       },
       {
@@ -55,11 +54,10 @@ model.jsonModel = {
             publishPayloadType: "CONFIGURED",
             publishPayload: {
                url: "/5/4/3/2/1",
-               type: "SHARE_PAGE_RELATIVE"
+               type: "PAGE_RELATIVE"
             },
             publishGlobal: null,
-            publishToParent: null,
-            useCurrentItemAsPayload: true
+            publishToParent: null
          }
       },
       {
@@ -83,7 +81,7 @@ model.jsonModel = {
             publishPayloadType: "CONFIGURED",
             publishPayload: {
                url: "/5/4/3/2/1",
-               type: "SHARE_PAGE_RELATIVE"
+               type: "PAGE_RELATIVE"
             }
          }
       },
@@ -108,7 +106,7 @@ model.jsonModel = {
             publishPayloadType: "CONFIGURED",
             publishPayload: {
                url: "/5/4/3/2/1",
-               type: "SHARE_PAGE_RELATIVE"
+               type: "PAGE_RELATIVE"
             }
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-262 to make the breadcrumb trail more abstract and useful for purposes (so that it isn't coupled to the document library) as well as making some styling updates.