### PR TITLE
AKU-331: Updated CrudService to encode URIs by default

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -38,6 +38,17 @@ define(["dojo/_base/declare",
    return declare(null, {
 
       /**
+       * Indicates whether or not to call the JavaScript encodeURI function on URLs before they
+       * are passed to [serviceXhr]{@link module:alfresc/core/CoreXhr#serviceXhr}. This defaults
+       * to true but can be overridden if required.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      encodeURIs: true,
+
+      /**
        * Should a cache busting parameter be added to the URL?
        *
        * @instance
@@ -107,8 +118,7 @@ define(["dojo/_base/declare",
        * @param {serviceXhrConfig} config The configuration for the request
        */
       serviceXhr: function alfresco_core_CoreXhr__serviceXhr(config) {
-         /*jshint maxcomplexity:12*/
-
+         /*jshint maxcomplexity:false*/
          var _this = this;
 
          if (config)
@@ -159,7 +169,8 @@ define(["dojo/_base/declare",
                   options.preventCache = (config.preventCache !== null)? config.preventCache : this.preventCache;
                }
 
-               var request = xhr(config.url, options).then(function(response) {
+               var url = this.encodeURIs ? encodeURI(config.url) : config.url;
+               var request = xhr(url, options).then(function(response) {
 
                   var id = lang.getObject("requestId", false, config);
                   if (id)

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -19,7 +19,7 @@
 
 /**
  * This is a generic service for handling CRUD requests between widgets and the repository. By default
- * all URLs will be encoded unless [encodeURIs]{@link module:alfresco/services/CrudService#encodeURIs}
+ * all URLs will be encoded unless [encodeURIs]{@link module:alfresco/core/CoreXhr#encodeURIs}
  * is configured to be false.
  *
  * @module alfresco/services/CrudService
@@ -47,17 +47,6 @@ define(["dojo/_base/declare",
        * @default [{i18nFile: "./i18n/CrudService.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/CrudService.properties"}],
-
-      /**
-       * Indicates whether or not to call the JavaScript encodeURI function on URLs before they
-       * are passed to [serviceXhr]{@link module:alfresc/core/CoreXhr#serviceXhr}. This defaults
-       * to true but can be overridden if required.
-       *
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      encodeURIs: true,
 
       /**
        * Constructor
@@ -213,7 +202,7 @@ define(["dojo/_base/declare",
          }
 
          var config = {
-            url: this.encodeURIs ? encodeURI(url) : url,
+            url: url,
             data: this.clonePayload(payload),
             alfTopic: payload.alfResponseTopic || null,
             method: "GET"
@@ -241,7 +230,7 @@ define(["dojo/_base/declare",
          var url = this.getUrlFromPayload(payload);
          if (url) {
             this.serviceXhr({
-               url: this.encodeURIs ? encodeURI(url) : url,
+               url: url,
                data: this.clonePayload(payload),
                method: "GET"
             });
@@ -259,7 +248,7 @@ define(["dojo/_base/declare",
       onCreate: function alfresco_services_CrudService__onCreate(payload) {
          var url = this.getUrlFromPayload(payload);
          this.serviceXhr({
-            url: this.encodeURIs ? encodeURI(url) : url,
+            url: url,
             data: this.clonePayload(payload),
             method: "POST",
             alfTopic: payload.alfResponseTopic,
@@ -279,7 +268,7 @@ define(["dojo/_base/declare",
       onUpdate: function alfresco_services_CrudService__onUpdate(payload) {
          var url = this.getUrlFromPayload(payload);
          this.serviceXhr({
-            url: this.encodeURIs ? encodeURI(url) : url,
+            url: url,
             data: this.clonePayload(payload),
             method: "PUT",
             alfTopic: payload.alfResponseTopic,
@@ -379,7 +368,7 @@ define(["dojo/_base/declare",
        */
       performDelete: function alfresco_services_CrudService__performDelete(url, payload) {
          this.serviceXhr({
-            url: this.encodeURIs ? encodeURI(url) : url,
+            url: url,
             method: "DELETE",
             data: this.clonePayload(payload),
             alfTopic: payload.responseTopic,

--- a/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
@@ -27,172 +27,182 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/helpers/pollUntil"],
         function(registerSuite, assert, require, TestCommon, pollUntil) {
 
-      var browser;
-
-      function closeAllDialogs() {
-         return browser.end()
-            .findAllByCssSelector(".dijitDialogCloseIcon")
-            .then(function(closeButtons) {
-               closeButtons.forEach(function(closeButton) {
-                  if (closeButton.isDisplayed()) {
-                     closeButton.click();
-                  }
-               });
-               browser.end();
-            })
-            .then(pollUntil(function() {
-               /*globals document*/
-               var underlay = document.getElementById("dijit_DialogUnderlay_0"),
-                  underlayHidden = underlay && underlay.style.display === "none";
-               return underlayHidden || null;
-            }, 5000));
-      }
-
-      registerSuite({
-         name: "CrudService",
-
-         setup: function() {
-            browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/CrudService", "CrudService")
-               .end();
-         },
-
-         beforeEach: function() {
+   var browser;
+   function closeAllDialogs() {
+      return browser.end()
+         .findAllByCssSelector(".dijitDialogCloseIcon")
+         .then(function(closeButtons) {
+            closeButtons.forEach(function(closeButton) {
+               if (closeButton.isDisplayed()) {
+                  closeButton.click();
+               }
+            });
             browser.end();
-         },
+         })
+         .then(pollUntil(function() {
+            /*globals document*/
+            var underlay = document.getElementById("dijit_DialogUnderlay_0"),
+               underlayHidden = underlay && underlay.style.display === "none";
+            return underlayHidden || null;
+         }, 5000));
+   }
 
-         "Valid DELETE call succeeds": function() {
-            return browser.findById("DELETE_SUCCESS_BUTTON")
-               .click()
+   registerSuite({
+      name: "CrudService",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/CrudService", "CrudService")
+            .end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Valid DELETE call succeeds": function() {
+         return browser.findById("DELETE_SUCCESS_BUTTON")
+            .click()
+         .end()
+
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_SUCCESS", "publish", "any"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Delete did not succeed");
+            });
+      },
+
+      "Invalid DELETE call fails": function() {
+         return browser.findById("DELETE_FAILURE_BUTTON")
+            .click()
+         .end()
+
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_FAILURE", "publish", "any"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Invalid delete did not fail");
+            });
+      },
+
+      "Failed DELETE displays failure message": function() {
+         return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+            .then(function(dialogBody) {
+               return dialogBody.getVisibleText()
+                  .then(function(messageText) {
+                     var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                     assert.equal(trimmed, "Test delete-failure message", "Delete failure message not displayed");
+                  });
+            });
+      },
+
+      "Valid UPDATE call succeeds": function() {
+         return closeAllDialogs()
+            .then(function() {
+               return browser.findById("UPDATE_SUCCESS_BUTTON")
+                  .click()
                .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_SUCCESS", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Delete did not succeed");
-               });
-         },
+               .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_SUCCESS", "publish", "any"))
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Update did not succeed");
+                  });
+            });
+      },
 
-         "Invalid DELETE call fails": function() {
-            return browser.findById("DELETE_FAILURE_BUTTON")
-               .click()
+      "Invalid UPDATE call fails": function() {
+         return browser.findById("UPDATE_FAILURE_BUTTON")
+            .click()
+         .end()
+
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_FAILURE", "publish", "any"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Invalid update did not fail");
+            });
+      },
+
+      "Failed UPDATE displays failure message": function() {
+         return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+            .then(function(dialogBody) {
+               return dialogBody.getVisibleText()
+                  .then(function(messageText) {
+                     var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                     assert.equal(trimmed, "Test update-failure message", "Update failure message not displayed");
+                  });
+            });
+      },
+
+      "Valid CREATE call succeeds": function() {
+         return closeAllDialogs()
+            .then(function() {
+               return browser.findById("CREATE_SUCCESS_BUTTON")
+                  .click()
                .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_FAILURE", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Invalid delete did not fail");
-               });
-         },
+               .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_SUCCESS", "publish", "any"))
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Create did not succeed");
+                  });
+            });
+      },
 
