### PR TITLE
AKU-294: Fixed header/footer

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -21,7 +21,39 @@
  * A layout control used to provide a scrollable central area with fixed-position header/footer widgets.
  *
  * @example <caption>Sample configuration:</caption>
- * {}
+ * {
+ *    name: "alfresco/layout/FixedHeaderFooter",
+ *    config: {
+ *       height: "300px",
+ *       widgetsForHeader: [
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          }
+ *       ],
+ *       widgets: [
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          },
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          },
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          },
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          },
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          }
+ *       ],
+ *       widgetsForFooter: [
+ *          {
+ *             name: "alfresco/logo/Logo"
+ *          }
+ *       ]
+ *    }
+ * }
  *
  * @module alfresco/layout/FixedHeaderFooter
  * @extends module:alfresco/core/ProcessWidgets

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A layout control used to provide a scrollable central area with fixed-position header/footer widgets.
+ *
+ * @example <caption>Sample configuration:</caption>
+ * {}
+ *
+ * @module alfresco/layout/FixedHeaderFooter
+ * @extends module:alfresco/core/ProcessWidgets
+ * @author Martin Doyle
+ */
+define(["alfresco/core/ProcessWidgets",
+      "alfresco/core/ResizeMixin",
+      "dojo/_base/array",
+      "dojo/_base/declare",
+      "dojo/_base/lang",
+      "dojo/aspect",
+      "dojo/dom-class",
+      "dojo/dom-construct",
+      "dojo/dom-style",
+      "dojo/topic",
+      "dojo/text!./templates/FixedHeaderFooter.html"
+   ],
+   function(ProcessWidgets, ResizeMixin, array, declare, lang, aspect, domClass, domConstruct, domStyle, topic, template) {
+
+      return declare([ProcessWidgets, ResizeMixin], {
+
+         /**
+          * The base class for the widget
+          *
+          * @instance
+          * @override
+          * @type {string}
+          * @default "alfresco-layout-FixedHeaderFooter"
+          */
+         baseClass: "alfresco-layout-FixedHeaderFooter",
+
+         /**
+          * An array of the CSS files to use with this widget.
+          *
+          * @instance
+          * @override
+          * @type {object[]}
+          * @default [{cssFile:"./css/FixedHeaderFooter.css"}]
+          */
+         cssRequirements: [{
+            cssFile: "./css/FixedHeaderFooter.css"
+         }],
+
+         /**
+          * The height of the widget (in CSS units)
+          *
+          * @type {string}
+          * @default "100%"
+          */
+         height: "100%",
+
+         /**
+          * The HTML template to use for the widget.
+          *
+          * @instance
+          * @override
+          * @type {String}
+          */
+         templateString: template,
+
+         /**
+          * How many ms to wait after the last publish before triggering a resize check
+          *
+          * @type {number}
+          */
+         _publishDebounceMs: 500,
+
+         /**
+          * The timeout pointer that's set/cleared during the publish debouncing
+          *
+          * @type {object}
+          */
+         _publishDebounceTimeout: null,
+
+         /**
+          * Run after widget has been created
+          *
+          * @instance
+          * @override
+          */
+         postCreate: function alfresco_layout_FixedHeaderFooter__postCreate() {
+
+            // We need to potentially resize sometimes ... use these triggers
+            this.alfSetupResizeSubscriptions(this._triggerResizeCheck, this);
+            aspect.after(topic, "publish", lang.hitch(this, function(originalReturnValue) {
+               this._triggerResizeCheck();
+               return originalReturnValue;
+            }));
+
+            // Set the height of the dom node
+            domStyle.set(this.domNode, {
+               height: this.height
+            });
+
+            // Add in the widgets
+            this._doProcessWidgets([{
+               widgets: this.widgetsForHeader,
+               node: this.header
+            }, {
+               widgets: this.widgets,
+               node: this.content
+            }, {
+               widgets: this.widgetsForFooter,
+               node: this.footer
+            }]);
+
+            // Do the resize
+            this._resize();
+         },
+
+         /**
+          * Call the processWidgets function for all provided widgets
+          *
+          * @instance
+          * @param    {object[]} widgetInfos The widget information as objects with 'widgets' and 'node' properties
+          */
+         _doProcessWidgets: function(widgetInfos) {
+            array.forEach(widgetInfos, function(widgetInfo) {
+               var widgets = widgetInfo.widgets,
+                  node = widgetInfo.node;
+               if (widgets && widgets.length) {
+                  this.processWidgets(widgets, node);
+               } else {
+                  domClass.add(node, "hidden");
+               }
+            }, this);
+         },
+
+         /**
+          * Resize the header/content/footer containers so that the
+          * content fits between the header and footer.
+          *
+          * @instance
+          */
+         _resize: function alfresco_layout_FixedHeaderFooter___resize() {
+            var widgetHeight = this.domNode.offsetHeight,
+               headerHeight = this.header.offsetHeight,
+               footerHeight = this.footer.offsetHeight;
+            domStyle.set(this.content, {
+               top: headerHeight + "px",
+               height: (widgetHeight - headerHeight - footerHeight) + "px"
+            });
+         },
+
+         /**
+          * This function is called when a resize check is required, but debounces
+          * the actual call for browser performance reasons.
+          *
+          * @instance
+          */
+         _triggerResizeCheck: function alfresco_layout_FixedHeaderFooter___triggerResizeCheck() {
+            clearTimeout(this._publishDebounceTimeout);
+            this._publishDebounceTimeout = setTimeout(lang.hitch(this, this._resize), this._publishDebounceMs);
+         }
+      });
+   });

