### PR TITLE
Updates to TinyMCE to correct JSDoc, NLS and WebScript descriptor

### DIFF
--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -19,8 +19,12 @@
 
 /*globals tinymce*/
 /**
- * This is a prototype widget that handles requirements and instantiation of a TinyMCE editor. It is
- * not ready for production use yet as there as still outstanding issues.
+ * This module can be used to create a TinyMCE editor it is primarily used by the 
+ * [TinyMCE form control]{@link module:alfresco/forms/controls/TinyMCE} but can be used independently
+ * if required. Without any additional configuration it will instantiate an editor using the Alfresco
+ * preferred configuration, however this can be overridden by providing 
+ * [specific configuration]{@link module:alfresco/forms/controls/TinyMCE#editorConfig} that will
+ * augment or override the [default configuration]{@link module:alfresco/forms/controls/TinyMCE#defaultEditorConfig}.
  *
  * @module alfresco/editors/TinyMCE
  * @extends external:dijit/_WidgetBase
@@ -39,6 +43,15 @@ define(["dojo/_base/declare",
 
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
+
+      /**
+       * An array of the i18n files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/TinyMCE.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/TinyMCE.properties"}],
 
       /**
        * Make sure TinyMCE is included on the page.
@@ -160,29 +173,28 @@ define(["dojo/_base/declare",
          }
          if (!config.menu) {
             config.menu = {
-               // TODO: I18N
                file: {
-                  title: "File",
+                  title: this.message("TinyMCE.toolbar.file.title"),
                   items: "newdocument | print"
                },
                edit: {
-                  title: "Edit",
+                  title: this.message("TinyMCE.toolbar.edit.title"),
                   items: "undo redo | cut copy paste pastetext | selectall | searchreplace"
                },
                insert: {
-                  title: "Insert",
+                  title: this.message("TinyMCE.toolbar.insert.title"),
                   items: "link image | charmap hr anchor pagebreak inserttime nonbreaking"
                },
                view: {
-                  title: "View",
+                  title: this.message("TinyMCE.toolbar.view.title"),
                   items: "fullscreen preview visualblocks code"
                },
                format: {
-                  title: "Format",
+                  title: this.message("TinyMCE.toolbar.format.title"),
                   items: "bold italic underline strikethrough superscript subscript | formats | removeformat"
                },
                table: {
-                  title: "Table",
+                  title: this.message("TinyMCE.toolbar.table.title"),
                   items: "inserttable tableprops deletetable | cell row column"
                }
             };

--- a/aikau/src/main/resources/alfresco/editors/i18n/TinyMCE.properties
+++ b/aikau/src/main/resources/alfresco/editors/i18n/TinyMCE.properties
@@ -1,0 +1,6 @@
+TinyMCE.toolbar.file.title=File
+TinyMCE.toolbar.edit.title=Edit
+TinyMCE.toolbar.insert.title=Insert
+TinyMCE.toolbar.view.title=View
+TinyMCE.toolbar.format.title=Format
+TinyMCE.toolbar.table.title=Table

--- a/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,8 +18,7 @@
  */
 
 /**
- * This is an initial prototype form control that wraps the [TinyMCE editor]{@link module:alfresco/editors/TinyMCE}.
- * It is not recommended for production use yet as there as still some outstanding issues to resolve.
+ * This a form control that wraps the [TinyMCE editor]{@link module:alfresco/editors/TinyMCE}.
  *
  * @module alfresco/forms/controls/TinyMCE
  * @extends module:alfresco/forms/controls/BaseFormControl
@@ -27,10 +26,8 @@
  */
 define(["alfresco/forms/controls/BaseFormControl",
         "dojo/_base/declare",
-        "alfresco/editors/TinyMCE",
-        "dojo/_base/lang",
-        "dojo/aspect"], 
-        function(BaseFormControl, declare, TinyMCE, lang, aspect) {
+        "alfresco/editors/TinyMCE"], 
+        function(BaseFormControl, declare, TinyMCE) {
    
    return declare([BaseFormControl], {
       
@@ -90,7 +87,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * 
        * @instance
        */
-      onEditorValueChange: function alfresco_forms_controls_TinyMCE__onEditorValueChange(evt) {
+      onEditorValueChange: function alfresco_forms_controls_TinyMCE__onEditorValueChange(/*jshint unused:false*/ evt) {
          var value = this.wrappedWidget.getValue();
          this.onValueChangeEvent(this.name, this.lastValue, value);
          this.lastValue = value;
@@ -103,9 +100,9 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        * @param {boolean} status Indicates the current status
        */
-      alfDisabled: function alfresco_forms_controls_BaseFormControl__alfDisabled(status) {
+      alfDisabled: function alfresco_forms_controls_BaseFormControl__alfDisabled(/*jshint unused:false*/ status) {
          this.inherited(arguments);
-         if (this.wrappedWidget != null)
+         if (this.wrappedWidget)
          {
             this.wrappedWidget.setDisabled(this._disabled);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/editors/TinyMCE.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/editors/TinyMCE.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
-  <shortname>TinyMCE Form Control Test</shortname>
+  <shortname>TinyMCE Form Control</shortname>
+  <description>This demonstrates the TinyMCE form control that can be used for rich-text content creation or editing.</description>
   <family>aikau-unit-tests</family>
   <url>/TinyMCE</url>
 </webscript>


### PR DESCRIPTION
It was noted that we failed to update the JSDoc for the TinyMCE related widgets following recent updates to make them production ready. I've updated the JSDoc to remove the warnings as well as added in some localization (which isn't used by default) and added a description for the test page.