### PR TITLE
AKU-341: Ensure that number spinner can be configured > 1000

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
@@ -104,8 +104,18 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {object} validationConfig The configuration for this validator
        */
       isNumberValidator: function alfresco_forms_controls_FormControlValidationMixin__isNumberValidator(validationConfig) {
-         var isValid = !isNaN(this.wrappedWidget.textbox.value);
-         this.reportValidationResult(validationConfig, isValid);
+         try
+         {
+            // See AKU-341 for details of why we handle commas and spaces...
+            var value = this.wrappedWidget.textbox.value.replace(",","").replace(" ","");
+            var parsedValue = parseFloat(value);
+            var isValid = !isNaN(parsedValue);
+            this.reportValidationResult(validationConfig, isValid);
+         }
+         catch(e)
+         {
+            this.reportValidationResult(validationConfig, false);
+         }
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
@@ -152,6 +152,14 @@ define(["intern!object",
             });
       },
 
+      "Check number with commas is valid": function() {
+         return browser.findByCssSelector("#NS6 span.validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "Validation error message should NOT be displayed");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
@@ -77,6 +77,17 @@ model.jsonModel = {
                      value: 3,
                      max: 5
                   }
+               },
+               {
+                  id: "NS6",
+                  name: "alfresco/forms/controls/NumberSpinner", 
+                  config: {
+                     fieldId: "NS6",
+                     name: "five",
+                     label: "Handle commas",
+                     description: "This is a number spinner initialised to a value over a 1000",
+                     value: 1001
+                  }
                }
             ]
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-341 and updates the validation of the NumberSpinner to ensure that commas and spaces are stripped out of numbers before they are validated.