### PR TITLE
AKU-353: Updated Paginator to hide controls on invalid page

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -245,9 +245,10 @@ define(["dojo/_base/declare",
              (totalRecords || totalRecords === 0) && 
              (startIndex || startIndex === 0))
          {
-            if (totalRecords === 0)
+            if (totalRecords === 0 || startIndex > totalRecords)
             {
                // Hide pagination controls when there are no results...
+               // Or if the startIndex is greater than the number of available results
                // domClass.add(this.domNode, "hidden");
                if (this.pageSelector)
                {

--- a/aikau/src/main/resources/alfresco/lists/templates/AlfList.html
+++ b/aikau/src/main/resources/alfresco/lists/templates/AlfList.html
@@ -1,9 +1,9 @@
 <div class="alfresco-lists-AlfList">
-   <div data-dojo-attach-point="noViewSelectedNode" class="info share-hidden">${noViewSelectedMessage}</div>
-   <div data-dojo-attach-point="noDataNode" class="info share-hidden">${noDataMessage}</div>
-   <div data-dojo-attach-point="dataFailureNode" class="info share-hidden">${dataFailureMessage}</div>
-   <div data-dojo-attach-point="dataLoadingNode" class="info share-hidden">${fetchingDataMessage}</div>
-   <div data-dojo-attach-point="renderingViewNode" class="info share-hidden">${renderingViewMessage}</div>
-   <div data-dojo-attach-point="viewsNode" class="info share-hidden"></div>
-   <div data-dojo-attach-point="dataLoadingMoreNode" class="info share-hidden">${fetchingMoreDataMessage}</div>
+   <div data-dojo-attach-point="noViewSelectedNode" class="info no-view-selected share-hidden">${noViewSelectedMessage}</div>
+   <div data-dojo-attach-point="noDataNode" class="info no-data share-hidden">${noDataMessage}</div>
+   <div data-dojo-attach-point="dataFailureNode" class="info data-failure share-hidden">${dataFailureMessage}</div>
+   <div data-dojo-attach-point="dataLoadingNode" class="info data-loading share-hidden">${fetchingDataMessage}</div>
+   <div data-dojo-attach-point="renderingViewNode" class="info rendering-view share-hidden">${renderingViewMessage}</div>
+   <div data-dojo-attach-point="viewsNode" class="info rendered-view share-hidden"></div>
+   <div data-dojo-attach-point="dataLoadingMoreNode" class="info data-loading-more share-hidden">${fetchingMoreDataMessage}</div>
 </div>

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -364,6 +364,119 @@ define(["intern!object",
       }
    });
 
+   registerSuite({
+      name: "Pagination Tests (invalid current page)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=14&currentPageSize=20", "Pagination Tests (invalid current page)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check no data message": function() {
+         return browser.findByCssSelector("#HASH_LIST .rendered-view")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "There is no data to render a view from", "No data message not displayed");
+            });
+      },
+
+      "Check that the pagination controls are all hidden": function() {
+         return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page selector was not hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_BACK")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page back button was not hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page indicator was not hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page forward button was not hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The items per page selector was not hidden");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   registerSuite({
+      name: "Pagination Tests (valid current page)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=13&currentPageSize=20", "Pagination Tests (invalid current page)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check results": function() {
+         return browser.findAllByCssSelector("#HASH_LIST tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "Unexpected number of results shown");
+            });
+      },
+
+      "Check that the pagination controls are all hidden": function() {
+         return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The page selector was hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_BACK")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The page back button was hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The page indicator was hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The page forward button was hidden");
+            })
+         .end()
+         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The items per page selector was hidden");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
    // See AKU-330...
    registerSuite({
       name: "Scroll to item test",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-352 to ensure that pagination controls are hidden when no data is available either because the data contains no items or because the page start index is greater than the number of results available to display (previously it was just addressing the former case where there were no items).