### PR TITLE
AKU-352: Remove hidePageSizeOnWidth attribute

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -245,7 +245,6 @@ define(["dojo/_base/declare",
                domClass.add(this.resultsPerPageGroup.domNode, "hidden");
             }
          }));
-         this._hideControlsOnResize = true;
       },
 
       /**
@@ -289,9 +288,6 @@ define(["dojo/_base/declare",
             }
             else
             {
-               // Ensure that controls can be redisplayed...
-               this._hideControlsOnResize = false;
-
                // Make sure the pagination controls aren't hidden...
                // domClass.remove(this.domNode, "hidden");
                if (this.pageSelector)

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -245,6 +245,7 @@ define(["dojo/_base/declare",
                domClass.add(this.resultsPerPageGroup.domNode, "hidden");
             }
          }));
+         this._hideControlsOnResize = true;
       },
 
       /**
@@ -288,6 +289,9 @@ define(["dojo/_base/declare",
             }
             else
             {
+               // Ensure that controls can be redisplayed...
+               this._hideControlsOnResize = false;
+
                // Make sure the pagination controls aren't hidden...
                // domClass.remove(this.domNode, "hidden");
                if (this.pageSelector)
@@ -407,16 +411,6 @@ define(["dojo/_base/declare",
        */
       pageSelectorGroup: null,
       
-      /**
-       * This is the minimum width the container node must be in order for the page size selector
-       * to be displayed.
-       *
-       * @instance
-       * @type {number}
-       * @default 1024
-       */
-      hidePageSizeOnWidth: 1024,
-
       /**
        * Indicates whether the paginator should be displayed in "compact" mode where only
        * the back and forward buttons are displayed.
@@ -577,7 +571,6 @@ define(["dojo/_base/declare",
                   id: this.id + "_RESULTS_PER_PAGE_SELECTOR",
                   label: this.message("list.paginator.docsPerPageSelect.label"),
                   selectionTopic: this.docsPerpageSelectionTopic,
-                  minRwdWidth: this.hidePageSizeOnWidth,
                   widgets: [
                      {
                         name: "alfresco/menus/AlfMenuGroup",

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -121,6 +121,15 @@ define(["intern!object",
             });
       },
 
+      "Resize and check that controls are all still hidden": function() {
+         return browser.setWindowSize(null, 1024, 300)
+            .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The items per page selector was revealed on resize");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -40,10 +40,7 @@ model.jsonModel = {
                               widgets: [
                                  {
                                     id: "PAGINATOR",
-                                    name: "alfresco/lists/Paginator",
-                                    config: {
-                                       hidePageSizeOnWidth: 100
-                                    }
+                                    name: "alfresco/lists/Paginator"
                                  },
                                  {
                                     id: "MENU_BAR_POPUP",
@@ -176,7 +173,6 @@ model.jsonModel = {
                                              name: "alfresco/lists/Paginator",
                                              config: {
                                                 documentsPerPage: 10,
-                                                hidePageSizeOnWidth: 100,
                                                 pageSizes: [5,10,20]
                                              }
                                           }
@@ -301,7 +297,6 @@ model.jsonModel = {
                                              name: "alfresco/lists/Paginator",
                                              config: {
                                                 documentsPerPage: 10,
-                                                hidePageSizeOnWidth: 100,
                                                 pageSizes: [5,10,20]
                                              }
                                           }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SitesList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SitesList.get.js
@@ -63,10 +63,7 @@ model.jsonModel = {
       },
       {
          id: "SITES_LIST_PAGINATION_MENU",
-         name: "alfresco/lists/Paginator",
-         config: {
-            hidePageSizeOnWidth: 50
-         }
+         name: "alfresco/lists/Paginator"
       },
       {
          name: "aikauTesting/mockservices/SitesPaginationMockXhr"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.js
@@ -92,7 +92,6 @@ model.jsonModel = {
                      popupMenusAbove: true,
                      useHash: false,
                      documentsPerPage: 10,
-                     hidePageSizeOnWidth: 10,
                      pageSizes: [5,10,20]
                   }
                }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -93,7 +93,6 @@ model.jsonModel = {
                            config: {
                               useHash: false,
                               documentsPerPage: 10,
-                              hidePageSizeOnWidth: 10,
                               pageSizes: [5,10,20]
                            }
                         }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
@@ -38,7 +38,6 @@ model.jsonModel = {
                            config: {
                               useHash: true,
                               documentsPerPage: 10,
-                              hidePageSizeOnWidth: 100,
                               pageSizes: [5,10,20]
                            }
                         }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedListDataFail.get.js
@@ -24,7 +24,6 @@ model.jsonModel = {
                   name: "alfresco/lists/Paginator",
                   config: {
                      documentsPerPage: 10,
-                     hidePageSizeOnWidth: 100,
                      pageSizes: [5,10,20]
                   }
                },


### PR DESCRIPTION
This PR addresses an additional comment that was raised on https://issues.alfresco.com/jira/browse/AKU-352. I originally added the "hidePageSizeOnWidth" as an experiment in alternative approaches to response web design, but really it's caused nothing but problems (see https://issues.alfresco.com/jira/browse/AKU-348) so I've removed it - it was inconsistent with the rest of the library and hasn't been used in production (the paginator is used, but this feature isn't relied upon and is likely to cause more confusion if left).