### PR TITLE
AKU-2: Added unitTestsGrid maven profile

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -55,6 +55,80 @@
                </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>unitTestsGrid</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.tomcat.maven</groupId>
+                        <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>2.2</version>
+                        <executions>
+                            <execution>
+                                <id>run-embedded-tomcat</id>
+                                <!-- Bind to the pre-integration-test phase -->
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <!-- Run will run the project as a dynamic webapp -->
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <fork>true</fork>
+                                    <port>8089</port>
+                                    <ignorePackaging>true</ignorePackaging>
+                                    <warSourceDirectory>${basedir}/target/test-classes/testApp</warSourceDirectory>
+                                    <!-- The context file allows us to map static resources in a virtual webapp -->
+                                    <contextFile>${project.basedir}/tomcat/context.xml</contextFile>
+                                    <useTestClasspath>true</useTestClasspath>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>shutdown-embedded-tomcat</id>
+                                <!-- Bind to the post-integration-test phase -->
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <!-- Safely stop tomcat when integration-test phase is done -->
+                                    <goal>shutdown</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                      <artifactId>maven-antrun-plugin</artifactId>
+                      <version>1.8</version>
+                      <executions>
+                        <execution>
+                          <id>run-unit-tests</id>
+                          <phase>integration-test</phase>
+                          <goals>
+                            <goal>run</goal>
+                          </goals>
+                          <configuration>
+                            <target>
+                              <echo>Running npm install</echo>
+                              <exec executable="npm" dir="${project.basedir}">
+                                <arg line="install"/>
+                              </exec>
+                              <echo>Running grunt test_grid</echo>
+                              <exec executable="grunt" dir="${project.basedir}">
+                                <arg line="test_grid"/>
+                              </exec>
+                            </target>
+                          </configuration>
+                        </execution>
+                      </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+               <dependency>
+                  <groupId>javax.servlet</groupId>
+                  <artifactId>servlet-api</artifactId>
+                  <version>2.5</version>
+                  <scope>provided</scope>
+               </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 

--- a/aikau/src/grunt/testing.js
+++ b/aikau/src/grunt/testing.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
    grunt.registerTask("test_local", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:local"]);
    grunt.registerTask("test", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:dev"]);
    grunt.registerTask("test_sl", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:sl"]);
-   grunt.registerTask("test_grid", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:grid"]);
+   grunt.registerTask("test_grid", ["waitServer", "clean:testScreenshots", "generate-require-everything", "intern:grid"]);
 
    // Watch for changes and retest
    grunt.registerTask("watchDev", ["watch:dev"]);


### PR DESCRIPTION
- Added unitTestsGrid maven profile
- Runtest_grid task in the Maven integration-test phase
- Unplugged startUnitTestApp task for grid as Tomcat is started during
the pre-integration-test phase by Maven.

I added a new Maven profile to avoid collision with ongoing
developments (ie: The run profile). For the same reasons, I kept all
the jetty part and only
unplugged that for the test_grid task.

Run command: mvn verify -PunitTestsGrid

@ohej , @MartinDoyleUK, could you guys review my changes and tell me if it's not colliding with your current developments around Tomcat ?

Thanks.

-Jp

