### PR TITLE
AKU-298: Add global support for additionalCssClasses

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -528,6 +528,15 @@ define(["dojo/_base/declare",
                      }).placeAt(instantiatedWidget.domNode);
                      domConstruct.place(infoWidget.domNode, instantiatedWidget.domNode, "first");
                   }
+
+                  // Look to see if we can add any additional CSS classes configured onto the instantiated widgets
+                  // This should cover any widgets created by a call to the processWidgets function but will
+                  // not capture widgets instantiated directly (which we should look to phase out) but this is
+                  // why "additionalCssClasses" may still be defined and set explicitly in some widgets.
+                  if (instantiatedWidget.domNode && initArgs.additionalCssClasses)
+                  {
+                     domClass.add(instantiatedWidget.domNode, initArgs.additionalCssClasses);
+                  }
                }
                catch (e)
                {

--- a/aikau/src/main/resources/alfresco/core/ProcessWidgets.js
+++ b/aikau/src/main/resources/alfresco/core/ProcessWidgets.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -35,9 +35,8 @@ define(["dojo/_base/declare",
         "alfresco/core/CoreWidgetProcessing",
         "dojo/text!./templates/ProcessWidgets.html",
         "dojo/dom-construct",
-        "dojo/dom-class",
-        "dojo/_base/array"], 
-        function(declare, _Widget, _Templated, AlfCore, CoreWidgetProcessing, template, domConstruct, domClass, array) {
+        "dojo/dom-class"], 
+        function(declare, _Widget, _Templated, AlfCore, CoreWidgetProcessing, template, domConstruct, domClass) {
    
    return declare([_Widget, _Templated, AlfCore, CoreWidgetProcessing], {
       
@@ -84,7 +83,7 @@ define(["dojo/_base/declare",
        * @instance postCreate
        */
       postCreate: function alfresco_core_ProcessWidgets__postCreate() {
-         domClass.add(this.domNode, (this.additionalCssClasses != null ? this.additionalCssClasses : ""));
+         domClass.add(this.domNode, this.additionalCssClasses || "");
          if (this.widgets)
          {
             this.processWidgets(this.widgets, this.containerNode);

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -370,6 +370,20 @@ define(["intern!object",
             });
       },
 
+      "Check that custom wrapper CSS defined in the model is present": function() {
+         return browser.findAllByCssSelector(".custom-wrapper-class")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Could not find custom wrapper class");
+            });
+      },
+
+      "Check that custom item CSS defined in the model is present": function() {
+         return browser.findAllByCssSelector(".custom-item-class")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Could not find custom item class");
+            });
+      },
+
       "Drag and drop and item": function () {
          return browser.findByCssSelector("#dojoUnique1 .title")
             .moveMouseTo()
@@ -430,7 +444,7 @@ define(["intern!object",
             });
       },
 
-     "Post Coverage Results": function() {
+      "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/modeller.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/modeller.get.js
@@ -65,12 +65,16 @@ model.jsonModel = {
                      {
                         name: "alfresco/dnd/DroppedItemWrapper",
                         config: {
+                           additionalCssClasses: "custom-wrapper-class",
                            showEditButton: true,
                            label: "{label}",
                            value: "{value}",
                            widgets: [
                               {
-                                 name: "alfresco/dnd/DroppedItemWidgets"
+                                 name: "alfresco/dnd/DroppedItemWidgets",
+                                 config: {
+                                    additionalCssClasses: "custom-item-class"
+                                 }
                               }
                            ]
                         }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-298 to provide support for the "additionalCssClasses" attribute whenever processWidgets is called. Specifically this meets DND requirements of being able to set CSS classes on modelled dropped items.