### PR TITLE
AKU-66: Remove use of blockConcurrentRequests

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -113,15 +113,6 @@ define(["dojo/_base/declare",
       requestInProgress: false,
 
       /**
-       * Should we prevent multiple simultaneous requests
-       *
-       * @instance
-       * @default false
-       * @type {Boolean}
-       */
-      blockConcurrentRequests: false,
-
-      /**
        * Indicates whether Infinite Scroll should be used when requesting documents
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -464,7 +464,8 @@ define(["dojo/_base/declare",
        * @instance
        */
       loadData: function alfresco_search_AlfSearchList__loadData() {
-         if (this.requestInProgress && this.blockConcurrentRequests)
+         // jshint maxcomplexity:false
+         if (this.requestInProgress)
          {
             // TODO: Inform user that request is in progress?
             this.alfLog("log", "Search request ignored because progress is already in progress");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SearchList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SearchList.get.js
@@ -221,7 +221,6 @@ model.jsonModel = {
                "sortField",
                "sortAscending"
             ],
-            blockConcurrentRequests: false,
             widgets: [
                {
                   name: "alfresco/search/AlfSearchListView"


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-66 and removes the blockConcurrentRequests which is never used and had the result of allowing concurrent requests to occur.