### PR TITLE
AKU-336: Annotating JSDoc with support statements

### DIFF
--- a/aikau/conf.json
+++ b/aikau/conf.json
@@ -8,7 +8,9 @@
         "includePattern": ".+\\.js(doc)?$",
         "excludePattern": "(^|\\/|\\\\)\\$"
     },
-    "plugins": [],
+    "plugins": [
+      "src/jsdoc-plugins/customization-support-tags"
+    ],
     "templates": {
         "cleverLinks": false,
         "monospaceLinks": false

--- a/aikau/src/jsdoc-plugins/customization-support-tags.js
+++ b/aikau/src/jsdoc-plugins/customization-support-tags.js
@@ -1,0 +1,69 @@
+/* global exports */
+exports.defineTags = function(dictionary) {
+
+   // When something is page safe it can be used in a page model in the knowledge that it isn't
+   // going to be removed or significantly changed in a future release (this should be applied
+   // to widgets and services)
+   dictionary.defineTag("pageSafe", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.pageSafe) { doclet.pageSafe = true; }
+      }
+   });
+
+   // When a module is mixin safe it means that a 3rd party widgets can extend it
+   dictionary.defineTag("extendSafe", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.extendSafe) { doclet.extendSafe = true; }
+      }
+   });
+
+   // When a module is mixin safe it means that a 3rd party can mix it into their own widgets
+   // without worrying about it being removed
+   dictionary.defineTag("mixinSafe", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.mixinSafe) { doclet.mixinSafe = true; }
+      }
+   });
+
+   // When a module is use safe it means that a 3rd party can reference it within their own
+   // widgets and services - this typically applies to utility modules.
+   dictionary.defineTag("useSafe", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.useSafe) { doclet.useSafe = true; }
+      }
+   });
+
+   // When a function is marked as "callable" it can be safely called by an extending module, but
+   // it should not be overridden or extended
+   dictionary.defineTag("callable", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.callable) { doclet.callable = true; }
+      }
+   });
+
+   // When a function is marked as "extendable" it can be safely overridden in an extending module
+   // but the inherited behaviour MUST be called before any other code is executed in the extending
+   // function
+   dictionary.defineTag("extendable", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.extendable) { doclet.extendable = true; }
+      }
+   });
+
+   // When a function is marked as "overrideable" it can be safely overridden in an extending module
+   // and that the extending module does not need to call the inherited behaviour. However it is
+   // required that the function perform the designated task and return the expected data.
+   dictionary.defineTag("overrideable", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.overrideable) { doclet.overrideable = true; }
+      }
+   });
+
+   // When a function is marked as "extensionPoint" it indicates that the purpose of the function
+   // is for extending modules to override it to add additional capabilities.
+   dictionary.defineTag("extensionPoint", {
+      onTagged: function(doclet, /*jshint unused:false*/ tag) {
+         if (!doclet.extensionPoint) { doclet.extensionPoint = true; }
+      }
+   });
+};

--- a/aikau/src/jsdoc-templates/alfresco/tmpl/details.tmpl
+++ b/aikau/src/jsdoc-templates/alfresco/tmpl/details.tmpl
@@ -53,6 +53,34 @@ if (data.defaultvalue && data.defaultvaluetype === 'object') {
         <?js }); ?></ul>
     </dd>
 
+    <?js if (data.pageSafe) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This module is safe to be used in an Aikau page model (at least until the next major release).</li></ul>
+    </dd>
+    <?js } ?> 
+
+    <?js if (data.extendSafe) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This module is safe to be extended by 3rd-party widgets or services (at least until the next major release).</li></ul>
+    </dd>
+    <?js } ?> 
+
+    <?js if (data.mixinSafe) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This module is safe to be mixed into 3rd-party widgets and services (at least until the next major release).</li></ul>
+    </dd>
+    <?js } ?> 
+
+    <?js if (data.useSafe) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This module is safe to be used in 3rd party modules (at least until the next major release).</li></ul>
+    </dd>
+    <?js } ?> 
+
     <dt class="tag-copyright">Copyright:</dt>
     <dd class="tag-copyright"><ul class="dummy"><li>Copyright (C) 2005-<?js= new Date().getFullYear() ?> Alfresco Software Limited</li></ul></dd>
 
