### PR TITLE
AKU-283: Loading... message does not disappear

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -911,7 +911,7 @@ define([
                   this._gotoNextResult();
                }
             } else {
-               this._startSearch(this.searchBox.value);
+               this._debounceNewSearch(this.searchBox.value);
             }
          },
 
@@ -928,7 +928,7 @@ define([
                   this._gotoNextResult();
                }
             } else {
-               this._startSearch(this.searchBox.value);
+               this._debounceNewSearch(this.searchBox.value);
             }
          },
 
@@ -1359,6 +1359,11 @@ define([
 
             // Make sure we have some that need updating
             if (!this._itemsToUpdateFromStore.length) {
+
+               // Add loaded CSS-state to control
+               domClass.add(this.domNode, this.rootClass + "--loaded");
+
+               // Nothing else needed!
                return;
             }
 
@@ -1386,9 +1391,18 @@ define([
                      contentNode.setAttribute("title", labelObj.full);
                   }, this);
 
+                  // Add loaded CSS-state to control
+                  domClass.add(this.domNode, this.rootClass + "--loaded");
+
                }),
                failureHandler = lang.hitch(this, function(err) {
+
+                  // Log the error
                   this.alfLog("error", "Error updating labels from store", err);
+
+                  // Add loaded CSS-state to control
+                  domClass.add(this.domNode, this.rootClass + "--loaded");
+
                });
 
             // Make the query

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
@@ -299,9 +299,9 @@ define(["dojo/_base/declare",
          // search term request parameter...
          payload.query = query[this.queryAttribute || "name"];
 
-         this._optionsHandle = [];
-         this._optionsHandle.push(this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, "onQueryOptions", response, query, resultsProperty), true));
-         this._optionsHandle.push(this.alfSubscribe(responseTopic, lang.hitch(this, "onQueryOptions", response, query, resultsProperty), true));
+         var optionsHandle = [];
+         optionsHandle.push(this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, "onQueryOptions", response, query, resultsProperty, optionsHandle), true));
+         optionsHandle.push(this.alfSubscribe(responseTopic, lang.hitch(this, "onQueryOptions", response, query, resultsProperty, optionsHandle), true));
          this.alfPublish(this.publishTopic, payload, true);
          return response;
       },
@@ -345,8 +345,8 @@ define(["dojo/_base/declare",
        * @param {string} resultsProperty A dot-notation address in the payload that should contain the list of options.
        * @param {object} payload The options to use
        */
-      onQueryOptions: function alfresco_forms_controls_utilities_ServiceStore__onQueryOptions(dfd, query, resultsProperty, payload) {
-         this.alfUnsubscribeSaveHandles([this._optionsHandle]);
+      onQueryOptions: function alfresco_forms_controls_utilities_ServiceStore__onQueryOptions(dfd, query, resultsProperty, optionsHandle, payload) {
+         this.alfUnsubscribeSaveHandles([optionsHandle]);
          var results = lang.getObject(resultsProperty, false, payload);
          if (results)
          {

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -42,6 +42,19 @@ define([
             browser.end();
          },
 
+         "Controls are fully loaded": function() {
+            return browser.findAllByCssSelector("#MULTISELECT_1_CONTROL.alfresco-forms-controls-MultiSelect--loaded")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "First MultiSelect control not fully loaded");
+               })
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_2_CONTROL.alfresco-forms-controls-MultiSelect--loaded")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Second MultiSelect control not fully loaded");
+               });
+         },
+
          "Preset values are rendered by control": function() {
             return browser.findAllByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice")
                .then(function(elements) {
@@ -60,6 +73,17 @@ define([
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "tag11", "Did not display second tag label correctly");
+               });
+         },
+
+         "Clicking on control no longer loses responses to a second query": function() {
+            return browser.findByCssSelector("#MULTISELECT_2_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 14, "Did not bring up results");
                });
          },
 

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/MultiSelectMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/MultiSelectMockService.js
@@ -96,6 +96,14 @@ define(["alfresco/core/Core",
          }],
 
          /**
+          * A self-incrementing response delay that permits easy replication of a race-condition bug
+          *
+          * @type {number}
+          * @default  0
+          */
+         _responseDelayMs: 250,
+
+         /**
           * Constructor
           *
           * @instance
@@ -113,9 +121,11 @@ define(["alfresco/core/Core",
           * @param    {object} payload The publish payload
           */
          _getCelestialCategories: function alfresco_testing_mockservices_MultiSelectMockService___getCelestialCategories(payload) {
-            this.alfPublish(payload.alfResponseTopic || payload.responseTopic, {
-               response: this._celestialCategories
-            });
+            setTimeout(lang.hitch(this, function() {
+               this.alfPublish(payload.alfResponseTopic || payload.responseTopic, {
+                  response: this._celestialCategories
+               });
+            }), (this._responseDelayMs += 50));
          }
       });
    });


### PR DESCRIPTION
This addresses issue [AKU-283](https://issues.alfresco.com/jira/browse/AKU-283), which had an occasional problem with the Loading... message not disappearing when selecting a control. This was caused by a double search request triggering a bug inside the `ServiceStore` which meant that the later response handler was removed by the first response to come back. It has been fixed by preventing the double search and also fixing the bug in `ServiceStore`.