### PR TITLE
Fix issue in alfresco/services/DocumentService introduced by previous commit

### DIFF
--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -344,7 +344,7 @@ define(["dojo/_base/declare",
 
          // Sort parameters
          params += "&sortAsc=" + payload.sortAscending + "&sortField=" + encodeURIComponent(payload.sortField);
-         if (payload.site)
+         if (!payload.site)
          {
             if (payload.libraryRoot)
             {


### PR DESCRIPTION
Stefan spotted an issue with the DocumentLibrary failing to load documents and I've tracked it down to an incorrect correction to a JSHint issue. This PR corrects that mistake.