### PR TITLE
AKU-350: Improve default FixedHeaderFooter size handling

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -60,153 +60,212 @@
  * @author Martin Doyle
  */
 define(["alfresco/core/ProcessWidgets",
-      "alfresco/core/ResizeMixin",
-      "dojo/_base/array",
-      "dojo/_base/declare",
-      "dojo/_base/lang",
-      "dojo/aspect",
-      "dojo/dom-class",
-      "dojo/dom-construct",
-      "dojo/dom-style",
-      "dojo/topic",
-      "dojo/text!./templates/FixedHeaderFooter.html"
-   ],
-   function(ProcessWidgets, ResizeMixin, array, declare, lang, aspect, domClass, domConstruct, domStyle, topic, template) {
+        "alfresco/core/ResizeMixin",
+        "dojo/_base/array",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/aspect",
+        "dojo/dom-class",
+        "dojo/dom-construct",
+        "dojo/dom-style",
+        "dojo/topic",
+        "dojo/text!./templates/FixedHeaderFooter.html",
+        "jquery"],
+        function(ProcessWidgets, ResizeMixin, array, declare, lang, aspect, domClass, domConstruct, domStyle, topic, template, $) {
 
-      return declare([ProcessWidgets, ResizeMixin], {
+   return declare([ProcessWidgets, ResizeMixin], {
 
-         /**
-          * The base class for the widget
-          *
-          * @instance
-          * @override
-          * @type {string}
-          * @default "alfresco-layout-FixedHeaderFooter"
-          */
-         baseClass: "alfresco-layout-FixedHeaderFooter",
+      /**
+       * The base class for the widget
+       *
+       * @instance
+       * @type {string}
+       * @default "alfresco-layout-FixedHeaderFooter"
+       */
+      baseClass: "alfresco-layout-FixedHeaderFooter",
 
-         /**
-          * An array of the CSS files to use with this widget.
-          *
-          * @instance
-          * @override
-          * @type {object[]}
-          * @default [{cssFile:"./css/FixedHeaderFooter.css"}]
-          */
-         cssRequirements: [{
-            cssFile: "./css/FixedHeaderFooter.css"
-         }],
+      /**
+       * An array of the CSS files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/FixedHeaderFooter.css"}]
+       */
+      cssRequirements: [{
+         cssFile: "./css/FixedHeaderFooter.css"
+      }],
 
-         /**
-          * The height of the widget (in CSS units)
-          *
-          * @type {string}
-          * @default "100%"
-          */
-         height: "100%",
+      /**
+       * The height of the widget (in CSS units). The default value is "auto" which means that the
+       * height of the widget will automatically be set to take up the available space from its current
+       * position to the bottom of the window or document (whichever is smallest) so that the entire
+       * widget is visible on page load. If a percentage height is set it is imperative that the enclosing
+       * DOM element has a fixed height (e.g. a value in pixels) otherwise the height will be calculated
+       * as 0.
+       *
+       * @instance
+       * @type {string}
+       * @default "auto"
+       */
+      height: "auto",
 
-         /**
-          * The HTML template to use for the widget.
-          *
-          * @instance
-          * @override
-          * @type {String}
-          */
-         templateString: template,
+      /**
+       * If this widget is placed into a widget that has padding then this allowance can be configured which
+       * will be substituted from the calculated height to take padding into account so that an outer scroll
+       * bar is not required on the page. This defaults to 0 and has only been provided for potential 
+       * convenience. This value will only be used on when [height]{@link module:alfresco/layout/FixedHeaderFooter#height}
+       * is set to "auto" (which is also the default).
+       *
+       * @instance
+       * @type {number}
+       * @default 0
+       */
+      autoHeightPaddingAllowance: 0,
 
-         /**
-          * How many ms to wait after the last publish before triggering a resize check
-          *
-          * @type {number}
-          */
-         _publishDebounceMs: 500,
+      /**
+       * If this is configured to be true the the height of the widget will be reset as the browser window is resized.
+       * This will only occur  when [height]{@link module:alfresco/layout/FixedHeaderFooter#height} is set to "auto" 
+       * (which is also the default). The default value for this is false.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      recalculateAutoHeightOnResize: false,
 
-         /**
-          * The timeout pointer that's set/cleared during the publish debouncing
-          *
-          * @type {object}
-          */
-         _publishDebounceTimeout: null,
+      /**
+       * The HTML template to use for the widget.
+       *
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
 
-         /**
-          * Run after widget has been created
-          *
-          * @instance
-          * @override
-          */
-         postCreate: function alfresco_layout_FixedHeaderFooter__postCreate() {
+      /**
+       * How many ms to wait after the last publish before triggering a resize check
+       *
+       * @instance
+       * @type {number}
+       * @default 500
+       */
+      _publishDebounceMs: 500,
 
-            // We need to potentially resize sometimes ... use these triggers
-            this.alfSetupResizeSubscriptions(this._triggerResizeCheck, this);
-            aspect.after(topic, "publish", lang.hitch(this, function(originalReturnValue) {
-               this._triggerResizeCheck();
-               return originalReturnValue;
-            }));
+      /**
+       * The timeout pointer that's set/cleared during the publish debouncing
+       *
+       * @instance
+       * @type {object}
+       * @default null
+       */
+      _publishDebounceTimeout: null,
 
+      /**
+       * Run after widget has been created
+       *
+       * @instance
+       */
+      postCreate: function alfresco_layout_FixedHeaderFooter__postCreate() {
+         // We need to potentially resize sometimes ... use these triggers
+         this.alfSetupResizeSubscriptions(this._triggerResizeCheck, this);
+         aspect.after(topic, "publish", lang.hitch(this, function(originalReturnValue) {
+            this._triggerResizeCheck();
+            return originalReturnValue;
+         }));
+
+         this.setHeight();
+
+         // Add in the widgets
+         this._doProcessWidgets([{
+            widgets: this.widgetsForHeader,
+            node: this.header
+         }, {
+            widgets: this.widgets,
+            node: this.content
+         }, {
+            widgets: this.widgetsForFooter,
+            node: this.footer
+         }]);
+
+         // Do the resize
+         this._resize();
+      },
+
+      setHeight: function alfresco_layout_FixedHeaderFooter__setHeight() {
+         // When no height is specified (the only way to do this would be to configure in 
+         // null or 0) or the height is left as the default we'll try and set a sensible
+         // height based on the available space in the client window/document.
+         if (!this.height || this.height === "auto")
+         {
+            var offset = $(this.domNode).offset();
+            var docHeight = $(document).height(),
+                clientHeight = $(window).height();
+
+            // Work with either the window or document height depending upon which is smallest...
+            var h = (docHeight < clientHeight) ? docHeight : clientHeight;
+            var height = (h - offset.top - this.autoHeightPaddingAllowance) + "px";
+
+            // Set the height of the dom node
+            domStyle.set(this.domNode, {
+               height: height
+            });
+         }
+         else
+         {
             // Set the height of the dom node
             domStyle.set(this.domNode, {
                height: this.height
             });
-
-            // Add in the widgets
-            this._doProcessWidgets([{
-               widgets: this.widgetsForHeader,
-               node: this.header
-            }, {
-               widgets: this.widgets,
-               node: this.content
-            }, {
-               widgets: this.widgetsForFooter,
-               node: this.footer
-            }]);
-
-            // Do the resize
-            this._resize();
-         },
-
-         /**
-          * Call the processWidgets function for all provided widgets
-          *
-          * @instance
-          * @param    {object[]} widgetInfos The widget information as objects with 'widgets' and 'node' properties
-          */
-         _doProcessWidgets: function(widgetInfos) {
-            array.forEach(widgetInfos, function(widgetInfo) {
-               var widgets = widgetInfo.widgets,
-                  node = widgetInfo.node;
-               if (widgets && widgets.length) {
-                  this.processWidgets(widgets, node);
-               } else {
-                  domClass.add(node, "hidden");
-               }
-            }, this);
-         },
-
-         /**
-          * Resize the header/content/footer containers so that the
-          * content fits between the header and footer.
-          *
-          * @instance
-          */
-         _resize: function alfresco_layout_FixedHeaderFooter___resize() {
-            var widgetHeight = this.domNode.offsetHeight,
-               headerHeight = this.header.offsetHeight,
-               footerHeight = this.footer.offsetHeight;
-            domStyle.set(this.content, {
-               top: headerHeight + "px",
-               height: (widgetHeight - headerHeight - footerHeight) + "px"
-            });
-         },
-
-         /**
-          * This function is called when a resize check is required, but debounces
-          * the actual call for browser performance reasons.
-          *
-          * @instance
-          */
-         _triggerResizeCheck: function alfresco_layout_FixedHeaderFooter___triggerResizeCheck() {
-            clearTimeout(this._publishDebounceTimeout);
-            this._publishDebounceTimeout = setTimeout(lang.hitch(this, this._resize), this._publishDebounceMs);
          }
-      });
+      },
+
+      /**
+       * Call the processWidgets function for all provided widgets
+       *
+       * @instance
+       * @param {object[]} widgetInfos The widget information as objects with 'widgets' and 'node' properties
+       */
+      _doProcessWidgets: function alfresco_layout_FixedHeaderFooter___doProcessWidgets(widgetInfos) {
+         array.forEach(widgetInfos, function(widgetInfo) {
+            var widgets = widgetInfo.widgets,
+               node = widgetInfo.node;
+            if (widgets && widgets.length) {
+               this.processWidgets(widgets, node);
+            } else {
+               domClass.add(node, "hidden");
+            }
+         }, this);
+      },
+
+      /**
+       * Resize the header/content/footer containers so that the
+       * content fits between the header and footer.
+       *
+       * @instance
+       */
+      _resize: function alfresco_layout_FixedHeaderFooter___resize() {
+         if (this.recalculateAutoHeightOnResize === true)
+         {
+            this.height = this.setHeight();
+         }
+
+         var widgetHeight = this.domNode.offsetHeight,
+             headerHeight = this.header.offsetHeight,
+             footerHeight = this.footer.offsetHeight;
+         domStyle.set(this.content, {
+            top: headerHeight + "px",
+            height: (widgetHeight - headerHeight - footerHeight) + "px"
+         });
+      },
+
+      /**
+       * This function is called when a resize check is required, but debounces
+       * the actual call for browser performance reasons.
+       *
+       * @instance
+       */
+      _triggerResizeCheck: function alfresco_layout_FixedHeaderFooter___triggerResizeCheck() {
+         clearTimeout(this._publishDebounceTimeout);
+         this._publishDebounceTimeout = setTimeout(lang.hitch(this, this._resize), this._publishDebounceMs);
+      }
    });
+});

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -18,38 +18,72 @@
  */
 
 /**
- * A layout control used to provide a scrollable central area with fixed-position header/footer widgets.
+ * <p>This widget provides a simple way in which you can keep a "header" and/or "footer" always visible whilst
+ * any overflowing main content is scrolled. The [header]{@link module:alfresco/layout/FixedHeaderFooter#widgetsForHeader},
+ * [footer]{@link module:alfresco/layout/FixedHeaderFooter#widgetsForFooter} and 
+ * [main content]{@link module:alfresco/layout/FixedHeaderFooter#widgetsForFooter} should be defined as standard
+ * widget models.</p>
+ * <p>The overall [height]{@link module:alfresco/layout/FixedHeaderFooter#height} of the widget can be explicitly 
+ * set but can also be left (or set) to the default value of "auto" which will make the widget take up all the available
+ * space in the client window below it. It is also possible to 
+ * [configure]{@link module:alfresco/layout/FixedHeaderFooter#recalculateAutoHeightOnResize} the widget so that it will
+ * automatically reset the height as the window changes in size.</p>
  *
- * @example <caption>Sample configuration:</caption>
+ * @example <caption>Example configuration:</caption>
  * {
  *    name: "alfresco/layout/FixedHeaderFooter",
  *    config: {
- *       height: "300px",
+ *       height: "auto",
+ *       recalculateAutoHeightOnResize: true,
  *       widgetsForHeader: [
  *          {
- *             name: "alfresco/logo/Logo"
+ *             name: "alfresco/menus/AlfMenuBar",
+ *             config: {
+ *                widgets: [
+ *                   {
+ *                      name: "alfresco/menus/AlfMenuBarItem",
+ *                      config: {
+ *                         label: "Menu item in header"
+ *                      }
+ *                   }
+ *                ]
+ *             }
  *          }
  *       ],
  *       widgets: [
  *          {
- *             name: "alfresco/logo/Logo"
- *          },
- *          {
- *             name: "alfresco/logo/Logo"
- *          },
- *          {
- *             name: "alfresco/logo/Logo"
- *          },
- *          {
- *             name: "alfresco/logo/Logo"
- *          },
- *          {
- *             name: "alfresco/logo/Logo"
+ *             name: "alfresco/lists/AlfList",
+ *             config: {
+ *                currentData: {
+ *                   items: [
+ *                      { name: "one" }, { name: "two" }, { name: "three" }
+ *                   ]
+ *                },
+ *                widgets: [
+ *                   {
+ *                      name: "alfresco/lists/views/HtmlListView",
+ *                      config: {
+ *                         propertyToRender: "name"
+ *                      }
+ *                   }
+ *                ]
+ *             }
  *          }
  *       ],
  *       widgetsForFooter: [
  *          {
- *             name: "alfresco/logo/Logo"
+ *             name: "alfresco/menus/AlfMenuBar",
+ *             config: {
+ *                popupMenusAbove: true,
+ *                widgets: [
+ *                   {
+ *                      name: "alfresco/menus/AlfMenuBarItem",
+ *                      config: {
+ *                         label: "Menu item in footer"
+ *                      }
+ *                   }
+ *                ]
+ *             }
  *          }
  *       ]
  *    }
@@ -58,6 +92,7 @@
  * @module alfresco/layout/FixedHeaderFooter
  * @extends module:alfresco/core/ProcessWidgets
  * @author Martin Doyle
+ * @author Dave Draper
  */
 define(["alfresco/core/ProcessWidgets",
         "alfresco/core/ResizeMixin",

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -23,70 +23,120 @@
  * @author Martin Doyle
  */
 define(["intern!object",
-      "intern/chai!assert",
-      "alfresco/TestCommon"
-   ],
-   function(registerSuite, assert, TestCommon) {
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+       function(registerSuite, assert, TestCommon) {
 
-      var browser;
-      registerSuite({
-         name: "FixedHeaderFooter tests",
+   var browser;
+   registerSuite({
+      name: "FixedHeaderFooter tests",
 
-         setup: function() {
-            browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/FixedHeaderFooter#currentItem=10", "FixedHeaderFooter Tests").end();
-         },
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/FixedHeaderFooter#currentItem=10", "FixedHeaderFooter Tests").end();
+      },
 
-         beforeEach: function() {
-            browser.end();
-         },
+      beforeEach: function() {
+         browser.end();
+      },
 
-         "Total height is correct": function() {
-            return browser.findById("HEADER_FOOTER")
-               .getSize()
-               .then(function(size) {
-                  assert.equal(size.height, 300, "Height not as per widget config");
-               });
-         },
+      "Total height is correct": function() {
+         return browser.findById("HEADER_FOOTER")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, 300, "Height not as per widget config");
+            });
+      },
 
-         "Only content is scrollable": function() {
-            function nodeOverflows(selector) {
-               var node = document.querySelector(selector);
-               return node.scrollHeight > node.offsetHeight;
-            }
-
-            return browser.execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__header"])
-               .then(function(overflows) {
-                  assert.isFalse(overflows, "Header is not same height as its content");
-               })
-
-            .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
-               .then(function(overflows) {
-                  assert.isTrue(overflows, "Content is not overflowing");
-               })
-
-            .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__footer"])
-               .then(function(overflows) {
-                  assert.isFalse(overflows, "Footer is not same height as its content");
-               });
-         },
-
-         "List has automatically scrolled to correct location": function() {
-            // See AKU-330
-            // The FixedHeaderFooter widget provides the best way of testing scrolling that is NOT on the
-            // main document...
-            function getScrollTop(selector) {
-               var node = document.querySelector(selector);
-               return node.scrollTop;
-            }
-            return browser.execute(getScrollTop, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
-               .then(function(scrollTop) {
-                  assert.notEqual(scrollTop, 0, "List did not scroll");
-               });
-         },
-
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
+      "Only content is scrollable": function() {
+         function nodeOverflows(selector) {
+            var node = document.querySelector(selector);
+            return node.scrollHeight > node.offsetHeight;
          }
-      });
+
+         return browser.execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__header"])
+            .then(function(overflows) {
+               assert.isFalse(overflows, "Header is not same height as its content");
+            })
+
+         .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
+            .then(function(overflows) {
+               assert.isTrue(overflows, "Content is not overflowing");
+            })
+
+         .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__footer"])
+            .then(function(overflows) {
+               assert.isFalse(overflows, "Footer is not same height as its content");
+            });
+      },
+
+      "List has automatically scrolled to correct location": function() {
+         // See AKU-330
+         // The FixedHeaderFooter widget provides the best way of testing scrolling that is NOT on the
+         // main document...
+         function getScrollTop(selector) {
+            var node = document.querySelector(selector);
+            return node.scrollTop;
+         }
+         return browser.execute(getScrollTop, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
+            .then(function(scrollTop) {
+               assert.notEqual(scrollTop, 0, "List did not scroll");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
    });
+
+   registerSuite({
+      name: "FixedHeaderFooter tests (auto height calculations)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AutoHeightFixedHeaderFooter", "FixedHeaderFooter tests (auto height calculations)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check height is calculated": function() {
+         var windowHeight;
+         return browser.findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowHeight = size.height;
+            })
+         .end()
+         .findByCssSelector("#HEADER_FOOTER")
+            .getSize()
+            .then(function(size) {
+               // PLEASE NOTE: 20 pixels deducted for test page padding
+               assert.equal(size.height, windowHeight - 20, "Height not calculated correctly");
+            });
+      },
+
+      "Check auto resizing": function() {
+         var windowHeight;
+         return browser.setWindowSize(null, 1024, 300)
+            .sleep(100) // Wait for resize debounce
+            .findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowHeight = size.height;
+            })
+         .end()
+         .findByCssSelector("#HEADER_FOOTER")
+            .getSize()
+            .then(function(size) {
+               // PLEASE NOTE: 20 pixels deducted for test page padding
+               assert.equal(size.height, windowHeight - 20, "Height not calculated correctly");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Auto height FixedHeaderFooter</shortname>
+  <description>Demonstrates the alfresco/layout/FixedHeaderFooter widget using the default height configuration so that it automatically takes up enough space to take it to take up the available room on page load.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AutoHeightFixedHeaderFooter</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.js
@@ -1,0 +1,103 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/FixedHeaderFooter",
+         id: "HEADER_FOOTER",
+         config: {
+            autoHeightPaddingAllowance: 10,
+            recalculateAutoHeightOnResize: true,
+            widgetsForHeader: [
+               {
+                  id: "FIXED_BREADCRUMBS",
+                  name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+                  config: {
+                     breadcrumbs: [
+                        {
+                           label: "Some"
+                        },
+                        {
+                           label: "Example"
+                        },
+                        {
+                           label: "Breadcrumb"
+                        },
+                        {
+                           label: "Trail"
+                        }
+                     ]
+                  }
+               }
+            ],
+            widgets: [
+               {
+                  id: "LIST",
+                  name: "alfresco/documentlibrary/AlfDocumentList",
+                  config: {
+                     useHash: true,
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/AlfListView",
+                           config: {
+                              itemKey: "index",
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Row",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/renderers/Property",
+                                                      config: {
+                                                         propertyToRender: "index"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ],
+            widgetsForFooter: [
+               {
+                  id: "CUSTOM_PAGE_SIZE_PAGINATOR",
+                  name: "alfresco/lists/Paginator",
+                  config: {
+                     popupMenusAbove: true,
+                     useHash: false,
+                     documentsPerPage: 10,
+                     hidePageSizeOnWidth: 10,
+                     pageSizes: [5,10,20]
+                  }
+               }
+            ]
+         }
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -88,21 +88,13 @@ model.jsonModel = {
                      ],
                      widgetsForFooter: [
                         {
-                           id: "MENU_BAR",
-                           name: "alfresco/menus/AlfMenuBar",
+                           id: "CUSTOM_PAGE_SIZE_PAGINATOR",
+                           name: "alfresco/lists/Paginator",
                            config: {
-                              widgets: [
-                                 {
-                                    id: "CUSTOM_PAGE_SIZE_PAGINATOR",
-                                    name: "alfresco/lists/Paginator",
-                                    config: {
-                                       useHash: false,
-                                       documentsPerPage: 10,
-                                       hidePageSizeOnWidth: 100,
-                                       pageSizes: [5,10,20]
-                                    }
-                                 }
-                              ]
+                              useHash: false,
+                              documentsPerPage: 10,
+                              hidePageSizeOnWidth: 10,
+                              pageSizes: [5,10,20]
                            }
                         }
                      ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-350 to change the default behaviour of the alfresco/layout/FixedHeaderFooter widget. I've added a unit test for the new auto sizing capabilities as well as improving the JSDoc so that developers can understand the limitations of using a percentage based height.