### PR TITLE
AKU-316: Update forms to support hashVarsForUpdate

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfFilterMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfFilterMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -49,7 +49,7 @@ define(["dojo/_base/declare",
        */
       processFilter: function alfresco_documentlibrary__AlfFilterMixin__processFilter(data) {
          var filterObj = ioQuery.queryToObject(data);
-         if (filterObj == null)
+         if (!filterObj)
          {
             // The default filter is root location in a document lib...
             filterObj = {

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -128,8 +128,8 @@ define(["dojo/_base/declare",
        * @return {boolean}
        * @private
        */
-      doHashVarUpdate: function alfresco_documentlibrary__AlfHashMixin__doHashVarUpdate(payload, updateInstanceValues) {
-         return this.payloadContainsUpdateableVar(payload, updateInstanceValues) && 
+      doHashVarUpdate: function alfresco_documentlibrary__AlfHashMixin__doHashVarUpdate(payload, updateInstanceValues, updateObject) {
+         return this.payloadContainsUpdateableVar(payload, updateInstanceValues, updateObject) && 
                 this.payloadContainsRequiredUpdateableVars(payload) && 
                 this.payloadContainsEqualUpdateableVars(payload);
       },
@@ -147,13 +147,18 @@ define(["dojo/_base/declare",
        * @param {boolean} updateInstanceValues Indicates whether or not the list instance should be updated with the payload values
        * @return {boolean}
        */
-      payloadContainsUpdateableVar: function alfresco_documentlibrary__AlfHashMixin__payloadContainsUpdateableVar(payload, updateInstanceValues) {
+      payloadContainsUpdateableVar: function alfresco_documentlibrary__AlfHashMixin__payloadContainsUpdateableVar(payload, updateInstanceValues, updateObject) {
+         // jshint maxcomplexity:false
          var containsUpdateableVar = false;
 
          // No hashVarsForUpdate - return true
          if(!this.hashVarsForUpdate || this.hashVarsForUpdate.length === 0)
          {
             containsUpdateableVar = true;
+            if (updateInstanceValues === true)
+            {
+               lang.mixin(updateObject || this, payload);
+            }
          }
          else
          {
@@ -164,7 +169,8 @@ define(["dojo/_base/declare",
                {
                   if (updateInstanceValues === true)
                   {
-                     this[this.hashVarsForUpdate[i]] = payload[this.hashVarsForUpdate[i]];
+                     var objectToUpdate = updateObject || this;
+                     objectToUpdate[this.hashVarsForUpdate[i]] = payload[this.hashVarsForUpdate[i]];
                   }
                   containsUpdateableVar = true;
                }

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -474,11 +474,18 @@ define(["dojo/_base/declare",
          // but is not actually part of the form data)...
          delete payload.alfTopic;
          delete payload.alfPublishScope;
-         var currHash = ioQuery.objectToQuery(payload);
          
+         // Make sure that only the controls with names listed in hashVarsForUpdate are set on the URL hash...
+         var updatedHash = {};
+         this.payloadContainsUpdateableVar(payload, true, updatedHash);
+
+         var currHash =  ioQuery.queryToObject(hash());
+         lang.mixin(currHash, updatedHash);
+         var hashString = ioQuery.objectToQuery(currHash);
+
          // Publish so that the NavigationService can set the hash fragment...
          this.alfPublish("ALF_NAVIGATE_TO_PAGE", {
-            url: currHash,
+            url: hashString,
             type: "HASH"
          }, true);
       },
@@ -491,11 +498,13 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The publication topic.
        */
-      onHashChange: function alfresco_forms_Form__onHashChange(payload) {
+      onHashChange: function alfresco_forms_Form__onHashChange(hashString) {
          if (this.useHash === true)
          {
-            var hashData = this.processFilter(payload);
-            this.setValue(hashData);
+            var currHash = ioQuery.queryToObject(hashString);
+            var updatedFormValue = {};
+            this.doHashVarUpdate(currHash, true, updatedFormValue);
+            this.setValue(updatedFormValue);
          }
       },
 
@@ -525,7 +534,7 @@ define(["dojo/_base/declare",
                if (this.okButtonPublishTopic &&
                    lang.trim(this.okButtonPublishTopic) !== "")
                {
-                  this.alfSubscribe(this.okButtonPublishTopic, lang.hitch(this, "setHashFragment"), this.okButtonPublishGlobal);
+                  this.alfSubscribe(this.okButtonPublishTopic, lang.hitch(this, this.setHashFragment), this.okButtonPublishGlobal);
                }
                else
                {
@@ -587,7 +596,9 @@ define(["dojo/_base/declare",
             if (this.useHash)
             {
                var currHash = ioQuery.queryToObject(hash());
-               this.setValue(currHash);
+               var updatedFormValue = {};
+               this.doHashVarUpdate(currHash, true, updatedFormValue);
+               this.setValue(updatedFormValue);
             }
             else
             {

--- a/aikau/src/test/resources/alfresco/forms/HashFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/HashFormTest.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+
+   registerSuite({
+      name: "HashForm Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/HashForm#field1=one&field2=two&field3=three", "HashForm Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Test that field 3 is NOT set in FORM1": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_3 .dijitInputInner")
+            .getProperty("value")
+            .then(function(value) {
+               assert.equal(value, "", "Field 3 in first form should not have been set");
+            });
+      },
+
+      "Test that field 3 IS set in FORM2": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_6 .dijitInputInner")
+            .getProperty("value")
+            .then(function(value) {
+               assert.equal(value, "three", "Field 3 in first form should not have been set");
+            });
+      },
+
+      "Update field 1 and field3 and check that only field 1 updates the URL hash": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_1 .dijitInputInner")
+            .clearValue()
+            .type("Update1")
+         .end()
+         .findByCssSelector("#HASH_TEXT_BOX_3 .dijitInputInner")
+            .clearValue()
+            .type("Update2")
+         .end()
+         .findByCssSelector("#HASH_FORM1 .confirmationButton > span")
+            .click()
+            .execute("return window.location.hash.toString()")
+            .then(function(hash) {
+               assert.equal(hash, "#field1=Update1&field2=two&field3=three", "Form submit did not update hash fragment as expected");
+            });
+      },
+
+      "Check that field 1 in FORM2 was updated": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_4 .dijitInputInner")
+            .getProperty("value")
+            .then(function(value) {
+               assert.equal(value, "Update1", "Field 3 in first form should have been updated");
+            });
+      },
+
+      "Update field 1 and field3 and check that both fields updates the URL hash": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_4 .dijitInputInner")
+            .clearValue()
+            .type("Reset1")
+         .end()
+         .findByCssSelector("#HASH_TEXT_BOX_6 .dijitInputInner")
+            .clearValue()
+            .type("Reset2")
+         .end()
+         .findByCssSelector("#HASH_FORM2 .confirmationButton > span")
+            .click()
+            .execute("return window.location.hash.toString()")
+            .then(function(hash) {
+               assert.equal(hash, "#field1=Reset1&field2=two&field3=Reset2", "Form submit did not update hash fragment as expected");
+            });
+      },
+
+      "Check that field 3 in FORM1 was NOT updated": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_3 .dijitInputInner")
+            .getProperty("value")
+            .then(function(value) {
+               assert.equal(value, "Update2", "Field 3 in first form should NOT have been updated");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -87,6 +87,7 @@ define({
       "src/test/resources/alfresco/forms/CrudFormTest",
       "src/test/resources/alfresco/forms/DynamicFormTest",
       "src/test/resources/alfresco/forms/FormsTest",
+      "src/test/resources/alfresco/forms/HashFormTest",
       "src/test/resources/alfresco/forms/SingleTextFieldFormTest",
 
       "src/test/resources/alfresco/forms/controls/AutoSetTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Form (using URL hashing)</shortname>
+  <description>Demonstrates how the browser URL hash can be used to control the value of the form</description>
+  <family>aikau-unit-tests</family>
+  <url>/HashForm</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.js
@@ -1,0 +1,132 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets: [
+      {
+         id: "SET_HASH",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set Form Via Hash",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "field1=updatedField1&field2=updatedField2",
+               type: "HASH"
+            }
+         }
+      },
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Hash based form (some fields only)",
+            widgets: [
+               {
+                  id: "HASH_FORM1",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     showOkButton: true,
+                     okButtonPublishTopic: "SET_HASH",
+                     okButtonLabel: "Set Hash",
+                     showCancelButton: false,
+                     useHash: true,
+                     hashVarsForUpdate: ["field1","field2"],
+                     pubSubScope: "FORM1_",
+                     widgets: [
+                        {
+                           id: "HASH_TEXT_BOX_1",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 1",
+                              name: "field1",
+                              value: ""
+                           }
+                        },
+                        {
+                           id: "HASH_TEXT_BOX_2",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 2",
+                              name: "field2",
+                              value: ""
+                           }
+                        },
+                        {
+                           id: "HASH_TEXT_BOX_3",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 3",
+                              name: "field3",
+                              value: ""
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Hash based form (all fields)",
+            widgets: [
+               {
+                  id: "HASH_FORM2",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     showOkButton: true,
+                     okButtonPublishTopic: "SET_HASH",
+                     okButtonLabel: "Set Hash",
+                     showCancelButton: false,
+                     useHash: true,
+                     pubSubScope: "FORM2_",
+                     widgets: [
+                        {
+                           id: "HASH_TEXT_BOX_4",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 1",
+                              name: "field1",
+                              value: ""
+                           }
+                        },
+                        {
+                           id: "HASH_TEXT_BOX_5",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 2",
+                              name: "field2",
+                              value: ""
+                           }
+                        },
+                        {
+                           id: "HASH_TEXT_BOX_6",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 3",
+                              name: "field3",
+                              value: ""
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-316 in updating alfresco/forms/Form to support the hashVarsForUpdate property defined in the alfresco/documentlibrary/_AlfHashMixin. This means that it's now possible to configure a form so that only some form control values are updated from the hash and that only certain form control values update the hash.