### PR TITLE
AKU-290: Updates to prevent menu items opening on hover

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfDropDownMenu.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -30,10 +30,8 @@ define(["dojo/_base/declare",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/menus/AlfMenuItemWrapper",
         "dojo/_base/array",
-        "dojo/dom-class",
-        "dojo/_base/event",
-        "dojo/on"], 
-        function(declare, DropDownMenu, AlfCore, CoreWidgetProcessing, AlfMenuItemWrapper, array, domClass, event, on) {
+        "dojo/dom-class"], 
+        function(declare, DropDownMenu, AlfCore, CoreWidgetProcessing, AlfMenuItemWrapper, array, domClass) {
    
    return declare([DropDownMenu, AlfCore, CoreWidgetProcessing], {
       
@@ -53,7 +51,6 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfDropDownMenu__postCreate() {
-         
          this.inherited(arguments);
          
          // Add a custom class to the container node (this has been done to prevent us overriding the default
@@ -76,7 +73,7 @@ define(["dojo/_base/declare",
        */
       allWidgetsProcessed: function alfresco_menus_AlfDropDownMenu__allWidgetsProcessed(widgets) {
          var _this = this;
-         array.forEach(widgets, function(widget, i) {
+         array.forEach(widgets, function(widget) {
              // Add the widget to the drop down menu...
             _this.addChild(widget);
          });
@@ -89,8 +86,7 @@ define(["dojo/_base/declare",
        * @param {integer} insertIndex The index at which to insert the child
        */
       addChild: function alfresco_menus_AlfDropDownMenu__addChild(widget, insertIndex) {
-         
-         if (widget.domNode.tagName.toUpperCase() != "TR")
+         if (widget.domNode.tagName.toUpperCase() !== "TR")
          {
             // If the entry is not a table row then we will wrap it within one (provided by the
             // AlfMenuItemWrapper widget) such that the menu item is rendered correctly within the
@@ -119,7 +115,6 @@ define(["dojo/_base/declare",
        * @instance
        */
       focusNext: function alfresco_menus_AlfDropDownMenu__focusNext() {
-         
          var groupParent = this.getParent();
          if (domClass.contains(this.focusedChild.domNode, "last-focusable-entry"))
          {
@@ -155,7 +150,6 @@ define(["dojo/_base/declare",
        * @instance
        */
       focusPrev: function alfresco_menus_AlfDropDownMenu__focusPrev() {
-         
          // Set up sensible variables for the various contexts...
          var groupParent = this.getParent(); 
 
@@ -197,7 +191,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} widget The child to remove
        */
-      removeChild: function alfresco_menus_AlfDropDownMenu__removeChild(widget) {
+      removeChild: function alfresco_menus_AlfDropDownMenu__removeChild(/*jshint unused:false*/ widget) {
          this.inherited(arguments);
          this.setFirstAndLastMarkerClasses();
       },
@@ -212,12 +206,11 @@ define(["dojo/_base/declare",
        * @instance
        */
       setFirstAndLastMarkerClasses: function alfresco_menus_AlfDropDownMenu__setFirstAndLastMarkerClasses() {
-         
          var noOfChildren = this.getChildren().length;
          if (noOfChildren > 0)
          {
             // Remove any previous first/last class markers...
-            array.forEach(this.getChildren(), function(child, index) {
+            array.forEach(this.getChildren(), function(child) {
                domClass.remove(child.domNode, "first-focusable-entry");
                domClass.remove(child.domNode, "last-focusable-entry");
             });

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBar.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -45,6 +45,20 @@ define(["dojo/_base/declare",
     */
    var CustomMenuBar = declare([MenuBar, AlfCore], {
       
+      /**
+       * Extends the default menu bar capabilities to prevent any popup menus from being opened purely by
+       * hovering over them. See AKU-290.
+       *
+       * @instance
+       * @param {object} item The item hovered over
+       */
+      onItemHover: function alfresco_menus_AlfMenuBar_CustomMenuBar__onItemHover(/*jshint unused:false*/item){
+         if(this.activated){
+            this.activated = false;
+         }
+         this.inherited(arguments);
+      },
+
       /**
        * This boolean attribute is used as an indicator of whether or not the MenuBar popups should
        * be locked in the open state.
@@ -135,15 +149,13 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuBar__postCreate() {
-         
-         // We need a menu...
          this._menuBar = new CustomMenuBar({});
          this._menuBar.placeAt(this.containerNode);
 
          if (this.widgets && this.widgets instanceof Array)
          {
             // Convert any i18n keys into the translated labels...
-            array.forEach(this.widgets, function(entry, i) {
+            array.forEach(this.widgets, function(entry) {
                if (entry.config && entry.config.label)
                {
                   entry.config.label = this.message(entry.config.label);
@@ -164,7 +176,7 @@ define(["dojo/_base/declare",
        * @param widgets The widgets that have been successfully instantiated.
        */
       allWidgetsProcessed: function alfresco_menus_AlfMenuBar__allWidgetsProcessed(widgets) {
-         array.forEach(widgets, function(entry, i) {
+         array.forEach(widgets, function(entry) {
             this._menuBar.addChild(entry);
          }, this);
       }

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
@@ -34,10 +34,8 @@ define(["dojo/_base/declare",
         "alfresco/menus/_AlfPopupCloseMixin",
         "dojo/dom-construct",
         "dojo/dom-class",
-        "alfresco/menus/AlfMenuGroups",
-        "service/constants/Default",
-        "dijit/place"], 
-        function(declare, PopupMenuBarItem, AlfCore, CoreWidgetProcessing, AlfCoreRwd, _AlfPopupCloseMixin, domConstruct, domClass, AlfMenuGroups, AlfConstants, place) {
+        "alfresco/menus/AlfMenuGroups"], 
+        function(declare, PopupMenuBarItem, AlfCore, CoreWidgetProcessing, AlfCoreRwd, _AlfPopupCloseMixin, domConstruct, domClass) {
    
    return declare([PopupMenuBarItem, AlfCore, CoreWidgetProcessing, AlfCoreRwd, _AlfPopupCloseMixin], {
       
@@ -123,8 +121,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuBarPopup__postCreate() {
-         
-         if (this.iconClass && this.iconClass != "dijitNoIcon")
+         if (this.iconClass && this.iconClass !== "dijitNoIcon")
          {
             this.iconNode = domConstruct.create("img", { 
                className: this.iconClass, 
@@ -161,24 +158,5 @@ define(["dojo/_base/declare",
          // Call the method provided by the _AlfPopupCloseMixin to handle popup close events...
          this.registerPopupCloseEvent();
       }
-      
-      // The following code has been left intentionally commented out...
-      // When popup menu items are used the popup is automatically moved to be a child of the document
-      // body to prevent clipping issues, however when a menu bar is used as part of a widget running
-      // in full-screen mode (e.g. as we would like to for the DocumentLibrary) then the menu is never 
-      // displayed. A bug has been filed with the Dojo Community to address this here: https://bugs.dojotoolkit.org/ticket/18085
-      // startup: function alfresco_menus_AlfMenuBarPopup__startup() {
-      //    this.inherited(arguments);
-      //    this.ownerDocumentBody.removeChild(this.popup.domNode);
-      //    this.domNode.appendChild(this.popup.domNode);
-      //    this.popup.ownerDocumentBody = this.domNode;
-      // },
-
-      // _openPopup: function alfresco_menus_AlfMenuBarPopup___openPopup() {
-      //    this.inherited(arguments);
-      //    this.ownerDocumentBody.removeChild(this.popup.domNode.parentNode);
-      //    this.domNode.appendChild(this.popup.domNode.parentNode);
-      //    place.around(this.popup.domNode, this.domNode, ["below"], true);
-      // }
    });
 });

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuGroup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuGroup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -79,7 +79,6 @@ define(["dojo/_base/declare",
          this.templateString = string.substitute(template, { ddmTemplateString: AlfDropDownMenu.prototype.templateString});
       },
       
-      
       /**
        * Sets the group label and creates a new alfresco/menus/AlfDropDownMenu to contain the items 
        * in the group.
@@ -87,7 +86,6 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuGroup__postCreate() {
-         
          if (this.label === "")
          {
             // If there is no label for the title then hide the title node entirely...
@@ -124,7 +122,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt
        */
-      _onRightArrow: function(/*Event*/ evt){
+      _onRightArrow: function(evt){
          if(this.focusedChild && this.focusedChild.popup && !this.focusedChild.disabled)
          {
              // This first block is identical to that of the inherited function...
@@ -218,7 +216,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {boolean} bool 
        */
-      _setSelected: function alfresco_menus_AlfMenuGroup___setSelected(bool) {
+      _setSelected: function alfresco_menus_AlfMenuGroup___setSelected(/*jshint unused:false*/bool) {
          this._selected = true;
       }
    });

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuGroups.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuGroups.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -58,7 +58,6 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuGroups__postCreate() {
-         
          // Set up keyboard handling...
          var l = this.isLeftToRight();
          this._openSubMenuKey = l ? keys.RIGHT_ARROW : keys.LEFT_ARROW;
@@ -77,7 +76,7 @@ define(["dojo/_base/declare",
        */
       allWidgetsProcessed: function alfresco_menus_AlfMenuGroups__allWidgetsProcessed(widgets) {
          var _this = this;
-         array.forEach(widgets, function(widget, i) {
+         array.forEach(widgets, function(widget) {
             _this.addChild(widget);
          });
       },
@@ -91,7 +90,6 @@ define(["dojo/_base/declare",
        * @param {integer} insertIndex The index to add the widget at
        */
       addChild: function alfresco_menus_AlfMenuGroups__addChild(widget, insertIndex) {
-         
          if (widget.isInstanceOf(AlfMenuGroup))
          {
             // Check to see if the current entry is an AlfMenuGroup.


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-290 which is something of an edge case condition (e.g. it requires the user to hover over a different drop-down menu from the one just actioned, and this may or may not be something that often happens). However to prevent this issue occurring I'm disabling the auto open on hover feature in the menu bar. Theoretically the reported problem (that the popup-menu becomes detached) could be reproduced now if the user *clicks* on another menu, but this is even more of an edge case.