### PR TITLE
AKU-358, AKU-364: Added initial InfiniteScrollArea widget

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Events.js
+++ b/aikau/src/main/resources/alfresco/core/Events.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -43,163 +43,172 @@ define(["dojo/_base/declare",
         "alfresco/core/EventsTopicMixin"],
         function(declare, AlfCore, on, lang, EventsTopicMixin) {
 
-      return declare([AlfCore, EventsTopicMixin], {
+   return declare([AlfCore, EventsTopicMixin], {
 
-         /**
-          * How frequently do we want rate limited events to trigger?
-          *
-          * @instance
-          * @type {int}
-          * @default 300
-          */
-         triggerInterval: 300,
+      /**
+       * How frequently do we want rate limited events to trigger?
+       *
+       * @instance
+       * @type {int}
+       * @default 300
+       */
+      triggerInterval: 300,
 
-         /**
-          * Used to store a handle to cancel the scroll timeout.
-          *
-          * @instance
-          * @type {int}
-          * @default: null
-          */
-         scrollTimeout: null,
+      /**
+       * A specific element to detect the scroll position of. If this is left as the default of null
+       * then the overall window will be used.
+       *
+       * @instance
+       * @type {element}
+       * @default null
+       */
+      scrollElement: null,
 
-         /**
-          * Used to store a handle to cancel the resize timeout.
-          *
-          * @instance
-          * @type {int}
-          * @default: null
-          */
-         resizeTimeout: null,
+      /**
+       * Used to store a handle to cancel the scroll timeout.
+       *
+       * @instance
+       * @type {int}
+       * @default: null
+       */
+      scrollTimeout: null,
 
-         /**
-          * The scroll event triggers once when the page had loaded. Generally we don't need this.
-          * Should we ignore it?
-          *
-          * @instance
-          * @type Boolean
-          * @default true
-          */
-         ignoreInitialScroll: true,
+      /**
+       * Used to store a handle to cancel the resize timeout.
+       *
+       * @instance
+       * @type {int}
+       * @default: null
+       */
+      resizeTimeout: null,
 
-         /**
-          *  Has the initial scroll event as specified in ignoreInitialScroll happened yet?
-          */
-         hasInitialScrollHappened: false,
+      /**
+       * The scroll event triggers once when the page had loaded. Generally we don't need this.
+       * Should we ignore it?
+       *
+       * @instance
+       * @type Boolean
+       * @default true
+       */
+      ignoreInitialScroll: true,
 
-         /**
-          * Constructor - called when module is mixed in. Registers the listeners.
-          *
-          * @instance
-          * @param {object} args modules to mixin
-          */
-         constructor: function alfresco_core_Events_constructor(args) {
-            lang.mixin(this, args);
-            this.alfLog('log', 'alfresco/core/Events Registering');
+      /**
+       *  Has the initial scroll event as specified in ignoreInitialScroll happened yet?
+       */
+      hasInitialScrollHappened: false,
 
-            on(window, "scroll", lang.hitch(this, "onScroll"));
-            // TODO: Sweep through modules and replace individual resize listeners with this?
-            on(window, "resize", lang.hitch(this, "onResize"));
-         },
+      /**
+       * Registers the event listeners.
+       *
+       * @instance
+       */
+      registerEventListeners: function alfresco_core_Events__registerEventListeners() {
+         this.alfLog("log", "Registering listeners...");
 
-         /**
-          * The limit function. Prevents multiple events triggering in very quick succession.
-          *
-          * In Throttle mode:
-          * Triggers once per triggerInterval for as long as the event keeps being fired.
-          * TODO: In throttle mode should event trigger before or after delay? (currently after)
-          *
-          * In debounce mode:
-          * Triggers only once there is a gap of triggerInterval in the event being fired.
-          *
-          * @instance
-          * @param {string} timeout variable name containing timeout.
-          * @param {string} topic event to trigger
-          * @param {int} triggerInterval Optional override for this.triggerInterval
-          * @param {bool} throttle switches to throttle mode.
-          */
-         _limit: function alfresco_core_Events__debounce(timeout, topic, triggerInterval, throttle) {
-            // If we've already got a timeout, we need to rate limit
-            if (this[timeout]) {
-               if (throttle) {
-                  // In throttle mode, ignore subsequent events while timeout exists
-                  return;
-               }
-               // In debounce mode, clear timeout and let a new one get set.
-               clearTimeout(this[timeout]);
+         var targetElement = this.scrollElement || window;
+         on(targetElement, "scroll", lang.hitch(this, this.onScroll));
+
+         // TODO: Sweep through modules and replace individual resize listeners with this?
+         on(targetElement, "resize", lang.hitch(this, this.onResize));
+      },
+
+      /**
+       * The limit function. Prevents multiple events triggering in very quick succession.
+       *
+       * In Throttle mode:
+       * Triggers once per triggerInterval for as long as the event keeps being fired.
+       * TODO: In throttle mode should event trigger before or after delay? (currently after)
+       *
+       * In debounce mode:
+       * Triggers only once there is a gap of triggerInterval in the event being fired.
+       *
+       * @instance
+       * @param {string} timeout variable name containing timeout.
+       * @param {string} topic event to trigger
+       * @param {int} triggerInterval Optional override for this.triggerInterval
+       * @param {bool} throttle switches to throttle mode.
+       */
+      _limit: function alfresco_core_Events__debounce(timeout, topic, triggerInterval, throttle) {
+         // If we've already got a timeout, we need to rate limit
+         if (this[timeout]) {
+            if (throttle) {
+               // In throttle mode, ignore subsequent events while timeout exists
+               return;
             }
-
-            var timer = triggerInterval || this.triggerInterval;
-
-            // set a timeout, storing a reference to allow us to check status/cancel later.
-            this[timeout] = setTimeout(lang.hitch(this, "onTimeout", topic, timeout), timer);
-         },
-
-         /**
-          * Calls [_limit]{@link module:alfresco/core/Events#_limit} in debounce mode.
-          * @instance
-          * @param {int} timeout
-          * @param {string} topic
-          * @param {int} triggerInterval
-          */
-         _debounce: function alfresco_core_Events__debounce(timeout, topic, triggerInterval) {
-            this._limit(timeout, topic, triggerInterval, false);
-         },
-
-         /**
-          * Calls [_limit]{@link module:alfresco/core/Events#_limit} in throttle mode.
-          * @instance
-          * @param {int} timeout
-          * @param {string} topic
-          * @param {int} triggerInterval
-          */
-         _throttle: function alfresco_core_Events__throttle(timeout, topic, triggerInterval) {
-            this._limit(timeout, topic, triggerInterval, true);
-         },
-
-         /**
-          * Called by _limit once the event triggers.
-          * Publishes the requested topic & clears any timeout.
-          *
-          * @instance
-          * @param {string} topic
-          * @param {string} timeout variable name for var containing the timeout ref.
-          */
-         onTimeout: function alfresco_core_Events_onTimeout(topic, timeout) {
-            this.alfPublish(topic);
-            // clear the timeout so events can trigger again.
-            this[timeout] = false;
-         },
-
-         /**
-          * Throttles browser scroll events.
-          * The event only triggers every [triggerInterval]{@link module:alfresco/core/Events#triggerInterval} ms.
-          *
-          * @instance
-          * @fires eventsScrollTopic
-          */
-         onScroll: function alfresco_core_Events_onScroll() {
-            // TODO: For performance, the throttle call probably shouldn't happen in an if statement.
-            if (this.ignoreInitialScroll && !this.hasInitialScrollHappened)
-            {
-               this.hasInitialScrollHappened = true;
-            }
-            else
-            {
-               this._throttle("scrollTimeout", this.eventsScrollTopic);
-            }
-         },
-
-         /**
-          * Debounces browser resize events.
-          * Event triggers once the user stops resizing for [triggerInterval]{@link module:alfresco/core/Events#triggerInterval} ms.
-          *
-          * @instance
-          * @fires eventsResizeTopic
-          */
-         onResize: function alfresco_core_Events_onResize() {
-            this._debounce("resizeTimeout", this.eventsResizeTopic);
+            // In debounce mode, clear timeout and let a new one get set.
+            clearTimeout(this[timeout]);
          }
 
-      });
+         var timer = triggerInterval || this.triggerInterval;
+
+         // set a timeout, storing a reference to allow us to check status/cancel later.
+         this[timeout] = setTimeout(lang.hitch(this, "onTimeout", topic, timeout), timer);
+      },
+
+      /**
+       * Calls [_limit]{@link module:alfresco/core/Events#_limit} in debounce mode.
+       * @instance
+       * @param {int} timeout
+       * @param {string} topic
+       * @param {int} triggerInterval
+       */
+      _debounce: function alfresco_core_Events__debounce(timeout, topic, triggerInterval) {
+         this._limit(timeout, topic, triggerInterval, false);
+      },
+
+      /**
+       * Calls [_limit]{@link module:alfresco/core/Events#_limit} in throttle mode.
+       * @instance
+       * @param {int} timeout
+       * @param {string} topic
+       * @param {int} triggerInterval
+       */
+      _throttle: function alfresco_core_Events__throttle(timeout, topic, triggerInterval) {
+         this._limit(timeout, topic, triggerInterval, true);
+      },
+
+      /**
+       * Called by _limit once the event triggers.
+       * Publishes the requested topic & clears any timeout.
+       *
+       * @instance
+       * @param {string} topic
+       * @param {string} timeout variable name for var containing the timeout ref.
+       */
+      onTimeout: function alfresco_core_Events_onTimeout(topic, timeout) {
+         this.alfPublish(topic);
+         // clear the timeout so events can trigger again.
+         this[timeout] = false;
+      },
+
+      /**
+       * Throttles browser scroll events.
+       * The event only triggers every [triggerInterval]{@link module:alfresco/core/Events#triggerInterval} ms.
+       *
+       * @instance
+       * @fires eventsScrollTopic
+       */
+      onScroll: function alfresco_core_Events_onScroll() {
+         // TODO: For performance, the throttle call probably shouldn't happen in an if statement.
+         if (this.ignoreInitialScroll && !this.hasInitialScrollHappened)
+         {
+            this.hasInitialScrollHappened = true;
+         }
+         else
+         {
+            this._throttle("scrollTimeout", this.eventsScrollTopic);
+         }
+      },
+
+      /**
+       * Debounces browser resize events.
+       * Event triggers once the user stops resizing for [triggerInterval]{@link module:alfresco/core/Events#triggerInterval} ms.
+       *
+       * @instance
+       * @fires eventsResizeTopic
+       */
+      onResize: function alfresco_core_Events_onResize() {
+         this._debounce("resizeTimeout", this.eventsResizeTopic);
+      }
    });
+});

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -139,10 +139,8 @@ define(["dojo/_base/declare",
       onPathChanged: function alfresco_documentlibrary_AlfDocumentList__onPathChanged(payload) {
          if (payload.path)
          {
-            if (this.useInfiniteScroll === true)
-            {
-               this.clearViews();
-            }
+            // Clear any old data when infinite scroll is enabled (see AKU-358)
+            this.useInfiniteScroll && this.clearViews();
 
             if (this.useHash === true)
             {
@@ -182,10 +180,8 @@ define(["dojo/_base/declare",
       onCategoryChanged: function alfresco_documentlibrary_AlfDocumentList__onCategoryChanged(payload) {
          if (payload.path)
          {
-            if (this.useInfiniteScroll === true)
-            {
-               this.clearViews();
-            }
+            // Clear any old data when infinite scroll is enabled (see AKU-358)
+            this.useInfiniteScroll && this.clearViews();
 
             if (this.useHash === true)
             {
@@ -225,10 +221,8 @@ define(["dojo/_base/declare",
       onFilterChanged: function alfresco_documentlibrary_AlfDocumentList__onFilterChanged(payload) {
          if (payload.value)
          {
-            if (this.useInfiniteScroll === true)
-            {
-               this.clearViews();
-            }
+            // Clear any old data when infinite scroll is enabled (see AKU-358)
+            this.useInfiniteScroll && this.clearViews();
 
             if (this.useHash === true)
             {
@@ -268,10 +262,8 @@ define(["dojo/_base/declare",
       onTagChanged: function alfresco_documentlibrary_AlfDocumentList__onTagChanged(payload) {
          if (payload.value)
          {
-            if (this.useInfiniteScroll === true)
-            {
-               this.clearViews();
-            }
+            // Clear any old data when infinite scroll is enabled (see AKU-358)
+            this.useInfiniteScroll && this.clearViews();
 
             if (this.useHash === true)
             {

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -139,6 +139,11 @@ define(["dojo/_base/declare",
       onPathChanged: function alfresco_documentlibrary_AlfDocumentList__onPathChanged(payload) {
          if (payload.path)
          {
+            if (this.useInfiniteScroll === true)
+            {
+               this.clearViews();
+            }
+
             if (this.useHash === true)
             {
                var currHash = ioQuery.queryToObject(hash());
@@ -177,6 +182,11 @@ define(["dojo/_base/declare",
       onCategoryChanged: function alfresco_documentlibrary_AlfDocumentList__onCategoryChanged(payload) {
          if (payload.path)
          {
+            if (this.useInfiniteScroll === true)
+            {
+               this.clearViews();
+            }
+
             if (this.useHash === true)
             {
                var currHash = ioQuery.queryToObject(hash());
@@ -215,6 +225,11 @@ define(["dojo/_base/declare",
       onFilterChanged: function alfresco_documentlibrary_AlfDocumentList__onFilterChanged(payload) {
          if (payload.value)
          {
+            if (this.useInfiniteScroll === true)
+            {
+               this.clearViews();
+            }
+
             if (this.useHash === true)
             {
                var currHash = ioQuery.queryToObject(hash());
@@ -253,6 +268,11 @@ define(["dojo/_base/declare",
       onTagChanged: function alfresco_documentlibrary_AlfDocumentList__onTagChanged(payload) {
          if (payload.value)
          {
+            if (this.useInfiniteScroll === true)
+            {
+               this.clearViews();
+            }
+
             if (this.useHash === true)
             {
                var currHash = ioQuery.queryToObject(hash());

--- a/aikau/src/main/resources/alfresco/layout/InfiniteScrollArea.js
+++ b/aikau/src/main/resources/alfresco/layout/InfiniteScrollArea.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This layout widget can be wrapped around any [paginated list]{@link module:alfresco/lists/AlfSortablePaginatedList}
+ * configured to use [infinite scrolling]{@link module:alfresco/lists/AlfList#useInfiniteScroll] 
+ * that is expected to grow taller than the height of its containing widget. It will automatically update its parent
+ * widget to publish events as the bottom of the scrolling area is reached which will in turn cause the list to request
+ * the next page of data. If the list is only constrained by the height of the browser then the
+ * [InfiniteScrollService]{@link module:alfresco/services/InfiniteScrollService} should be used instead.
+ *
+ * @example <caption>List inside a [FixedHeaderFooter]{@link module:alfresco/layout/FixedHeaderFooter} widget</caption>
+ * {
+ *   name: "alfresco/layout/FixedHeaderFooter",
+ *   config: {
+ *     height: "200px",
+ *     widgets: [
+ *       {
+ *         name: "alfresco/layout/InfiniteScrollArea",
+ *         config: {
+ *           widgets: [
+ *             {
+ *               name: "alfresco/lists/AlfSortablePaginatedList"
+ *               config: {
+ *                 useInfiniteScroll: true,
+ *                 widgets: [
+ *                   // Declare view here
+ *                 ]
+ *               }
+ *             }
+ *           ]
+ *         }
+ *       }
+ *     ]
+ *   }
+ * }
+ * 
+ * @module alfresco/layout/InfiniteScrollArea
+ * @extends module:alfresco/core/ProcessWidgets
+ * @mixes module:alfresco/services/InfiniteScrollService
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/ProcessWidgets",
+        "alfresco/services/InfiniteScrollService"], 
+        function(declare, ProcessWidgets, InfiniteScrollService) {
+   
+   return declare([ProcessWidgets, InfiniteScrollService], {
+      
+      /**
+       * The CSS class (or a space separated list of classes) to include in the DOM node.
+       * 
+       * @instance
+       * @type {string}
+       * @default "alfresco-layout-InfiniteScrollArea"
+       */
+      baseClass: "alfresco-layout-InfiniteScrollArea",
+
+      /**
+       * This overrides the [inherited default]{@link module:alfresco/services/InfiniteScrollService#_deferEventListenerRegistration}
+       * to ensure that the [registerEventListeners function]{@link module:alfresco/core/Events#registerEventListeners} is not called.
+       *
+       * @instance
+       * @type {boolean}
+       * @default true
+       */
+      _deferEventListenerRegistration: true,
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/core/ProcessWidgets#postCreate} to
+       * set the mixed in [element]{@link module:alfresco/core/Events#scrollElement}
+       * to detect scroll position on
+       *
+       * @instance
+       */
+      postCreate: function alfresco_layout_InfiniteScrollArea__postCreate() {
+         this.inherited(arguments);
+
+         // Set the scrollElement to be the element containing this widget (this is expect to have the scroll
+         // bars)...
+         this.scrollElement = this.domNode.parentNode;
+         this.registerEventListeners();
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/layout/VerticalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/VerticalWidgets.js
@@ -66,7 +66,7 @@ define(["alfresco/core/ProcessWidgets",
        * 
        * @instance
        * @type {string}
-       * @default "horizontal-widgets"
+       * @default "alfresco-layout-VerticalWidgets"
        */
       baseClass: "alfresco-layout-VerticalWidgets",
 

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -367,6 +367,7 @@ define(["dojo/_base/declare",
                }
                else
                {
+                  _this.clearViews();
                   _this.loadData();
                }
             }, this._filterDelay);

--- a/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
+++ b/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
@@ -36,10 +36,8 @@ define(["dojo/_base/declare",
         "alfresco/core/Events",
         "alfresco/core/EventsTopicMixin",
         "alfresco/core/DomElementUtils",
-        "dojo/dom-geometry",
-        "jquery",
-        "jqueryui"],
-        function(declare, AlfCore, _AlfDocumentListTopicMixin, lang, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils, domGeom, $) {
+        "dojo/dom-geometry"],
+        function(declare, AlfCore, _AlfDocumentListTopicMixin, lang, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils, domGeom) {
 
    return declare([AlfCore, _AlfDocumentListTopicMixin, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils], {
 
@@ -132,8 +130,8 @@ define(["dojo/_base/declare",
       nearBottom: function alfresco_services_InfiniteScrollService__nearBottom() {
          if (this.scrollElement)
          {
-            var scrollPos = $(this.scrollElement).scrollTop();
-            var height = $(this.domNode).height();
+            var scrollPos = this.scrollElement.scrollTop;
+            var height = this.domNode.offsetHeight;
             return 0 >= (height - scrollPos - this.scrollTolerance);
          }
          else

--- a/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
+++ b/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
@@ -36,8 +36,10 @@ define(["dojo/_base/declare",
         "alfresco/core/Events",
         "alfresco/core/EventsTopicMixin",
         "alfresco/core/DomElementUtils",
-        "dojo/dom-geometry"],
-        function(declare, AlfCore, _AlfDocumentListTopicMixin, lang, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils, domGeom) {
+        "dojo/dom-geometry",
+        "jquery",
+        "jqueryui"],
+        function(declare, AlfCore, _AlfDocumentListTopicMixin, lang, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils, domGeom, $) {
 
    return declare([AlfCore, _AlfDocumentListTopicMixin, AlfCoreEvents, AlfCoreEventsTopicMixin, AlfDomUtils], {
 
@@ -62,6 +64,16 @@ define(["dojo/_base/declare",
       scrollTolerance: 500,
 
       /**
+       * This overrides the [inherited default]{@link module:alfresco/services/InfiniteScrollService#_deferEventListenerRegistration}
+       * to ensure that the [registerEventListeners function]{@link module:alfresco/core/Events#registerEventListeners} is not called.
+       *
+       * @instance
+       * @type {boolean}
+       * @default true
+       */
+      _deferEventListenerRegistration: false,
+
+      /**
        * @instance
        * @listens scrollReturn
        * @listens requestFinishedTopic
@@ -70,6 +82,12 @@ define(["dojo/_base/declare",
       constructor: function alfresco_services_InfiniteScrollService__constructor(args) {
          declare.safeMixin(this, args);
 
+         // Register the events listeners...
+         if (!this._deferEventListenerRegistration)
+         {
+            this.registerEventListeners();
+         }
+         
          // hook point to allow other widgets to let us know when they're done processing a scroll request.
          this.alfSubscribe(this.scrollReturn, lang.hitch(this, this.onScrollReturn));
 
@@ -112,10 +130,19 @@ define(["dojo/_base/declare",
        * @returns {boolean}
        */
       nearBottom: function alfresco_services_InfiniteScrollService__nearBottom() {
-         var currentScrollPos = domGeom.docScroll().y,
-             docHeight = this.getDocumentHeight(),
-             viewport = domGeom.getContentBox(document.body).h;
-         return 0 >= (docHeight - viewport - currentScrollPos - this.scrollTolerance);
+         if (this.scrollElement)
+         {
+            var scrollPos = $(this.scrollElement).scrollTop();
+            var height = $(this.domNode).height();
+            return 0 >= (height - scrollPos - this.scrollTolerance);
+         }
+         else
+         {
+            var currentScrollPos = domGeom.docScroll().y;
+            var docHeight = this.getDocumentHeight();
+            var viewport = domGeom.getContentBox(document.body).h;
+            return 0 >= (docHeight - viewport - currentScrollPos - this.scrollTolerance);
+         }
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -171,69 +171,69 @@ define(["intern!object",
       }
    });
 
-   // registerSuite({
-   //    name: "AlfSortablePaginatedList Tests (data load failure)",
+   registerSuite({
+      name: "AlfSortablePaginatedList Tests (data load failure)",
       
-   //    setup: function() {
-   //       browser = this.remote;
-   //       return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
-   //    },
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
+      },
       
-   //    beforeEach: function() {
-   //       browser.end();
-   //    },
+      beforeEach: function() {
+         browser.end();
+      },
 
-   //    "Check data failure message": function() {
-   //       return browser.findByCssSelector("#LIST .data-failure")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isTrue(displayed, "Loading message not displayed");
-   //          });
-   //    },
+      "Check data failure message": function() {
+         return browser.findByCssSelector("#LIST .data-failure")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Loading message not displayed");
+            });
+      },
 
-   //    "Check that the pagination controls are all hidden": function() {
-   //       return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isFalse(displayed, "The page selector was NOT hidden");
-   //          })
-   //       .end()
-   //       .findByCssSelector("#PAGINATOR_PAGE_BACK")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isFalse(displayed, "The page back button was NOT hidden");
-   //          })
-   //       .end()
-   //       .findByCssSelector("#PAGINATOR_PAGE_MARKER")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isFalse(displayed, "The page indicator was NOT hidden");
-   //          })
-   //       .end()
-   //       .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isFalse(displayed, "The page forward button was NOT hidden");
-   //          })
-   //       .end()
-   //       .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isFalse(displayed, "The items per page selector was NOT hidden");
-   //          });
-   //    },
+      "Check that the pagination controls are all hidden": function() {
+         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page selector was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_BACK")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page back button was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_MARKER")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page indicator was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The page forward button was NOT hidden");
+            })
+         .end()
+         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The items per page selector was NOT hidden");
+            });
+      },
 
-   //    "Resize and check that controls are all still hidden": function() {
-   //       return browser.setWindowSize(null, 1024, 300)
-   //          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-   //          .isDisplayed()
-   //          .then(function(displayed) {
-   //             assert.isFalse(displayed, "The items per page selector was revealed on resize");
-   //          });
-   //    },
+      "Resize and check that controls are all still hidden": function() {
+         return browser.setWindowSize(null, 1024, 300)
+            .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The items per page selector was revealed on resize");
+            });
+      },
 
-   //    "Post Coverage Results": function() {
-   //       TestCommon.alfPostCoverageResults(this, browser);
-   //    }
-   // });
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
 });

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -47,6 +47,9 @@ define(["intern!object",
          .pressKeys(keys.ARROW_DOWN)
       .end()
       .getLastPublish("DOCUMENT_LIST_ALF_EVENTS_SCROLL")
+         .then(function(payload) {
+            assert.isNotNull(payload, "Document list scroll event not registered");
+         })
       .end()
       .findAllByCssSelector("#DOCUMENT_LIST tr")
          .then(function(elements) {
@@ -60,6 +63,9 @@ define(["intern!object",
          .click()
       .end()
       .getLastPublish("DOCUMENT_LIST_ALF_DOCLIST_REQUEST_FINISHED")
+         .then(function(payload) {
+            assert.isNotNull(payload, "More results not loaded");
+         })
       .end()
       .findAllByCssSelector("#DOCUMENT_LIST tr")
          .then(function(elements) {
@@ -119,6 +125,9 @@ define(["intern!object",
             .pressKeys(keys.ARROW_DOWN)
          .end()
          .getLastPublish("INFINITE_SCROLL_AREA_ALF_EVENTS_SCROLL")
+            .then(function(payload) {
+               assert.isNotNull(payload, "List scroll event not registered");
+            })
          .end()
          .findAllByCssSelector("#INFITE_SCROLL_LIST tr")
             .then(function(elements) {
@@ -135,6 +144,9 @@ define(["intern!object",
             .click()
          .end()
          .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED")
+            .then(function(payload) {
+               assert.isNotNull(payload, "More results not loaded");
+            })
          .end()
          .findAllByCssSelector("#INFITE_SCROLL_LIST tr")
             .then(function(elements) {

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -23,10 +23,51 @@
 define(["intern!object",
         "intern/chai!assert",
         "require",
-        "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"], 
+        function (registerSuite, assert, require, TestCommon, keys) {
+
+   
 
    var browser;
+
+   var testClearingDocumentList = function(buttonId, errorMsg) {
+      return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+         .click()
+      .end()
+      .findByCssSelector("#DOCUMENT_LIST tr:nth-child(1) .alfresco-renderers-Property")
+         .click()
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+         .pressKeys(keys.ARROW_DOWN)
+      .end()
+      .getLastPublish("DOCUMENT_LIST_ALF_EVENTS_SCROLL")
+      .end()
+      .findAllByCssSelector("#DOCUMENT_LIST tr")
+         .then(function(elements) {
+            assert.lengthOf(elements, 20, "Additional rows were not loaded when the bottom of the list was reached");
+         })
+      .end()
+      .findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+         .click()
+      .end()
+      .findByCssSelector(buttonId)
+         .click()
+      .end()
+      .getLastPublish("DOCUMENT_LIST_ALF_DOCLIST_REQUEST_FINISHED")
+      .end()
+      .findAllByCssSelector("#DOCUMENT_LIST tr")
+         .then(function(elements) {
+            assert.lengthOf(elements, 10, errorMsg);
+         });
+   };
+
+
    registerSuite({
       name: "AlfSortablePaginatedList Tests",
       
@@ -41,7 +82,7 @@ define(["intern!object",
 
       "Check URL hash controls displayed page": function() {
          // See AKU-293
-         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) .alfresco-renderers-Property .value")
+         return browser.findByCssSelector("#HASH_LIST tr:nth-child(1) .alfresco-renderers-Property .value")
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "21", "The currentPage URL hash parameter was ignored on load");
@@ -58,80 +99,141 @@ define(["intern!object",
       },
 
       "Count the rows": function() {
-         return browser.findAllByCssSelector(".alfresco-lists-views-layouts-Row")
+         return browser.findAllByCssSelector("#HASH_LIST .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
                assert.lengthOf(elements, 20, "There should only be twenty rows");
             });
       },
 
+      "Scroll to bottom of basic infinite scroll area": function() {
+         // Click on the first row to give it focus...
+         return browser.findByCssSelector("#INFITE_SCROLL_LIST tr:nth-child(1) .alfresco-renderers-Property")
+            .click()
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+         .end()
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_EVENTS_SCROLL")
+         .end()
+         .findAllByCssSelector("#INFITE_SCROLL_LIST tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 20, "Additional rows were not loaded when the bottom of the list was reached");
+            });
+      },
+
+      "Simulate a filter data request": function() {
+         // Clear previous pub/sub log (so that we can detect the next load)...
+         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+            .click()
+         .end()
+         .findByCssSelector("#SIMULATE_FILTER_label")
+            .click()
+         .end()
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED")
+         .end()
+         .findAllByCssSelector("#INFITE_SCROLL_LIST tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 10, "Old data not cleared when data filter request applied");
+            });
+      },
+
+      "Simulate a path change": function() {
+         return browser.then(function() {
+            return testClearingDocumentList("#SIMULATE_PATH_CHANGE_label", "Old data not cleared when path change request applied");
+         });
+      },
+
+      "Simulate a category change": function() {
+         return browser.then(function() {
+            return testClearingDocumentList("#SIMULATE_CATEGORY_CHANGE_label", "Old data not cleared when category change request applied");
+         });
+      },
+
+      "Simulate a tag change": function() {
+         return browser.then(function() {
+            return testClearingDocumentList("#SIMULATE_TAG_CHANGE_label", "Old data not cleared when tag change request applied");
+         });
+      },
+
+      "Simulate a filter change": function() {
+         return browser.then(function() {
+            return testClearingDocumentList("#SIMULATE_FILTER_CHANGE_label", "Old data not cleared when filter change request applied");
+         });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });
 
-   registerSuite({
-      name: "AlfSortablePaginatedList Tests (data load failure)",
+   // registerSuite({
+   //    name: "AlfSortablePaginatedList Tests (data load failure)",
       
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
-      },
+   //    setup: function() {
+   //       browser = this.remote;
+   //       return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
+   //    },
       
-      beforeEach: function() {
-         browser.end();
-      },
+   //    beforeEach: function() {
+   //       browser.end();
+   //    },
 
-      "Check data failure message": function() {
-         return browser.findByCssSelector("#LIST .data-failure")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "Loading message not displayed");
-            });
-      },
+   //    "Check data failure message": function() {
+   //       return browser.findByCssSelector("#LIST .data-failure")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isTrue(displayed, "Loading message not displayed");
+   //          });
+   //    },
 
-      "Check that the pagination controls are all hidden": function() {
-         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page selector was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_PAGE_BACK")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page back button was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_PAGE_MARKER")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page indicator was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page forward button was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The items per page selector was NOT hidden");
-            });
-      },
+   //    "Check that the pagination controls are all hidden": function() {
+   //       return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isFalse(displayed, "The page selector was NOT hidden");
+   //          })
+   //       .end()
+   //       .findByCssSelector("#PAGINATOR_PAGE_BACK")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isFalse(displayed, "The page back button was NOT hidden");
+   //          })
+   //       .end()
+   //       .findByCssSelector("#PAGINATOR_PAGE_MARKER")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isFalse(displayed, "The page indicator was NOT hidden");
+   //          })
+   //       .end()
+   //       .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isFalse(displayed, "The page forward button was NOT hidden");
+   //          })
+   //       .end()
+   //       .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isFalse(displayed, "The items per page selector was NOT hidden");
+   //          });
+   //    },
 
-      "Resize and check that controls are all still hidden": function() {
-         return browser.setWindowSize(null, 1024, 300)
-            .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The items per page selector was revealed on resize");
-            });
-      },
+   //    "Resize and check that controls are all still hidden": function() {
+   //       return browser.setWindowSize(null, 1024, 300)
+   //          .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+   //          .isDisplayed()
+   //          .then(function(displayed) {
+   //             assert.isFalse(displayed, "The items per page selector was revealed on resize");
+   //          });
+   //    },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   });
+   //    "Post Coverage Results": function() {
+   //       TestCommon.alfPostCoverageResults(this, browser);
+   //    }
+   // });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
@@ -1,3 +1,31 @@
+var view = {
+   name: "alfresco/lists/views/AlfListView",
+   config: {
+      widgets: [
+         {
+            name: "alfresco/lists/views/layouts/Row",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/renderers/Property",
+                              config: {
+                                 propertyToRender: "index"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ]
+   }
+};
+
 model.jsonModel = {
    services: [
       {
@@ -21,55 +49,166 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         id: "HASH_CUSTOM_PAGE_SIZES",
-         name: "alfresco/layout/ClassicWindow",
+         name: "alfresco/layout/HorizontalWidgets",
          config: {
-            title: "Custom page sizes",
-            pubSubScope: "HASH_CUSTOM_",
             widgets: [
                {
-                  id: "HASH_MENU_BAR",
-                  name: "alfresco/menus/AlfMenuBar",
+                  id: "HASH_CUSTOM_PAGE_SIZES",
+                  name: "alfresco/layout/ClassicWindow",
                   config: {
+                     title: "Custom page sizes",
+                     pubSubScope: "HASH_CUSTOM_",
                      widgets: [
                         {
-                           id: "HASH_CUSTOM_PAGE_SIZE_PAGINATOR",
-                           name: "alfresco/lists/Paginator",
+                           id: "HASH_MENU_BAR",
+                           name: "alfresco/menus/AlfMenuBar",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "HASH_CUSTOM_PAGE_SIZE_PAGINATOR",
+                                    name: "alfresco/lists/Paginator",
+                                    config: {
+                                       useHash: true,
+                                       documentsPerPage: 10,
+                                       pageSizes: [5,10,20]
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "HASH_LIST",
+                           name: "alfresco/lists/AlfSortablePaginatedList",
                            config: {
                               useHash: true,
-                              documentsPerPage: 10,
-                              pageSizes: [5,10,20]
+                              currentPageSize: 10,
+                              widgets: [view]
                            }
                         }
                      ]
                   }
                },
                {
-                  id: "HASH_LIST",
-                  name: "alfresco/lists/AlfSortablePaginatedList",
+                  id: "INFINITE_SCROLL_AREA",
+                  name: "alfresco/layout/ClassicWindow",
                   config: {
-                     useHash: true,
-                     currentPageSize: 10,
+                     title: "Infinite Scroll Area",
+                     pubSubScope: "INFINITE_SCROLL_AREA_",
                      widgets: [
                         {
-                           name: "alfresco/lists/views/AlfListView",
+                           name: "alfresco/layout/FixedHeaderFooter",
                            config: {
+                              height: "200px",
+                              widgetsForHeader: [
+                                 {
+                                    id: "SIMULATE_FILTER",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Simulate filter",
+                                       publishTopic: "FILTER_THIS",
+                                       publishPayload: {
+                                          name: "simulated"
+                                       }
+                                    }
+                                 }
+                              ],
                               widgets: [
                                  {
-                                    name: "alfresco/lists/views/layouts/Row",
+                                    name: "alfresco/layout/InfiniteScrollArea",
                                     config: {
+                                       scrollTolerance: 300,
                                        widgets: [
                                           {
-                                             name: "alfresco/lists/views/layouts/Cell",
+                                             id: "INFITE_SCROLL_LIST",
+                                             name: "alfresco/lists/AlfSortablePaginatedList",
                                              config: {
-                                                widgets: [
-                                                   {
-                                                      name: "alfresco/renderers/Property",
-                                                      config: {
-                                                         propertyToRender: "index"
-                                                      }
-                                                   }
-                                                ]
+                                                useHash: false,
+                                                useInfiniteScroll: true,
+                                                currentPageSize: 10,
+                                                filteringTopics: ["FILTER_THIS"],
+                                                widgets: [view]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "INFINITE_SCROLL_AREA_WITH_DOCLIST",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Infinite Scroll Area (Document List)",
+                     pubSubScope: "DOCUMENT_LIST_",
+                     widgets: [
+                        {
+                           name: "alfresco/layout/FixedHeaderFooter",
+                           config: {
+                              height: "200px",
+                              widgetsForHeader: [
+                                 {
+                                    id: "SIMULATE_PATH_CHANGE",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Simulate Path Change",
+                                       publishTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
+                                       publishPayload: {
+                                          path: "simulated"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "SIMULATE_CATEGORY_CHANGE",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Simulate Category Change",
+                                       publishTopic: "ALF_DOCUMENTLIST_CATEGORY_CHANGED",
+                                       publishPayload: {
+                                          path: "simulated"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "SIMULATE_TAG_CHANGE",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Simulate Tag Change",
+                                       publishTopic: "ALF_DOCUMENTLIST_TAG_CHANGED",
+                                       publishPayload: {
+                                          value: "simulated"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "SIMULATE_FILTER_CHANGE",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Simulate Filter Change",
+                                       publishTopic: "ALF_DOCLIST_FILTER_SELECTION",
+                                       publishPayload: {
+                                          value: "simulated"
+                                       }
+                                    }
+                                 }
+                              ],
+                              widgets: [
+                                 {
+                                    name: "alfresco/layout/InfiniteScrollArea",
+                                    config: {
+                                       scrollTolerance: 300,
+                                       widgets: [
+                                          {
+                                             id: "DOCUMENT_LIST",
+                                             name: "alfresco/documentlibrary/AlfDocumentList",
+                                             config: {
+                                                useHash: false,
+                                                useInfiniteScroll: true,
+                                                currentPageSize: 10,
+                                                widgets: [view]
                                              }
                                           }
                                        ]


### PR DESCRIPTION
This PR addresses both https://issues.alfresco.com/jira/browse/AKU-364 and https://issues.alfresco.com/jira/browse/AKU-358. It provides a new alfresco/layout/InfiniteScrollArea widget that allows lists to support infinite scrolling pagination when they don't take up the entire page height. It also addresses the issue where data filtering does not clear previous page data (or in the document list when paths/filters/tags/categories are applied).