### PR TITLE
AKU-301: Support alternative edit item publications in DND

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/css/DynamicForm.css
+++ b/aikau/src/main/resources/alfresco/forms/css/DynamicForm.css
@@ -1,0 +1,3 @@
+.alfresco-forms-DynamicForm .buttons.alfresco-forms-DynamicForm--hidden {
+   display: none;
+}

--- a/aikau/src/test/resources/alfresco/dnd/AlternateEditorTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/AlternateEditorTest.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+
+      name: "DND Alternative Editing Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/alternative-editor-dnd", "DND Alternative Editing Tests")
+            .end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/dnd/AlternateEditorTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/AlternateEditorTest.js
@@ -41,6 +41,61 @@ define(["intern!object",
          browser.end();
       },
 
+      "Check that dynamic form buttons aren't displayed initially": function() {
+         return browser.findByCssSelector(".alfresco-forms-DynamicForm .buttons")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The form buttons should not have been displayed initially because no form controls are configured");
+            });
+      },
+
+      "Check that no text boxes are displayed initially": function() {
+         return browser.findAllByCssSelector(".alfresco-forms-controls-TextBox")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "No TextBox widgets should exist before edit");
+            });
+      },
+
+      "Check edit doesn't open a dialog": function() {
+         return browser.findByCssSelector(".action.edit > img")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-dialogs-AlfDialog")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "Dialog unexpectedly created");
+            });
+      },
+
+      "Check that dynamic form buttons are displayed after edit": function() {
+         return browser.findByCssSelector(".alfresco-forms-DynamicForm .buttons")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The form buttons should have been displayed after edit operation");
+            });
+      },
+
+      "Check that 3 text boxes are displayed after editing": function() {
+         return browser.findAllByCssSelector(".alfresco-forms-controls-TextBox")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "TextBox widgets should have been created");
+            });
+      },
+
+      "Edit description": function() {
+         return browser.findByCssSelector(".alfresco-forms-DynamicForm .alfresco-forms-controls-TextArea textarea")
+            .clearValue()
+            .type("Updated description")
+         .end()
+         .findByCssSelector(".alfresco-forms-DynamicForm .confirmationButton > span")
+            .click()
+         .end()
+         .findByCssSelector(".alfresco-dnd-DroppedItemWidgets .alfresco-forms-controls-TextArea .description")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Updated description", "The description was not updated");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,7 +31,7 @@ define({
     * @type [string]
     */
    // Uncomment and add specific tests as necessary during development!
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/dnd/DndTest"
    ],
 