-         "Failed DELETE displays failure message": function() {
-            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
-               .then(function(dialogBody) {
-                  return dialogBody.getVisibleText()
-                     .then(function(messageText) {
-                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
-                        assert.equal(trimmed, "Test delete-failure message", "Delete failure message not displayed");
-                     });
-               });
-         },
+      "Invalid CREATE call fails": function () {
+         return browser.findById("CREATE_FAILURE_BUTTON")
+            .click()
+         .end()
 
-         "Valid UPDATE call succeeds": function() {
-            return closeAllDialogs()
-               .then(function() {
-                  return browser.findById("UPDATE_SUCCESS_BUTTON")
-                     .click()
-                     .end()
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_FAILURE", "publish", "any"))
+            .then(function (elements) {
+               assert.lengthOf(elements, 1, "Invalid create did not fail");
+            });
+      },
 
-                  .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_SUCCESS", "publish", "any"))
-                     .then(function(elements) {
-                        assert.lengthOf(elements, 1, "Update did not succeed");
-                     });
-               });
-         },
+      "Failed CREATE displays failure message": function () {
+         return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+            .then(function (dialogBody) {
+               return dialogBody.getVisibleText()
+                  .then(function (messageText) {
+                     var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                     assert.equal(trimmed, "Test create-failure message", "Create failure message not displayed");
+                  });
+            });
+      },
 
