### PR TITLE
AKU-346: Ensure workflow assignment uses correct URL

### DIFF
--- a/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
@@ -26,19 +26,21 @@
  * @extends module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreXhr
  * @mixes module:alfresco/core/UrlUtils
+ * @mixes module:alfresco/services/_NavigationServiceTopicMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/core/CoreXhr",
         "alfresco/core/UrlUtils",
+        "alfresco/services/_NavigationServiceTopicMixin",
         "service/constants/Default",
         "dojo/_base/lang",
         "dojo/_base/array",
         "alfresco/core/NodeUtils"],
-        function(declare, AlfCore, AlfCoreXhr, UrlUtils, AlfConstants, lang, array, NodeUtils) {
+        function(declare, AlfCore, AlfCoreXhr, UrlUtils, _NavigationServiceTopicMixin, AlfConstants, lang, array, NodeUtils) {
 
-   return declare([AlfCore, AlfCoreXhr, UrlUtils], {
+   return declare([AlfCore, AlfCoreXhr, UrlUtils, _NavigationServiceTopicMixin], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -128,11 +130,11 @@ define(["dojo/_base/declare",
             };
 
             var url = this.buildUrl(this.startWorkflowPage, null);
-            this.alfPublish("ALF_POST_TO_PAGE", {
+            this.alfPublish(this.postToPageTopic, {
                method: "POST",
-               type: "FULL_PAGE",
+               type: this.fullPath,
                url: url,
-               target: payload.currentTarget || "CURRENT",
+               target: payload.currentTarget || this.currentTarget,
                parameters: postBody
             });
          }

--- a/aikau/src/test/resources/alfresco/services/actions/WorkflowTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/WorkflowTest.js
@@ -47,6 +47,11 @@ define(["intern!object",
          .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_POST_TO_PAGE", "url", "/aikau/page/dp/ws/start-workflow"))
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Workflow not assigned");
+            })
+         .end()
+         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_POST_TO_PAGE", "type", "FULL_PATH"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Workflow URL type incorrect");
             });
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-346 to correct a problem with the way that workflow assignment URLs were being constructed. I don't like the mixin approach for topics, but it makes sense to use it whilst we have one already defined so I've updated the WorkflowService and added a test to prevent any future regressions.