### PR TITLE
AKU-345: Added error handling on buildUrl in NavigationService

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -115,9 +115,13 @@ define(["dojo/_base/declare",
          {
             url = AlfConstants.URL_CONTEXT + data.url;
          }
-         else if (data.type === this.fullPath)
+         else if (data.type === this.fullPath || data.type === this.hashPath)
          {
             url = data.url;
+         }
+         else
+         {
+            this.alfLog("error", "An unknown URL type of '" + data.type + "' was provided for a navigation request", data, this);
          }
          return url;
       },
@@ -141,19 +145,21 @@ define(["dojo/_base/declare",
          {
             this.alfLog("log", "Page navigation request received:", data);
             var url = this.buildUrl(data);
-
-            // Determine the location of the URL...
-            if (data.type === this.hashPath)
+            if (url)
             {
-               hash(data.url);
-            }
-            else if (!data.target || data.target === this.currentTarget)
-            {
-               window.location = url;
-            }
-            else if (data.target === this.newTarget)
-            {
-               window.open(url);
+               // Determine the location of the URL...
+               if (data.type === this.hashPath)
+               {
+                  hash(url);
+               }
+               else if (!data.target || data.target === this.currentTarget)
+               {
+                  window.location = url;
+               }
+               else if (data.target === this.newTarget)
+               {
+                  window.open(url);
+               }
             }
          }
       },
@@ -165,34 +171,36 @@ define(["dojo/_base/declare",
        * @param data
        */
       postToPage: function alfresco_services_NavigationService__postToPage(data) {
-         // Support for POST requests
-         var form = domConstruct.create("form");
-         form.method = "POST";
-         form.action = this.buildUrl(data);
-         if (data.target === this.newTarget)
+         var url = this.buildUrl(data);
+         if (url)
          {
-            form.target = "_blank";
-         }
-         var parameters = data.parameters || {};
-         for (var name in parameters)
-         {
-            if (parameters.hasOwnProperty(name))
+            var form = domConstruct.create("form");
+            form.method = "POST";
+            form.action = url;
+            if (data.target === this.newTarget)
             {
-               var value = parameters[name];
-               if (value)
+               form.target = "_blank";
+            }
+            var parameters = data.parameters || {};
+            for (var name in parameters)
+            {
+               if (parameters.hasOwnProperty(name))
                {
-                  var input;
-                  input = domConstruct.create("input");
-                  input.setAttribute("name", name);
-                  input.setAttribute("type", "hidden");
-                  input.value = value;
-                  domConstruct.place(input, form);
+                  var value = parameters[name];
+                  if (value)
+                  {
+                     var input;
+                     input = domConstruct.create("input");
+                     input.setAttribute("name", name);
+                     input.setAttribute("type", "hidden");
+                     input.value = value;
+                     domConstruct.place(input, form);
+                  }
                }
             }
+            domConstruct.place(form, document.body);
+            form.submit();
          }
-
-         domConstruct.place(form, document.body);
-         form.submit();
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -41,6 +41,15 @@ define(["intern!object",
          browser.end();
       },
 
+      "Set a hash": function() {
+         return browser.findByCssSelector("#SET_HASH_label")
+            .click()
+            .execute("return window.location.hash.toString()")
+            .then(function(hash) {
+               assert.equal(hash, "#hash1=bob&hash2=ted", "Setting a hash didn't work");
+            });
+      },
+
       "Post to current page": function() {
          return browser.findAllByCssSelector("#NOTHING_POSTED")
                .then(function(elements) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
@@ -38,6 +38,19 @@ model.jsonModel = {
    widgets: [
       label,
       {
+         id: "SET_HASH",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set a hash",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "#hash1=bob&hash2=ted",
+               type: "HASH",
+               target: "CURRENT"
+            }
+         }
+      },
+      {
          id: "POST_TO_CURRENT_PAGE",
          name: "alfresco/buttons/AlfButton",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-345 to improve the error logging in the alfresco/services/NavigationService, but even more importantly it revealed a more serious issue where hashing was broken. There wasn't a unit test to cover this so I've added one.