### PR TITLE
AKU-362: Non hash breadcrumb trail

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -38,6 +38,7 @@
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/core/CoreWidgetProcessing
  * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
@@ -47,6 +48,7 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/AlfBreadcrumbTrail.html",
         "alfresco/core/Core",
+        "alfresco/core/CoreWidgetProcessing",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/documentlibrary/AlfBreadcrumb",
@@ -54,10 +56,10 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template,  AlfCore, _AlfDocumentListTopicMixin, _PublishPayloadMixin,
-                 AlfBreadcrumb, lang, array, domConstruct, domClass) {
+        function(declare, _WidgetBase, _TemplatedMixin, template,  AlfCore, CoreWidgetProcessing, _AlfDocumentListTopicMixin, 
+                 _PublishPayloadMixin, AlfBreadcrumb, lang, array, domConstruct, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _PublishPayloadMixin, _AlfDocumentListTopicMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, _PublishPayloadMixin, _AlfDocumentListTopicMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -117,9 +119,9 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default null
+       * @default "/"
        */
-      currentPath: null,
+      currentPath: "/",
 
       /**
        * Indicates whether the browser URL hash will be used to provide the breadcrumb trail. If this is
@@ -130,16 +132,6 @@ define(["dojo/_base/declare",
        * @default false
        */
       useHash: false,
-
-      /**
-       * The topic to subscribe to for listening to changes to the path. This is only used when 
-       * [useHash]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#useHash} is set to false.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      pathChangeTopic: null,
 
       /**
        * This indicates that the final breadcrumb in the trail  is 
@@ -312,7 +304,10 @@ define(["dojo/_base/declare",
       renderBreadcrumb: function alfresco_documentlibrary_AlfBreadcrumbTrail__renderBreadcrumb(breadcrumb, /*jshint unused:false*/ index) {
          if (breadcrumb.label)
          {
-            var bc = new AlfBreadcrumb(breadcrumb);
+            var bc = this.createWidget({
+               name: "alfresco/documentlibrary/AlfBreadcrumb",
+               config: breadcrumb
+            });
             bc.placeAt(this.containerNode);
          }
       },

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -324,7 +324,6 @@ define(["dojo/_base/declare",
          {
             this.onDocumentClick(payload);
          }
-
       },
 
       /**
@@ -336,9 +335,9 @@ define(["dojo/_base/declare",
          if (payload.url)
          {
             this.currentFilter = this.processFilter(payload.url);
-            if (this._readyToLoad) 
+            if (!this.useHash && this.currentFilter.path)
             {
-               this.loadData();
+               this.alfPublish(this.pathChangeTopic, this.currentFilter);
             }
          }
          else

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -310,7 +310,7 @@ define(["dojo/_base/declare"],
        * @event requestInProgressTopic
        * @instance
        * @type {string}
-       * @default ALF_DOCLIST_REQUEST_IN_PROGRESS
+       * @default "ALF_DOCLIST_REQUEST_IN_PROGRESS"
        */
       requestInProgressTopic: "ALF_DOCLIST_REQUEST_IN_PROGRESS",
 
@@ -321,9 +321,20 @@ define(["dojo/_base/declare"],
        * @event requestFinishedTopic
        * @instance
        * @type {string}
-       * @default ALF_DOCLIST_REQUEST_FINISHED
+       * @default "ALF_DOCLIST_REQUEST_FINISHED"
        */
-      requestFinishedTopic: "ALF_DOCLIST_REQUEST_FINISHED"
+      requestFinishedTopic: "ALF_DOCLIST_REQUEST_FINISHED",
 
+      /**
+       * This topic should be published to indicate that a path has been changed. It is used by both the
+       * [AlfDocumentList]{@link module:alfresco/documentlibrary/AlfDocumentList} and the
+       * [AlfBreadcrumbTrail]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail}, but the default
+       * value can be overridden through configuration if required.
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_DOCUMENTLIST_PATH_CHANGED"
+       */
+      pathChangeTopic: "ALF_DOCUMENTLIST_PATH_CHANGED"
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
@@ -110,6 +110,7 @@ define(["alfresco/lists/views/layouts/Row",
           */
          widgetsAndAttachPoints: [{
             _attachPoint: "selector",
+            id: "DETAILED_VIEW_SELECTOR",
             name: "alfresco/renderers/Selector",
             config: {
                publishGlobal: false,
@@ -117,10 +118,12 @@ define(["alfresco/lists/views/layouts/Row",
             }
          }, {
             _attachPoint: "indicators",
+            id: "DETAILED_VIEW_INDICATORS",
             name: "alfresco/renderers/Indicators"
          }, {
             _attachPoint: "thumbnail",
             name: "alfresco/renderers/Thumbnail",
+            id: "DETAILED_VIEW_THUMBNAIL",
             config: {
                showDocumentPreview: true,
                publishGlobal: false,
@@ -128,20 +131,25 @@ define(["alfresco/lists/views/layouts/Row",
             }
          }, {
             _attachPoint: "lockedBanner",
+            id: "DETAILED_VIEW_LOCKED_BANNER",
             name: "alfresco/renderers/LockedBanner"
          }, {
             _attachPoint: "name",
+            id: "DETAILED_VIEW_NAME",
             name: "alfresco/renderers/InlineEditPropertyLink",
             config: {
                propertyToRender: "node.properties.cm:name",
                postParam: "prop_cm_name",
-               renderSize: "large"
+               renderSize: "large",
+               linkPublishGlobal: false,
+               linkPublishToParent: true
             }
          }, {
             _attachPoint: "title",
             _render: function(item) {
                return item.node.properties["cm:title"];
             },
+            id: "DETAILED_VIEW_TITLE",
             name: "alfresco/renderers/InlineEditProperty",
             config: {
                propertyToRender: "node.properties.cm:title",
@@ -154,21 +162,25 @@ define(["alfresco/lists/views/layouts/Row",
             _render: function(item) {
                return !item.node.isContainer && !(item.workingCopy && item.workingCopy.isWorkingCopy);
             },
+            id: "DETAILED_VIEW_VERSION",
             name: "alfresco/renderers/Version",
             config: {
                onlyShowOnHover: true
             }
          }, {
             _attachPoint: "date",
+            id: "DETAILED_VIEW_DATE",
             name: "alfresco/renderers/Date"
          }, {
             _attachPoint: "size",
             _render: function(item) {
                return !item.node.isContainer;
             },
+            id: "DETAILED_VIEW_SIZE",
             name: "alfresco/renderers/Size"
          }, {
             _attachPoint: "description",
+            id: "DETAILED_VIEW_DESCRIPTION",
             name: "alfresco/renderers/InlineEditProperty",
             config: {
                propertyToRender: "node.properties.cm:description",
@@ -181,6 +193,7 @@ define(["alfresco/lists/views/layouts/Row",
             _render: function(item) {
                return !(item.workingCopy && item.workingCopy.isWorkingCopy);
             },
+            id: "DETAILED_VIEW_TAGS",
             name: "alfresco/renderers/Tags",
             config: {
                propertyToRender: "node.properties.cm:taggable",
@@ -193,24 +206,28 @@ define(["alfresco/lists/views/layouts/Row",
             _render: function(item) {
                return item.node.properties["cm:categories"];
             },
+            id: "DETAILED_VIEW_CATEGORY",
             name: "alfresco/renderers/Category"
          }, {
             _attachPoint: "favourite",
             _render: function(item) {
                return !(item.workingCopy && item.workingCopy.isWorkingCopy);
             },
+            id: "DETAILED_VIEW_FAVOURITE",
             name: "alfresco/renderers/Favourite"
          }, {
             _attachPoint: "like",
             _render: function(item) {
                return !(item.workingCopy && item.workingCopy.isWorkingCopy);
             },
+            id: "DETAILED_VIEW_LIKE",
             name: "alfresco/renderers/Like"
          }, {
             _attachPoint: "comments",
             _render: function(item) {
                return !(item.workingCopy && item.workingCopy.isWorkingCopy);
             },
+            id: "DETAILED_VIEW_COMMENTS",
             name: "alfresco/renderers/Comments",
             config: {
                subscriptionTopic: "ALF_GET_COMMENTS_SUCCESS",
@@ -222,6 +239,7 @@ define(["alfresco/lists/views/layouts/Row",
             _render: function(item) {
                return !item.node.isContainer && !(item.workingCopy && item.workingCopy.isWorkingCopy);
             },
+            id: "DETAILED_VIEW_QUICKSHARE",
             name: "alfresco/renderers/QuickShare"
          }, {
             _attachPoint: "commentsReveal",
@@ -229,11 +247,13 @@ define(["alfresco/lists/views/layouts/Row",
             config: {
                subscriptionTopic: "ALF_REVEAL_COMMENTS",
                widgets: [{
+                  id: "DETAILED_VIEW_COMMENTS_LIST",
                   name: "alfresco/renderers/CommentsList"
                }]
             }
          }, {
             _attachPoint: "actions",
+            id: "DETAILED_VIEW_ACTIONS",
             name: "alfresco/renderers/Actions",
             config: {
                publishGlobal: false,

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -66,11 +66,11 @@ define(["dojo/_base/declare",
        */
       onLinkClick: function alfresco_renderers_InlineEditPropertyLink__onLinkClick(evt) {
          evt && event.stop(evt);
+         var publishGlobal = this.linkPublishGlobal || false,
+             publishToParent = this.linkPublishToParent || false;
          if (this.linkPublishTopic && lang.trim(this.linkPublishTopic))
          {
-            var publishGlobal = this.linkPublishGlobal || false,
-               publishToParent = this.linkPublishToParent || false,
-               publishPayload = this.generatePayload(this.linkPublishPayload,
+            var publishPayload = this.generatePayload(this.linkPublishPayload,
                                                       this.currentItem,
                                                       null, 
                                                       this.linkPublishPayloadType, 
@@ -83,7 +83,7 @@ define(["dojo/_base/declare",
             // If no topic has been provided then assume this to be a standard document/folder link...
             this.linkPublishPayload = {};
             var publishTopic = this.generateFileFolderLink(this.linkPublishPayload);
-            this.alfPublish(publishTopic, this.linkPublishPayload, true);
+            this.alfPublish(publishTopic, this.linkPublishPayload, publishGlobal, publishToParent);
          }
       }
    });

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -1,4 +1,4 @@
-/* global config,remote,user,msg */
+/* global config,remote,user,msg,url */
 
 // Look for any DocumentLibrary XML configuration. This is expected to exist in Alfresco Share
 // but may not exist in other clients...
@@ -572,7 +572,7 @@ function getDocLibFilters() {
    return filters;
 }
 
-function getDocLibTree(siteId, containerId, rootNode, rootLabel) {
+function getDocLibTree(options) {
    var tree = {
       name: "alfresco/layout/Twister",
       config: {
@@ -582,10 +582,10 @@ function getDocLibTree(siteId, containerId, rootNode, rootLabel) {
             {
                name: "alfresco/navigation/PathTree",
                config: {
-                  siteId: siteId,
-                  containerId: containerId,
-                  rootNode: rootNode,
-                  rootLabel: rootLabel
+                  siteId: options.siteId,
+                  containerId: options.containerId,
+                  rootNode: options.rootNode,
+                  rootLabel: options.rootLabel
                }
             }
          ]
@@ -594,16 +594,16 @@ function getDocLibTree(siteId, containerId, rootNode, rootLabel) {
    return tree;
 }
 
-function getDocLibTags(siteId, containerId, rootNode) {
+function getDocLibTags(options) {
    var tags = {
       id: "DOCLIB_TAGS",
       name: "alfresco/documentlibrary/AlfTagFilters",
       config: {
          label: "filter.label.tags",
          additionalCssClasses: "no-borders",
-         siteId: siteId,
-         containerId: containerId,
-         rootNode: rootNode
+         siteId: options.siteId,
+         containerId: options.containerId,
+         rootNode: options.rootNode
       }
    };
    return tags;
@@ -1030,16 +1030,16 @@ function getDocLibConfigMenu() {
  * DOCUMENT LIST CONSTRUCTION                                                      *
  *                                                                                 *
  ***********************************************************************************/
-function getDocLibList(siteId, containerId, rootNode, rawData) {
+function getDocLibList(options) {
    return {
       id: "DOCLIB_DOCUMENT_LIST",
       name: "alfresco/documentlibrary/AlfDocumentList",
       config: {
-         rawData: rawData || false,
-         useHash: true,
-         siteId: siteId,
-         containerId: containerId,
-         rootNode: rootNode,
+         rawData: options.rawData || false,
+         useHash: (options.useHash !== false),
+         siteId: options.siteId,
+         containerId: options.containerId,
+         rootNode: options.rootNode,
          usePagination: true,
          showFolders: docLibPrefrences.showFolders,
          sortAscending: docLibPrefrences.sortAscending,
@@ -1167,12 +1167,10 @@ function getDocLibToolbar() {
 /**
  * Builds the JSON model for rendering a DocumentLibrary. 
  * 
- * @param {string} siteId The id of the site to render the document library for (if applicable)
- * @param {string} containerId The id of the container to render (if applicable - sites only)
- * @param {string} rootNode The node that is the root of the DocumentLibrary to render
+ * 
  * @returns {object} An object containing the JSON model for a DocumentLibrary
  */
-function getDocLib(siteId, containerId, rootNode, rootLabel, rawData) {
+function getDocLib(options) {
    var docLibModel = {
       id: "DOCLIB_SIDEBAR",
       name: "alfresco/layout/AlfSideBarContainer",
@@ -1188,8 +1186,8 @@ function getDocLib(siteId, containerId, rootNode, rootLabel, rawData) {
                config: {
                   widgets: [
                      getDocLibFilters(),
-                     getDocLibTree(siteId, containerId, rootNode, rootLabel),
-                     getDocLibTags(siteId, containerId, rootNode),
+                     getDocLibTree(options),
+                     getDocLibTags(options),
                      getDocLibCategories()
                   ]
                }
@@ -1205,9 +1203,10 @@ function getDocLib(siteId, containerId, rootNode, rootLabel, rawData) {
                         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
                         config: {
                            hide: docLibPrefrences.hideBreadcrumbTrail,
-                           rootLabel: rootLabel,
+                           rootLabel: options.rootLabel,
                            lastBreadcrumbIsCurrentNode: true,
-                           useHash: true,
+                           useHash: (options.useHash !== false),
+                           pathChangeTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
                            lastBreadcrumbPublishTopic: "ALF_NAVIGATE_TO_PAGE",
                            lastBreadcrumbPublishPayload: {
                               url: "folder-details?nodeRef={currentNode.parent.nodeRef}",
@@ -1218,12 +1217,15 @@ function getDocLib(siteId, containerId, rootNode, rootLabel, rawData) {
                            lastBreadcrumbPublishPayloadModifiers: ["processInstanceTokens"]
                         }
                      },
-                     getDocLibList(siteId, containerId, rootNode, rawData)
+                     getDocLibList(options)
                   ]
                }
             }
          ]
       }
    };
+   if (options.pubSubScope) {
+      docLibModel.pubSubScope = options.pubSubScope;
+   }
    return docLibModel;
 }

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!expect",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, expect, assert, require, TestCommon) {
+
+   var browser;
+
+   // PLEASE NOTE:
+   // We're going to run the same tests on the Document Library with URL hashing enabled and then disabled
+   // so the tests are abstracted to their own individual functions for re-use (this is slightly different
+   // that other tests)...
+   var countInitialBreadcrumbs = function() {
+      return browser.findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+         .then(function(elements) {
+            assert.lengthOf(elements, 1, "No breadcrumbs were rendered on page load");
+         }); 
+   };
+
+   var checkInitialBreadcrumbText = function() {
+      return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb .breadcrumb")
+         .getVisibleText()
+         .then(function(text) {
+            assert.equal(text, "Documents", "The initial breadcrumb was rendered incorrectly");
+         });
+   };
+
+   var clickOnFolderLink = function() {
+      return browser.findByCssSelector("#DETAILED_VIEW_NAME_ITEM_0 .alfresco-renderers-Property")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "The breadcrumb trail was not updated");
+            });
+         };
+
+   var checkAddedBreadcrumbText = function() {
+      return browser.findByCssSelector("#DOCLIB_BREADCRUMB_TRAIL .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) .breadcrumb")
+         .getVisibleText()
+         .then(function(text) {
+            assert.equal(text, "DetailedView", "The added breadcrumb was not rendered correctly");
+         });
+   };
+
+   var returnToRoot = function() {
+      return browser.findByCssSelector("#DOCLIB_BREADCRUMB_TRAIL .alfresco-documentlibrary-AlfBreadcrumb:nth-child(1) .breadcrumb")
+         .clearLog()
+         .click()
+      .end()
+      .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+      .findAllByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem")
+         .then(function(elements) {
+            assert.lengthOf(elements, 3, "The data wasn't reloaded");
+         })
+      .end()
+      .findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+         .then(function(elements) {
+            assert.lengthOf(elements, 1, "The breadcrumb trail was not updated");
+         });
+   };
+
+   registerSuite({
+      name: "Document Library Test (default)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/DocLib", "Document Library Test").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Count the initial breadcrumbs": function() {
+         return browser.then(function() {
+            return countInitialBreadcrumbs();
+         });
+      },
+
+      "Check the initial breadcrumb text": function() {
+         return browser.then(function() {
+            return checkInitialBreadcrumbText();
+         });
+      },
+
+      "Click on a folder link and check for updated breadcrumb": function() {
+         return browser.then(function() {
+            return clickOnFolderLink();
+         });
+      },
+
+      "Check the added breadcrumb text": function() {
+         return browser.then(function() {
+            return checkAddedBreadcrumbText();
+         });
+      },
+
+      "Use the breadcrumb trail to return to the root": function() {
+         return browser.then(function() {
+            return returnToRoot();
+         });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   registerSuite({
+      name: "Document Library Test (no URL hashing)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/DocLibNoHash", "Document Library Test (no URL hashing)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Count the initial breadcrumbs": function() {
+         return browser.then(function() {
+            return countInitialBreadcrumbs();
+         });
+      },
+
+      "Check the initial breadcrumb text": function() {
+         return browser.then(function() {
+            return checkInitialBreadcrumbText();
+         });
+      },
+
+      "Click on a folder link and check for updated breadcrumb": function() {
+         return browser.then(function() {
+            return clickOnFolderLink();
+         });
+      },
+
+      "Check the added breadcrumb text": function() {
+         return browser.then(function() {
+            return checkAddedBreadcrumbText();
+         });
+      },
+
+      "Use the breadcrumb trail to return to the root": function() {
+         return browser.then(function() {
+            return returnToRoot();
+         });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -70,6 +70,7 @@ define({
 
       "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest",
       "src/test/resources/alfresco/documentlibrary/CreateContentTest",
+      "src/test/resources/alfresco/documentlibrary/DocumentLibraryTest",
       "src/test/resources/alfresco/documentlibrary/DocumentListTest",
       "src/test/resources/alfresco/documentlibrary/DocumentSelectorTest",
       "src/test/resources/alfresco/documentlibrary/PaginationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLib.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLib.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
-  <shortname>DocLib Test</shortname>
+  <shortname>Document Library Example </shortname>
+  <description>This provides an example of building the standard Document Library using the doclib.lib.js library file.</description>
   <family>aikau-unit-tests</family>
   <url>/DocLib</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Document Library Example (no URL hashing)</shortname>
+  <description>This provides an example of building a Document Library using the doclib.lib.js library file that does not use URL hash to log the current location within the document library.</description>
+  <family>aikau-unit-tests</family>
+  <url>/DocLibNoHash</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.js
@@ -23,7 +23,9 @@ model.jsonModel = {
          siteId: "site1", 
          containerId: "documentlibrary", 
          rootNode: null, 
-         rootLabel: "Documents"
+         rootLabel: "Documents",
+         useHash: false,
+         pubSubScope: "TEST_"
       }),
       {
          name: "aikauTesting/mockservices/FullDocLibMockXhr"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.properties
@@ -1,0 +1,1 @@
+surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-362 (and it might also resolve https://issues.alfresco.com/jira/browse/AKU-374). The breadcrumb trail was not working with URL hashing disabled so I have added tests for checking a Document Library (created using an updated version of the doclib.lib.js file) with useHash enabled and disabled and also with and without a pubSubScope.