### PR TITLE
AKU-328: WidgetInfo click-bubbling problem

### DIFF
--- a/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
+++ b/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
@@ -89,8 +89,9 @@ define(["dojo/_base/declare",
        * selecte widget.
        * 
        * @instance
+       * @param {object} evt Dojo-normalised event object
        */
-      showInfo: function alfresco_debug_WidgetInfo__showInfo() {
+      showInfo: function alfresco_debug_WidgetInfo__showInfo(evt) {
          if (!this.ttd)
          {
             this.displayIdLabel = this.message("widgetInfo.displayId.label");
@@ -125,6 +126,9 @@ define(["dojo/_base/declare",
                popup.close(this.ttd);
             }
          });
+
+         // Prevent bubbling
+         evt && evt.stopPropagation();
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
+++ b/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
@@ -1,75 +1,71 @@
-.alfresco-developer-mode-Enabled .alfresco-debug-Info.highlight {
-   position: relative;
-   padding: 20px;
-   box-shadow: 0 0 3px red;
+.alfresco-developer-mode-Enabled {
+   .alfresco-debug-Info {
+      &.highlight {
+         box-shadow: 0 0 3px red;
+         padding: 20px;
+         position: relative;
+         &:hover {
+            background-color: rgba(255,180,0,.2);
+            box-shadow: 0 0 3px orange;
+         }
+      }
+      > .alfresco-debug-WidgetInfo {
+         display: block;
+      }
+   }
+   .alfresco-debug-PageInfo {
+      display: block;
+   }
 }
 
-.alfresco-debug-Info.highlight {
-   transition: padding 1s ease-in-out;
-}
-
-.alfresco-developer-mode-Enabled .alfresco-debug-Info.highlight:hover {
-   box-shadow: 0 0 3px orange;
-   background-color: rgba(255,180,0,0.2);
-}
-
-.alfresco-developer-mode-Enabled .alfresco-debug-Info > .alfresco-debug-WidgetInfo {
-   display: block;
-}
-
-.alfresco-debug-Info > .alfresco-debug-WidgetInfo {
-   position: absolute;
-   top: 3px;
-   right: 3px;
-   display: none;
+.alfresco-debug-Info {
+   &.highlight {
+      transition: padding .5s cubic-bezier(.25, .75, .5, .9);
+   }
+   > .alfresco-debug-WidgetInfo {
+      display: none;
+      position: absolute;
+      right: 3px;
+      top: 3px;
+   }
 }
 
 .alfresco-debug-WidgetInfoDialog {
    font-size: @large-font-size;
-}
-
-.alfresco-debug-WidgetInfoDialog td.label {
-   color: @de-emphasized-font-color;
-}
-
-.alfresco-debug-WidgetInfoDialog td.value {
-   color: @general-font-color;
-   font-family: @bold-font;
+   outline: none !important;
+   td {
+      &.label {
+         color: @de-emphasized-font-color;
+      }
+      &.value {
+         color: @general-font-color;
+         font-family: @bold-font;
+      }
+   }
 }
 
 .alfresco-debug-WidgetInfoDialogPopup {
    box-shadow: none !important;
 }
 
-.alfresco-debug-WidgetInfoDialog {
-   outline: none !important;
-}
-
 .alfresco-debug-PageInfo {
+   background-color: #ffc800;
+   border: 4px solid #ffb400;
    display: none;
-   height: 20px;
    font-size: @large-font-size;
-   background-color: #FFC800;
-   border: 4px solid #FFB400;
+   height: 20px;
    padding: 5px;
-}
-
-.alfresco-debug-PageInfo > span.label {
-   color: @de-emphasized-font-color;
-   margin-right: 10px;
-}
-
-.alfresco-debug-PageInfo > span.value {
-   color: @general-font-color;
-   font-family: @bold-font;
-   margin-right: 10px;
-}
-
-.alfresco-debug-PageInfo > a {
-   color: @general-font-color;
-   text-decoration: none;
-}
-
-.alfresco-developer-mode-Enabled .alfresco-debug-PageInfo {
-   display: block;
+   > span.label {
+      color: @de-emphasized-font-color;
+      margin-right: 10px;
+   }
+   > span.value {
+      color: @general-font-color;
+      font-family: @bold-font;
+      margin-right: 10px;
+   }
+   > a {
+      color: @general-font-color;
+      text-decoration: none;
+   }
 }

--- a/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
+++ b/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
@@ -101,6 +101,17 @@ define(["intern!object",
             });
       },
 
+      "Clicking info button does not activate click event on widget": function() {
+         return browser.findByCssSelector("#LINK .alfresco-debug-WidgetInfo img")
+            .click()
+            .end()
+
+         .getLastPublish("LINK_CLICKED")
+            .then(function(payload) {
+               assert.isNull(payload, "Payload published incorrectly when clicking info link");
+            });
+      },
+      
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
+      "src/test/resources/alfresco/debug/WidgetInfoTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
   <shortname>WidgetInfo Test</shortname>
+  <description>Simple test page for demonstrating the WidgetInfo functionality</description>
   <family>aikau-unit-tests</family>
   <url>/WidgetInfo</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/debug/WidgetInfo.get.js
@@ -33,10 +33,16 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/navigation/Link",
+         id: "LINK",
+         config: {
+            label: "Test link",
+            title: "This link will do a test publish",
+            publishTopic: "LINK_CLICKED"
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-328](https://issues.alfresco.com/jira/browse/AKU-328) which solves a problem with the WidgetInfo class, where click-bubbling is preventing the info button being useful in Debug mode when a widget already has a click handler.