### PR TITLE
AKU-305: Header menu right-click broken

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
@@ -71,7 +71,7 @@ define(["dojo/_base/declare",
             // to prevent future maintenance issues, but given this is "non-functional" code it's not important at the moment.
             // We want to build a URL to set as the "href" attribute of the <a> element.
             var anchorUrl;
-            if (!type || type === this.pageRelativePath)
+            if (!type || type === this.pageRelativePath  || type === this.sharePageRelativePath)
             {
                anchorUrl = AlfConstants.URL_PAGECONTEXT + url;
             }

--- a/aikau/src/test/resources/alfresco/menus/MenuTests.js
+++ b/aikau/src/test/resources/alfresco/menus/MenuTests.js
@@ -376,6 +376,14 @@ define(["intern!object",
                );
       },
 
+      "Share relative page URLs are correct": function() {
+         return browser.findByCssSelector("#MENU_ITEM_7 .alfresco-navigation-_HtmlAnchorMixin")
+            .getAttribute("href")
+            .then(function(href) {
+               assert.equal(href, "/aikau/page/MENU_ITEM_7", "Share relative page URL incorrect");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
+      "src/test/resources/alfresco/menus/MenuTests"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/BasicMenuTestPage.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/BasicMenuTestPage.get.js
@@ -129,7 +129,8 @@ model.jsonModel = {
                            config: {
                               id: "MENU_ITEM_7",
                               label: "dd2.mi7",
-                              targetUrl: "MENU_ITEM_7"
+                              targetUrl: "MENU_ITEM_7",
+                              targetUrlType: "SHARE_PAGE_RELATIVE"
                            }
                         },
                         {


### PR DESCRIPTION
This addresses issue [AKU-305](https://issues.alfresco.com/jira/browse/AKU-305), which points out that the right-click is not working in the header-menu. This is because the URL defined on the link is incorrect, due to a missing condition from a previous deprecation. This has been added in, and tests updated.