@@ -60,6 +88,35 @@ if (data.defaultvalue && data.defaultvaluetype === 'object') {
     <dd class="tag-license"><ul class="dummy"><li>GNU Lesser General Public License, see: <a href="https://wiki.alfresco.com/wiki/Open_Source_Licensing">Open Source Licensing</a></li></ul></dd>
 
     <?js } ?>
+
+    <?js if (data.callable) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This function is safe to call by extending or mixing modules (at least until the next major release).</li></ul>
+    </dd>
+    <?js } ?> 
+
+    <?js if (data.extendable) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This function is safe to be overridden by extending or mixing modules (at least until the next major release). The inherited code must be called in the overriding function and if the inherited function returns a value then that value must be returned by the overriding function.</li></ul>
+    </dd>
+    <?js } ?> 
+
+    <?js if (data.overrideable) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This function is safe to be overridden by extending or mixing modules (at least until the next major release). The inherited code does not need to be called however the overriding function must perform the
+        designated action and return the appropriate data where appropriate.</li></ul>
+    </dd>
+    <?js } ?> 
+
+    <?js if (data.extensionPoint) { ?>
+    <dt class="tag-default">Support:</dt>
+    <dd class="tag-default">
+        <ul><li>This function is provided as an extension point and is safe to be overridden by extending or mixing modules (at least until the next major release).</li></ul>
+    </dd>
+    <?js } ?> 
 
     <?js if (data.defaultvalue) {?>
     <dt class="tag-default">Default Value:</dt>

--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -18,10 +18,11 @@
  */
 
 /**
- * This should be mixed into all Alfresco widgets as it provides the essential functions that they will
+ * This should be mixed into all Alfresco widgets and services as it provides the essential functions that they will
  * undoubtedly required, e.g. logging, publication/subscription handling, i18n message handling, etc.
  *
  * @module alfresco/core/Core
+ * @mixinSafe
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -75,6 +76,7 @@ define(["dojo/_base/declare",
        * This function is based on the version that can be found in alfresco.js. It searches through all of
        * the available scopes for the widget and for all of the widgets inherited from.
        *
+       * @callable
        * @instance
        * @param {string} p_messageId The id of the message to be displayed.
        * @returns {string} A localized form of the supplied message
@@ -180,6 +182,7 @@ define(["dojo/_base/declare",
        * attacks. This wraps the dojox/html/entities encode function. It is intentionally wrapped so that
        * if we need to make a change (e.g. change the encoding handling) we can make it in one place
        *
+       * @callable
        * @instance
        * @returns The encoded input string
        */
@@ -208,6 +211,13 @@ define(["dojo/_base/declare",
        */
       dataBindingCallbacks: null,
 
+      /**
+       * This function converts notation into an internal notation style.
+       * 
+       * @instance
+       * @param  {string} dotNotation A dot notation representation of the location within the data model to set.
+       * @return {string} The processed notation
+       */
       alfProcessDataDotNotation: function alfresco_core_Core__alfProcessDataDotNotation(dotNotation) {
          var re = /(\.|\[)/g;
          return dotNotation.replace(re, "._alfValue$1");
@@ -383,6 +393,7 @@ define(["dojo/_base/declare",
        * calling the Dojo implementation directly to allow us to make changes to the implementation or
        * to introduce additional features (such as scoping) or updates to the payload.
        *
+       * @callable
        * @instance
        * @param {String | Array} topics The topic(s) on which to publish
        * @param {object} payload The payload to publish on the supplied topic
@@ -428,6 +439,7 @@ define(["dojo/_base/declare",
       /**
        * Publish an event after waiting for the specified delay.
        *
+       * @instance
        * @param topic {String} topic to publish
        * @param payload {Object} the payload to be pushed to the publish event
        * @param delay {Number} ms delay in how long to wait before publishing the event
@@ -448,6 +460,7 @@ define(["dojo/_base/declare",
        * to introduce additional features (such as scoping) or updates to the callback. The subscription
        * handle that gets created is add to [alfSubscriptions]{@link module:alfresco/core/Core#alfSubscriptions}
        *
+       * @callable
        * @instance
        * @param {string} topic The topic on which to subscribe
        * @param {function} callback The callback function to call when the topic is published on.
@@ -494,6 +507,7 @@ define(["dojo/_base/declare",
        * This function wraps the standard unsubscribe function. It should always be used rather than call
        * the Dojo implementation directly.
        *
+       * @callable
        * @instance
        * @param {object|array} handle The subscription handle to unsubscribe
        */
@@ -527,6 +541,7 @@ define(["dojo/_base/declare",
        * This is a helper function for unsubscribing from subscription handles that are set-up with unique
        * topics to guarantee recipients.
        *
+       * @callable
        * @instance
        * @param {array} handles The handles to unsubscribe
        */
@@ -550,6 +565,7 @@ define(["dojo/_base/declare",
        *
        * This also removes any data binding listeners that have been registered.
        *
+       * @callable
        * @instance
        * @param {boolean} preserveDom
        */
@@ -629,6 +645,7 @@ define(["dojo/_base/declare",
        * default it simply delegates to the standard browser console object but could optionally be overridden or
        * extended to provide advanced capabilities like posting client-side logs back to the server, etc.
        *
+       * @callable
        * @instance
        * @param {string} severity The severity of the message to be logged
        * @param {string} message The message to be logged
@@ -657,7 +674,6 @@ define(["dojo/_base/declare",
        * @returns {object} A dojo/promise/Promise
        */
       alfPublishToPromise: function alfresco_core_Core__alfPubSubToPromise(topic, payload, global, parentScope) {
-
          // Setup the publish variables and handlers
          var deferred = new Deferred(),
             responseTopic = uuid(),

--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -22,6 +22,7 @@
  *
  * @module alfresco/core/CoreWidgetProcessing
  * @extends module:alfresco/core/Core
+ * @mixinSafe
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -44,6 +45,7 @@ define(["dojo/_base/declare",
        * widgets array is passed to the [processWidget]{@link module:alfresco/core/Core#processWidget} function
        * to handle it's creation.
        *
+       * @callable
        * @instance
        * @param {array} widgets An array of the widget definitions to instantiate
        * @param {element} rootNode The DOM node which should be used to add instantiated widgets to
@@ -181,7 +183,6 @@ define(["dojo/_base/declare",
        * @param {boolean} negate Whether or not to negate the evaluated rule
        */
       setupVisibilityConfigProcessing: function alfresco_core_CoreWidgetProcessing__setupVisibilityConfigProcessing(widget, negate) {
-
          // Set a default for negation if not provided...
          negate = (negate != null) ? negate : false;
 
@@ -343,6 +344,7 @@ define(["dojo/_base/declare",
       /**
        * This is an extension point for handling the completion of calls to [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        *
+       * @extensionPoint
        * @instance
        * @param {Array} widgets An array of all the widgets that have been processed
        */
@@ -592,7 +594,8 @@ define(["dojo/_base/declare",
        * Processes filter configuration. This looks for either "renderFilters" (e.g. a filter containing
        * sub-filters) or "renderFilter" (i.e. a single filter containing one or more rules to evaluate).
        * It then delegates processing to the appropriate function
-       * 
+       *
+       * @instance
        * @param  {object} filterConfig The configuration to inspect
        * @return {boolean} True if all filters have evaluated successfully and false otherwise.
        */
@@ -619,7 +622,8 @@ define(["dojo/_base/declare",
       /**
        * This function is used to to determine whether or not a filter containing multiple sub-filters evaluates to true. 
        * The sub-filters themselves can contain further nested filters.
-       * 
+       *
+       * @instance
        * @param  {object[]} renderFilterConfig The configuration for the filter array
        * @param  {string} renderFilterMethod Either ANY or ALL 
        * @return {boolean} True if the filter passes and false otherwise
@@ -653,7 +657,8 @@ define(["dojo/_base/declare",
        * This function is used to to determine whether or not a single filter evaluates to true. Note that a single
        * filter can consist of multiple rules where all rules or just one rule must evaluate to true in order for
        * the filter to pass.
-       * 
+       *
+       * @instance
        * @param  {object[]} renderFilterConfig The configuration for the filter array
        * @param  {string} renderFilterMethod Either ANY or ALL 
        * @return {boolean} True if the filter passes and false otherwise

--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -18,7 +18,11 @@
  */
 
 /**
+ * This module should be mixed into any widget or service that needs to make XHR calls to REST APIs on
+ * either the client or the Alfresco Repository.
+ * 
  * @module alfresco/core/CoreXhr
+ * @mixinSafe
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -115,6 +119,7 @@ define(["dojo/_base/declare",
        *
        *
        * @instance
+       * @callable
        * @param {serviceXhrConfig} config The configuration for the request
        */
       serviceXhr: function alfresco_core_CoreXhr__serviceXhr(config) {
@@ -399,8 +404,7 @@ define(["dojo/_base/declare",
        * @instance
        * @return {*}
        */
-      isCsrfFilterEnabled: function alfresco_core_CoreXhr__isCsrfFilterEnabled()
-      {
+      isCsrfFilterEnabled: function alfresco_core_CoreXhr__isCsrfFilterEnabled() {
          return AlfConstants.CSRF_POLICY.enabled;
       },
 
@@ -410,8 +414,7 @@ define(["dojo/_base/declare",
        * @instance
        * @return {String} The name of the request header to put the token in.
        */
-      getCsrfHeader: function alfresco_core_CoreXhr__getCsrfHeader()
-      {
+      getCsrfHeader: function alfresco_core_CoreXhr__getCsrfHeader() {
          return this.csrfResolve(AlfConstants.CSRF_POLICY.header);
       },
 
@@ -421,8 +424,7 @@ define(["dojo/_base/declare",
        * @instance
        * @return {String} The name of the request header to put the token in.
        */
-      getCsrfParameter: function alfresco_core_CoreXhr__getCsrfParameter()
-      {
+      getCsrfParameter: function alfresco_core_CoreXhr__getCsrfParameter() {
          return this.csrfResolve(AlfConstants.CSRF_POLICY.parameter);
       },
 
@@ -432,8 +434,7 @@ define(["dojo/_base/declare",
        * @instance
        * @return {String} The name of the request header to put the token in.
        */
-      getCsrfCookie: function alfresco_core_CoreXhr__getCsrfCookie()
-      {
+      getCsrfCookie: function alfresco_core_CoreXhr__getCsrfCookie() {
          return this.csrfResolve(AlfConstants.CSRF_POLICY.cookie);
       },
 
@@ -446,8 +447,7 @@ define(["dojo/_base/declare",
        * @instance
        * @returns {String} The name of the request header to put the token in.
        */
-      getCsrfToken: function alfresco_core_CoreXhr__getCsrfToken()
-      {
+      getCsrfToken: function alfresco_core_CoreXhr__getCsrfToken() {
          var token = null;
          var cookieName = this.getCsrfCookie();
          if (cookieName)

--- a/aikau/src/main/resources/alfresco/core/JsNode.js
+++ b/aikau/src/main/resources/alfresco/core/JsNode.js
@@ -59,6 +59,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       constructor: function alfresco_core_JsNode__constructor(args) {
+         // jshint maxcomplexity:false
          if (ObjectTypeUtils.isString(args))
          {
             // The supplied node is a String (and is expected to be a JSON string so should be parsed into an object)...

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -29,6 +29,7 @@
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreWidgetProcessing
  * @mixes module:alfresco/documentlibrary/_AlfHashMixin
+ * @pageSafe
  * @author Dave Draper
  */
 define(["dojo/_base/declare",

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -87,6 +87,7 @@
  * @mixes external:dojo/_FocusMixin
  * @mixes module:alfresco/forms/controls/FormControlValidationMixin
  * @mixes module:alfresco/core/Core
+ * @extendSafe
  * @author Dave Draper
  * @Richard Smith
  */
@@ -631,7 +632,7 @@ define(["dojo/_base/declare",
        * @param {object} option The option configuration
        * @param {number} index The index of the option
        */
-      processOptionLabel: function alfresco_forms_controls_BaseFormControl__processOptionLabel(option, index) {
+      processOptionLabel: function alfresco_forms_controls_BaseFormControl__processOptionLabel(option, /*jshint unused:false*/ index) {
          // Get the option label and value attributes...
          // These are the values to look up in each item of the the options data array...
          // They default to "label" and "value" if not specified
@@ -660,7 +661,7 @@ define(["dojo/_base/declare",
        * @param {object} subscription The details of the subscription to create
        * @param {number} index The index of the topic
        */
-      createOptionsChangesTo: function alfresco_forms_controls_BaseFormControl__createOptionsChangesTo(optionsConfig, subscription, index) {
+      createOptionsChangesTo: function alfresco_forms_controls_BaseFormControl__createOptionsChangesTo(optionsConfig, subscription, /*jshint unused:false*/ index) {
          if (subscription.targetId)
          {
             // Create the subscription...
@@ -672,7 +673,6 @@ define(["dojo/_base/declare",
          {
             this.alfLog("warn", "No 'targetId' defined in subscription config", subscription, optionsConfig, this);
          }
-         
       },
       
       /**
@@ -684,7 +684,7 @@ define(["dojo/_base/declare",
        * @param {object} subscription The details of the subscription to create
        * @param {number} index The index of the topic
        */
-      createOptionsSubscriptions: function alfresco_forms_controls_BaseFormControl__createOptionsSubscriptions(optionsConfig, subscription, index) {
+      createOptionsSubscriptions: function alfresco_forms_controls_BaseFormControl__createOptionsSubscriptions(optionsConfig, subscription, /*jshint unused:false*/ index) {
          if (subscription.topic)
          {
             // Create the subscription...
@@ -918,7 +918,6 @@ define(["dojo/_base/declare",
        * @param {object} config
        */
       processConfig: function alfresco_forms_controls_BaseFormControl__processConfig(attribute, config) {
-         
          if (config)
          {
             // Set the initial value...
@@ -999,7 +998,7 @@ define(["dojo/_base/declare",
        * @param {object} rule The rule to process.
        * @param {number} index The index of the rule.
        */
-      processRule: function alfresco_forms_controls_BaseFormControl__processRule(attribute, rule, index) {
+      processRule: function alfresco_forms_controls_BaseFormControl__processRule(attribute, rule, /*jshint unused:false*/ index) {
          if (rule.targetId)
          {
             if (typeof this._rulesEngineData[attribute][rule.targetId] === "undefined")
@@ -1030,7 +1029,6 @@ define(["dojo/_base/declare",
        * @param {object} payload The publication posted on the topic that triggered the rule
        */
       evaluateRules: function alfresco_forms_controls_BaseFormControl__evaluateRules(attribute, payload) {
-         
          this.alfLog("log", "RULES EVALUATION('" + attribute + "'): Field '" + this.fieldId + "'");
 
          // Set the current value that triggered the evaluation of rules...
@@ -1293,7 +1291,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload This is expected to be an empty object or null.
        */
-      onWidgetAddedToDocument: function alfresco_forms_controls_BaseFormControl__onWidgetAddedToDocument(payload) {
+      onWidgetAddedToDocument: function alfresco_forms_controls_BaseFormControl__onWidgetAddedToDocument(/*jshint unused:false*/ payload) {
+         // jshint maxstatements:false
          if ($.contains(document.body, this.domNode))
          {
             this.alfUnsubscribe(this.widgetProcessingCompleteSubscription);
@@ -1411,6 +1410,7 @@ define(["dojo/_base/declare",
        * once it's part of the document to ensure that no unsafe value (e.g. an XSS attack) can be
        * executed as part of the initial page rendering.
        *
+       * @extendable
        * @instance
        */
       completeWidgetSetup: function alfresco_forms_controls_BaseFormControl__completeWidgetSetup() {
@@ -1422,22 +1422,24 @@ define(["dojo/_base/declare",
        * Whenever a widgets value changes we need to publish the details out to the other form controls (that exist in the
        * same scope) so that they can modify their appearance/behaviour as necessary). This function sets up the default events 
        * that indicate that a wigets value has changed. This function can be overridden to handle non-Dojo widgets or when 
-       * multiple widgets represent a single control. 
-       * 
+       * multiple widgets represent a single control. If this function is overridden then the overriding function
+       * must ensure that the [onValueChangeEvent]{@link module:alfresco/forms/controls/BaseFormControl#onValueChangeEvent}
+       * is function is called when the value of the form control created by the
+       * [createFormControl]{@link module:alfresco/forms/controls/BaseFormControl#createFormControl} function
+       * changes.
+       *
        * @instance
+       * @overrideable
        */
       setupChangeEvents: function alfresco_forms_controls_BaseFormControl__setupChangeEvents() {
-         if (this.wrappedWidget)
+         if (this.wrappedWidget && typeof this.wrappedWidget.watch === "function")
          {
-            if (this.wrappedWidget.watch)
-            {
-               // TODO: Do we need to do anything with the watch handle when the widget is destroyed?
-               this.wrappedWidget.watch("value", lang.hitch(this, this.onValueChangeEvent));
-            } 
-            else
-            {
-               this.alfLog("warn", "No watch method found on wrapped widget", this);
-            }
+            // TODO: Do we need to do anything with the watch handle when the widget is destroyed?
+            this.wrappedWidget.watch("value", lang.hitch(this, this.onValueChangeEvent));
+         } 
+         else
+         {
+            this.alfLog("warn", "No watch method found on wrapped widget", this);
          }
       },
       
@@ -1461,6 +1463,7 @@ define(["dojo/_base/declare",
        * Dojo widgets (or use multiple widgets) should override this implementation to return the correct value.
        * 
        * @instance
+       * @extendable
        * @returns {object} The current value of the field.
        */
       getValue: function alfresco_forms_controls_BaseFormControl__getValue() {
@@ -1518,8 +1521,12 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * 
+       * Sets the value of the form control created by the 
+       * [createFormControl]{@link module:alfresco/forms/controls/BaseFormContro#createFormControl}
+       * function.
+       *  
        * @instance
+       * @extendable
        * @param {object} value The value to set.
        */
       setValue: function alfresco_forms_controls_BaseFormControl__setValue(value) {
@@ -1561,7 +1568,7 @@ define(["dojo/_base/declare",
        */
       valueSubscribe: function alfresco_forms_controls_BaseFormControl__valueSubscribe(payload) {
          var value = lang.getObject("value", false, payload);
-         if (value != null)
+         if (value || value === false || value === 0)
          {
             this.setValue(value);
          }
@@ -1635,31 +1642,37 @@ define(["dojo/_base/declare",
       },
       
       /**
+       * This function must be overriden by extending widgets to create and return an actual form control instance.
        * 
        * @instance
-       * @param {object} config
+       * @overrideable
+       * @param {object} config The configuration to use when instantiating the form control
        */
-      createFormControl: function alfresco_forms_controls_BaseFormControl__createFormControl(config) {
+      createFormControl: function alfresco_forms_controls_BaseFormControl__createFormControl(/*jshint unused:false*/ config) {
          // Extension point
       },
       
       /**
+       * This is a method that is expected to be overridden. We won't even assume that the widget configuration
+       * will be standard Dojo configuration because we might be instantiated a custom or 3rd party library widget.
        * 
        * @instance
+       * @overrideable
        * @returns {object} The configuration for the form control.
        */
       getWidgetConfig: function alfresco_forms_controls_BaseFormControl__getWidgetConfig() {
-         // This is a method that is expected to be overridden. We won't even assume that the widget configuration
-         // will be standard Dojo configuration because we might be instantiated a custom or 3rd party library widget.
          return {};
       },
       
       /**
+       * This is a life-cycle is provided as an extension point to be overridden to perform additional 
+       * actions once the form control has been created.
        * 
        * @instance
+       * @extensionPoint
        */
       startup: function alfresco_forms_controls_BaseFormControl__startup() {
-         
+         // No action by default
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -106,6 +106,7 @@
  *
  * @module alfresco/services/DialogService
  * @extends module:alfresco/core/Core
+ * @pageSafe
  * @author Dave Draper
  * @author David Webster
  */


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-336 and defines some new JSDoc tags that can be used to indicate which modules and functions will be supported in Aikau going forwards. An initial set of modules have been updated to use these tags. This is not necessarily the final implementation but we'll need to review at the sprint end to see if we're happy with the approach going forwards.