### PR TITLE
AKU-368: Ensure that text content in dialogs is centre aligned

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -55,6 +55,10 @@
    padding: 0px;
 }
 
+.alfresco-dialogs-AlfDialog--textContent .dialog-body {
+  text-align: center;
+}
+
 .alfresco-dialog-AlfDialog .dijitDialogPaneContent {
    border-top: @standard-border;
    padding: 0;

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -295,6 +295,13 @@ define(["dojo/_base/declare",
             handleOverflow: handleOverflow,
             fixedWidth: fixedWidth
          };
+
+         // Ensure that text content is center aligned (see AKU-368)...
+         if (dialogConfig.content)
+         {
+            dialogConfig.additionalCssClasses += " alfresco-dialogs-AlfDialog--textContent";
+         }
+
          var dialog = new AlfDialog(dialogConfig);
 
          if (payload.publishOnShow)

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -23,6 +23,7 @@ model.jsonModel = {
             publishPayload: {
                dialogId: "FD1",
                dialogTitle: "Form Dialog 1",
+               additionalCssClasses: "custom-classes",
                textContent: "Hello World",
                publishOnShow: [
                   {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-368 to ensure that text only dialogs have that text centre aligned. I've not added a test for this as there seems little value for something relatively trivial like this.