### PR TITLE
AKU-297: Removed DND "flutter" 

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/Constants.js
+++ b/aikau/src/main/resources/alfresco/dnd/Constants.js
@@ -74,6 +74,15 @@ define([],function() {
       requestAdditionalConfigEvent: "onAdditionalConfigRequest",
 
       /**
+       * Emitted when a item is dragged over a [DragAndDropNestedTarget]{@link module:alfresco/dnd/DragAndDropNestedTarget}.
+       * 
+       * @instance
+       * @type {string}
+       * @default "onNestedDragOverEvent"
+       */
+      nestedDragOverEvent: "onNestedDragOverEvent",
+
+      /**
        * Emitted when a item is dragged out of a [DragAndDropNestedTarget]{@link module:alfresco/dnd/DragAndDropNestedTarget}.
        * 
        * @instance

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropNestedTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropNestedTarget.js
@@ -56,11 +56,6 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_dnd_DragAndDropNestedTarget__postCreate() {
          this.inherited(arguments);
          on(this.domNode, Constants.itemSavedEvent, lang.hitch(this, this.onItemSaved));
-
-         if (this.previewTarget)
-         {
-            this.previewTarget.onDraggingOut = lang.hitch(this, this.onItemDraggedOut);
-         }
       },
 
       /**
@@ -69,7 +64,22 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
+      onItemDraggedOver: function alfresco_dnd_DragAndDropNestedTarget__onItemDraggedOver() {
+         this.inherited(arguments);
+         on.emit(this.domNode, Constants.nestedDragOverEvent, {
+            bubbles: true,
+            cancelable: true
+         });
+      },
+      
+      /**
+       * Called whenever an item is dragged out of the current drop target. This is emits an event
+       * to indicating that this has occurred to enabled nested drop targets to be supported.
+       * 
+       * @instance
+       */
       onItemDraggedOut: function alfresco_dnd_DragAndDropNestedTarget__onItemDraggedOut() {
+         this.inherited(arguments);
          on.emit(this.domNode, Constants.nestedDragOutEvent, {
             bubbles: true,
             cancelable: true

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -164,10 +164,17 @@ define(["dojo/_base/declare",
                widget.onItemsUpdated();
             }
          }, true);
+
+         if (this.previewTarget)
+         {
+            this.previewTarget.onDraggingOut = lang.hitch(this, this.onItemDraggedOut);
+            this.previewTarget.onDraggingOver = lang.hitch(this, this.onItemDraggedOver);
+         }
          
          // Listen for widgets requesting to be deleted...
          on(this.previewNode, Constants.deleteItemEvent, lang.hitch(this, this.deleteItem));
          on(this.previewNode, Constants.nestedDragOutEvent, lang.hitch(this, this.onNestedDragOut));
+         on(this.previewNode, Constants.nestedDragOverEvent, lang.hitch(this, this.onNestedDragOver));
 
          var _this = this;
          this.watch("value", function(name, oldValue, newValue) {
@@ -417,6 +424,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       onItemsUpdated: function alfresco_dnd_DragAndDropTarget__onItemsUpdated() {
+         domClass.remove(this.previewNode, "alfresco-dnd-DragAndDropTarget--over");
          on.emit(this.domNode, Constants.updateItemsEvent, {
             bubbles: true,
             cancelable: true,
@@ -469,6 +477,26 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Called whenever an item is dragged out of the current drop target. This is emits an event
+       * to indicating that this has occurred to enabled nested drop targets to be supported.
+       * 
+       * @instance
+       */
+      onItemDraggedOver: function alfresco_dnd_DragAndDropTarget__onItemDraggedOver() {
+         domClass.add(this.previewNode, "alfresco-dnd-DragAndDropTarget--over");
+      },
+
+      /**
+       * Called whenever an item is dragged out of the current drop target. This is emits an event
+       * to indicating that this has occurred to enabled nested drop targets to be supported.
+       * 
+       * @instance
+       */
+      onItemDraggedOut: function alfresco_dnd_DragAndDropTarget__onItemDraggedOut() {
+         domClass.remove(this.previewNode, "alfresco-dnd-DragAndDropTarget--over");
+      },
+
+      /**
        * This function is called when a [DragAndDropNestedTarget]{@link module:alfresco/dnd/DragAndDropNestedTarget}
        * has an item dragged out of it. This function will then call the Dojo dojo.dnd.Manager singleton to let it know
        * that the item is currently over the current target. This is required because the Dojo drag and drop framework
@@ -478,9 +506,23 @@ define(["dojo/_base/declare",
        * @param {object} evt The drag out event
        */
       onNestedDragOut: function alfresco_dnd_DragAndDropTarget__onNestedDragOut(evt) {
+         domClass.add(this.previewNode, "alfresco-dnd-DragAndDropTarget--over");
          evt && Event.stop(evt);
          var m = DndManager.manager();
          m.overSource(this.previewTarget);
+      },
+
+      /**
+       * This function is called when a [DragAndDropNestedTarget]{@link module:alfresco/dnd/DragAndDropNestedTarget}
+       * has an item dragged over it. This then updates the CSS classes to indicate that the item is no longer
+       * the current target (because the nested target is the current target).
+       *
+       * @instance 
+       * @param {object} evt The drag out event
+       */
+      onNestedDragOver: function alfresco_dnd_DragAndDropTarget__onNestedDragOver(evt) {
+         // jshint unused:false
+         domClass.remove(this.previewNode, "alfresco-dnd-DragAndDropTarget--over");
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/dnd/css/DragAndDropTarget.css
+++ b/aikau/src/main/resources/alfresco/dnd/css/DragAndDropTarget.css
@@ -18,3 +18,8 @@
    /*border: none;*/
    padding-right: 50px;
 }
+
+.alfresco-dnd-DragAndDropTarget .previewPanel.alfresco-dnd-DragAndDropTarget--over {
+   box-shadow: inset 5px 5px 10px -4px rgba(255, 165, 0, 0.75);
+   border: 1px solid orange;
+}

--- a/aikau/src/main/resources/alfresco/dnd/css/DroppedItemWrapper.css
+++ b/aikau/src/main/resources/alfresco/dnd/css/DroppedItemWrapper.css
@@ -11,7 +11,7 @@
    position: relative;
    min-width: 100px;
    box-shadow: 0.33px 2px 8px rgba(0, 0, 0, 0.3);
-   transition: margin-top .2s .2s ease-out, margin-bottom .2s .2s ease-out;
+   /*transition: margin-top .2s .2s ease-out, margin-bottom .2s .2s ease-out;*/
 }
 
 .alfresco-dnd-DroppedItemWrapper.dojoDndItemOver {
@@ -43,7 +43,7 @@
    clear: right;
 }
 
-.alfresco-dnd-DroppedItemWrapper.dojoDndItem.dojoDndItemOver.dojoDndItemBefore {
+/*.alfresco-dnd-DroppedItemWrapper.dojoDndItem.dojoDndItemOver.dojoDndItemBefore {
    margin-top: 20px;
    transition: margin-top .2s ease-out;
 }
@@ -51,7 +51,7 @@
 .alfresco-dnd-DroppedItemWrapper.dojoDndItem.dojoDndItemOver.dojoDndItemAfter {
    margin-bottom: 20px;
    transition: margin-bottom .2s ease-out;
-}
+}*/
 
 .alfresco-dnd-DroppedItemWrapper > .control {
    display: inline-block;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-297 (or at least makes an attempt to). By removing the transitions and margin updates this should help to indicate whether or not there are deeper issues with moving items around a nested DND structure. The JavaScript now tracks and sets explicit Aikau classes to indicate the current drop target.