### PR TITLE
Add 'withHandles' pass through to DragAndDropTargetControl

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/DragAndDropTargetControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DragAndDropTargetControl.js
@@ -113,7 +113,8 @@ define(["dojo/_base/declare",
             pubSubScope: this.pubSubScope,
             parentPubSubScope: this.pubSubScope,
             acceptTypes: this.acceptTypes,
-            useModellingService: this.useModellingService
+            useModellingService: this.useModellingService,
+            withHandles: this.withHandles
          };
          if (this.widgetsForWrappingDroppedItems)
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/DragAndDropTargetControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DragAndDropTargetControl.js
@@ -100,7 +100,16 @@ define(["dojo/_base/declare",
        * @default null
        */
       widgetsForDroppedItems: null,
-      
+
+      /**
+       * Indicates whether or not dragging should be done with handles.
+       *
+       * @instance
+       * @type {boolean}
+       * @default true
+       */
+      withHandles: true,
+
       /**
        * Return the configuration for the widget
        * 


### PR DESCRIPTION
It is not possible to configure a DragAndDropTargetControl to work with it's drag and drop handles false, because the declarative configuration property 'withHandles' is not passed through to the DragAndDropTarget it generates. This PR makes a small change to allow this.