### PR TITLE
AKU-306: MultiSelect keyboard nav in IE11 broken - IE11 has changed i…

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -671,7 +671,7 @@ define([
          _getCursorPositionWithinTextbox: function alfresco_forms_controls_MultiSelect___getCursorPositionWithinTextbox() {
             var cursorPos = 0,
                range;
-            if (this.searchBox.createTextRange) {
+            if (this.searchBox.createTextRange && document.selection) { // IE11 passes first condition, but fails on second (AKU-306)
                range = document.selection.createRange().duplicate();
                range.moveEnd("character", this.searchBox.value.length);
                if (!range.text) {


### PR DESCRIPTION
This addresses issue [AKU-306](https://issues.alfresco.com/jira/browse/AKU-306), which notes that MultiSelect keyboard navigation is broken in IE11. This is because IE11 has changed its text selection mechanics, so needed an update to the feature detection test used.