--- a/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
+++ b/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
@@ -2,7 +2,6 @@
    overflow: hidden;
    position: relative;
    &__header, &__content, &__footer {
-      border: 1px solid red;
       left: 0;
       position: absolute;
       right: 0;

--- a/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
+++ b/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
@@ -1,0 +1,21 @@
+.alfresco-layout-FixedHeaderFooter {
+   overflow: hidden;
+   position: relative;
+   &__header, &__content, &__footer {
+      border: 1px solid red;
+      left: 0;
+      position: absolute;
+      right: 0;
+   }
+   &__header {
+      top: 0;
+   }
+   &__footer {
+      bottom: 0;
+   }
+   &__content {
+      height: 0;
+      overflow: auto;
+      top: 0;
+   }
+}

--- a/aikau/src/main/resources/alfresco/layout/templates/FixedHeaderFooter.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/FixedHeaderFooter.html
@@ -1,0 +1,5 @@
+<div class="${baseClass}">
+   <div class="${baseClass}__header" data-dojo-attach-point="header"></div>
+   <div class="${baseClass}__content" data-dojo-attach-point="content"></div>
+   <div class="${baseClass}__footer" data-dojo-attach-point="footer"></div>
+</div>

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a unit test for the FixedHeaderFooter widget
+ *
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, TestCommon) {
+
+      var browser;
+      registerSuite({
+         name: "FixedHeaderFooter tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/FixedHeaderFooter", "FixedHeaderFooter Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Test": function() {
+            return browser.findByCssSelector("*")
+               .getLogEntries();
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -41,9 +41,34 @@ define(["intern!object",
             browser.end();
          },
 
-         "Test": function() {
-            return browser.findByCssSelector("*")
-               .getLogEntries();
+         "Total height is correct": function() {
+            return browser.findById("HEADER_FOOTER")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 300, "Height not as per widget config");
+               });
+         },
+
+         "Only content is scrollable": function() {
+            function nodeOverflows(selector) {
+               var node = document.querySelector(selector);
+               return node.scrollHeight > node.offsetHeight;
+            }
+
+            return browser.execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__header"])
+               .then(function(overflows) {
+                  assert.isFalse(overflows, "Header is not same height as its content");
+               })
+
+            .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
+               .then(function(overflows) {
+                  assert.isTrue(overflows, "Content is not overflowing");
+               })
+
+            .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__footer"])
+               .then(function(overflows) {
+                  assert.isFalse(overflows, "Footer is not same height as its content");
+               });
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/actions/WorkflowTest"
+      "src/test/resources/alfresco/layout/FixedHeaderFooterTest"
    ],
 
    /**
@@ -116,6 +116,7 @@ define({
       "src/test/resources/alfresco/layout/AlfSideBarContainerTest",
       "src/test/resources/alfresco/layout/AlfTabContainerTest",
       "src/test/resources/alfresco/layout/BasicLayoutTest",
+      "src/test/resources/alfresco/layout/FixedHeaderFooterTest",
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
       "src/test/resources/alfresco/layout/StripedContentTest",
       "src/test/resources/alfresco/layout/TwisterTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>FixedHeaderFooter Test</shortname>
+  <description>Demonstrates the FixedHeaderFooter layout widget by showing a list with menus above and below</description>
+  <family>aikau-unit-tests</family>
+  <url>/FixedHeaderFooter</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -1,0 +1,63 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/StripedContent",
+         config: {
+            contentWidth: "960px",
+            widgets: [
+               {
+                  name: "alfresco/layout/FixedHeaderFooter",
+                  stripeStyle: "margin: 50px 0;",
+                  config: {
+                     height: "300px",
+                     widgetsForHeader: [
+                        {
+                           name: "alfresco/logo/Logo"
+                        }
+                     ],
+                     widgets: [
+                        {
+                           name: "alfresco/logo/Logo"
+                        },
+                        {
+                           name: "alfresco/logo/Logo"
+                        },
+                        {
+                           name: "alfresco/logo/Logo"
+                        },
+                        {
+                           name: "alfresco/logo/Logo"
+                        },
+                        {
+                           name: "alfresco/logo/Logo"
+                        },
+                        {
+                           name: "alfresco/logo/Logo"
+                        }
+                     ],
+                     widgetsForFooter: [
+                        {
+                           name: "alfresco/logo/Logo"
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -8,6 +8,12 @@ model.jsonModel = {
                all: true
             }
          }
+      },
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
       }
    ],
    widgets: [
@@ -18,37 +24,86 @@ model.jsonModel = {
             widgets: [
                {
                   name: "alfresco/layout/FixedHeaderFooter",
-                  stripeStyle: "margin: 50px 0;",
+                  id: "HEADER_FOOTER",
+                  stripeStyle: "margin: 0 0 50px;",
                   config: {
                      height: "300px",
                      widgetsForHeader: [
                         {
-                           name: "alfresco/logo/Logo"
+                           id: "FIXED_BREADCRUMBS",
+                           name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+                           config: {
+                              breadcrumbs: [
+                                 {
+                                    label: "Stairway"
+                                 },
+                                 {
+                                    label: "To"
+                                 },
+                                 {
+                                    label: "Heaven"
+                                 }
+                              ]
+                           }
                         }
                      ],
                      widgets: [
                         {
-                           name: "alfresco/logo/Logo"
-                        },
-                        {
-                           name: "alfresco/logo/Logo"
-                        },
-                        {
-                           name: "alfresco/logo/Logo"
-                        },
-                        {
-                           name: "alfresco/logo/Logo"
-                        },
-                        {
-                           name: "alfresco/logo/Logo"
-                        },
-                        {
-                           name: "alfresco/logo/Logo"
+                           id: "LIST",
+                           name: "alfresco/documentlibrary/AlfDocumentList",
+                           config: {
+                              useHash: false,
+                              currentPageSize: 10,
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/AlfListView",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Row",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      config: {
+                                                         widgets: [
+                                                            {
+                                                               name: "alfresco/renderers/Property",
+                                                               config: {
+                                                                  propertyToRender: "index"
+                                                               }
+                                                            }
+                                                         ]
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
                         }
                      ],
                      widgetsForFooter: [
                         {
-                           name: "alfresco/logo/Logo"
+                           id: "MENU_BAR",
+                           name: "alfresco/menus/AlfMenuBar",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "CUSTOM_PAGE_SIZE_PAGINATOR",
+                                    name: "alfresco/lists/Paginator",
+                                    config: {
+                                       useHash: false,
+                                       documentsPerPage: 10,
+                                       hidePageSizeOnWidth: 100,
+                                       pageSizes: [5,10,20]
+                                    }
+                                 }
+                              ]
+                           }
                         }
                      ]
                   }


### PR DESCRIPTION
This addresses issue [AKU-294](https://issues.alfresco.com/jira/browse/AKU-294), which requests a new, fixed-height widget with a header, footer and scrollable central content area inside it.