### PR TITLE
AKU-353: Hide pagination controls on data failure

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -92,6 +92,16 @@ define(["dojo/_base/declare"],
        * @default "ALF_DOCLIST_DOCUMENTS_LOADED"
        */
       documentsLoadedTopic: "ALF_DOCLIST_DOCUMENTS_LOADED",
+
+      /**
+       * This topic is used to indicate that documents could not be loaded.
+       * 
+       * @event documentLoadFailedTopic
+       * @instance
+       * @type {string} 
+       * @default "ALF_DOCLIST_DOCUMENTS_LOAD_FAILED"
+       */
+      documentLoadFailedTopic: "ALF_DOCLIST_DOCUMENTS_LOAD_FAILED",
       
       /**
        * This topic is used to publish changes of page within the current location.

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1055,6 +1055,7 @@ define(["dojo/_base/declare",
          this.alfLog("error", "Data Load Failed", response, originalRequestConfig);
          this.currentData = null;
          this.showDataLoadFailure();
+         this.alfPublish(this.documentLoadFailedTopic, {});
          this.alfPublish(this.requestFinishedTopic, {});
       },
 

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -68,4 +68,61 @@ define(["intern!object",
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });
+
+   registerSuite({
+      name: "AlfSortablePaginatedList Tests (data load failure)",
+      
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check data failure message": function() {
+         return browser.findByCssSelector("#LIST .data-failure")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Loading message not displayed");
+            });
+      },
+
+      "Check that the pagination controls are all hidden": function() {
+         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page selector was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_BACK")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page back button was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_MARKER")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page indicator was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page forward button was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The items per page selector was NOT hidden");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfSortablePaginatedList (data failure)</shortname>
+  <description>Shows an AlfSortablePaginatedList configured to make a data request that will fail.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfSortablePaginatedListDataFail</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.js
@@ -1,0 +1,78 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "List that fails to load data",
+            widgets: [
+               {
+                  id: "PAGINATOR",
+                  name: "alfresco/lists/Paginator",
+                  config: {
+                     documentsPerPage: 10,
+                     hidePageSizeOnWidth: 100,
+                     pageSizes: [5,10,20]
+                  }
+               },
+               {
+                  id: "LIST",
+                  name: "alfresco/lists/AlfSortablePaginatedList",
+                  config: {
+                     currentPageSize: 10,
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/AlfListView",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Row",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/renderers/Property",
+                                                      config: {
+                                                         propertyToRender: "index"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         // Note: just using any mock xhr service that will fail...
+         name: "aikauTesting/mockservices/DocumentLibraryMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This is a second attempt at addressing https://issues.alfresco.com/jira/browse/AKU-352 (the previous PR: https://github.com/Alfresco/Aikau/pull/277 addressed some of the issues, but not a specific use case). This update ensures that pagination controls are hidden when data fails to load at all. The unit tests have been updated to address this.