@@ -41,7 +41,7 @@ define({
     * @instance
     * @type [string]
     */
-   xbaseFunctionalSuites: [
+   baseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 
@@ -61,6 +61,7 @@ define({
 
       "src/test/resources/alfresco/debug/WidgetInfoTest",
 
+      "src/test/resources/alfresco/dnd/AlternateEditorTest",
       "src/test/resources/alfresco/dnd/DndTest",
       "src/test/resources/alfresco/dnd/FormCreationTest",
       "src/test/resources/alfresco/dnd/ModelCreationServiceTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,8 +31,8 @@ define({
     * @type [string]
     */
    // Uncomment and add specific tests as necessary during development!
-   xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/debug/WidgetInfoTest"
+   baseFunctionalSuites: [
+      "src/test/resources/alfresco/dnd/DndTest"
    ],
 
    /**
@@ -41,7 +41,7 @@ define({
     * @instance
     * @type [string]
     */
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Drag-and-drop (alternate edit display)</shortname>
+  <description>Shows an example configuring an alternative editor for dropped items</description>
+  <family>aikau-unit-tests</family>
+  <url>/alternative-editor-dnd</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.js
@@ -1,0 +1,167 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      {
+         name: "alfresco/services/DragAndDropModellingService",
+         config: {
+            models: [
+               {
+                  property: "name",
+                  targetValues: ["alfresco/forms/controls/(.*)"],
+                  widgetsForConfig: [
+                     {
+                        id: "ALF_EDIT_FORM_CONTROL_NAME",
+                        name: "alfresco/forms/controls/TextBox",
+                        config: {
+                           fieldId: "NAME",
+                           name: "name",
+                           visibilityConfig: {
+                              initialValue: false
+                           }
+                        }
+                     },
+                     {
+                        id: "ALF_EDIT_FORM_CONTROL_LABEL",
+                        name: "alfresco/forms/controls/TextBox",
+                        config: {
+                           fieldId: "LABEL",
+                           label: "Label",
+                           description: "The label for the form field value",
+                           name: "config.label"
+                        }
+                     },
+                     {
+                        id: "ALF_EDIT_FORM_CONTROL_DESCRIPTION",
+                        name: "alfresco/forms/controls/TextArea",
+                        config: {
+                           fieldId: "DESCRIPTION",
+                           label: "Description",
+                           description: "The description of the form field value",
+                           name: "config.description"
+                        }
+                     },
+                     {
+                        id: "ALF_EDIT_FORM_CONTROL_VALUE",
+                        name: "alfresco/forms/controls/TextBox",
+                        config: {
+                           fieldId: "VALUE",
+                           label: "Value",
+                           description: "The initial value to assign the form field",
+                           name: "config.value"
+                        }
+                     }
+                  ],
+                  widgetsForDisplay: [
+                     {
+                        name: "alfresco/dnd/DroppedItemWrapper",
+                        config: {
+                           additionalCssClasses: "custom-wrapper-class",
+                           showEditButton: true,
+                           label: "{label}",
+                           value: "{value}",
+                           widgets: [
+                              {
+                                 name: "alfresco/dnd/DroppedItemWidgets",
+                                 config: {
+                                    additionalCssClasses: "custom-item-class"
+                                 }
+                              }
+                           ],
+                           editPublishTopic: "EDIT_ITEM"
+                        }
+                     }
+                  ]
+               }
+
+            ]
+         }
+      },
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "DRAG_PALETTE",
+                  name: "alfresco/dnd/DragAndDropItems",
+                  config: {
+                     items: [
+                        {
+                           type: [ "widget" ],
+                           label: "Text Area",
+                           value: {
+                              name: "alfresco/forms/controls/TextArea",
+                              config: {
+                                 label: "No Label",
+                                 description: "No description",
+                                 value: ""
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "FORM",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     scopeFormControls: false,
+                     okButtonLabel: "Save",
+                     okButtonPublishTopic: "FORM_POST",
+                     okButtonPublishGlobal: true,
+                     showCancelButton: false,
+                     widgets: [
+                        {
+                           id: "ROOT_DROPPED_ITEMS",
+                           name: "alfresco/forms/controls/DragAndDropTargetControl",
+                           config: {
+                              label: "Widgets",
+                              name: "widgets",
+                              value: [
+                                 {
+                                    label: "Test",
+                                    name: "alfresco/forms/controls/TextArea",
+                                    config: {
+                                       label: "Preset label",
+                                       description: "Preset Description",
+                                       value: "Preset value"
+                                    }
+                                 }
+                              ],
+                              acceptTypes: ["widget"],
+                              useModellingService: true
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/DynamicForm",
+                  config: {
+                     subscriptionTopic: "EDIT_ITEM",
+                     formWidgetsProperty: "widgets",
+                     formWidetsPropertyStringified: false,
+                     formValueProperty: "formValue",
+                     okButtonPublishGlobal: true
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/alternate-edit.get.js
@@ -148,6 +148,7 @@ model.jsonModel = {
                   }
                },
                {
+                  id: "DYNAMIC_FORM",
                   name: "alfresco/forms/DynamicForm",
                   config: {
                      subscriptionTopic: "EDIT_ITEM",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-301 and allows developers to configure alternative publication topics and payloads for editing dropped items. The default behaviour of requesting that a dialog be displayed is retained and a unit test has been added to edit dropped items using the "alfresco/forms/DynamicForm" widget which has been updated to support this use case and make it more abstract.