### PR TITLE
AKU-310: CheckBox selection in Selenium - Create new CheckBox test pa…

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/CheckBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/CheckBox.js
@@ -60,7 +60,7 @@ define(["alfresco/forms/controls/BaseFormControl",
       /**
        * @instance
        */
-      createFormControl: function alfresco_forms_controls_CheckBox__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_CheckBox__createFormControl(config, /*jshint unused:false*/ domNode) {
          var additionalCssClasses = "";
          if (this.additionalCssClasses !== null)
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/css/CheckBox.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/CheckBox.css
@@ -1,5 +1,11 @@
 /* This will place the check box on the same line as the label row */
-.alfresco-forms-controls-CheckBox > .title-row,
-.alfresco-forms-controls-CheckBox > .control-row {
-   display: inline-block;
+.alfresco-forms-controls-CheckBox {
+   > .title-row, > .control-row {
+      display: inline-block;
+   }
+   > .title-row {
+      > label {
+         cursor: pointer;
+      }
+   }
 }

--- a/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @author Dave Draper
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon",
+      "intern/dojo/node!leadfoot/keys"
+   ],
+   function(registerSuite, assert, require, TestCommon, keys) {
+
+      var browser;
+      registerSuite({
+         name: "CheckBox Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/CheckBox", "CheckBox Control Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Initial value is set correctly": function() {
+            return browser.findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isTrue(isSelected, "Checkbox not selected at startup");
+               });
+         },
+
+         "Value can be updated by publish": function() {
+            return browser.findById("UNCHECK_CHECKBOX")
+               .click()
+               .end()
+
+            .findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isFalse(isSelected, "Checkbox not deselected by publish");
+               });
+         },
+
+         "Keyboard navigation and selection is supported": function() {
+            return browser.pressKeys(keys.TAB)
+               .pressKeys(keys.SPACE)
+               .end()
+
+            .findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isTrue(isSelected, "Checkbox value not changed by keyboard");
+               });
+         },
+
+         "Can modify checkbox value with mouse": function() {
+            return browser.findByCssSelector("#CAN_BUILD label")
+               .click()
+               .end()
+
+            .findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isFalse(isSelected, "Checkbox value not changed by mouse");
+               });
+         },
+
+         "Form correctly posts value": function() {
+            return browser.findByCssSelector("#CHECKBOX_FORM > .buttons > .confirmationButton .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "POST_FORM",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "canbuild", false, "Failed to submit checkbox value correctly");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/menus/MenuTests"
+      "src/test/resources/alfresco/forms/controls/CheckBoxTest"
    ],
 
    /**
@@ -89,6 +89,7 @@ define({
 
       "src/test/resources/alfresco/forms/controls/AutoSetTest",
       "src/test/resources/alfresco/forms/controls/BaseFormTest",
+      "src/test/resources/alfresco/forms/controls/CheckBoxTest",
       "src/test/resources/alfresco/forms/controls/CodeMirrorTest",
       "src/test/resources/alfresco/forms/controls/ComboBoxTest",
       "src/test/resources/alfresco/forms/controls/ContainerPickerTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>CheckBox Test</shortname>
+  <description>This is a test page for the alfresco/forms/controls/CheckBox control</description>
+  <family>aikau-unit-tests</family>
+  <url>/CheckBox</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.js
@@ -24,17 +24,6 @@ model.jsonModel = {
             }
          }
       },
-      // {
-      //    id: "CHECK_CHECKBOX",
-      //    name: "alfresco/buttons/AlfButton",
-      //    config: {
-      //       label: "Check checkbox",
-      //       publishTopic: "SET_FORM_VALUE",
-      //       publishPayload: {
-      //          canbuild: true
-      //       }
-      //    }
-      // },
       {
          name: "alfresco/html/Spacer",
          config: {
@@ -74,5 +63,4 @@ model.jsonModel = {
          name: "alfresco/logging/DebugLog"
       }
    ]
-   // simple stuff, setting checkbox via publication, making sure it can be toggled on/off with mouse and keyboard
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.js
@@ -1,0 +1,78 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DialogService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [
+      {
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            id: "UNCHECK_CHECKBOX",
+            label: "Uncheck checkbox",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               canbuild: false
+            }
+         }
+      },
+      // {
+      //    id: "CHECK_CHECKBOX",
+      //    name: "alfresco/buttons/AlfButton",
+      //    config: {
+      //       label: "Check checkbox",
+      //       publishTopic: "SET_FORM_VALUE",
+      //       publishPayload: {
+      //          canbuild: true
+      //       }
+      //    }
+      // },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/forms/Form",
+         config: {
+            id: "CHECKBOX_FORM",
+            okButtonPublishTopic: "POST_FORM",
+            setValueTopic: "SET_FORM_VALUE",
+            scopeFormControls: false,
+            value: {
+               canbuild: true
+            },
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/CheckBox",
+                  config: {
+                     name: "canbuild",
+                     id: "CAN_BUILD",
+                     label: "Yes we can",
+                     description: "Can we build it?"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+   // simple stuff, setting checkbox via publication, making sure it can be toggled on/off with mouse and keyboard
+};


### PR DESCRIPTION
This addresses issue [AKU-310](https://issues.alfresco.com/jira/browse/AKU-310), which originated with a problem selecting checkboxes in Selenium. While not able to reproduce that issue, we have still created a discrete test page and set of tests for the CheckBox control, in order to try and prevent future regressions.