### PR TITLE
AKU-342: Make infinite scroll generic

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentListInfiniteScroll.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentListInfiniteScroll.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -19,100 +19,14 @@
 
 /**
  * @module alfresco/documentlibrary/AlfDocumentListInfiniteScroll
- *
- * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
- * @author david.webster@alfresco.com
+ * @extends external:dijit/_WidgetBase
+ * @mixes module:alfresco/services/InfiniteScrollService
+ * @author David Webster
+ * @deprecated Since 1.0.20 - Use [alfresco/services/InfiniteScrollService]{@link module:alfresco/services/InfiniteScrollService} as a service instead.
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "alfresco/core/Core",
-        "dojo/_base/lang",
-        "alfresco/core/Events",
-        "alfresco/core/EventsTopicMixin",
-        "dojo/dom-geometry",
-        "alfresco/core/DomElementUtils"],
-        function(declare,_WidgetBase, _AlfDocumentListTopicMixin, AlfCore, lang, AlfCoreEvents, AlfCoreEventsTopicMixin, domGeom, AlfDomUtils) {
-
-   return declare([_WidgetBase, _AlfDocumentListTopicMixin, AlfCore, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils], {
-
-      /**
-       * Used to keep track of the current status of the InfiniteScroll
-       *
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      dataloadInProgress: false,
-
-      /**
-       * Scroll tolerance in pixels.
-       *
-       * How close to the bottom of the page do we want to get before we request the next items?
-       *
-       * @instance
-       * @type {int}
-       * @default 500
-       */
-      scrollTolerance: 500,
-
-      /**
-       * @instance
-       * @listens scrollReturn
-       * @listens requestFinishedTopic
-       * @listens eventsScrollTopic
-       */
-      postMixInProperties: function alfresco_documentlibrary_AlfDocumentListInfiniteScroll_postMixInProperties() {
-
-         // hook point to allow other widgets to let us know when they're done processing a scroll request.
-         this.alfSubscribe(this.scrollReturn, lang.hitch(this, this.onScrollReturn));
-
-         // Bind to this explicitly to reduce duplication in other widgets
-         this.alfSubscribe(this.requestFinishedTopic, lang.hitch(this, this.onScrollReturn));
-
-         // tie in to the events scroll module.
-         this.alfSubscribe(this.eventsScrollTopic, lang.hitch(this, this.onEventsScroll));
-      },
-
-      /**
-       * When the scroll event triggers, check location and pass on the warning that we're near the bottom of the page
-       * sets dataloadInProgress to prevent duplicated triggers when the page is scrolled slowly.
-       *
-       * @instance
-       * @param {object} payload
-       */
-      onEventsScroll: function alfresco_documentlibrary_AlfDocumentListInfiniteScroll_onEventsScroll(payload) {
-         if (this.nearBottom() && !this.dataloadInProgress) {
-            this.dataloadInProgress = true;
-            this.alfPublish(this.scrollNearBottom);
-         }
-      },
-
-      /**
-       * Called when infinite scroll request has been processed and allows us to trigger further scroll events
-       *
-       * @instance
-       * @param {object} payload
-       */
-      onScrollReturn: function alfresco_documentlibrary_AlfDocumentListInfiniteScroll_onScrollReturn(payload) {
-         this.dataloadInProgress = false;
-      },
-
-      /**
-       * The calculation to determine if we're at or close to the bottom of the page yet or now.
-       * "close to" bottom is defined by scrollTolerance var.
-       *
-       * @instance
-       * @returns {boolean}
-       */
-      nearBottom: function alfresco_documentlibrary_AlfDocumentListInfiniteScroll_nearBottom() {
-         var currentScrollPos = domGeom.docScroll().y,
-            docHeight = this.getDocumentHeight(),
-            viewport = domGeom.getContentBox(this.ownerDocumentBody).h;
-
-
-         return 0 >= (docHeight - viewport - currentScrollPos - this.scrollTolerance);
-      }
-
-   });
+        "dijit/_WidgetBase", 
+        "alfresco/services/InfiniteScrollService"], 
+        function(declare, _WidgetBase, InfiniteScrollService) {
+   return declare([_WidgetBase, InfiniteScrollService], {});
 });

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -991,7 +991,16 @@ define(["dojo/_base/declare",
          if (view)
          {
             this.showRenderingMessage();
-            view.setData(this.currentData);
+
+            if (this.useInfiniteScroll)
+            {
+               view.augmentData(this.currentData);
+               this.currentData = view.getData();
+            }
+            else
+            {
+               view.setData(this.currentData);
+            }
             view.renderView(this.useInfiniteScroll);
             this.showView(view);
 

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -398,7 +398,12 @@ define(["dojo/_base/declare",
        */
       onScrollNearBottom: function alfresco_lists_AlfSortablePaginatedList__onScrollNearBottom(/*jshint unused:false*/payload) {
          // Process Infinite Scroll, if enabled & if we've not hit the end of the results
-         if(this.useInfiniteScroll && this.currentData.totalRecords < this.currentData.numberFound)
+         // NOTE: The use of the currentData.totalRecords and currentData.numberFound is only retained to support
+         //       AlfSearchList and faceted search in Share - generic infinite scroll should be done via the
+         //       totalRecords, startIndex and currentPageSize values...
+         if(this.useInfiniteScroll && 
+            ((this.totalRecords > (this.startIndex + this.currentPageSize)) ||
+            (this.currentData.totalRecords < this.currentData.numberFound)))
          {
             this.currentPage++;
             this.loadData();

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -364,7 +364,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       allItemsRendered: function alfresco_lists_views_layouts_Grid__allItemsRendered() {
-         if(this.showNextLink && this.currentData.totalRecords < this.currentData.numberFound)
+         if(this.showNextLink && 
+            ((this.totalRecords > (this.startIndex + this.currentPageSize)) ||
+            (this.currentData.totalRecords < this.currentData.numberFound)))
          {
             this.processWidgets([{
                name: "alfresco/layout/VerticalWidgets",

--- a/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
+++ b/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This service should be included on a page whenever you want to configure an
+ * [AlfSortablePaginatedList]{@link module:alfresco/lists/AlfSortablePaginatedList} to be
+ * configured to use infinite scrolling for handling pagination.
+ * 
+ * @module alfresco/services/InfiniteScrollService
+ * @extends module:alfresco/core/Core
+ * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
+ * @mixes module:alfresco/core/Events
+ * @mixes module:alfresco/core/AlfCoreEventsTopicMixin
+ * @author david.webster@alfresco.com
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
+        "dojo/_base/lang",
+        "alfresco/core/Events",
+        "alfresco/core/EventsTopicMixin",
+        "alfresco/core/DomElementUtils",
+        "dojo/dom-geometry"],
+        function(declare, AlfCore, _AlfDocumentListTopicMixin, lang, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils, domGeom) {
+
+   return declare([AlfCore, _AlfDocumentListTopicMixin, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils], {
+
+      /**
+       * Used to keep track of the current status of the InfiniteScroll
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      dataloadInProgress: false,
+
+      /**
+       * Scroll tolerance in pixels.
+       *
+       * How close to the bottom of the page do we want to get before we request the next items?
+       *
+       * @instance
+       * @type {int}
+       * @default 500
+       */
+      scrollTolerance: 500,
+
+      /**
+       * @instance
+       * @listens scrollReturn
+       * @listens requestFinishedTopic
+       * @listens eventsScrollTopic
+       */
+      constructor: function alfresco_services_InfiniteScrollService__constructor(args) {
+         declare.safeMixin(this, args);
+
+         // hook point to allow other widgets to let us know when they're done processing a scroll request.
+         this.alfSubscribe(this.scrollReturn, lang.hitch(this, this.onScrollReturn));
+
+         // Bind to this explicitly to reduce duplication in other widgets
+         this.alfSubscribe(this.requestFinishedTopic, lang.hitch(this, this.onScrollReturn));
+
+         // tie in to the events scroll module.
+         this.alfSubscribe(this.eventsScrollTopic, lang.hitch(this, this.onEventsScroll));
+      },
+
+      /**
+       * When the scroll event triggers, check location and pass on the warning that we're near the bottom of the page
+       * sets dataloadInProgress to prevent duplicated triggers when the page is scrolled slowly.
+       *
+       * @instance
+       * @param {object} payload
+       */
+      onEventsScroll: function alfresco_services_InfiniteScrollService__onEventsScroll(/*jshint unused:false*/ payload) {
+         if (this.nearBottom() && !this.dataloadInProgress) {
+            this.dataloadInProgress = true;
+            this.alfPublish(this.scrollNearBottom);
+         }
+      },
+
+      /**
+       * Called when infinite scroll request has been processed and allows us to trigger further scroll events
+       *
+       * @instance
+       * @param {object} payload
+       */
+      onScrollReturn: function alfresco_services_InfiniteScrollService__onScrollReturn(/*jshint unused:false*/ payload) {
+         this.dataloadInProgress = false;
+      },
+
+      /**
+       * The calculation to determine if we're at or close to the bottom of the page yet or now.
+       * "close to" bottom is defined by scrollTolerance var.
+       *
+       * @instance
+       * @returns {boolean}
+       */
+      nearBottom: function alfresco_services_InfiniteScrollService__nearBottom() {
+         var currentScrollPos = domGeom.docScroll().y,
+             docHeight = this.getDocumentHeight(),
+             viewport = domGeom.getContentBox(document.body).h;
+         return 0 >= (docHeight - viewport - currentScrollPos - this.scrollTolerance);
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/lists/InfiniteScrollTest.js
+++ b/aikau/src/test/resources/alfresco/lists/InfiniteScrollTest.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var countResults = function(expected) {
+      browser.findAllByCssSelector(".alfresco-search-AlfSearchResult")
+         .then(function(elements) {
+            assert(elements.length === expected, "Counting Result, expected: " + expected + ", found: " + elements.length);
+         })
+      .end();
+   };
+   var scrollToBottom = function() {
+      browser.execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
+         .sleep(2000)
+      .end();
+   };
+   var scrollToTop = function() {
+      browser.execute("return window.scrollTo(0,0)")
+         .sleep(2000)
+      .end();
+   };
+
+   var browser;
+   registerSuite({
+      name: "Infinite Scroll Tests",
+      
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollList", "Infinite Scroll Tests").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Trigger Infinite Scroll": function() {
+         return browser.sleep(1000)
+            // Trigger Infinite Scroll.
+            .then(function(){
+               scrollToBottom();
+               scrollToTop();
+               scrollToBottom();
+            })
+
+            // Count Results. there should be 50. (Request 2)
+            .then(function(){
+               countResults(50);
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -129,6 +129,7 @@ define({
       "src/test/resources/alfresco/lists/AlfHashListTest",
       "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
       "src/test/resources/alfresco/lists/FilteredListTest",
+      "src/test/resources/alfresco/lists/InfiniteScrollTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
       "src/test/resources/alfresco/lists/views/layouts/RowTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfList (using infinite scroll)</shortname>
+  <description>Shows an AlfList configured with infinite scrolling</description>
+  <family>aikau-unit-tests</family>
+  <url>/InfiniteScrollList</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.js
@@ -1,0 +1,70 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/InfiniteScrollService",
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "DEFAULT_CONFIG",
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Default page settings",
+            widgets: [
+               {
+                  id: "LIST",
+                  name: "alfresco/lists/AlfSortablePaginatedList",
+                  config: {
+                     useHash: false,
+                     useInfiniteScroll: true,
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/AlfListView",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Row",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/renderers/Property",
+                                                      config: {
+                                                         propertyToRender: "index"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-342 to ensure that all instances of "alfresco/lists/AlfSortablePaginatedList" support infinite scrolling (and not just the "alfresco/search/AlfSearchList"). I've also deprecated the "alfresco/documentlibrary/AlfDocumentListInfiniteScroll" widget (because it was badly packaged) and replaced it with the "alfresco/services/InfiniteScrollService" (as this capability it provides makes more sense as a service than a widget).