### PR TITLE
AKU-296: Dialog height incorrect

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -40,7 +40,7 @@
    padding: 12px;
    overflow: auto;
    height: ~"calc(100% - 50px)";
-   margin-bottom: 37px;
+   margin-bottom: 42px;
 }
 
 .alfresco-dialog-AlfDialog.iefooter .dialog-body {


### PR DESCRIPTION
This addresses issue [AKU-296](https://issues.alfresco.com/jira/browse/AKU-296) which has content slightly overflowing the bottom of the dialog content and being cropped.