### PR TITLE
AKU-356: Auto-publish form on field changes

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -290,7 +290,7 @@ define(["dojo/_base/declare",
             valid: isValid,
             invalidFormControls: this.invalidFormControls
          });
-         if(this.autoSavePublishTopic !== null && (isValid || this.autoSaveOnInvalid)) {
+         if(this.autoSavePublishTopic && typeof this.autoSavePublishTopic === "string" && (isValid || this.autoSaveOnInvalid)) {
             this.alfPublish(this.autoSavePublishTopic, this.autoSavePublishPayload || this.getValue(), this.autoSavePublishGlobal);
          }
       },
@@ -585,7 +585,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       createButtons: function alfresco_forms_Form__createButtons() {
-         if (this.showOkButton === true && this.autoSavePublishTopic === null)
+         if (this.showOkButton === true && !this.autoSavePublishTopic)
          {
             var onButtonClass = this.okButtonClass ? this.okButtonClass : "";
             this.okButton = new AlfButton({
@@ -618,7 +618,7 @@ define(["dojo/_base/declare",
             domConstruct.destroy(this.okButtonNode);
          }
          
-         if (this.showCancelButton === true && this.autoSavePublishTopic === null)
+         if (this.showCancelButton === true && !this.autoSavePublishTopic)
          {
             this.cancelButton = new AlfButton({
                pubSubScope: this.pubSubScope,

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -18,10 +18,38 @@
  */
 
 /**
- * This is the root module for all Aikau forms. It is intended to work with widgets that extend the
+ * <p>This is the root module for all Aikau forms. It is intended to work with widgets that extend the
  * [BaseFormControl]{@link module:alfresco/forms/controls/BaseFormControl} and handles setting and 
  * getting there values as well as creating and controlling the behaviour of buttons that can be
- * used to publish the overall value of the controls that the form contains.
+ * used to publish the overall value of the controls that the form contains.</p>
+ * 
+ * <p>Auto-publishing forms:<br />
+ * It is also possible to setup a form to automatically publish itself whenever its values change,
+ * and optionally to also do so if any of its values are invalid (see example below).<br />
+ * NOTE: If the autoSavePublishTopic is specified, then the OK and Cancel buttons are automatically
+ * disabled.</p>
+ *
+ * @example <caption>Example configuration for auto-publishing (including invalid) form:</caption>
+ * {
+ *    name: "alfresco/forms/Form",
+ *    config: {
+ *       autoSavePublishTopic: "AUTOSAVE_FORM",
+ *       autoSavePublishGlobal: true,
+ *       autoSaveOnInvalid: true,
+ *       widgets: [
+ *          {
+ *             name: "alfresco/forms/controls/TextBox",
+ *             config: {
+ *                name: "control",
+ *                label: "Autosave form control (even invalid)",
+ *                requirementConfig: {
+ *                   initialValue: true
+ *                }
+ *             }
+ *           }
+ *        ]
+ *     }
+ *  }
  * 
  * @module alfresco/forms/Form
  * @extends external:dijit/_WidgetBase

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -377,7 +377,7 @@ define(["dojo/_base/declare",
       /**
        * @instance
        * @type {object}
-       * @defualt null
+       * @default null
        */
       okButtonPublishPayload: null,
       
@@ -408,14 +408,14 @@ define(["dojo/_base/declare",
       /**
        * @instance
        * @type {object}
-       * @defualt null
+       * @default null
        */
       cancelButtonPublishPayload: null,
 
       /**
        * @instance
        * @type {object}
-       * @defualt null
+       * @default null
        */
       cancelButtonPublishGlobal: null,
       

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -257,10 +257,14 @@ define(["dojo/_base/declare",
        * @instance
        */
       publishFormValidity: function alfresco_forms_Form__publishFormValidity() {
+         var isValid = this.invalidFormControls.length === 0;
          this.alfPublish("ALF_FORM_VALIDITY", {
-            valid: this.invalidFormControls.length === 0,
+            valid: isValid,
             invalidFormControls: this.invalidFormControls
          });
+         if(this.autoSavePublishTopic !== null && (isValid || this.autoSaveOnInvalid)) {
+            this.alfPublish(this.autoSavePublishTopic, this.autoSavePublishPayload || this.getValue(), this.autoSavePublishGlobal);
+         }
       },
       
       /**
@@ -420,6 +424,44 @@ define(["dojo/_base/declare",
       cancelButtonPublishGlobal: null,
       
       /**
+       * If this is not null, then the form will auto-publish on this topic whenever a form's
+       * values change. This setting overrides and will remove the OK and Cancel buttons.
+       * 
+       * @instance 
+       * @type {string}
+       * @default null
+       */
+      autoSavePublishTopic: null,
+      
+      /**
+       * The payload to publish (will be the form's values if not specified)
+       * 
+       * @instance
+       * @type {object}
+       * @default null
+       */
+      autoSavePublishPayload: null,
+      
+      /**
+       * @instance 
+       * @type {string}
+       * @default null
+       */
+      autoSavePublishGlobal: null,
+
+      /**
+       * Whether, when autoSavePublish is enabled (i.e. autoSavePublishTopic is not null),
+       * to also publish when the form contains invalid values. If this is enabled, then
+       * the publish payload will have an additional alfFormInvalid property, which will
+       * be set to true.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      autoSaveOnInvalid: false,
+      
+      /**
        * This can be configured with details of additional buttons to be included with the form.
        * Any button added will have the publishPayload set with the form value. 
        * 
@@ -515,7 +557,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       createButtons: function alfresco_forms_Form__createButtons() {
-         if (this.showOkButton === true)
+         if (this.showOkButton === true && this.autoSavePublishTopic === null)
          {
             var onButtonClass = this.okButtonClass ? this.okButtonClass : "";
             this.okButton = new AlfButton({
@@ -548,7 +590,7 @@ define(["dojo/_base/declare",
             domConstruct.destroy(this.okButtonNode);
          }
          
-         if (this.showCancelButton === true)
+         if (this.showCancelButton === true && this.autoSavePublishTopic === null)
          {
             this.cancelButton = new AlfButton({
                pubSubScope: this.pubSubScope,

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1434,8 +1434,7 @@ define(["dojo/_base/declare",
       setupChangeEvents: function alfresco_forms_controls_BaseFormControl__setupChangeEvents() {
          if (this.wrappedWidget && typeof this.wrappedWidget.watch === "function")
          {
-            // TODO: Do we need to do anything with the watch handle when the widget is destroyed?
-            this.wrappedWidget.watch("value", lang.hitch(this, this.onValueChangeEvent));
+            this.own(this.wrappedWidget.watch("value", lang.hitch(this, this.onValueChangeEvent)));
          } 
          else
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1568,7 +1568,7 @@ define(["dojo/_base/declare",
        */
       valueSubscribe: function alfresco_forms_controls_BaseFormControl__valueSubscribe(payload) {
          var value = lang.getObject("value", false, payload);
-         if (value || value === false || value === 0)
+         if (value !== null && typeof value !== "undefined")
          {
             this.setValue(value);
          }

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
@@ -67,6 +67,7 @@ define(["dojo/_base/declare"],
                _this.validate();
             });
          }
+         this.inherited(arguments);
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -175,6 +175,10 @@ define(["intern/dojo/node!fs",
                   fs.writeFile(screenshotPath, screenshot.toString("binary"), "binary");
                });
          };
+         command.session.clearLog = function() {
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+               .click();
+         };
          command.session.getLastPublish = function(topicName) {
             return this.getLogEntries({
                type: "PUBLISH",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/lists/views/AlfListViewTest"
+      "src/test/resources/alfresco/forms/controls/BaseFormTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -15,27 +15,10 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         name: "alfresco/forms/Form",
-         config: {
-            widgets: [
-               {
-                  id: "FORM_FIELD",
-                  name: "alfresco/forms/controls/DojoValidationTextBox",
-                  config: {
-                     pubSubScope: "TEST_SCOPE_",
-                     valueSubscriptionTopic: "SET_FORM_CONTROL_VALUE",
-                     name: "control",
-                     label: "This is my form control:"
-                  }
-               }
-            ]
-         }
-      },
-      {
          name: "alfresco/buttons/AlfButton",
          config: {
             id: "SET_FORM_VALUE_1",
-            label: "Set form value 1 (fault)",
+            label: "Publish update without payload",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_"
          }
@@ -44,7 +27,7 @@ model.jsonModel = {
          name: "alfresco/buttons/AlfButton",
          config: {
             id: "SET_FORM_VALUE_2",
-            label: "Set form value 2 (fault)",
+            label: "Incorrect fieldname in update payload",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
             publishPayload: {
@@ -56,7 +39,7 @@ model.jsonModel = {
          name: "alfresco/buttons/AlfButton",
          config: {
             id: "SET_FORM_VALUE_3",
-            label: "Set form value 3",
+            label: "Update and set string value",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
             publishPayload: {
@@ -68,7 +51,7 @@ model.jsonModel = {
          name: "alfresco/buttons/AlfButton",
          config: {
             id: "SET_FORM_VALUE_4",
-            label: "Set form value 4",
+            label: "Update and set number value",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
             publishPayload: {
@@ -80,7 +63,7 @@ model.jsonModel = {
          name: "alfresco/buttons/AlfButton",
          config: {
             id: "SET_FORM_VALUE_5",
-            label: "Set form value 5",
+            label: "Update and set boolean value",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
             publishPayload: {
@@ -89,10 +72,92 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "10px"
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/forms/Form",
+         id: "BASIC_FORM",
+         config: {
+            widgets: [
+               {
+                  id: "FORM_FIELD",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     pubSubScope: "TEST_SCOPE_",
+                     valueSubscriptionTopic: "SET_FORM_CONTROL_VALUE",
+                     name: "control",
+                     label: "Basic form control"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/forms/Form",
+         id: "AUTOSAVE_FORM",
+         config: {
+            autoSavePublishTopic: "AUTOSAVE_FORM_1",
+            autoSavePublishGlobal: true,
+            pubSubScope: "AUTOSAVE1_",
+            widgets: [
+               {
+                  id: "AUTOSAVE_FORM_FIELD",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     name: "control",
+                     label: "Autosave form control",
+                     value: "Foo",
+                     valueSubscriptionTopic: "SET_FORM_CONTROL_VALUE",
+                     requirementConfig: {
+                        initialValue: true
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/forms/Form",
+         id: "AUTOSAVE_FORM_INVALID",
+         config: {
+            autoSavePublishTopic: "AUTOSAVE_FORM_2",
+            autoSavePublishGlobal: true,
+            autoSaveOnInvalid: true,
+            pubSubScope: "AUTOSAVE2_",
+            widgets: [
+               {
+                  id: "AUTOSAVE_INVALID_FORM_FIELD",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     name: "control",
+                     label: "Autosave form control (even invalid)",
+                     value: "Bar",
+                     valueSubscriptionTopic: "SET_FORM_CONTROL_VALUE",
+                     requirementConfig: {
+                        initialValue: true
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-356](https://issues.alfresco.com/jira/browse/AKU-356), and permits the auto-publishing of a form when its values change. By default, it will not publish when any of its values are invalid, but this can be turned on with a config option. For full usage information, see the JSDoc.