### PR TITLE
AKU-307: Memory leak in ResizeMixin

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -77,8 +77,11 @@ define(["dojo/_base/declare",
          }
          else
          {
-            var scope = (resizeHandlerCallScope != null) ? resizeHandlerCallScope : this;
-            on(window, "resize", lang.hitch(scope, resizeHandler));
+            var scope = (resizeHandlerCallScope != null) ? resizeHandlerCallScope : this,
+               resizeListener = on(window, "resize", lang.hitch(scope, resizeHandler));
+            if(typeof this.own === "function") { // If we're in a widget, use it to handle cleaning up the listener
+               this.own(resizeListener);
+            }
             this.alfSubscribe(this.alfResizeNodeTopic, lang.hitch(this, this.alfOnNodeResized, resizeHandler, scope), true);
          }
       },


### PR DESCRIPTION
This addresses issue [AKU-307](https://issues.alfresco.com/jira/browse/AKU-307), which highlights a potential memory leak in ResizeMixin. The fix assumes that most of the time this mixin will be used in a widget, and if it has then it should use the "own" method ensure the resize listener is cleaned up when the widget is destroyed.