### PR TITLE
AKU-321: Added alfresco/lists/views/HtmlListView

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/HtmlListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/HtmlListView.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This module extends the [base list view]{@link module:alfresco/lists/views/AlfListView} to render a simple
+ * HTML list of items. It is intended to be used when only a single 
+ * [property]{@link module:alfresco/lists/views/HtmlListView#propertyToRender} from each item in the list needs
+ * to be displayed. This view replaces the standard [ListRenderer]{@link module:alfresco/lists/views/ListRenderer}
+ * with a [custom list renderer]{@link module:alfresco/lists/views/HtmlListViewRenderer} that iterates over the list
+ * of items and renders a single property of each one as an individual bullet. The bullet style can be configured
+ * using the [listStyleType]{@link module:alfresco/lists/views/HtmlListView#listStyleType} attributes.
+ *
+ * @example <caption>Example of using the view within a list:</caption>
+ * {
+ *   name: "alfresco/lists/AlfList",
+ *   config: {
+ *     widgets: [
+ *       {
+ *         name: "alfresco/lists/views/HtmlListView",
+ *         config: {
+ *           propertyToRender: "node.properties.cm:name",
+ *           listStyleType: "square"
+ *         }
+ *       }
+ *     ]
+ *   }
+ * 
+ * @module alfresco/lists/views/HtmlListView
+ * @extends module:alfresco/lists/views/AlfListView
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/views/AlfListView",
+        "dojo/text!./templates/HtmlListView.html",
+        "alfresco/lists/views/HtmlListViewRenderer"], 
+        function(declare, AlfListView, template, HtmlListViewRenderer) {
+
+   return declare([AlfListView], {
+
+      /**
+       * The HTML template to use for the widget.
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
+
+      /**
+       * This is the dot-notation addressed property within each item to render as the value in the list
+       * element.
+       *
+       * @instance
+       * @type {string}
+       * @default  "displayName"
+       */
+      propertyToRender: "displayName",
+
+      /**
+       * The bullet style to apply to each list item. These should be set to one of the supported
+       * [link-style-type values]{@link https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type}.
+       *
+       * @instance
+       * @type {string}
+       * @default "none"
+       */
+      listStyleType: "none",
+
+      /**
+       * Overrides the [inherited function]{@link module:alfresco/lists/views/AlfListView#createListRenderer}
+       * to create an [HtmlListViewRenderer]{@link module:alfresco/lists/views/HtmlListViewRenderer}.
+       * 
+       * @instance
+       * @returns {object} A new [HtmlListViewRenderer]{@link module:alfresco/lists/views/HtmlListViewRenderer}
+       */
+      createListRenderer: function alfresco_lists_views_HtmlListView__createListRenderer() {
+         var dlr = new HtmlListViewRenderer({
+            items: this.currentData.items,
+            propertyToRender: this.propertyToRender || "displayName",
+            listStyleType: this.listStyleType || "none"
+         });
+         return dlr;
+      },
+
+      /**
+       * Override the default selector to match the li elements created by the renderer.
+       *
+       * @instance
+       * @type {string}
+       * @default "li.alfresco-lists-views-HtmlListView--item"
+       */
+      renderFilterSelectorQuery: "li.alfresco-lists-views-HtmlListView--item"
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/HtmlListViewRenderer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/HtmlListViewRenderer.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This module is expected to be used as the [ListRenderer]{@link module:alfresco/lists/views/ListRenderer}
+ * for the [HtmlListView]{@link module:alfresco/lists/views/HtmlListView}. It iterates over the supplied list
+ * of [items]{@link module:alfresco/lists/views/HtmlListViewRenderer#items} and outputs each one as an HTML
+ * li element. This widget is not expected to be included directly in a page model but rather should be referenced
+ * programmatically from within other widgets.
+ * 
+ * @module alfresco/lists/views/HtmlListViewRenderer
+ * @extends module:alfresco/lists/views/ListRenderer
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/views/ListRenderer",
+        "dojo/text!./templates/HtmlListViewRenderer.html",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "dojo/dom-construct"], 
+        function(declare, ListRenderer, template, lang, array, domConstruct) {
+   
+   return declare([ListRenderer], {
+
+      /**
+       * Overides the inherited template.
+       *
+       * @instance
+       * @type {string}
+       */
+      templateString: template,
+
+      /**
+       * The bullet style to apply to each list item.
+       *
+       * @instance
+       * @type {string}
+       * @default "none"
+       */
+      listStyleType: "none",
+
+      /**
+       * Should be set to an array of items to render as HTML li elements.
+       *
+       * @instance
+       * @type {object[]}
+       * @default null
+       */
+      items: null,
+
+      /**
+       * Overrides the [inherited function]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin#renderData}
+       * to iterate over the items that are expected to have been provided by a parent  
+       * [HtmlListView]{@link module:alfresco/lists/views/HtmlListView#createListRenderer}.
+       * 
+       * @instance
+       */
+      renderData: function alfresco_lists_views_HtmlListViewRenderer__renderData() {
+         array.forEach(this.items, function(item) {
+            var property = lang.getObject(this.propertyToRender, false, item);
+            if (property || property === 0 || property === false)
+            {
+               domConstruct.create("li", {
+                  "class": "alfresco-lists-views-HtmlListView--item",
+                  innerHTML: property,
+                  style: "list-style-type:" + this.listStyleType
+               }, this.domNode, "last");
+            }
+         }, this);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListView.html
+++ b/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListView.html
@@ -1,0 +1,3 @@
+<div class="alfresco-lists-views-HtmlListView">
+   <div class="items" data-dojo-attach-point="tableNode"></div>
+</div>

--- a/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListViewRenderer.html
+++ b/aikau/src/main/resources/alfresco/lists/views/templates/HtmlListViewRenderer.html
@@ -1,0 +1,1 @@
+<ul class="alfresco-lists-views-HtmlListView--renderer"></ul>

--- a/aikau/src/test/resources/alfresco/lists/views/HtmlListViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/HtmlListViewTest.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "HtmlListView Tests",
+      
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/HtmlListView", "HtmlListView Tests").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Count the list elements (DEFAULTS)": function() {
+         return browser.findAllByCssSelector("#DEFAULTS.alfresco-lists-AlfList li")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "Unexpected number of li elements found");
+            });
+      },
+
+      "Check the properties have been rendered correctly (DEFAULTS)": function() {
+         // Just check a couple...
+         return browser.findByCssSelector("#DEFAULTS.alfresco-lists-AlfList li:nth-child(1)")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "bob", "First item rendered incorrectly");
+            })
+         .end()
+         .findByCssSelector("#DEFAULTS.alfresco-lists-AlfList li:nth-child(4)")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "trevor", "Last item rendered incorrectly");
+            });
+      },
+
+      "Check that the list style is overridden (DEFAULTS)": function() {
+         return browser.findAllByCssSelector(".alfresco-lists-AlfList li[style=\"list-style-type:none\"]")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "List style type not overridden");
+            });
+      },
+
+      "Count the list elements (OVERRIDES)": function() {
+         return browser.findAllByCssSelector("#OVERRIDES.alfresco-lists-AlfList li")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "Unexpected number of li elements found");
+            });
+      },
+
+      "Check the properties have been rendered correctly (OVERRIDES)": function() {
+         // Just check a couple...
+         return browser.findByCssSelector("#OVERRIDES.alfresco-lists-AlfList li:nth-child(1)")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "one", "First item rendered incorrectly");
+            })
+         .end()
+         .findByCssSelector("#OVERRIDES.alfresco-lists-AlfList li:nth-child(4)")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "four", "Last item rendered incorrectly");
+            });
+      },
+
+      "Check that the list style is overridden (OVERRIDES)": function() {
+         return browser.findAllByCssSelector(".alfresco-lists-AlfList li[style=\"list-style-type:square\"]")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "List style type not overridden");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -127,6 +127,7 @@ define({
       "src/test/resources/alfresco/lists/AlfHashListTest",
       "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
       "src/test/resources/alfresco/lists/FilteredListTest",
+      "src/test/resources/alfresco/lists/views/HtmlListViewTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
       "src/test/resources/alfresco/lists/views/layouts/RowTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>HtmlListView</shortname>
+  <description>This is an example of an AlfList using the HtmlListView. It is a very simple view that just renders single properties from each listed item in an HTML li element.</description>
+  <family>aikau-unit-tests</family>
+  <url>/HtmlListView</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/HtmlListView.get.js
@@ -1,0 +1,104 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Defaults",
+                     widgets: [
+                        {
+                           id: "DEFAULTS",
+                           name: "alfresco/lists/AlfList",
+                           config: {
+                              currentData: {
+                                 items: [
+                                    {
+                                       name: "one",
+                                       displayName: "bob"
+                                    },
+                                    {
+                                       name: "two",
+                                       displayName: "ted"
+                                    },
+                                    {
+                                       name: "three",
+                                       displayName: "geoff"
+                                    },
+                                    {
+                                       name: "four",
+                                       displayName: "trevor"
+                                    }
+                                 ]
+                              },
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/HtmlListView"
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Overrides propertyToRender and listStyleType",
+                     widgets: [
+                        {
+                           id: "OVERRIDES",
+                           name: "alfresco/lists/AlfList",
+                           config: {
+                              currentData: {
+                                 items: [
+                                    {
+                                       name: "one",
+                                       displayName: "bob"
+                                    },
+                                    {
+                                       name: "two",
+                                       displayName: "ted"
+                                    },
+                                    {
+                                       name: "three",
+                                       displayName: "geoff"
+                                    },
+                                    {
+                                       name: "four",
+                                       displayName: "trevor"
+                                    }
+                                 ]
+                              },
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/HtmlListView",
+                                    config: {
+                                       listStyleType: "square",
+                                       propertyToRender: "name"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-321 and provides a simple view for lists that outputs a single property from each item as an HTML li element.