### PR TITLE
Add ability to passthrough maven options to startTestApp

### DIFF
--- a/aikau/src/grunt/shell.js
+++ b/aikau/src/grunt/shell.js
@@ -13,10 +13,18 @@ module.exports = function(grunt) {
 
          // Aikau test server
          startTestApp: {
-            command: "mvn jetty:run",
+            command: "mvn clean jetty:run",
             options: {
                stderr: false,
-               async: true
+               async: false
+            }
+         },
+         // Aikau test server start up for Bamboo.
+         startTestAppOptions: {
+            command: "mvn clean jetty:run " + grunt.option("mvnOptions"),
+            options: {
+               stderr: false,
+               async: false
             }
          },
          stopTestApp: {
@@ -25,7 +33,7 @@ module.exports = function(grunt) {
 
          // Maven
          mavenInstall: {
-            command: "mvn install"
+            command: "mvn clean install"
          },
          mavenProcessTestResources: {
             command: "mvn -q process-test-resources"

--- a/aikau/src/grunt/testing.js
+++ b/aikau/src/grunt/testing.js
@@ -34,7 +34,12 @@ module.exports = function(grunt) {
          .then(function(inUse) {
             if (!inUse) {
                grunt.log.writeln("Starting unit test app...");
-               grunt.task.run("shell:startTestApp");
+               // Bamboo needs to add parameters when the test app starts up.
+               if (grunt.option("mvnOptions")) {
+                  grunt.task.run("shell:startTestAppOptions");
+               } else {
+                  grunt.task.run("shell:startTestApp");
+               }
                done();
             } else {
                grunt.log.writeln("Jetty unit test application appears to be running already...");


### PR DESCRIPTION
Run with the command: 
grunt startUnitTestApp --mvnOptions='-DproxyUrl="10.181.129.80" -DproxyPort="5677" -DunitTestAppBaseUrl=${HOSTNAME} -DbrowserName="internet explorer"'

(note the single quotes around all the maven options, preserving the double quotes inside it. It allows arbitrary mvn options)

I've also added "clean" to the mvn commands as we've found we need that locally.