### PR TITLE
AKU-347: Breadcrumb overflow CSS updates

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
@@ -1,6 +1,11 @@
 /* CSS for this was adapted from https://css-tricks.com/triangle-breadcrumbs/ */
 .alfresco-documentlibrary-AlfBreadcrumb { 
    float: left; 
+   height: 30px;
+   padding-top: 1px;
+   padding-bottom: 1px;
+   padding-right: 1px;
+   background: @breadcrumb-border-color;
 }
 .alfresco-documentlibrary-AlfBreadcrumb a {
    text-decoration: none; 
@@ -10,6 +15,7 @@
    display: block;
    float: left;
    cursor: pointer;
+   height: 20px;
 }
 
 .alfresco-documentlibrary-AlfBreadcrumb a:after { 
@@ -17,12 +23,12 @@
    display: block;
    width: 0;
    height: 0;
-   border-top: 50px solid transparent;
-   border-bottom: 50px solid transparent;
-   border-left: 30px solid @breadcrumb-background-color;
+   border-top: 15px solid transparent;
+   border-bottom: 15px solid transparent;
+   border-left: 10px solid @breadcrumb-background-color;
    position: absolute;
    top: 50%;
-   margin-top: -50px;
+   margin-top: -15px;
    left: 100%;
    z-index: 2;
 }
@@ -32,12 +38,12 @@
    display: block;
    width: 0; 
    height: 0;
-   border-top: 50px solid transparent;
-   border-bottom: 50px solid transparent;
-   border-left: 30px solid @breadcrumb-border-color;
+   border-top: 15px solid transparent;
+   border-bottom: 15px solid transparent;
+   border-left: 10px solid @breadcrumb-border-color;
    position: absolute;
    top: 50%;
-   margin-top: -50px;
+   margin-top: -15px;
    margin-left: 1px;
    left: 100%;
    z-index: 1;

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumbTrail.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumbTrail.css
@@ -4,7 +4,7 @@
    font-family: @bold-font;
    color: @breadcrumb-font-color;
    font-size: @normal-font-size;
-   border: 1px solid @standard-border-color;
+   border-left: 1px solid @standard-border-color;
 }
 
 .alfresco-documentlibrary-AlfBreadcrumbTrail.hidden {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
@@ -64,6 +64,74 @@ model.jsonModel = {
          }
       },
       {
+         id: "OVERFLOW_BREADCRUMBS",
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "FIXED_BREADCRUMBS",
+                  widthPx: 400,
+                  name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+                  config: {
+                     breadcrumbs: [
+                        {
+                           label: "There's"
+                        },
+                        {
+                           label: "a"
+                        },
+                        {
+                           label: "lady"
+                        },
+                        {
+                           label: "who's"
+                        },
+                        {
+                           label: "sure"
+                        },
+                        {
+                           label: "all"
+                        },
+                        {
+                           label: "that"
+                        },
+                        {
+                           label: "glitters"
+                        },
+                        {
+                           label: "is"
+                        },
+                        {
+                           label: "gold,"
+                        },
+                        {
+                           label: "and"
+                        },
+                        {
+                           label: "she's"
+                        },
+                        {
+                           label: "buying"
+                        },
+                        {
+                           label: "a"
+                        },
+                        {
+                           label: "breadcrumb"
+                        },
+                        {
+                           label: "to"
+                        },
+                        {
+                           label: "heaven"
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
          id: "CHANGE_NODEREF",
          name: "alfresco/buttons/AlfButton",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-347. I've updated the test page so that we'll always display at least one overflowing breadcrumb trail for us to inspect when making any future design changes, however there are no updates to the unit tests because this isn't exactly testable without actually looking at it!

I've attached a screenshot to the JIRA ticket so that you can see what the output should look like