### PR TITLE
Add some error handling to Service loading method

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -20,7 +20,7 @@
 /**
  * This is used as the default root object when instantiating a page. There should be no need
  * to ever instantiate this widget directly.
- * 
+ *
  * @module alfresco/core/Page
  * @extends module:alfresco/core/ProcessWidgets
  * @author Dave Draper
@@ -38,11 +38,11 @@ define(["alfresco/core/ProcessWidgets",
         "alfresco/core/PubQueue",
         "jquery", // NOTE: Need to include JQuery at root page to prevent XHR require request for first module that uses it
         "alfresco/core/shims"],
-        function(ProcessWidgets, AlfConstants, string, declare, domConstruct, array, 
+        function(ProcessWidgets, AlfConstants, string, declare, domConstruct, array,
                  lang, domClass, win, PubQueue, jquery, shims) {
-   
+
    return declare([ProcessWidgets], {
-      
+
       /**
        * This is the base class for the page
        *
@@ -55,7 +55,7 @@ define(["alfresco/core/ProcessWidgets",
       /**
        * Overrides the superclass implementation to call [processServices]{@link module:alfresco/core/Core#processServices}
        * and [processWidgets]{@link module:alfresco/core/Core#processWidgets} as applicable.
-       * 
+       *
        * @instance
        */
       postCreate: function alfresco_core_Page__postCreate() {
@@ -72,9 +72,9 @@ define(["alfresco/core/ProcessWidgets",
                this.extensionDownloadUrl = AlfConstants.URL_PAGECONTEXT + "generator/extension?webscriptId=" + this.webScriptId;
                this.extensionDownloadLabel = "(Click to generate extension JAR)";
                var pageInfoTemplate = "<div class=\"alfresco-debug-PageInfo\">" +
-                  "<span class=\"label\">${webScriptLabel}</span>" + 
-                  "<span class=\"value\">${webScriptId}</span>" + 
-                  "<a href=\"${extensionDownloadUrl}\">${extensionDownloadLabel}</a>" + 
+                  "<span class=\"label\">${webScriptLabel}</span>" +
+                  "<span class=\"value\">${webScriptId}</span>" +
+                  "<a href=\"${extensionDownloadUrl}\">${extensionDownloadLabel}</a>" +
                "</div>";
                var pageInfo = string.substitute(pageInfoTemplate, this);
                var pageInfoDom = domConstruct.toDom(pageInfo);
@@ -99,7 +99,7 @@ define(["alfresco/core/ProcessWidgets",
             PubQueue.getSingleton().release();
          }
       },
-      
+
       /**
        * @instance
        */
@@ -117,12 +117,12 @@ define(["alfresco/core/ProcessWidgets",
 
       /**
        * Handles the dependency management and instantiation of services required.
-       * 
+       *
        * @instance
        * @param {Array} services An array of the services to be instantiated.
        * @param {function} callback A function to call once the service has been instantiated
        * @param {object} callbackScope The scope with which to call the callback
-       * @param {number} index The index of the service to create 
+       * @param {number} index The index of the service to create
        */
       processServices: function alfresco_core_Page__processServices(services, callback, callbackScope, index) {
          if (services)
@@ -134,7 +134,7 @@ define(["alfresco/core/ProcessWidgets",
 
             // Reset the processing complete flag (this is to support multiple invocations of widget processing)...
             this.serviceProcessingComplete = false;
-            
+
             // TODO: Using these attributes will not support multiple calls to processWidgets from within the same object instance
             this._processedServiceCountdown = services.length;
             this._processedServices = [];
@@ -149,21 +149,21 @@ define(["alfresco/core/ProcessWidgets",
       /**
        * This method will instantiate a new service having requested that its JavaScript resource and
        * dependent resources be downloaded. In principle all of the required resources should be available
-       * if the service is being processed in the context of the Surf framework and dependency analysis of 
-       * the page has been completed. However, if this is being performed as an asynchronous event it may 
+       * if the service is being processed in the context of the Surf framework and dependency analysis of
+       * the page has been completed. However, if this is being performed as an asynchronous event it may
        * be necessary for Dojo to request additional modules. This is why the callback function is required
        * to ensure that successfully instantiated modules can be kept track of.
-       * 
+       *
        * @instance
        * @param {object} config The configuration for the service
        * @param {element} domNode The DOM node to attach the service to
        * @param {function} callback A function to call once the service has been instantiated
        * @param {object} callbackScope The scope with which to call the callback
-       * @param {number} index The index of the service to create (this will effect it's location in the 
+       * @param {number} index The index of the service to create (this will effect it's location in the
        * [_processedServices]{@link module:alfresco/core/Core#_processedServices} array)
        */
       createService: function alfresco_core_Page__createService(config, callback, callbackScope, index) {
-         
+
          var dep = null,
              serviceConfig = {};
          if (typeof config === "string")
@@ -187,11 +187,23 @@ define(["alfresco/core/ProcessWidgets",
          var _this = this;
          var requires = [dep];
          require(requires, function(ServiceType) {
+            // Error handling. If the require call is successful, ServiceType will be a function.
+            if (typeof ServiceType !== "function") {
+
+               // Use the closure variables to infer the current service name
+               var serviceName = _this.services[_this._processedServices.length];
+               if (typeof serviceName === "object" && serviceName.name) {
+                  serviceName = serviceName.name;
+               }
+
+               // Throw the error. Most common reason for require call to fail is a typo in the service name.
+               throw "Unable to locate service: " + serviceName;
+            }
+
             var service = new ServiceType(serviceConfig);
             _this.servicesToDestroy.push(service);
 
-            if (callback)
-            {
+            if (callback) {
                // If there is a callback then call it with any provided scope (but default to the
                // "this" as the scope if one isn't provided).
                callback.call((callbackScope || _this), service, index);
@@ -201,28 +213,28 @@ define(["alfresco/core/ProcessWidgets",
 
       /**
        * Used to keep track of all the services created as a result of a call to the [processWidgets]{@link module:alfresco/core/Core#processWidgets} function
-       * 
+       *
        * @instance
        * @type {Array}
        * @default null
        */
       _processedServices: null,
-      
+
       /**
        * This is used to countdown the services that are still waiting to be created. It is initialised to the size
        * of the services array supplied to the [processServices]{@link module:alfresco/core/Core#processServices} function.
-       * 
-       * @instance 
+       *
+       * @instance
        * @type {number}
        * @default null
        */
       _processedServiceCountdown: null,
-      
+
       /**
-       * This function registers the creation of a service. It decrements the 
+       * This function registers the creation of a service. It decrements the
        * [_processedServiceCountdown]{@link module:alfresco/core/Core#_processedServiceCountdown} attribute
        * and calls the [allServicesProcessed]{@link module:alfresco/core/Core#allServicesProcessed} function when it reaches zero.
-       * 
+       *
        * @instance
        * @param {object} service The service that has just been processed.
        * @param {number} index The target index of the service
@@ -237,29 +249,29 @@ define(["alfresco/core/ProcessWidgets",
          {
             this._processedServices[index] = service;
          }
-         
+
          if (this._processedServiceCountdown === 0)
          {
             this.allServicesProcessed(this._processedServices);
             this.serviceProcessingComplete = true;
          }
       },
-      
+
       /**
        * This is set from false to true after the [allServicesProcessed]{@link module:alfresco/core/Core#allServicesProcessed}
-       * extension point function is called. It can be used to check whether or not service processing is complete. 
-       * This is to allow for checks that service processing has been completed BEFORE attaching a listener to the 
+       * extension point function is called. It can be used to check whether or not service processing is complete.
+       * This is to allow for checks that service processing has been completed BEFORE attaching a listener to the
        * [allServicesProcessed]{@link module:alfresco/core/Core#allServicesProcessed} function.
-       * 
+       *
        * @instance
        * @type {boolean}
        * @default false
        */
       serviceProcessingComplete: false,
-      
+
       /**
        * This is an extension point for handling the completion of calls to [processWidgets]{@link module:alfresco/core/Core#processWidgets}
-       * 
+       *
        * @instance
        * @param {Array} services An array of all the services that have been processed
        */
@@ -282,7 +294,7 @@ define(["alfresco/core/ProcessWidgets",
          this.alfLog("log", "All page widgets processed");
          // TODO: Need to be able to notify widgets that they can start publications in the knowledge that other widgets are available
          // to respond...
-         
+
          if (this.publishOnReady)
          {
             array.forEach(this.publishOnReady, lang.hitch(this, "onReadyPublish"));


### PR DESCRIPTION
This code throws a better error message if the service wasn't loaded properly. This can be considered part of the work to prevent silent failures.

Previous error was: "BOOM! number is not a function"
New error is: "BOOM! Unable to locate service: aikauTesting/mockservices/404"

I think there's more we could do to let the user know of require failures. I'll pop a JIRA feature request in the queue.

Note: No tests added, as I'm not sure what tests you can do for a page that throws a JS error on load.