### PR TITLE
AKU-322: Update ControlRow to publish initial value of its children

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/ControlRow.js
+++ b/aikau/src/main/resources/alfresco/forms/ControlRow.js
@@ -134,7 +134,7 @@ define(["alfresco/layout/HorizontalWidgets",
        * @param {object} widget The widget to get the value from
        * @param {number} index The index of the widget
        */
-      addChildFormControlValue: function alfresco_forms_ControlRow__addChildFormControlValue(values, widget, index) {
+      addChildFormControlValue: function alfresco_forms_ControlRow__addChildFormControlValue(values, widget, /*jshint unused:false*/ index) {
          if (typeof widget.addFormControlValue === "function")
          {
             widget.addFormControlValue(values);
@@ -157,7 +157,7 @@ define(["alfresco/layout/HorizontalWidgets",
        * @param {object} widget The widget to get the value from
        * @param {number} index The index of the widget
        */
-      updateChildFormControlValue: function alfresco_forms_ControlRow__updateChildFormControlValue(values, widget, index) {
+      updateChildFormControlValue: function alfresco_forms_ControlRow__updateChildFormControlValue(values, widget, /*jshint unused:false*/ index) {
          if (typeof widget.addFormControlValue === "function")
          {
             widget.updateFormControlValue(values);
@@ -179,10 +179,37 @@ define(["alfresco/layout/HorizontalWidgets",
        * @param {object} widget The widget to validate
        * @param {number} index The index of the widget to validate
        */
-      validateChildFormControlValue: function alfresco_forms_ControlRow__validateChildFormControlValue(widget, index) {
+      validateChildFormControlValue: function alfresco_forms_ControlRow__validateChildFormControlValue(widget, /*jshint unused:false*/ index) {
          if (typeof widget.validateFormControlValue === "function")
          {
             widget.validateFormControlValue();
+         }
+      },
+
+      /**
+       * Iterates over the child form controls and publishes the value of each one.
+       * 
+       * @instance
+       * @param {Deferred} deferred A deferred object can optionally be passed. This will only be resolved as widget value
+       */
+      publishValue: function alfresco_forms_ControlRow__publishValue(deferred) {
+         array.forEach(this._processedWidgets, lang.hitch(this, this.publishChildValue, deferred));
+      },
+
+      /**
+       * This is called by the [publishValue]{@link module:alfresco/forms/ControlRow#publishValue} function for each
+       * of the child form controls in the row and calls its 
+       * [publishValue]{@link module:alfresco/forms/controls/BaseFormControl#publishValue} function.
+       * 
+       * @instance
+       * @param {Deferred} deferred A deferred object can optionally be passed. This will only be resolved as widget value
+       * @param {object} widget The widget to validate
+       * @param {number} index The index of the widget to validate
+       */
+      publishChildValue: function alfresco_forms_ControlRow__publishChildValue(deferred, widget, /*jshint unused:false*/ index) {
+         if (typeof widget.publishValue === "function")
+         {
+            widget.publishValue(deferred);
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/forms/ControlRow.js
+++ b/aikau/src/main/resources/alfresco/forms/ControlRow.js
@@ -190,7 +190,7 @@ define(["alfresco/layout/HorizontalWidgets",
        * Iterates over the child form controls and publishes the value of each one.
        * 
        * @instance
-       * @param {Deferred} deferred A deferred object can optionally be passed. This will only be resolved as widget value
+       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
        */
       publishValue: function alfresco_forms_ControlRow__publishValue(deferred) {
          array.forEach(this._processedWidgets, lang.hitch(this, this.publishChildValue, deferred));
@@ -202,7 +202,7 @@ define(["alfresco/layout/HorizontalWidgets",
        * [publishValue]{@link module:alfresco/forms/controls/BaseFormControl#publishValue} function.
        * 
        * @instance
-       * @param {Deferred} deferred A deferred object can optionally be passed. This will only be resolved as widget value
+       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
        * @param {object} widget The widget to validate
        * @param {number} index The index of the widget to validate
        */

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1576,7 +1576,7 @@ define(["dojo/_base/declare",
        * all of its controls values to process all rules.
        * 
        * @instance
-       * @param {Deferred} deferred A deferred object can optionally be passed. This will only be resolved as widget value
+       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
        * initialization completes.
        */
       publishValue: function alfresco_forms_controls_BaseFormControl__publishValue(deferred) {

--- a/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
+++ b/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "ControlRow Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/ControlRow", "ControlRow Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Test child form controls publish values": function() {
+         return browser.findByCssSelector("#DB1_label")
+            .click()
+         .end()
+         .getLastPublish("FORM1__valueChangeOf_SELECT1")
+            .then(function(payload) {
+               assert.equal(payload.value, "ONE", "The initial value of the select field wasn't published");
+            })
+         .getLastPublish("FORM1_TEST")
+            .then(function(payload) {
+               assert.equal(payload.selected, "ONE", "The dynamic payload button didn't get the published update");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
+++ b/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
@@ -47,6 +47,10 @@ define(["intern!object",
             .then(function(payload) {
                assert.equal(payload.value, "ONE", "The initial value of the select field wasn't published");
             })
+         .getLastPublish("FORM1__valueChangeOf_TEXTBOX1")
+         .then(function(payload) {
+            assert.equal(payload.value, "Initial Value", "The initial value of the text box field wasn't published");
+         })
          .getLastPublish("FORM1_TEST")
             .then(function(payload) {
                assert.equal(payload.selected, "ONE", "The dynamic payload button didn't get the published update");

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -82,6 +82,7 @@ define({
 
       "src/test/resources/alfresco/footer/FooterTest",
 
+      "src/test/resources/alfresco/forms/ControlRowTest",
       "src/test/resources/alfresco/forms/CrudFormTest",
       "src/test/resources/alfresco/forms/DynamicFormTest",
       "src/test/resources/alfresco/forms/FormsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>ControlRow</shortname>
+  <description>Demonstrates the use of an alfresco/forms/ControlRow to place multiple form controls on a single row.</description>
+  <family>aikau-unit-tests</family>
+  <url>/ControlRow</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
@@ -39,6 +39,17 @@ model.jsonModel = {
                                  ]
                               }
                            }
+                        },
+                        {
+                           id: "TEXTBOX1",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "TEXTBOX1",
+                              name: "textbox",
+                              label: "Some Text",
+                              description: "Created to ensure that initial value is published",
+                              value: "Initial Value"
+                           }
                         }
                      ]
                   }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
@@ -1,0 +1,70 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "FORM1",
+         name: "alfresco/forms/Form",
+         config: {
+            pubSubScope: "FORM1_",
+            widgets: [
+               {
+                  id: "CR1",
+                  name: "alfresco/forms/ControlRow",
+                  config: {
+                     widgets: [
+                        {
+                           id: "SELECT1",
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              fieldId: "SELECT1",
+                              name: "select",
+                              label: "Select option",
+                              description: "Selecting an option should update the dynamic payload button",
+                              optionsConfig: {
+                                 fixed: [
+                                    { label: "One", value: "ONE" },
+                                    { label: "Two", value: "TWO" }
+                                 ]
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "DB1",
+         name: "alfresco/buttons/AlfDynamicPayloadButton",
+         config: {
+            pubSubScope: "FORM1_",
+            label: "Dynamically Updated Button",
+            publishTopic: "TEST",
+            publishPayloadSubscriptions: [
+               {
+                  topic: "_valueChangeOf_SELECT1",
+                  dataMapping: {
+                     value: "selected"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-322. I've reproduced the reported issue and created a unit test to verify the problem and then fixed the issue in the "alfresco/forms/ControlRow" widget.