### PR TITLE
AKU-343: Ensure that Paginator updates user preferences

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -61,6 +61,7 @@
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBar",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
+        "alfresco/services/_PreferenceServiceTopicMixin",
         "dojo/_base/lang",
         "dojo/_base/array",
         "alfresco/menus/AlfMenuBarSelect",
@@ -69,10 +70,10 @@ define(["dojo/_base/declare",
         "alfresco/menus/AlfCheckableMenuItem",
         "dijit/registry",
         "dojo/dom-class"], 
-        function(declare, AlfMenuBar, _AlfDocumentListTopicMixin, lang, array, AlfMenuBarSelect, AlfMenuGroups, 
-                 AlfMenuGroup, AlfCheckableMenuItem, registry, domClass) {
+        function(declare, AlfMenuBar, _AlfDocumentListTopicMixin, _PreferenceServiceTopicMixin, lang, array, 
+                 AlfMenuBarSelect, AlfMenuGroups, AlfMenuGroup, AlfCheckableMenuItem, registry, domClass) {
 
-   return declare([AlfMenuBar, _AlfDocumentListTopicMixin], {
+   return declare([AlfMenuBar, _AlfDocumentListTopicMixin, _PreferenceServiceTopicMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -160,6 +161,10 @@ define(["dojo/_base/declare",
          if (payload && payload.value && payload.value !== this.documentsPerPage && this.isValidPageSize(payload.value))
          {
             this.documentsPerPage = payload.value;
+            this.alfPublish(this.setPreferenceTopic, {
+               preference: "org.alfresco.share.documentList.documentsPerPage",
+               value: this.documentsPerPage
+            });
          }
       },
       

--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -25,6 +25,7 @@
  * @module alfresco/services/PreferenceService
  * @extends module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreXhr
+ * @mixes module:alfresco/services/_PreferenceServiceTopicMixin
  * @mixes module:alfresco/services/_AlfDocumentListTopicMixin
  * @author Dave Draper
  */

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -129,6 +129,20 @@ define(["intern!object",
             });
       },
 
+      "Test that user page size user preference is updated": function() {
+         return browser.findByCssSelector("tr.mx-row:nth-child(1) .mx-url")
+            .getVisibleText()
+            .then(function(text) {
+               assert.include(text, "aikau/proxy/alfresco/api/people/guest/preferences", "Page size preference not updated");
+            })
+         .end()
+         .findByCssSelector("tr.mx-row:nth-child(1) .mx-payload")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "{\"org\":{\"alfresco\":{\"share\":{\"documentList\":{\"documentsPerPage\":50}}}}}", "Page size preference not with correct value");
+            });
+      },
+
       "Test previous page button is still disabled (after increasing page size)": function() {
          browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
             .then(function(elements) {
@@ -297,6 +311,24 @@ define(["intern!object",
             .then(function(text) {
                assert(text === "9", "Page number not correct, expected '9' but saw: " + text);
             });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // See AKU-330...
+   registerSuite({
+      name: "Pagination Tests (Custom page sizes)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests (Custom page sizes)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
       },
 
       "Starting page is initialised and working (useHash=false)": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -21,6 +21,9 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
+      },
+      {
          name: "alfresco/layout/HorizontalWidgets",
          config: {
             widgets: [
@@ -62,6 +65,7 @@ model.jsonModel = {
                            name: "alfresco/lists/AlfSortablePaginatedList",
                            config: {
                               useHash: false,
+                              currentPageSize: 50, // This will be overridden by the user preference
                               widgets: [
                                  {
                                     name: "alfresco/lists/views/AlfListView",

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PreferenceServiceMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PreferenceServiceMockXhr.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @module aikauTesting/mockservices/PreferenceServiceMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr",
+        "dojo/text!./responseTemplates/Preferences/Preferences.json",
+        "alfresco/services/PreferenceService"], 
+        function(declare, MockXhr, Preferences, PreferenceService) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * Extend the constructor to create a PreferenceService once the Mock Server is setup, this needs to
+       * be done like this because the first thing the PreferenceService does is to make an XHR request
+       * for user preferences. This means that if the PreferenceService is included as part of the test
+       * page model that a 401 redirect will occur because the services are created BEFORE the widgets.
+       * 
+       * @instance
+       * @param  {array} args Constructor arguments
+       */
+      constructor: function alfresco_testing_mockservices_PreferenceServiceMockXhr__constructor(args) {
+         // jshint nonew:false, unused:false
+         new PreferenceService();
+      },
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_PreferenceServiceMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("GET",
+                                    /(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":7962},
+                                     Preferences]);
+            this.server.respondWith("POST",
+                                    /(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":7962},
+                                     Preferences]);
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Preferences/Preferences.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Preferences/Preferences.json
@@ -1,0 +1,73 @@
+{
+   "org": {
+      "alfresco": {
+         "ext": {
+            "sites": {
+               "favourites": {
+                  "rulessite": {
+                     "createdAt": "2015-04-14T10:19:34.840Z"
+                  },
+                  "site": {
+                     "createdAt": "2015-03-13T09:59:45.880Z"
+                  },
+                  "site1": {
+                     "createdAt": "2015-03-23T13:24:24.434Z"
+                  }
+               }
+            }
+         },
+         "share": {
+            "activities": {
+               "component-2-1": {
+                  "filter": "all"
+               }
+            },
+            "documentList": {
+               "documentsPerPage": 25,
+               "galleryColumns": 7,
+               "hideNavBar": false,
+               "showFolders": true,
+               "showSidebar": true,
+               "viewRendererName": "simple"
+            },
+            "documents": {
+               "favourites": "workspace:\/\/SpacesStore\/5fa74ad3-9b5b-461b-9df5-de407f1f4fe7,workspace:\/\/SpacesStore\/8fe12e94-f092-4d41-9823-cb94507b44d9,workspace:\/\/SpacesStore\/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+            },
+            "folders": {
+               "favourites": "workspace:\/\/SpacesStore\/835646cd-3265-4f35-95af-5a97ae7f4011"
+            },
+            "logging": {
+               "all": true,
+               "enabled": true,
+               "error": true,
+               "filter": ""
+            },
+            "searchList": {
+               "viewRendererName": "detailed"
+            },
+            "sideBarWidth": 291,
+            "sites": {
+               "favourites": {
+                  "rulessite": true,
+                  "site": true,
+                  "site1": true
+               },
+               "recent": {
+                  "_0": "site1",
+                  "_1": "swsdp",
+                  "_2": "site",
+                  "_3": "marketing-site",
+                  "_4": "rulessite"
+               }
+            },
+            "tasks": {
+               "dashlet": {
+                  "component-1-2": {
+                     "filter": "activeTasks"
+                  }
+               }
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-343. It would appear that the alfresco/lists/Paginator was not currently updating the user preference when they changed page size, however it was requesting the user preference and using that (so overriding any configured value). I've updated the Paginator and updated the unit tests to ensure that page preferences are set. 

I've also broken up the Pagination tests into smaller suites because they're so large they frequently take the code coverage server down - hopefully this should help.