### PR TITLE
AKU-300: Search result has incorrect link for events

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -23,11 +23,12 @@
  * @module alfresco/renderers/_SearchResultLinkMixin
  * @author Richard Smith
  */
-define(["dojo/_base/declare",
+define(["alfresco/core/TemporalUtils",
+        "dojo/_base/declare",
         "dojo/_base/lang"], 
-        function(declare, lang) {
+        function(TemporalUtils, declare, lang) {
    
-   return declare(null, {
+   return declare([TemporalUtils], {
 
       /**
        * This function generates a payload for the [NavigationService]{@link module:alfresco/services/NavigationService}
@@ -106,9 +107,12 @@ define(["dojo/_base/declare",
                break;
 
             case "calendarevent":
+               var dateProperty = lang.getObject("fromDate", false, this.currentItem),
+                  eventDate = dateProperty && this.fromISO8601(dateProperty),
+                  formattedDate = eventDate && this.formatDate(eventDate, "yyyy-mm-dd");
                if (site)
                {
-                  payload.url = "site/" + site + "/calendar";
+                  payload.url = "site/" + site + "/calendar?date=" + formattedDate;
                }
                break;
 

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -175,6 +175,13 @@ define(["intern/dojo/node!fs",
                   fs.writeFile(screenshotPath, screenshot.toString("binary"), "binary");
                });
          };
+         command.session.getLastPublish = function(topicName) {
+            return this.getLogEntries({
+               type: "PUBLISH",
+               topic: topicName,
+               pos: "last"
+            });
+         };
          command.session.getLogEntries = function(filter, waitPeriod) {
 
             // Normalise arguments

--- a/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
@@ -91,11 +91,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLogEntries({
-                  type: "PUBLISH",
-                  topic: "POST_FORM",
-                  pos: "last"
-               })
+            .getLastPublish("POST_FORM")
                .then(function(payload) {
                   assert.deepPropertyVal(payload, "canbuild", false, "Failed to submit checkbox value correctly");
                });

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -193,11 +193,7 @@ define([
                .click()
                .end()
 
-            .getLogEntries({
-                  type: "PUBLISH",
-                  topic: "FORM_POST",
-                  pos: "last"
-               })
+            .getLastPublish("FORM_POST")
                .then(function(payload) {
                   assert.isNotNull(payload, "Could not find form submission");
                   if (payload) {
@@ -324,11 +320,7 @@ define([
                .click()
                .end()
 
-            .getLogEntries({
-                  type: "PUBLISH",
-                  topic: "DIALOG_POST",
-                  pos: "last"
-               })
+            .getLastPublish("DIALOG_POST")
                .then(function(payload) {
                   assert.isNotNull(payload, "Could not find dialog submission");
                   if (payload) {

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -19,59 +19,68 @@
 
 /**
  * This test generates some variations on AlfSearchResult to test the various if statements in the rendering widgets involved
- * 
+ *
  * @author Richard Smith
  */
 define(["intern!object",
-        "intern/chai!expect",
-        "require",
-        "alfresco/TestCommon"], 
-        function (registerSuite, expect, require, TestCommon) {
+      "intern/chai!assert",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, TestCommon) {
 
-   var browser;
-   var activeElementId;
-      
-   registerSuite({
-      name: "AlfSearchResult Tests",
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfSearchResult", "AlfSearchResult Tests").end();
-      },
+      registerSuite({
+         name: "AlfSearchResult Tests",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfSearchResult", "AlfSearchResult Tests").end();
+         },
 
-     "Check the correct number of rows is shown": function () {
-         return browser.findAllByCssSelector("#SEARCH_RESULTS table tbody tr")
-            .then(function (rows){
-               expect(rows).to.have.length(11, "There should be 11 search result rows shown");
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Correct number of rows is shown": function() {
+            return browser.findAllByCssSelector(".alfresco-search-AlfSearchResult")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 12, "Wrong number of results rendered");
+               });
+         },
+
+         "Clicked result becomes focused": function() {
+            var activeElementId;
+            return browser.findByCssSelector(".alfresco-search-AlfSearchResult:last-child")
+               .click()
+               .end()
+
+            .getActiveElement()
+               .then(function(element) {
+                  activeElementId = element.elementId;
+               })
+               .end()
+
+            .findByCssSelector(".alfresco-search-AlfSearchResult:last-child")
+
+            .then(function(element) {
+               assert.equal(element.elementId, activeElementId, "The clicked element has not become focused");
             });
-      },
+         },
 
-      "Check that a clicked search result at the bottom of the screen becomes focused": function() {
-         return browser.findByCssSelector("#SEARCH_RESULTS table tbody tr:last-of-type")
-            .click()
-         .end()
+         "Event result opens correct date in calendar": function() {
+            return browser.findByCssSelector(".alfresco-search-AlfSearchResult:last-child .nameAndTitleCell .alfresco-renderers-PropertyLink > .inner")
+               .click()
+               .end()
 
-         // Store the id of the currently focused (active) element
-         .getActiveElement()
-            .then(function (element){
-               activeElementId = element._elementId;
-            })
-         .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "url", "site/eventResult/calendar?date=2015-04-01", "Did not navigate to correct page");
+               });
+         },
 
-         // Are the clicked row of the results and the currently focused item the same?
-         .findByCssSelector("#SEARCH_RESULTS table tbody tr:last-of-type")
-            .then(function (clickedElement){
-               var clickedElementId = clickedElement._elementId;
-               expect(clickedElementId).to.equal(activeElementId, "The clicked element has not become focused");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
    });
-});

--- a/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
@@ -47,11 +47,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLogEntries({
-                  type: "PUBLISH",
-                  topic: "ALF_SELECTED_FILES_CHANGED",
-                  pos: "last"
-               })
+            .getLastPublish("ALF_SELECTED_FILES_CHANGED")
                .then(function(payload) {
                   assert.isNotNull(payload, "Selected files change not published");
                   if (payload) {
@@ -66,11 +62,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLogEntries({
-                  type: "PUBLISH",
-                  topic: "ALF_SELECTED_FILES_CHANGED",
-                  pos: "last"
-               })
+            .getLastPublish("ALF_SELECTED_FILES_CHANGED")
                .then(function(payload) {
                   assert.isNotNull(payload, "Selected files change not published");
                   if (payload) {

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -75,11 +75,7 @@ define(["intern!object",
             .click()
          .end()
          // Wait for page load
-         .getLogEntries({
-            type: "PUBLISH",
-            topic: "ALF_WIDGET_PROCESSING_COMPLETE",
-            pos: "last"
-         })
+         .getLastPublish("ALF_WIDGET_PROCESSING_COMPLETE")
          .findAllByCssSelector("#NOTHING_POSTED")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Original URL not reloaded");

--- a/aikau/src/test/resources/alfresco/services/actions/NodeLocationTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/NodeLocationTest.js
@@ -43,11 +43,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SITE_NODE_DEFAULT_label")
             .click()
          .end()
-         .getLogEntries({
-            type: "PUBLISH",
-            topic: "ALF_NAVIGATE_TO_PAGE",
-            pos: "last"
-         })
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
             assert.isNotNull(payload, "Navigation publication not found");
             if (payload) {
@@ -60,11 +56,7 @@ define(["intern!object",
          return browser.findByCssSelector("#NODE_DEFAULT_label")
             .click()
          .end()
-         .getLogEntries({
-            type: "PUBLISH",
-            topic: "ALF_NAVIGATE_TO_PAGE",
-            pos: "last"
-         })
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
             assert.isNotNull(payload, "Navigation publication not found");
             if (payload) {
@@ -77,11 +69,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SITE_NODE_CUSTOM_label")
             .click()
          .end()
-         .getLogEntries({
-            type: "PUBLISH",
-            topic: "CUSTOM_ALF_NAVIGATE_TO_PAGE",
-            pos: "last"
-         })
+         .getLastPublish("CUSTOM_ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
             assert.isNotNull(payload, "Navigation publication not found");
             if (payload) {
@@ -94,11 +82,7 @@ define(["intern!object",
          return browser.findByCssSelector("#NODE_CUSTOM_label")
             .click()
          .end()
-         .getLogEntries({
-            type: "PUBLISH",
-            topic: "CUSTOM_ALF_NAVIGATE_TO_PAGE",
-            pos: "last"
-         })
+         .getLastPublish("CUSTOM_ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
             assert.isNotNull(payload, "Navigation publication not found");
             if (payload) {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/CheckBoxTest"
+      "src/test/resources/alfresco/search/AlfSearchResultTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -177,11 +177,32 @@ model.jsonModel = {
                      modifiedByUser: "bsmith",
                      description: "Wiki result description",
                      site: {
-                     	title: "Wiki result site title",
-                     	shortName: "wikiResult"
+                        title: "Wiki result site title",
+                        shortName: "wikiResult"
                      },
                      path: "/one/two/three/four",
                      size: 283746
+                  },
+                  {
+                     nodeRef: "dummy://nodeRef/1",
+                     "type": "calendarevent",
+                     "name": "1432113732076-6118.ics",
+                     "displayName": "Event result",
+                     "description": "",
+                     "modifiedOn": "2015-05-20T10:22:12.079+01:00",
+                     "modifiedByUser": "admin",
+                     "modifiedBy": "Administrator",
+                     "fromDate": "2015-04-01T12:00:00.000+01:00",
+                     "size": -1,
+                     "mimetype": "",
+                     "site":
+                     {
+                        "shortName": "eventResult",
+                        "title": "Event result site title"
+                     },
+                     "container": "calendar",
+                     "lastThumbnailModification": [],
+                     "tags": []
                   }
                ]
             },
@@ -220,7 +241,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       },
       {
          name: "aikauTesting/TestCoverageResults"


### PR DESCRIPTION
This addresses issue [AKU-300](https://issues.alfresco.com/jira/browse/AKU-300) which notes that calendar events in search results to not navigate to the correct page when clicked. It also includes an update to the testing code to make it easier to query the pub/sub debug log.