### PR TITLE
Adding library version information to the manifest.mf

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -134,7 +134,7 @@
                         <artifactItem>
                            <groupId>org.dojotoolkit</groupId>
                            <artifactId>dojo</artifactId>
-                           <version>1.10.4</version>
+                           <version>${dependency.dojo.version}</version>
                            <type>zip</type>
                            <classifier>distribution</classifier>
                            <overWrite>true</overWrite>

--- a/aikau/src/main/resources/extension-module/aikau-extension.xml
+++ b/aikau/src/main/resources/extension-module/aikau-extension.xml
@@ -12,20 +12,20 @@
                   <dojo-pages>
                      <enabled>true</enabled>
                      <loader-trace-enabled>false</loader-trace-enabled>
-                     <bootstrap-file>/res/js/lib/dojo-1.10.4/dojo/dojo.js</bootstrap-file>
+                     <bootstrap-file>/res/js/lib/dojo-${dependency.dojo.version}/dojo/dojo.js</bootstrap-file>
                      <page-widget>alfresco/core/Page</page-widget>
                      <base-url>/res/</base-url>
                      <default-less-configuration>/js/aikau/${project.version}/alfresco/css/less/defaults.less</default-less-configuration><messages-object>Alfresco</messages-object>
                      <packages>
                          <package name="service"      location="../service"/>
-                         <package name="dojo"         location="js/lib/dojo-1.10.4/dojo"/>
-                         <package name="dijit"        location="js/lib/dojo-1.10.4/dijit"/>
-                         <package name="dojox"        location="js/lib/dojo-1.10.4/dojox"/>
+                         <package name="dojo"         location="js/lib/dojo-${dependency.dojo.version}/dojo"/>
+                         <package name="dijit"        location="js/lib/dojo-${dependency.dojo.version}/dijit"/>
+                         <package name="dojox"        location="js/lib/dojo-${dependency.dojo.version}/dojox"/>
                          <package name="alfresco"     location="js/aikau/${project.version}/alfresco"/>
                          <package name="surf"         location="js/surf"/>
                          <package name="cm"           location="js/lib/code-mirror"/>
-                         <package name="jquery"       location="js/lib/jquery-1.11.1" main="jquery-1.11.1.min"/>
-                         <package name="jqueryui"     location="js/lib/jquery-ui-1.11.1" main="jquery-ui.min"/>
+                         <package name="jquery"       location="js/lib/jquery-${dependency.jquery.version}" main="jquery-${dependency.jquery.version}.min"/>
+                         <package name="jqueryui"     location="js/lib/jquery-ui-${dependency.jquery-ui.version}" main="jquery-ui.min"/>
                      </packages>
                   </dojo-pages>
                </web-framework>

--- a/aikau/src/test/resources/testApp/WEB-INF/surf.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf.xml
@@ -99,7 +99,7 @@
                <loader-trace-enabled>false</loader-trace-enabled>
                
                <!-- This is the file that will be loaded when Dojo is bootstrapped -->
-               <bootstrap-file>/res/js/lib/dojo-1.10.4/dojo/dojo.js</bootstrap-file>
+               <bootstrap-file>/res/js/lib/dojo-${dependency.dojo.version}/dojo/dojo.js</bootstrap-file>
                
                <!-- This is the widget that will be used to load the page -->
                <page-widget>alfresco/core/Page</page-widget>
@@ -111,15 +111,15 @@
                
                <messages-object>Alfresco</messages-object>
                <packages>
-                   <package name="dojo"         location="js/lib/dojo-1.10.4/dojo"/>
-                   <package name="dijit"        location="js/lib/dojo-1.10.4/dijit"/>
-                   <package name="dojox"        location="js/lib/dojo-1.10.4/dojox"/>
+                   <package name="dojo"         location="js/lib/dojo-${dependency.dojo.version}/dojo"/>
+                   <package name="dijit"        location="js/lib/dojo-${dependency.dojo.version}/dijit"/>
+                   <package name="dojox"        location="js/lib/dojo-${dependency.dojo.version}/dojox"/>
                    <package name="alfresco"     location="js/aikau/${project.version}/alfresco"/>
                    <package name="aikauTesting" location="js/aikau/testing"/>
                    <package name="cm"           location="js/lib/code-mirror"/>
                    <package name="surf"         location="js/surf"/>
