### PR TITLE
AKU-373: Autosave payload not mixing in form values

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -285,13 +285,17 @@ define(["dojo/_base/declare",
        * @instance
        */
       publishFormValidity: function alfresco_forms_Form__publishFormValidity() {
-         var isValid = this.invalidFormControls.length === 0;
+         var isValid = this.invalidFormControls.length === 0,
+            autoSavePayload;
          this.alfPublish("ALF_FORM_VALIDITY", {
             valid: isValid,
             invalidFormControls: this.invalidFormControls
          });
          if(this.autoSavePublishTopic && typeof this.autoSavePublishTopic === "string" && (isValid || this.autoSaveOnInvalid)) {
-            this.alfPublish(this.autoSavePublishTopic, this.autoSavePublishPayload || this.getValue(), this.autoSavePublishGlobal);
+            autoSavePayload = lang.mixin(this.autoSavePublishPayload || {}, {
+               alfValidForm: isValid
+            }, this.getValue());
+            this.alfPublish(this.autoSavePublishTopic, autoSavePayload, this.autoSavePublishGlobal);
          }
       },
       

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -130,6 +130,7 @@ define(["intern!object",
             .getLastPublish("AUTOSAVE_FORM_1")
             .then(function(payload) {
                assert.propertyVal(payload, "control", "wibble", "Did not autosave updated value");
+               assert.propertyVal(payload, "alfValidForm", true, "Did not autosave validity property");
             });
       },
 
@@ -152,6 +153,15 @@ define(["intern!object",
             .getLastPublish("AUTOSAVE_FORM_2")
             .then(function(payload) {
                assert.propertyVal(payload, "control", "", "Did not autosave updated, invalid value");
+               assert.propertyVal(payload, "alfValidForm", false, "Did not autosave validity property");
+            });
+      },
+
+      "Autosaving with defined payload mixes payload into form values": function(){
+         return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD") // Need to get session to check for publish
+            .getLastPublish("AUTOSAVE_FORM_2")
+            .then(function(payload) {
+               assert.propertyVal(payload, "customProperty", "awooga", "Did not mix custom payload into form values");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -137,6 +137,9 @@ model.jsonModel = {
          config: {
             autoSavePublishTopic: "AUTOSAVE_FORM_2",
             autoSavePublishGlobal: true,
+            autoSavePublishPayload: {
+               customProperty: "awooga"
+            },
             autoSaveOnInvalid: true,
             pubSubScope: "AUTOSAVE2_",
             widgets: [


### PR DESCRIPTION
This addresses issue [AKU-373](https://issues.alfresco.com/jira/browse/AKU-373) where the autosave payload, if specified, is not mixing in form values. The tests have also been updated accordingly.