### PR TITLE
AKU-344: Dialog containing PublishingDropDownMenu close

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -54,10 +54,11 @@ define(["dojo/_base/declare",
         "dojo/dom-geometry",
         "dojo/html",
         "dojo/aspect",
+        "dojo/on",
         "jquery",
         "alfresco/layout/SimplePanel"], 
         function(declare, Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin, lang, sniff, array,
-                 domConstruct, domClass, domStyle, domGeom, html, aspect, $) {
+                 domConstruct, domClass, domStyle, domGeom, html, aspect, on, $) {
    
    return declare([Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin], {
       
@@ -168,6 +169,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_dialogs_AlfDialog__postCreate() {
+         // jshint maxcomplexity:false
          this.inherited(arguments);
 
          // Listen for requests to resize the dialog...
@@ -261,11 +263,11 @@ define(["dojo/_base/declare",
       
          // Publish events if the dialog moves
          if(this._moveable) {
-            aspect.after(this._moveable, "onMoveStart", lang.hitch(this, function(returnVal, originalArgs) {
+            aspect.after(this._moveable, "onMoveStart", lang.hitch(this, function(returnVal, /*jshint unused:false*/ originalArgs) {
                this.alfPublish("ALF_DIALOG_MOVE_START", null, true);
                return returnVal;
             }));
-            aspect.after(this._moveable, "onMoveStop", lang.hitch(this, function(returnVal, originalArgs) {
+            aspect.after(this._moveable, "onMoveStop", lang.hitch(this, function(returnVal, /*jshint unused:false*/ originalArgs) {
                this.alfPublish("ALF_DIALOG_MOVE_STOP", null, true);
                return returnVal;
             }));
@@ -283,6 +285,18 @@ define(["dojo/_base/declare",
          domStyle.set(document.documentElement, "overflow", "");
          domClass.remove(this.domNode, "dialogDisplayed");
          domClass.add(this.domNode, "dialogHidden");
+         
+         // Normalise closing dialog by re-issuing escape key use (which could 
+         // actually have been used to close the dialog, but this ensures that
+         // any widgets listening for this keyup event get notificed)...
+         on.emit(this.domNode, "keyup", {
+            bubbles: true, 
+            cancelable: true, 
+            keyCode: 27, 
+            charCode: 27, 
+            keyCodeArg : 27, 
+            charCodeArg: 0
+         }); 
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -24,7 +24,7 @@
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
- * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -32,13 +32,13 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/Cell.html",
         "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing",
+        "alfresco/lists/views/layouts/_LayoutMixin",
         "dojo/dom-class",
         "dojo/dom-style",
         "dojo/dom-attr"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, domClass, domStyle, domAttr) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, _LayoutMixin, domClass, domStyle, domAttr) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Column.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Column.js
@@ -24,7 +24,7 @@
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
- * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -32,11 +32,11 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/Column.html",
         "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing",
+        "alfresco/lists/views/layouts/_LayoutMixin",
         "dojo/dom-construct"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, domConstruct) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, _LayoutMixin, domConstruct) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -27,7 +27,7 @@
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
  * @mixes module:alfresco/core/Core
- * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -38,7 +38,7 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Grid.html",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing",
+        "alfresco/lists/views/layouts/_LayoutMixin",
         "dojo/keys",
         "dojo/_base/lang",
         "dojo/_base/array",
@@ -46,12 +46,11 @@ define(["dojo/_base/declare",
         "dojo/dom-geometry",
         "dojo/query",
         "dojo/dom-style",
-        "dijit/registry",
-        "dojo/dom",
-        "dojo/on"], 
-        function(declare, _WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, template, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing, keys, lang, array, domConstruct, domGeom, query, domStyle, registry, dom, on) {
+        "dijit/registry"], 
+        function(declare, _WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, template, _MultiItemRendererMixin, 
+                 AlfCore, _LayoutMixin, keys, lang, array, domConstruct, domGeom, query, domStyle, registry) {
 
-   return declare([_WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([_WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, _MultiItemRendererMixin, AlfCore, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -255,7 +254,7 @@ define(["dojo/_base/declare",
        * @param {element} node The node to set width on
        * @param {number} index The current index of the element in the array
        */
-      resizeCell: function alfresco_lists_views_layouts_Grid__resizeCell(containerNodeMarginBox, widthToSet, node, index) {
+      resizeCell: function alfresco_lists_views_layouts_Grid__resizeCell(containerNodeMarginBox, widthToSet, node, /*jshint unused:false*/ index) {
          domStyle.set(node, {"width": widthToSet});
          var dimensions = {
             w: widthToSet,
@@ -272,9 +271,9 @@ define(["dojo/_base/declare",
        * @param {object} widgetNode The DOM node that possibly has a widget associated. Use registry to check
        * @param {integer} index The index of the node
        */
-      resizeWidget: function alfresco_lists_views_layouts_Grid__resizeWidget(dimensions, widgetNode, index) {
+      resizeWidget: function alfresco_lists_views_layouts_Grid__resizeWidget(dimensions, widgetNode, /*jshint unused:false*/ index) {
          var widget = registry.byNode(widgetNode);
-         if (widget != null && typeof widget.resize === "function")
+         if (widget && typeof widget.resize === "function")
          {
             widget.resize(dimensions);
          }
@@ -289,8 +288,7 @@ define(["dojo/_base/declare",
        * @param {element} rootNode The DOM node to create the new DOM node as a child of
        * @param {string} rootClassName A string containing one or more space separated CSS classes to set on the DOM node
        */
-      createWidgetDomNode: function alfresco_lists_views_layouts_Grid__createWidgetDomNode(widget, rootNode, rootClassName) {
-         
+      createWidgetDomNode: function alfresco_lists_views_layouts_Grid__createWidgetDomNode(widget, rootNode, /*jshint unused:false*/ rootClassName) {
          var nodeToAdd = rootNode;
          if (this.currentIndex % this.columns === 0)
          {
@@ -316,7 +314,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      renderNextItem: function alfresco_lists_views_layout__MultiItemRendererMixin__renderNextItem() {
+      renderNextItem: function alfresco_lists_views_layouts_Grid__renderNextItem() {
          if (this.nextLinkDisplay)
          {
             var cell = this.nextLinkDisplay.domNode.parentNode;

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -25,7 +25,7 @@
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
  * @mixes module:alfresco/core/Core
- * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -34,11 +34,11 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Row.html",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing",
+        "alfresco/lists/views/layouts/_LayoutMixin",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing, domClass) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, _LayoutMixin, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module alfresco/lists/views/layouts/_LayoutMixin
+ * @extends module:alfresco/core/CoreWidgetProcessing
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/CoreWidgetProcessing"], 
+        function(declare, CoreWidgetProcessing) {
+   
+   return declare([CoreWidgetProcessing], {
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/core/CoreWidgetProcessing#processWidgetConfig}
+       * to update the widget id (if configured) so that it is appended with "_ITEM_<index>" (where <index> is the
+       * index of the current item being iterated over).
+       *
+       * @instance
+       * @param {object} widget The widget configuration build configuration for
+       * @return {object} The arguments that can be used when instantiating the widget configuration processed
+       */
+      processWidgetConfig: function alfresco_lists_views_layouts_Cell__processWidgetConfig(widget) {
+         if (widget.id)
+         {
+            widget.id = widget.id + "_ITEM_" + this.currentItem.index;
+         }
+         return this.inherited(arguments);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
@@ -18,6 +18,14 @@
  */
 
 /**
+ * This mixin module extends [CoreWidgetProcessing]{@link module:alfresco/core/CoreWidgetProcessing} to provide
+ * some additional identification processing for widgets in the alfresco/lists/layouts package. This is necessary to ensure
+ * that an "id" attribute can be given to an widget in the alfresco/renderers package and for that attribute to be
+ * updated to include the index of the current item. This is required because the renderers and list layout controls
+ * are typically used when iterating over multiple items and Aikau ensures that each widget has a unique "id". Therefore
+ * in order to be able to use unique identifiers within a page model it is necessary to update the "id" on each iteration
+ * to prevent duplications.
+ * 
  * @module alfresco/lists/views/layouts/_LayoutMixin
  * @extends module:alfresco/core/CoreWidgetProcessing
  * @author Dave Draper

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
@@ -41,11 +41,10 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-style",
-        "dojo/dom-attr",
         "dojo/on",
         "dojo/_base/event"], 
         function(declare, CoreWidgetProcessing, ObjectProcessingMixin, ObjectTypeUtils, JsNode, _AlfDocumentListTopicMixin, 
-                 domClass, array, lang, domStyle, domAttr, on, event) {
+                 domClass, array, lang, domStyle, on, event) {
    
    return declare([CoreWidgetProcessing, ObjectProcessingMixin, _AlfDocumentListTopicMixin], {
 

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
@@ -41,10 +41,11 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-style",
+        "dojo/dom-attr",
         "dojo/on",
         "dojo/_base/event"], 
         function(declare, CoreWidgetProcessing, ObjectProcessingMixin, ObjectTypeUtils, JsNode, _AlfDocumentListTopicMixin, 
-                 domClass, array, lang, domStyle, on, event) {
+                 domClass, array, lang, domStyle, domAttr, on, event) {
    
    return declare([CoreWidgetProcessing, ObjectProcessingMixin, _AlfDocumentListTopicMixin], {
 
@@ -265,7 +266,6 @@ define(["dojo/_base/declare",
        * @param {Object[]}
        */
       allWidgetsProcessed: function alfresco_lists_views_layout___MultiItemRendererMixin__allWidgetsProcessed(widgets) {
-         
          // Push the processed widgets for the last item into the array of rendered widgets...
          if (!this._renderedItemWidgets)
          {
@@ -329,6 +329,9 @@ define(["dojo/_base/declare",
          {
             this.rootWidgetSubscriptions = [];
          }
+
+         // Create an id based on the index of the item...
+         widget.domNode.id = this.id + "_ITEM_" + index;
 
          if (this.supportsItemSelection === true)
          {

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
@@ -323,15 +323,12 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget to add the styling to
        * @param {number} index The index of the widget
        */
-      rootWidgetProcessing: function alfresco_lists_views_layout___MultiItemRendererMixin__rootWidgetProcessing(widget, index) {
+      rootWidgetProcessing: function alfresco_lists_views_layout___MultiItemRendererMixin__rootWidgetProcessing(widget, /*jshint unused:false*/ index) {
          domClass.add(widget.domNode, "alfresco-lists-views-layout-_MultiItemRendererMixin--item");
          if (!this.rootWidgetSubscriptions)
          {
             this.rootWidgetSubscriptions = [];
          }
-
-         // Create an id based on the index of the item...
-         widget.domNode.id = this.id + "_ITEM_" + index;
 
          if (this.supportsItemSelection === true)
          {

--- a/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
@@ -198,6 +198,7 @@ define(["dojo/_base/declare",
 
             // Create the widget...
             this._dropDownWidget = new Select({
+               id: this.id + "_SELECT",
                pubSubScope: uuid,
                fieldId: fieldId,
                value: this.value,

--- a/aikau/src/test/resources/alfresco/lists/views/layouts/RowTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/layouts/RowTest.js
@@ -47,7 +47,7 @@ define(["intern!object",
       },
 
       "Test colspan can be set on cell": function() {
-         return browser.findByCssSelector("#ONE_CELL td.alfresco-lists-views-layouts-Cell")
+         return browser.findByCssSelector("#CELL3_ITEM_0")
             .getAttribute("colspan")
             .then(function(colspan) {
                assert.equal(colspan, 2, "Colspan attribute not set on cell");

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -45,7 +45,7 @@ define(["intern!object",
          },
 
          "Property is rendered correctly": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "Test", "Value not rendered correctly");
@@ -53,14 +53,14 @@ define(["intern!object",
          },
 
          "Edit widget not initially created": function() {
-            return browser.findAllByCssSelector("#INLINE_EDIT > .editWidgetNode > *")
+            return browser.findAllByCssSelector("#INLINE_EDIT_ITEM_0 > .editWidgetNode > *")
                .then(function(elements) {
                   assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
                });
          },
 
          "Edit icon initially invisible": function() {
-            return browser.findByCssSelector("#INLINE_EDIT .editIcon")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Icon should not be displayed");
@@ -68,12 +68,12 @@ define(["intern!object",
          },
 
          "Icon appears on focus": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .then(function(element) {
                   element.type(""); // Focus on element
 
                   browser.end()
-                     .findByCssSelector("#INLINE_EDIT .editIcon")
+                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isTrue(result, "Edit icon was not revealed on focus");
@@ -82,12 +82,12 @@ define(["intern!object",
          },
 
          "Icon disappears on blur": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .then(function(element) {
                   element.type([keys.SHIFT, keys.TAB]); // Focus away from element
 
                   browser.end()
-                     .findByCssSelector("#INLINE_EDIT .editIcon")
+                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit icon was not hidden on blur");
@@ -96,11 +96,11 @@ define(["intern!object",
          },
 
          "Icon appears on mouseover": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .moveMouseTo()
                .end()
 
-            .findByCssSelector("#INLINE_EDIT .editIcon")
+            .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit icon was not revealed on mouse over");
@@ -112,7 +112,7 @@ define(["intern!object",
                .moveMouseTo(0, 0)
                .then(function() {
                   browser.end()
-                     .findByCssSelector("#INLINE_EDIT .editIcon")
+                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit icon was not hidden on mouse out");
@@ -121,7 +121,7 @@ define(["intern!object",
          },
 
          "Edit widgets are created on edit": function() {
-            return browser.findByCssSelector("#INLINE_EDIT .editIcon")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                .click()
                .end()
 
@@ -132,7 +132,7 @@ define(["intern!object",
          },
 
          "Read property is hidden when editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Read-only span was not hidden");
@@ -140,14 +140,14 @@ define(["intern!object",
          },
 
          "Save and cancel buttons are displayed when editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT .action.save")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Save button not visible when editing");
                })
                .end()
 
-            .findByCssSelector("#INLINE_EDIT .action.cancel")
+            .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Cancel button not visible when editing");
@@ -159,7 +159,7 @@ define(["intern!object",
                .pressKeys([keys.ESCAPE])
                .end()
 
-            .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Read-only value not revealed on cancelling edit");
@@ -167,7 +167,7 @@ define(["intern!object",
          },
 
          "Clicking on property fires topic": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .click()
                .end()
 
@@ -186,26 +186,26 @@ define(["intern!object",
          },
 
          "Clicking on cancel button stops editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .moveMouseTo()
                .then(function() {
                   return browser.end()
-                     .findByCssSelector("#INLINE_EDIT .editIcon")
+                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                      .click()
                      .end()
 
-                  .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+                  .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit mode not entered when clicking on icon");
                      })
                      .end()
 
-                  .findByCssSelector("#INLINE_EDIT .action.cancel")
+                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
                      .click()
                      .end()
 
-                  .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+                  .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                      .isDisplayed()
                      .then(function(result) {
                         assert.isTrue(result, "Read-only value not revealed on cancelling edit");
@@ -214,7 +214,7 @@ define(["intern!object",
          },
 
          "CTRL-E starts editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .pressKeys([keys.CONTROL, "e"])
                .pressKeys(keys.NULL)
                .end()
@@ -234,12 +234,12 @@ define(["intern!object",
                })
                .end()
 
-            .findByCssSelector("#INLINE_EDIT .dijitInputContainer input")
+            .findByCssSelector("#INLINE_EDIT_ITEM_0 .dijitInputContainer input")
                .clearValue()
                .type("New")
                .end()
 
-            .findByCssSelector("#INLINE_EDIT .action.save")
+            .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
                .click()
                .end()
 
@@ -262,7 +262,7 @@ define(["intern!object",
          },
 
          "Readonly view displayed when finished editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Read-only span not revealed on save");

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -45,7 +45,7 @@ define(["intern!object",
       },
 
       "Property is rendered correctly": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "Test", "Value not rendered correctly");
@@ -53,7 +53,7 @@ define(["intern!object",
       },
 
       "Edit widget not initially created": function() {
-         return browser.findAllByCssSelector("#INLINE_EDIT > .editWidgetNode > *")
+         return browser.findAllByCssSelector("#INLINE_EDIT_ITEM_0 > .editWidgetNode > *")
             .then(function(elements) {
                assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
             });
@@ -64,7 +64,7 @@ define(["intern!object",
             .moveMouseTo()
          .end()
          .sleep(250) // Make sure the mouse isn't over the row!
-         .findByCssSelector("#INLINE_EDIT .editIcon")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
             .isDisplayed()
             .then(function(result) {
                assert.isFalse(result, "Icon should not be displayed");
@@ -73,13 +73,13 @@ define(["intern!object",
 
       "Render on new line configuration doesn't effect icon": function() {
          var valueX;
-         return browser.findByCssSelector("#INLINE_EDIT .inlineEditValue")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .inlineEditValue")
             .getPosition()
             .then(function(p) {
                valueX = p.x;
             })
          .end()
-         .findByCssSelector("#INLINE_EDIT .editIcon")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
             .getPosition()
             .then(function(p) {
                assert.notEqual(valueX, p.x, "The value and icon should NOT be starting at the same X co-ordinate");
@@ -88,12 +88,12 @@ define(["intern!object",
       },
 
       "Icon appears on focus": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .then(function(element) {
                element.type(""); // Focus on element
 
                browser.end()
-                  .findByCssSelector("#INLINE_EDIT .editIcon")
+                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                   .isDisplayed()
                   .then(function(result) {
                      assert.isTrue(result, "Edit icon was not revealed on focus");
@@ -102,12 +102,12 @@ define(["intern!object",
       },
 
       "Icon disappears on blur": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .then(function(element) {
                element.type([keys.SHIFT, keys.TAB]); // Focus away from element
 
                browser.end()
-                  .findByCssSelector("#INLINE_EDIT .editIcon")
+                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                   .isDisplayed()
                   .then(function(result) {
                      assert.isFalse(result, "Edit icon was not hidden on blur");
@@ -116,11 +116,11 @@ define(["intern!object",
       },
 
       "Icon appears on mouseover": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .moveMouseTo()
             .end()
 
-         .findByCssSelector("#INLINE_EDIT .editIcon")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "Edit icon was not revealed on mouse over");
@@ -132,7 +132,7 @@ define(["intern!object",
             .moveMouseTo(0, 0)
             .then(function() {
                browser.end()
-                  .findByCssSelector("#INLINE_EDIT .editIcon")
+                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
                   .isDisplayed()
                   .then(function(result) {
                      assert.isFalse(result, "Edit icon was not hidden on mouse out");
@@ -141,7 +141,7 @@ define(["intern!object",
       },
 
       "Edit widgets are created on edit": function() {
-         return browser.findByCssSelector("#INLINE_EDIT .editIcon")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
             .click()
             .end()
 
@@ -152,7 +152,7 @@ define(["intern!object",
       },
 
       "Read property is hidden when editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .isDisplayed()
             .then(function(result) {
                assert.isFalse(result, "Read-only span was not hidden");
@@ -160,14 +160,14 @@ define(["intern!object",
       },
 
       "Save and cancel buttons are displayed when editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT .action.save")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "Save button not visible when editing");
             })
             .end()
 
-         .findByCssSelector("#INLINE_EDIT .action.cancel")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "Cancel button not visible when editing");
@@ -179,7 +179,7 @@ define(["intern!object",
             .pressKeys([keys.ESCAPE])
             .end()
 
-         .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "Read-only value not revealed on cancelling edit");
@@ -187,7 +187,7 @@ define(["intern!object",
       },
 
       "Clicking on read-only value starts editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .click()
             .end()
 
@@ -199,11 +199,11 @@ define(["intern!object",
       },
 
       "Clicking on cancel button stops editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT .action.cancel")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
             .click()
             .end()
 
-         .findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "Read-only value not revealed on cancelling edit");
@@ -211,7 +211,7 @@ define(["intern!object",
       },
 
       "CTRL-E starts editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .pressKeys([keys.CONTROL, "e"])
             .pressKeys(keys.NULL)
             .end()
@@ -224,12 +224,12 @@ define(["intern!object",
       },
 
       "Changes published on save": function() {
-         return browser.findByCssSelector("#INLINE_EDIT .dijitInputContainer input")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .dijitInputContainer input")
             .clearValue()
             .type("New")
             .end()
 
-         .findByCssSelector("#INLINE_EDIT .action.save")
+         .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
             .click()
             .end()
 
@@ -252,7 +252,7 @@ define(["intern!object",
       },
 
       "Readonly view displayed when finished editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "Read-only span not revealed on save");
@@ -265,16 +265,16 @@ define(["intern!object",
       },
 
       "Inline-edit select restores values on failed save": function() {
-         return browser.findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
+         return browser.findByCssSelector("#INLINE_SELECT_ITEM_0 > .alfresco-renderers-Property")
             .then(function(element) {
                return browser.moveMouseTo(element)
                   .then(function() {
                      return browser.end()
-                        .findByCssSelector("#INLINE_SELECT .editIcon")
+                        .findByCssSelector("#INLINE_SELECT_ITEM_0 .editIcon")
                         .click()
                         .end()
 
-                     .findByCssSelector("#INLINE_SELECT .alfresco-forms-controls-BaseFormControl .dijitArrowButtonInner")
+                     .findByCssSelector("#INLINE_SELECT_ITEM_0 .alfresco-forms-controls-BaseFormControl .dijitArrowButtonInner")
                         .click()
                         .end()
 
@@ -282,11 +282,11 @@ define(["intern!object",
                         .click()
                         .end()
 
-                     .findByCssSelector("#INLINE_SELECT .action.save")
+                     .findByCssSelector("#INLINE_SELECT_ITEM_0 .action.save")
                         .click()
                         .end()
 
-                     .findByCssSelector("#INLINE_SELECT > .alfresco-renderers-Property")
+                     .findByCssSelector("#INLINE_SELECT_ITEM_0 > .alfresco-renderers-Property")
                         .isDisplayed()
                         .then(function(result) {
                            assert.isTrue(result, "Read-only span not revealed on failed save");

--- a/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
@@ -47,7 +47,7 @@ define(["intern!object",
                // .moveMouseTo(null, 0, 0)
                //    .end()
 
-               .findByCssSelector("#BASIC .value")
+               .findByCssSelector("#BASIC_ITEM_0 .value")
                .getVisibleText()
                .then(function(resultText) {
                   assert(resultText === "Test", "Standard property not rendered correctly: " + resultText);
@@ -55,7 +55,7 @@ define(["intern!object",
          },
 
          "Check prefixed/suffixed property is rendered correctly": function() {
-            return browser.findByCssSelector("#PREFIX_SUFFIX .value")
+            return browser.findByCssSelector("#PREFIX_SUFFIX_ITEM_0 .value")
                .getVisibleText()
                .then(function(resultText) {
                   assert(resultText === "(Test)", "Prefix and suffix not rendered correctly: " + resultText);
@@ -63,7 +63,7 @@ define(["intern!object",
          },
 
          "Check new line property is rendered correctly": function() {
-            return browser.findByCssSelector("#NEW_LINE")
+            return browser.findByCssSelector("#NEW_LINE_ITEM_0")
                .getComputedStyle("display")
                .then(function(result) {
                   assert(result === "block", "New line not applied");
@@ -71,7 +71,7 @@ define(["intern!object",
          },
 
          "Check standard warning is rendered correctly": function() {
-            return browser.findByCssSelector("#WARN1 .value")
+            return browser.findByCssSelector("#WARN1_ITEM_0 .value")
                .getVisibleText()
                .then(function(resultText) {
                   assert.equal(resultText, "No property for: \"missing\"", "Standard warning not rendered correctly");
@@ -79,7 +79,7 @@ define(["intern!object",
          },
 
          "Check explicit warning is rendered correctly": function() {
-            return browser.findByCssSelector("#WARN2 .value")
+            return browser.findByCssSelector("#WARN2_ITEM_0 .value")
                .getVisibleText()
                .then(function(resultText) {
                   assert(resultText === "No description", "Explicit warning not rendered correctly: " + resultText);
@@ -93,7 +93,7 @@ define(["intern!object",
                })
                .end()
 
-            .findByCssSelector("#HOVER .inner")
+            .findByCssSelector("#HOVER_ITEM_0 .inner")
                .isDisplayed()
                .then(function(result) {
                   assert(result === false, "Hover displayed unexpectedly");
@@ -107,7 +107,7 @@ define(["intern!object",
                })
                .end()
 
-            .findByCssSelector("#HOVER .value")
+            .findByCssSelector("#HOVER_ITEM_0 .value")
                .isDisplayed()
                .then(function(result) {
                   assert(result === true, "Hover displayed unexpectedly");
@@ -115,7 +115,7 @@ define(["intern!object",
          },
 
          "Check label is rendered correctly": function() {
-            return browser.findByCssSelector("#LABEL .label")
+            return browser.findByCssSelector("#LABEL_ITEM_0 .label")
                .getVisibleText()
                .then(function(resultText) {
                   assert(resultText === "Label:", "Label not rendered correctly: " + resultText);
@@ -124,7 +124,7 @@ define(["intern!object",
 
          "Property is truncated when too long for max-width": function() {
             return browser.execute(function() {
-                  var property = document.getElementById("MAX_LENGTH"),
+                  var property = document.getElementById("MAX_LENGTH_ITEM_0"),
                      truncated = property.clientWidth < property.scrollWidth;
                   return truncated;
                })
@@ -133,7 +133,7 @@ define(["intern!object",
                })
                .end()
 
-            .findById("MAX_LENGTH")
+            .findById("MAX_LENGTH_ITEM_0")
                .then(function(elem) {
                   return elem.getSize();
                })
@@ -146,7 +146,7 @@ define(["intern!object",
          },
 
          "Truncated property displays full text on focus": function() {
-            return browser.findById("MAX_LENGTH")
+            return browser.findById("MAX_LENGTH_ITEM_0")
                .then(function(element) {
                   element.type(""); // Focus on element
 
@@ -160,7 +160,7 @@ define(["intern!object",
          },
 
          "Truncated property hides full text on blur": function() {
-            return browser.findById("MAX_LENGTH")
+            return browser.findById("MAX_LENGTH_ITEM_0")
                .then(function(element) {
                   element.type([keys.SHIFT, keys.TAB]); // Focus away from element
 
@@ -174,7 +174,7 @@ define(["intern!object",
          },
 
          "Truncated property displays full text on mouseover": function() {
-            return browser.findById("MAX_LENGTH")
+            return browser.findById("MAX_LENGTH_ITEM_0")
                .moveMouseTo()
                .end()
 

--- a/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
@@ -188,6 +188,38 @@ define(["intern!object",
             });
       },
 
+      "Test use in dialog": function() {
+         return browser.findByCssSelector("#SHOW_DIALOG_label")
+            .click()
+         .end()
+         // Wait for dialog...
+         .findAllByCssSelector("#DIALOG1.dialogDisplayed")
+         .end()
+         .findByCssSelector("#DIALOG_PDM_ITEM_2_SELECT_CONTROL")
+            .click()
+         .end()
+         // Select "Public" (there should be no response so the spinner will just keep spinning...)
+         .findByCssSelector("#DIALOG_PDM_ITEM_2_SELECT_CONTROL_menu tr:nth-child(1) .dijitMenuItemLabel")
+            .click()
+         .end()
+         .findByCssSelector("#DIALOG1 tr:nth-child(3) .alfresco-renderers-PublishingDropDownMenu .indicator.processing")
+            .isDisplayed()
+            .then(function (displayed) {
+               assert.isTrue(displayed, "The spinner icon is not present");
+            })
+         .end()
+         .findByCssSelector(".dijitDialogCloseIcon")
+            .click()
+         .end()
+         // Wait for dialog to be hidden...
+         .findAllByCssSelector("#DIALOG1.dialogHidden")
+         .end()
+         .findAllByCssSelector(TestCommon.topicSelector("CANCEL_UPDATE", "publish", "any"))
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Cancel publication not made on escape key");
+            });
+      },
+
       "Test menu publish is cleared on refresh": function() {
          return browser.refresh().end()
             .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_PUBLISHING_DROPDOWN_MENU", "alfTopic", "ALF_PUBLISHING_DROPDOWN_MENU"))

--- a/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
@@ -28,7 +28,7 @@ define(["intern!object",
         function (registerSuite, expect, assert, require, TestCommon) {
 
    var toggleSelector = function(id, status) {
-      return "#" + id + " ." + status;
+      return "#" + id + "_ITEM_0 ." + status;
    };
 
    var browser;
@@ -85,7 +85,7 @@ define(["intern!object",
       },
 
       "Like the document": function() {
-         return browser.findByCssSelector("#LIKES")
+         return browser.findByCssSelector("#LIKES_ITEM_0")
             .click()
          .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_ADD", "publish", "any"))
@@ -119,7 +119,7 @@ define(["intern!object",
       },
 
       "Unlike the document": function() {
-         return browser.findByCssSelector("#LIKES")
+         return browser.findByCssSelector("#LIKES_ITEM_0")
             .click()
          .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_REMOVE", "publish", "any"))
@@ -202,7 +202,7 @@ define(["intern!object",
       },
 
       "Favourite a document": function() {
-         return browser.findByCssSelector("#FAVOURITES")
+         return browser.findByCssSelector("#FAVOURITES_ITEM_0")
             .click()
          .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE", "publish", "any"))
@@ -228,7 +228,7 @@ define(["intern!object",
       },
 
       "Remove favourite": function() {
-         return browser.findByCssSelector("#FAVOURITES")
+         return browser.findByCssSelector("#FAVOURITES_ITEM_0")
             .click()
          .end()
          .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE", "publish", "any"))

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/layouts/Row.get.js
@@ -26,12 +26,12 @@ model.jsonModel = {
             },
             widgets: [
                {
-                  id: "TWO_CELLS",
                   name: "alfresco/lists/views/layouts/Row",
                   config: {
                      additionalCssClasses: "extra",
                      widgets: [
                         {
+                           id: "CELL1",
                            name: "alfresco/lists/views/layouts/Cell",
                            config: {
                               widgets: [
@@ -45,6 +45,7 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "CELL2",
                            name: "alfresco/lists/views/layouts/Cell",
                            config: {
                               widgets: [
@@ -61,11 +62,11 @@ model.jsonModel = {
                   }
                },
                {
-                  id: "ONE_CELL",
                   name: "alfresco/lists/views/layouts/Row",
                   config: {
                      widgets: [
                         {
+                           id: "CELL3",
                            name: "alfresco/lists/views/layouts/Cell",
                            config: {
                               colspan: 2,

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>PublishingDropDownMenu Test</shortname>
-  <description>This WebScript defines the PublishingDropDownMenu page test</description>
+  <shortname>PublishingDropDownMenu</shortname>
+  <description>Shows a list that includes examples of the alfresco/renderers/PublishingDropDownMenu. This renderer can be used to publish updates about the value it is changed to as the user makes those changes.</description>
   <family>aikau-unit-tests</family>
   <url>/PublishingDropDownMenu</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.js
@@ -1,3 +1,96 @@
+/* global widgetUtils */
+
+// Define a list model that will be used in both the main list on the page and then again in a dialog...
+var widgets = {
+   id: "LIST_VIEW_1",
+   name: "alfresco/lists/views/AlfListView",
+   config: {
+      subscribeToDocRequests: true,
+      currentData: {
+         items: [
+            {col1:"Test1", col2:"PUBLIC"},
+            {col1:"Test2", col2:"MODERATED"},
+            {col1:"Test3", col2:"PRIVATE"}
+         ]
+      },
+      widgetsForHeader: [
+         {
+            name: "alfresco/lists/views/layouts/HeaderCell",
+            config: {
+               label: "Heading 1"
+            }
+         },
+         {
+            name: "alfresco/lists/views/layouts/HeaderCell",
+            config: {
+               label: "Heading 2"
+            }
+         }
+      ],
+      widgets:[
+         {
+            name: "alfresco/lists/views/layouts/Row",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/renderers/Property",
+                              config: {
+                                 propertyToRender: "col1",
+                                 renderAsLink: false
+                              }
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              id: "PDM",
+                              name: "alfresco/renderers/PublishingDropDownMenu",
+                              config: {
+                                 publishTopic: "ALF_PUBLISHING_DROPDOWN_MENU",
+                                 publishPayload: {
+                                    shortName: {
+                                       alfType: "item",
+                                       alfProperty: "col1"
+                                    }
+                                 },
+                                 propertyToRender: "col2",
+                                 optionsConfig: {
+                                    fixed: [
+                                       {label: "Public", value: "PUBLIC"},
+                                       {label: "Moderated", value: "MODERATED"},
+                                       {label: "Private", value: "PRIVATE"}
+                                    ]
+                                 },
+                                 cancellationPublishTopic: "CANCEL_UPDATE",
+                                 cancellationPublishPayloadType: "CURRENT_ITEM"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ]
+   }
+};
+
+// Clone the widgets model so that we can override the ID for the PublishingDropDownMenu
+// This needs to be done because otherwise a duplicate ID will attempt to be registered and
+// will then be swapped out with an automatically generated one (which will make testing harder)...
+var widgetsCopy = JSON.parse(JSON.stringify(widgets));
+widgetsCopy.id = "LIST_VIEW_2";
+var pdm = widgetUtils.findObject(widgetsCopy, "id", "PDM");
+pdm.id = "DIALOG_PDM";
+
 model.jsonModel = {
    services: [
       {
@@ -10,93 +103,26 @@ model.jsonModel = {
          }
       },
       "aikauTesting/mockservices/PublishingDropDownMenuMockService",
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/ErrorReporter",
+      "alfresco/services/DialogService"
    ],
    widgets:[
+      widgets,
       {
-         name: "alfresco/lists/views/AlfListView",
+         id: "SHOW_DIALOG",
+         name: "alfresco/buttons/AlfButton",
          config: {
-            subscribeToDocRequests: true,
-            currentData: {
-               items: [
-                  {col1:"Test1", col2:"PUBLIC"},
-                  {col1:"Test2", col2:"MODERATED"},
-                  {col1:"Test3", col2:"PRIVATE"}
-               ]
-            },
-            widgetsForHeader: [
-               {
-                  name: "alfresco/lists/views/layouts/HeaderCell",
-                  config: {
-                     label: "Heading 1"
-                  }
-               },
-               {
-                  name: "alfresco/lists/views/layouts/HeaderCell",
-                  config: {
-                     label: "Heading 2"
-                  }
-               }
-            ],
-            widgets:[
-               {
-                  name: "alfresco/lists/views/layouts/Row",
-                  config: {
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/layouts/Cell",
-                           config: {
-                              widgets: [
-                                 {
-                                    name: "alfresco/renderers/Property",
-                                    config: {
-                                       propertyToRender: "col1",
-                                       renderAsLink: false
-                                    }
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           name: "alfresco/lists/views/layouts/Cell",
-                           config: {
-                              widgets: [
-                                 {
-                                    name: "alfresco/renderers/PublishingDropDownMenu",
-                                    config: {
-                                       publishTopic: "ALF_PUBLISHING_DROPDOWN_MENU",
-                                       publishPayload: {
-                                          shortName: {
-                                             alfType: "item",
-                                             alfProperty: "col1"
-                                          }
-                                       },
-                                       propertyToRender: "col2",
-                                       optionsConfig: {
-                                          fixed: [
-                                             {label: "Public", value: "PUBLIC"},
-                                             {label: "Moderated", value: "MODERATED"},
-                                             {label: "Private", value: "PRIVATE"}
-                                          ]
-                                       },
-                                       cancellationPublishTopic: "CANCEL_UPDATE",
-                                       cancellationPublishPayloadType: "CURRENT_ITEM"
-                                    }
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  }
-               }
-            ]
+            label: "Show dialog",
+            publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "DIALOG1",
+               dialogTitle: "Test dialog",
+               widgetsContent: [widgetsCopy]
+            }
          }
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses comments in https://issues.alfresco.com/jira/browse/AKU-344 relating to alfresco/renderers/PublishingDropDownMenu widgets not detecting cancellation actions when a dialog is closed (by clicking the close icon rather than using the ESCAPE key).

This change "normalises" behaviour by simulating an ESCAPE key press when the dialog closes to ensure that anything listening to the escape key is notified. In order to efficiently write the test for this I've made some updates to the way that iterated data (e.g. in lists) is handled so that IDs can be applied more effectively. This will go some way to addressing https://issues.alfresco.com/jira/browse/AKU-353.