### PR TITLE
Prototype HtmlListView

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/HtmlListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/HtmlListView.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @module alfresco/lists/views/HtmlListView
+ * @extends module:alfresco/lists/views/AlfListView
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/views/AlfListView",
+        "dojo/text!./templates/HtmlListView.html",
+        "alfresco/lists/views/ListRenderer",
+        "dojo/text!./templates/HtmlListViewRenderer.html",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "dojo/dom-construct"], 
+        function(declare, AlfListView, template, ListRenderer, rendererTemplate, lang, array, domConstruct) {
+   
+   var Renderer = declare([ListRenderer], {
+
+      templateString: rendererTemplate,
+
+      renderData: function alfresco_dnd_DragAndDropItems__renderData() {
+         array.forEach(this.items, function(item) {
+            var property = lang.getObject(this.propertyToRender, false, item);
+            if (property || property === 0 || property === false)
+            {
+               domConstruct.create("li", {
+                  "class": "alfresco-lists-views-HtmlListView--item",
+                  innerHTML: property
+               }, this.domNode, "last");
+            }
+         }, this);
+      }
+   });
+
+   return declare([AlfListView], {
+
+      /**
+       * The HTML template to use for the widget.
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
+
+      /**
+       * This is the dot-notation addressed property within each item to render as the value in the list
+       * element.
+       *
+       * @instance
+       * @type {string}
+       * @default  "displayName"
+       */
+      propertyToRender: "displayName",
+
+      /**
+       * Creates a new [ListRenderer]{@link module:alfresco/lists/views/ListRenderer}
+       * which is used to render the actual items in the view. This function can be overridden by extending views
+       * (such as the [Film Strip View]{@link module:alfresco/documentlibrary/views/AlfFilmStripView}) to create
+       * alternative widgets applicable to that view.
+       * 
+       * @instance
+       * @returns {object} A new [ListRenderer]{@link module:alfresco/lists/views/ListRenderer}
+       */
+      createListRenderer: function alfresco_dnd_DragAndDropItemsListView__createListRenderer() {
+         var dlr = new Renderer({
+            items: this.currentData.items,
+            propertyToRender: this.propertyToRender || "displayName"
+         });
+         return dlr;
+      },
+
+      /**
+       * Override the default selector to match the li elements created by the renderer.
+       *
+       * @instance
+       * @type {string}
+       * @default "li.alfresco-lists-views-HtmlListView--item"
+       */
+      renderFilterSelectorQuery: "li.alfresco-lists-views-HtmlListView--item"
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListView.html
+++ b/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListView.html
@@ -1,0 +1,3 @@
+<div class="alfresco-lists-views-HtmlListView">
+   <div class="items" data-dojo-attach-point="tableNode"></div>
+</div>

--- a/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListViewRenderer.html
+++ b/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListViewRenderer.html
@@ -1,0 +1,1 @@
+<ul class="alfresco-lists-views-HtmlListView--renderer"></ul>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>HtmlListView</shortname>
+  <description>This is an example of an AlfList using the HtmlListView. It is a very simple view that just renders single properties from each listed item in an HTML li element.</description>
+  <family>aikau-unit-tests</family>
+  <url>/HtmlListView</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.js
@@ -1,0 +1,44 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/lists/AlfList",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     name: "one"
+                  },
+                  {
+                     name: "two"
+                  },
+                  {
+                     name: "three"
+                  },
+                  {
+                     name: "four"
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  name: "alfresco/lists/views/HtmlListView",
+                  config: {
+                     propertyToRender: "name"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+};


### PR DESCRIPTION
PLEASE NOTE: Martin and David - do not pull this request (I'm just using this PR for education purposes).

This PR contains an example of how you can extend the current "alfresco/lists/views/AlfListView" and "alfresco/lists/views/ListRenderer" widgets to create a view that does present the list in a tabular form or use HTML table related elements. 

Instead it overrides base widgets and adds in new templates for rendering items. I've included a unit test page that demonstrates how this could be used. If you checkout the branch related to this PR and start the unit test application you can try it out at:  http://localhost:8089/aikau/page/tp/ws/HtmlListView