### PR TITLE
AKU-312: Dropdown not properly populated after keyboard selection

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -905,14 +905,7 @@ define([
             if (evt.target !== this.searchBox) {
                this.searchBox.focus();
             }
-            if (this._results.length && !this._resultsDropdownIsVisible()) {
-               this._showResultsDropdown();
-               if (!this._focusedResult) {
-                  this._gotoNextResult();
-               }
-            } else {
-               this._debounceNewSearch(this.searchBox.value);
-            }
+            this._showOrSearch();
          },
 
          /**
@@ -922,14 +915,7 @@ define([
           */
          _onFocus: function alfresco_forms_controls_MultiSelect___onSearchFocus() {
             domClass.add(this.domNode, this.rootClass + "--focused");
-            if (this._results.length) {
-               this._showResultsDropdown();
-               if (!this._focusedResult) {
-                  this._gotoNextResult();
-               }
-            } else {
-               this._debounceNewSearch(this.searchBox.value);
-            }
+            this._showOrSearch();
          },
 
          /**
@@ -1018,7 +1004,7 @@ define([
                      if (this._resultsDropdownIsVisible()) {
                         this._gotoNextResult();
                      } else {
-                        this._showResultsDropdown();
+                        this._showOrSearch();
                      }
                      evt.preventDefault();
                      break;
@@ -1132,6 +1118,7 @@ define([
          _resetSearchBox: function alfresco_forms_controls_MultiSelect___resetSearchBox() {
             this._currentSearchValue = "";
             this.searchBox.value = "";
+            this._results = [];
          },
 
          /**
@@ -1242,6 +1229,26 @@ define([
             this._hideEmptyMessage();
             this._hideErrorMessage();
             this._showResultsDropdown();
+         },
+
+         /**
+          * If we have current results then toggle the dropdown, otherwise perform a new search.
+          *
+          * @instance
+          */
+         _showOrSearch: function() {
+            if (this._results.length) {
+               if (!this._resultsDropdownIsVisible()) {
+                  this._showResultsDropdown();
+                  if (!this._focusedResult) {
+                     this._gotoNextResult();
+                  }
+               } else {
+                  this._hideResultsDropdown();
+               }
+            } else {
+               this._debounceNewSearch(this.searchBox.value);
+            }
          },
 
          /**

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -229,6 +229,21 @@ define([
                });
          },
 
+         "Selecting item with keyboard does not persist previous search": function() {
+            return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__search-box")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 7, "Did not return full list of results after keyboard choice selection");
+               })
+               .end()
+
+            .findById("FOCUS_HELPER_BUTTON")
+               .click()
+         },
+
          "Deleting all items disables confirmation button": function() {
             return browser.findByCssSelector("#MULTISELECT_1_CONTROL .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
                .click()

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/ActionsTest"
+      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
    ],
 
    /**


### PR DESCRIPTION
This addresses issue [AKU-312](https://issues.alfresco.com/jira/browse/AKU-312) where the MultiSelect results dropdown was not properly populated after keyboard selection. Have now properly reset the control after a choice is made, and changed what happens when the down arrow is pressed or the control is clicked. The test has also been updated accordingly.