-                   <package name="jquery"       location="js/lib/jquery-1.11.1" main="jquery-1.11.1.min"/>
-                   <package name="jqueryui"     location="js/lib/jquery-ui-1.11.1" main="jquery-ui.min"/>
+                   <package name="jquery"       location="js/lib/jquery-${dependency.jquery.version}" main="jquery-${dependency.jquery.version}.min"/>
+                   <package name="jqueryui"     location="js/lib/jquery-ui-${dependency.jquery.version}" main="jquery-ui.min"/>
                </packages>
             </dojo-pages>
         </web-framework>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
                       </manifestEntries>
                       <manifestSections>
                           <manifestSection>
-                              <name>Libraries</name>
+                              <name>Aikau Libraries</name>
                               <manifestEntries>
                                 <Surf>${dependency.surf.version}</Surf>
                                 <Dojo>${dependency.dojo.version}</Dojo>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
 
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <dependency.surf.version>5.0.d</dependency.surf.version>
+      <dependency.dojo.version>1.10.4</dependency.dojo.version>
+      <dependency.jquery.version>1.11.1</dependency.jquery.version>
+      <dependency.jquery-ui.version>1.11.1</dependency.jquery-ui.version>      
    </properties>
 
    <repositories> 
@@ -58,7 +62,7 @@
       <dependency>
          <groupId>org.springframework.extensions.surf</groupId>
          <artifactId>spring-surf-api</artifactId>
-         <version>5.0.d</version>
+         <version>${dependency.surf.version}</version>
          <scope>runtime</scope>
       </dependency>
 
@@ -104,8 +108,40 @@
                  <source>1.7</source>
                  <target>1.7</target>
              </configuration>
-            </plugin>
-      </plugins>
+         </plugin>
+         <plugin>
+              <artifactId>maven-jar-plugin</artifactId>
+              <version>2.6</version>
+              <configuration>
+                  <skipIfEmpty>true</skipIfEmpty>
+                  <archive>
+                      <manifest>
+                          <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                          <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                      </manifest>
+                      <manifestEntries>
+                          <Implementation-Version>${project.version}</Implementation-Version>
+                          <Build-Date>${maven.build.timestamp}</Build-Date>
+                          <Build-Name>${bamboo_planName}</Build-Name>
+                          <Build-Key>${bamboo_fullBuildKey}</Build-Key>
+                          <Build-Number>${bamboo_buildNumber}</Build-Number>
+                          <Build-Revision>${bamboo_repository_revision_number}</Build-Revision>
+                      </manifestEntries>
+                      <manifestSections>
+                          <manifestSection>
+                              <name>Libraries</name>
+                              <manifestEntries>
+                                <Surf>${dependency.surf.version}</Surf>
+                                <Dojo>${dependency.dojo.version}</Dojo>
+                                <Jquery>${dependency.jquery.version}</Jquery>
+                                <Jquery-ui>${dependency.jquery-ui.version}</Jquery-ui>
+                              </manifestEntries>
+                          </manifestSection>
+                      </manifestSections>
+                  </archive>
+              </configuration>
+           </plugin>
+      </plugins>            
    </build>
 
    <modules>


### PR DESCRIPTION
This change adds library information (available at build time) to the Jar manfest file. It just lists surf, dojo, jquery, jqueryui by using dependency properties in the pom.

This should make it easier to upgrade those libraries by just changing the property. However, I notice that jquery/jquery ui are saved in the source tree whereas dojo is a dependency.  That would require some rework.