-         "Invalid UPDATE call fails": function() {
-            return browser.findById("UPDATE_FAILURE_BUTTON")
-               .click()
+      "GET ALL success": function () {
+         return closeAllDialogs()
+            .then(function() {
+               return browser.findById("GET_ALL_DEFAULT_CACHE_BUTTON")
+                  .click()
                .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_FAILURE", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Invalid update did not fail");
-               });
-         },
+               .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_DEFAULT_CACHE_SUCCESS", "publish", "any"))
+                  .then(function (elements) {
+                     assert.lengthOf(elements, 1, "GET ALL didn't succeed");
+                  });
+            });
+      },
 
-         "Failed UPDATE displays failure message": function() {
-            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
-               .then(function(dialogBody) {
-                  return dialogBody.getVisibleText()
-                     .then(function(messageText) {
-                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
-                        assert.equal(trimmed, "Test update-failure message", "Update failure message not displayed");
-                     });
-               });
-         },
+      "GET ALL with prevent cache option success": function () {
+         return browser.findById("GET_ALL_PREVENT_CACHE_BUTTON")
+            .click()
+         .end()
 
-         "Valid CREATE call succeeds": function() {
-            return closeAllDialogs()
-               .then(function() {
-                  return browser.findById("CREATE_SUCCESS_BUTTON")
-                     .click()
-                     .end()
+         .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_PREVENT_CACHE_SUCCESS", "publish", "any"))
+            .then(function (elements) {
+               assert.lengthOf(elements, 1, "GET ALL with preventCache flag failed");
+            });
+      },
 
-                  .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_SUCCESS", "publish", "any"))
-                     .then(function(elements) {
-                        assert.lengthOf(elements, 1, "Create did not succeed");
-                     });
-               });
-         },
+      "Check URI encoding": function() {
+         return browser.findById("URL_ENCODING_REQUIRED_BUTTON")
+            .click()
+         .end()
+         .findByCssSelector("tr.mx-row:nth-child(9) .mx-url")
+            .getVisibleText()
+            .then(function(text) {
+               assert.include(text, "/aikau/proxy/alfresco/resources/nocache?filter=%25moomin", "URI was not encoded");
+            });
+      },
 
-         "Invalid CREATE call fails": function () {
-            return browser.findById("CREATE_FAILURE_BUTTON")
-               .click()
-               .end()
-
-               .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_FAILURE", "publish", "any"))
-               .then(function (elements) {
-                  assert.lengthOf(elements, 1, "Invalid create did not fail");
-               });
-         },
-
-         "Failed CREATE displays failure message": function () {
-            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
-               .then(function (dialogBody) {
-                  return dialogBody.getVisibleText()
-                     .then(function (messageText) {
-                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
-                        assert.equal(trimmed, "Test create-failure message", "Create failure message not displayed");
-                     });
-               });
-         },
-
-         "GET ALL success": function () {
-            return closeAllDialogs()
-               .then(function() {
-                  return browser.findById("GET_ALL_DEFAULT_CACHE_BUTTON")
-                     .click()
-                     .end()
-
-                     .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_DEFAULT_CACHE_SUCCESS", "publish", "any"))
-                     .then(function (elements) {
-                        assert.lengthOf(elements, 1, "GET ALL didn't succeed");
-                     });
-               })
-         },
-
-         "GET ALL with prevent cache option success": function () {
-            return browser.findById("GET_ALL_PREVENT_CACHE_BUTTON")
-               .click()
-               .end()
-
-               .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_PREVENT_CACHE_SUCCESS", "publish", "any"))
-               .then(function (elements) {
-                  assert.lengthOf(elements, 1, "GET ALL with preventCache flag failed");
-               });
-         },
-
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         }
-      });
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
    });
+});

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
@@ -119,6 +119,19 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "URL_ENCODING_REQUIRED_BUTTON",
+         config: {
+            label: "Encoded URI check",
+            publishTopic: "ALF_CRUD_GET_ALL",
+            publishPayload: {
+               url: "resources/nocache?filter=%moomin",
+               alfResponseTopic: "ALF_GET_ALL_PREVENT_CACHE",
+               failureMessage: "Test get all prevent cache message"
+            }
+         }
+      },
+      {
          name: "aikauTesting/mockservices/CrudServiceMockXhr"
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-331 to update the alfresco/services/CrudService to encode all URIs before they're requested (however, it's possible to configure the service so that URIs aren't encoded). A unit test has been added to verify encoding occurs.