### PR TITLE
AKU-318: Ensure that nested DND item label isn't lost when editing parent DND item

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -258,7 +258,7 @@ define(["dojo/_base/declare",
 
             // Set the value to be processed...
             this.currentItem = {};
-            this.currentItem.label = item.label;
+            this.currentItem.label = item.label || item.value.label; // If no label is provided on the item, check the value (See AKU-318)
             this.currentItem.value = item.value;
             this.processObject(["processCurrentItemTokens"], widgetModel);
             
@@ -295,7 +295,7 @@ define(["dojo/_base/declare",
 
                // Set the value to be processed...
                this.currentItem.value = clonedItem.value;
-               this.currentItem.label = clonedItem.label;
+               this.currentItem.label = clonedItem.label || clonedItem.value.label;
 
                // Check to see if a specific widget model has been requested for rendering the dropped item...
                // TODO Not sure that we actually care about this yet? If at all... shouldn't everything be part of the value?

--- a/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
@@ -201,6 +201,13 @@ define(["dojo/_base/declare",
          if (this.label)
          {
             this.labelNode.innerHTML = this.encodeHTML(this.message(this.label));
+
+            // Save the label as part of the overall value so that it is not lost when an enclosing
+            // widget is edited. See AKU-318
+            if (this.value)
+            {
+               this.value.label = this.label;
+            }
          }
          if (this.widgets !== null && this.widgets !== undefined)
          {
@@ -290,13 +297,18 @@ define(["dojo/_base/declare",
             var subscriptionTopic = this.generateUuid();
             var subscriptionHandle = this.alfSubscribe(subscriptionTopic, lang.hitch(this, this.onEditSave));
 
+            var payloadMixin = {
+               label: this.label,
+               subscriptionHandle: subscriptionHandle,
+               widgets: this.widgets
+            };
+            $.extend(true, payloadMixin, item);
+
             this.alfPublish("ALF_CREATE_FORM_DIALOG_REQUEST", {
                dialogId: "ALF_DROPPED_ITEM_CONFIGURATION_DIALOG",
                dialogTitle: item.name,
                formSubmissionTopic: subscriptionTopic,
-               formSubmissionPayloadMixin: {
-                  subscriptionHandle: subscriptionHandle
-               },
+               formSubmissionPayloadMixin: payloadMixin,
                dialogWidth: "80%",
                fixedWidth: true,
                formValue: item,

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -488,7 +488,8 @@ define(["intern!object",
             .click()
          .end()
 
-         .sleep(1000) // Make sure dialog disappears...
+         .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogHidden") // Wait for the dialog to be hidden
+         .end()
          .pressKeys(keys.TAB)
          .sleep(pause)
          .pressKeys(keys.ENTER)
@@ -514,6 +515,51 @@ define(["intern!object",
                assert.lengthOf(elements, 3, "Found an unexpected number of form controls");
             });
 
+      },
+
+      "Edit outer widget and check label is persisted": function() {
+         return browser.findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG .cancellationButton > span")
+               .click()
+            .end()
+            
+            .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogHidden") // Wait for the dialog to be hidden
+            .end()
+
+            .pressKeys(keys.SHIFT) // Need to tab backwards to the outer edit action
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.TAB)
+            .pressKeys(keys.SHIFT)
+            .sleep(pause)
+            .pressKeys(keys.ENTER)
+
+            .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed") // Wait for the dialog to render
+            .end()
+
+            // Now tab to confirmation button and close the dialog
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.TAB)
+            .sleep(pause)
+            .pressKeys(keys.ENTER)
+
+            .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogHidden") // Wait for the dialog to be hidden
+            .end()
+
+            // Check that the label has been preserved...
+            .findByCssSelector(".alfresco-dnd-DragAndDropTarget .alfresco-dnd-DragAndDropTarget span.label")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Horizontal Widgets", "The dropped item label was not preserved after editing parent");
+               });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/additional-config.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/additional-config.get.js
@@ -136,9 +136,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-318 to ensure that dropped item label information is not lost from a nested dropped item when editing the item that it has been dropped into.