### PR TITLE
AKU-349: Add support for menu bar popups to appear above menu

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBar.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBar.js
@@ -18,6 +18,62 @@
  */
 
 /**
+ * <p>This widget is the base to be used when constructing menus. Typically this widget should be configured with
+ * a combination of [menu bar items]{@link module:alfresco/menus/AlfMenuBarItem} and
+ * [popup menus]{@link module:alfresco/menus/AlfMenuBarPopup} (although custom menu widgets could also be included).
+ * This widget supports keyboard navigation using the cursor keys and enter or space for selection (please note that
+ * using the tab key will jump to the next widget - tab is not used to navigate items within the menu bar).</p>
+ * <p>The default menu bar behaviour is for all [popup menus]{@link module:alfresco/menus/AlfMenuBarPopup} to appear
+ * below the menu bar, however it is possible to configure this widget so that they appear above the menu bar by 
+ * configuring the [popupMenusAbove]{@link module:alfresco/menus/AlfMenuBar#popupMenusAbove} attribute to be true.</p>
+ *
+ * @example <caption>Typical menu bar configuration</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuBar",
+ *   config: {
+ *     widgets: [
+ *        {
+ *          name: "alfresco/menus/AlfMenuBarItem",
+ *          config: {
+ *            label: "Do something",
+ *            publishTopic: "DO_SOMETHING",
+ *            publishPayload: {
+ *               data: "INFO_ABOUT_WHAT_TO_DO"
+ *            }
+ *          }
+ *        }
+ *     ]
+ *   }
+ * }
+ *
+ * @example <caption>Configuring a menu bar with popups above</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuBar",
+ *   config: {
+ *     popupMenusAbove: true,
+ *     widgets: [
+ *        {
+ *          name: "alfresco/menus/AlfMenuBarPopup",
+ *          config: {
+ *            label: "More options...",
+ *            widgets: [
+ *              {
+ *                name: "alfresco/menus/AlfMenuItem",
+ *                config: {
+ *                  label: "Do something",
+ *                  publishTopic: "DO_SOMETHING",
+ *                  publishPayload: {
+ *                    data: "INFO_ABOUT_WHAT_TO_DO"
+ *                  }
+ *                }
+ *              }
+ *            ]
+ *          }
+ *        }
+ *     ]
+ *   }
+ * }
+ * 
  * @module alfresco/menus/AlfMenuBar
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
@@ -121,6 +177,18 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
+       * In some circumstances it may be required to have the [popup menus]{@link module:alfresco/menus/AlfMenuBarPopup}
+       * appear above the menu bar (e.g. if the menu bar is at the bottom of a page or layout control). This attribute
+       * can be configured to be true in order to support that requirement. The default value is false which will result
+       * in [popup menus]{@link module:alfresco/menus/AlfMenuBarPopup} being displayed below the menu bar.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      popupMenusAbove: false,
+
+      /**
        * A reference to the MenuBar
        * 
        * @instance
@@ -149,7 +217,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuBar__postCreate() {
-         this._menuBar = new CustomMenuBar({});
+         this._menuBar = new CustomMenuBar({
+            _orient: this.popupMenusAbove === true ? ["above"] : ["below"]
+         });
          this._menuBar.placeAt(this.containerNode);
 
          if (this.widgets && this.widgets instanceof Array)

--- a/aikau/src/test/resources/alfresco/menus/MenuBarOrientationTest.js
+++ b/aikau/src/test/resources/alfresco/menus/MenuBarOrientationTest.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Menu Bar Orientation Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/MenuBarOrientation", "Menu Bar Orientation Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that menu 1 appears above the menu bar": function() {
+         var menuTop;
+         return browser.findByCssSelector("#POPUP_MENU_text")
+            .getPosition()
+            .then(function(pos) {
+               menuTop = pos.y;
+            })
+            .click()
+         .end()
+         .findByCssSelector("#POPUP_MENU_dropdown")
+            .getPosition()
+            .then(function(pos) {
+                  assert(pos.y < menuTop, "Popup was not displayed above the menu bar");
+               });
+      },
+
+       "Check that menu 2 appears below the menu bar": function() {
+         var menuTop;
+         return browser.findByCssSelector("#DROPDOWN_MENU_text")
+            .getPosition()
+            .then(function(pos) {
+               menuTop = pos.y;
+            })
+            .click()
+         .end()
+         .findByCssSelector("#DROPDOWN_MENU_dropdown")
+            .getPosition()
+            .then(function(pos) {
+                  assert(pos.y > menuTop, "Popup was not displayed below the menu bar");
+               });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -148,6 +148,7 @@ define({
       "src/test/resources/alfresco/menus/AlfMenuTextForClipboardTest",
       "src/test/resources/alfresco/menus/AlfVerticalMenuBarTest",
       "src/test/resources/alfresco/menus/DisableMenuItemTest",
+      "src/test/resources/alfresco/menus/MenuBarOrientationTest",
       "src/test/resources/alfresco/menus/MenuTests",
 
       "src/test/resources/alfresco/misc/AlfTooltipTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/MenuBarOrientation.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/MenuBarOrientation.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Menu bar orientation</shortname>
+  <description>Demonstrates how menu popups can be configured to open upwards as well as drop down</description>
+  <family>aikau-unit-tests</family>
+  <url>/MenuBarOrientation</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/MenuBarOrientation.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/MenuBarOrientation.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/MenuBarOrientation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/MenuBarOrientation.get.js
@@ -1,0 +1,96 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "20px"
+         }
+      },
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Menu opens upwards",
+                     widgets: [
+                        {
+                           id: "MENUBAR1",
+                           name: "alfresco/menus/AlfMenuBar",
+                           config: {
+                              popupMenusAbove: true,
+                              widgets: [
+                                 {
+                                    id: "POPUP_MENU",
+                                    name: "alfresco/menus/AlfMenuBarPopup",
+                                    config: {
+                                       label: "Movin' on up",
+                                       widgets: [
+                                          {
+                                             id: "MENU_ITEM_1",
+                                             name: "alfresco/menus/AlfMenuItem",
+                                             config: {
+                                                label: "Item 1"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Menu opens downwards",
+                     widgets: [
+                        {
+                           id: "MENUBAR2",
+                           name: "alfresco/menus/AlfMenuBar",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "DROPDOWN_MENU",
+                                    name: "alfresco/menus/AlfMenuBarPopup",
+                                    config: {
+                                       label: "Down, down, deeper and down",
+                                       widgets: [
+                                          {
+                                             id: "MENU_ITEM_2",
+                                             name: "alfresco/menus/AlfMenuItem",
+                                             config: {
+                                                label: "Item 2"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-349 and provides support for allowing menu bars to be configured so that popups appear above, rather than below, the menu bar.