### PR TITLE
AKU-332: Identify empty results with CSS

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -51,15 +51,6 @@ define(["dojo/_base/declare",
    return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, _AlfDndDocumentUploadMixin], {
 
       /**
-       * The base CSS class for this widget
-       *
-       * @instance
-       * @type {string}
-       * @default "alfresco-lists-views-AlfListView"
-       */
-      baseClass: "alfresco-lists-views-AlfListView",
-
-      /**
        * An array of the i18n files to use with this widget.
        *
        * @instance
@@ -484,7 +475,7 @@ define(["dojo/_base/declare",
          if (this.noItemsMessage || this.widgetsForNoDataDisplay)
          {
             this.messageNode = domConstruct.create("div", {
-               className: this.baseClass + "__no-data",
+               className: "alfresco-lists-views-AlfListView__no-data",
                innerHTML: this.noItemsMessage
             }, this.domNode);
          }
@@ -509,7 +500,7 @@ define(["dojo/_base/declare",
       renderErrorDisplay: function alfresco_lists_views_AlfListView__renderErrorDisplay() {
          this.clearOldView();
          this.messageNode = domConstruct.create("div", {
-            className: this.baseClass + "__render-error",
+            className: "alfresco-lists-views-AlfListView__render-error",
             innerHTML: this.message("doclistview.rendering.error.message")
          }, this.domNode);
       },

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -51,6 +51,15 @@ define(["dojo/_base/declare",
    return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, _AlfDndDocumentUploadMixin], {
 
       /**
+       * The base CSS class for this widget
+       *
+       * @instance
+       * @type {string}
+       * @default "alfresco-lists-views-AlfListView"
+       */
+      baseClass: "alfresco-lists-views-AlfListView",
+
+      /**
        * An array of the i18n files to use with this widget.
        *
        * @instance
@@ -475,6 +484,7 @@ define(["dojo/_base/declare",
          if (this.noItemsMessage || this.widgetsForNoDataDisplay)
          {
             this.messageNode = domConstruct.create("div", {
+               className: this.baseClass + "__no-data",
                innerHTML: this.noItemsMessage
             }, this.domNode);
          }
@@ -499,6 +509,7 @@ define(["dojo/_base/declare",
       renderErrorDisplay: function alfresco_lists_views_AlfListView__renderErrorDisplay() {
          this.clearOldView();
          this.messageNode = domConstruct.create("div", {
+            className: this.baseClass + "__render-error",
             innerHTML: this.message("doclistview.rendering.error.message")
          }, this.domNode);
       },

--- a/aikau/src/main/resources/alfresco/lists/views/templates/AlfListView.html
+++ b/aikau/src/main/resources/alfresco/lists/views/templates/AlfListView.html
@@ -1,3 +1,3 @@
-<div class="alfresco-lists-views-AlfListView">
+<div class="${baseClass}">
    <table data-dojo-attach-point="tableNode" cellspacing="0" cellpadding="0"></table>
 </div>

--- a/aikau/src/main/resources/alfresco/lists/views/templates/AlfListView.html
+++ b/aikau/src/main/resources/alfresco/lists/views/templates/AlfListView.html
@@ -1,3 +1,3 @@
-<div class="${baseClass}">
+<div class="alfresco-lists-views-AlfListView">
    <table data-dojo-attach-point="tableNode" cellspacing="0" cellpadding="0"></table>
 </div>

--- a/aikau/src/test/resources/alfresco/lists/views/AlfListViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/AlfListViewTest.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["alfresco/TestCommon",
+      "intern/chai!assert",
+      "intern!object"
+   ],
+   function(TestCommon, assert, registerSuite) {
+
+      var browser;
+      registerSuite({
+         name: "AlfListView Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfListView", "AlfListView Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Can find loading message": function() {
+            return browser.findByCssSelector("#LOADING .alfresco-lists-AlfList > .data-loading");
+         },
+
+         "Can find data-load failure message": function() {
+            return browser.findByCssSelector("#DATA_LOAD_FAILURE .alfresco-lists-AlfList > .data-failure");
+         },
+
+         "Can find no-data message": function() {
+            return browser.findByCssSelector("#NO_DATA .alfresco-lists-views-AlfListView__no-data");
+         },
+
+         "Can find render-error message": function() {
+            return browser.findByCssSelector("#ERROR .alfresco-lists-views-AlfListView__render-error");
+         },
+
+         "Can find successfully loaded list": function() {
+            return browser.findAllByCssSelector("#SUCCESS .alfresco-renderers-Property")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "Did not render four list items successfully");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/dnd/DndTest"
+      "src/test/resources/alfresco/lists/views/AlfListViewTest"
    ],
 
    /**
@@ -131,6 +131,7 @@ define({
       "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
       "src/test/resources/alfresco/lists/FilteredListTest",
       "src/test/resources/alfresco/lists/InfiniteScrollTest",
+      "src/test/resources/alfresco/lists/views/AlfListViewTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
       "src/test/resources/alfresco/lists/views/layouts/RowTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfListView</shortname>
+  <description>This is an example of an AlfList using the AlfListView</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfListView</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.js
@@ -1,0 +1,69 @@
+var createList = function(id, label, loadTopic) {
+   return {
+      name: "alfresco/layout/VerticalWidgets",
+      config: {
+         id: id,
+         widgets: [{
+            name: "alfresco/html/Label",
+            config: {
+               label: label,
+               additionalCssClasses: "bold"
+            }
+         }, {
+            name: "alfresco/lists/AlfList",
+            config: {
+               loadDataPublishTopic: loadTopic,
+               widgets: [{
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [{
+                        name: "alfresco/lists/views/layouts/Row",
+                        config: {
+                           widgets: [{
+                              name: "alfresco/lists/views/layouts/Cell",
+                              config: {
+                                 widgets: [{
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "name"
+                                    }
+                                 }]
+                              }
+                           }]
+                        }
+                     }]
+                  }
+               }]
+            }
+         }]
+      }
+   };
+}
+
+model.jsonModel = {
+   services: [{
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         },
+      },
+      "aikauTesting/mockservices/AlfListViewMockService"
+   ],
+   widgets: [{
+      name: "alfresco/layout/HorizontalWidgets",
+      config: {
+         widgets: [
+            createList("LOADING", "Loading", "GET_NON_LOADING_LIST"),
+            createList("DATA_LOAD_FAILURE", "Data load failure", "GET_FAILING_LIST_DATA"),
+            createList("NO_DATA", "No data", "GET_EMPTY_LIST_DATA"),
+            createList("ERROR", "Error", "GET_ERROR_LIST_DATA"),
+            createList("SUCCESS", "Successful", "GET_LIST_DATA")
+         ]
+      }
+   }, {
+      name: "alfresco/logging/DebugLog"
+   }]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/AlfListViewMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/AlfListViewMockService.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/AlfListViewMockService
+ * @extends module:alfresco/core/Core
+ * @author Martin Doyle
+ */
+define(["alfresco/core/Core",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(AlfCore, declare, lang) {
+
+      return declare([AlfCore], {
+
+         /**
+          * The responses to subscribe and publish
+          *
+          * @type {Array}
+          */
+         responses: {
+            "GET_ERROR_LIST_DATA": {
+               items: [null]
+            },
+            "GET_EMPTY_LIST_DATA": {
+               items: []
+            },
+            "GET_FAILING_LIST_DATA": {
+               wibble: []
+            },
+            "GET_LIST_DATA": {
+               items: [{
+                  name: "Tinky Winky"
+               }, {
+                  name: "Dipsy"
+               }, {
+                  name: "Laa-Laa"
+               }, {
+                  name: "Po"
+               }]
+            },
+         },
+
+         /**
+          * Constructor
+          *
+          * @instance
+          * @param {array} args The constructor arguments.
+          */
+         constructor: function alfresco_testing_mockservices_AlfListViewMockService__constructor(args) {
+            /*jshint loopfunc:true*/
+            declare.safeMixin(this, args);
+            for (var topic in this.responses) {
+               if (this.responses.hasOwnProperty(topic)) {
+                  this.alfSubscribe(topic, lang.hitch(this, function(payload) {
+                     this.alfPublish(payload.alfResponseTopic + "_SUCCESS", {
+                        response: this.responses[payload.alfResponseTopic]
+                     });
+                  }));
+               }
+            }
+         }
+      });
+   });


### PR DESCRIPTION
This PR addresses issue [AKU-332](https://issues.alfresco.com/jira/browse/AKU-332), which requests CSS class identification of certain list elements/messages, in order to make them more testable/stylable.