### PR TITLE
AKU-361: Merge action types

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Actions.js
+++ b/aikau/src/main/resources/alfresco/renderers/Actions.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -22,13 +22,73 @@
  * [drop-down menu]{@link module:alfresco/menus/AlfMenuBarPopup} of [menu items]{@link module:alfresco/menus/AlfMenuItem}
  * representing an action set.</p>
  * 
- * <p>This module was written to intially support Alfresco document and folder actions as generated for a 
- * individual nodes but has since been expanded to support custom actions. The majority of the action handling
- * code is done by the [_ActionsMixin]{@link module:alfresco/renderers/_ActionsMixin}</p>
+ * <p>Actions are either derived from the "actions" attribute on the "currentItem" (which is typically populated through
+ * a REST API call to Share and it should be noted that calls to the Repository REST APIs will not include actions), or
+ * are defined by the [customActions]{@link module:alfresco/renderers/_ActionsMixin#customActions} and
+ * [widgetsForActions]{@link module:alfresco/renderers/_ActionsMixin#widgetsForActions} attributes.</p>
+ *
+ * <p>[Custom actions]{@link module:alfresco/renderers/_ActionsMixin#customActions} take precedence over all other actions
+ * and the [widgetsForActions]{@link module:alfresco/renderers/_ActionsMixin#widgetsForActions} attribute will only be
+ * used when neither [customActions]{@link module:alfresco/renderers/_ActionsMixin#customActions} or "actions" on the
+ * "currentItem" can be found. The purpose of the [widgetsForActions]{@link module:alfresco/renderers/_ActionsMixin#widgetsForActions}
+ * is to provide a set of default actions that are rendered based on the metadata of a node. The default set of actions
+ * can be replaced through configuration if required.</p>
+ *
+ * <p>It is possible to filter actions by configuring the [filterActions]{@link module:alfresco/renderers/_ActionsMixin#filterActions}
+ * to true and then providing either an [allowedActions]{@link module:alfresco/renderers/_ActionsMixin#allowedActions} array
+ * or [allowedActionsString]{@link module:alfresco/renderers/_ActionsMixin#allowedActionsString} string. Filtering only
+ * applied to actions on defined on the "currentItem" or in the 
+ * [customActions]{@link module:alfresco/renderers/_ActionsMixin#customActions} array.</p>
+ *
+ * <p>It is also possible to merge all types of actions by configured the 
+ * [mergeActions]{@link module:alfresco/renderers/_ActionsMixin#mergeActions} attribute to be true</p>
+ *
+ * @example <caption>Example of filtering currentItem actions</caption>
+ * {
+ *   name: "alfresco/renderers/Actions",
+ *   config: {
+ *     filterActions: true,
+ *     allowedActions: [
+ *       "folder-manage-rules",
+ *        "folder-download",
+ *        "folder-view-details"
+ *     ]
+ *   }
+ * }
+ * 
+ * @example <caption>Example of merging a custom action with currentItem actions (hiding all widgetsForActions)</caption>
+ * {
+ *   name: "alfresco/renderers/Actions",
+ *   config: {
+ *     mergeActions: true,
+ *     customActions: [
+ *       {
+ *         id: "CUSTOM",
+ *         label: "Custom Action",
+ *         publishTopic: "CUSTOM_ACTION_TOPIC",
+ *         publishPayloadType: "CURRENT_ITEM",
+ *         type: "javascript"
+ *       },
+ *     ],
+ *     widgetsForActions: []
+ *   }
+ * }
+ *
+ * @example <caption>Example of overriding widgetsForActions</caption>
+ * {
+ *   name: "alfresco/renderers/Actions",
+ *   config: {
+ *     widgetsForActions: [
+ *       {
+ *         name: "alfresco/renderers/actions/ManageAspects"
+ *       }
+ *     ]
+ *   }
+ * }
  * 
  * @module alfresco/renderers/Actions
  * @extends module:alfresco/menus/AlfMenuBar
- * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
+ * @mixes module:alfresco/renderers/_ActionsMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -41,7 +101,6 @@ define(["dojo/_base/declare",
         function(declare, AlfMenuBar, _ActionsMixin, AlfMenuBarPopup, AlfMenuGroup, AlfMenuItem, domClass) {
 
    return declare([AlfMenuBar, _ActionsMixin], {
-
       
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
@@ -28,144 +28,47 @@ define(["intern!object",
 
    var browser;
 
-   var checkAction = function(row, count, error) {
-      return browser.findByCssSelector("#LIST tr:nth-child(" + row + ") .dijitMenuBar")
-         .getAttribute("id")
-         .then(function(id) {
-            // NOTE: Uncomment for debugging
-            // console.log("ID is: " + id);
-            return browser.end().findByCssSelector("div.dijitPopup[dijitpopupparent=" + id +"]")
-               // NOTE: Uncomment for debugging
-               // .getAttribute("id")
-               // .then(function(popupId) {
-               //    console.log("Popup id is: " + popupId);
-               // })
-               .findAllByCssSelector(".alfresco-menus-AlfMenuItem .dijitMenuItemLabel")
-                  .then(function(elements) {
-                     // NOTE: Uncomment for debugging
-                     // console.log("Actions found: " + elements.length);
-                     assert.lengthOf(elements, count, error);
-                  });
-         });
-   };
-
-   var useAction = function(row) {
-      return browser.findByCssSelector("#LIST tr:nth-child(" + row + ") .dijitMenuBar")
-         .getAttribute("id")
-         .then(function(id) {
-            // NOTE: Uncomment for debugging
-            // console.log("ID is: " + id);
-            return browser.end().findByCssSelector("div.dijitPopup[dijitpopupparent=" + id +"]")
-               // NOTE: Uncomment for debugging
-               // .getAttribute("id")
-               // .then(function(popupId) {
-               //    console.log("Popup id is: " + popupId);
-               // })
-               .findByCssSelector(".alfresco-menus-AlfMenuItem .dijitMenuItemLabel")
-                  .click();
-         });
-   };
-
-
    registerSuite({
-      name: "Upload New Version Action Renderer Test",
+      name: "Action Renderer Test",
 
       setup: function() {
          browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/UploadNewVersionAction", "Upload New Version Action Renderer Test").end();
+         return TestCommon.loadTestWebScript(this.remote, "/ActionsRenderer", "Action Renderer Test").end();
       },
 
       beforeEach: function() {
          browser.end();
       },
 
-      "Check folder": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(1) .dijitMenuItemLabel > span:first-child")
+      "Count REST API actions": function() {
+         return browser.findByCssSelector("#REST_ACTIONS_ITEM_0_MENU_text")
             .click()
          .end()
-         .then(function() {
-            return checkAction(1, 0, "Upload new version action shouldn't be rendered for a folder");
-         });
-      },
-
-      "Check basic node": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(2) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(2, 1, "Upload new version action should be rendered for a basic node");
-         });
-      },
-
-      "Check working copy owner by user": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(3) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(3, 1, "Upload new version action should be rendered for working copy owned by the current user");
-         });
-      },
-
-      "Check working copy owner by another user": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(4) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(4, 0, "Upload new version action should not be rendered for a working copy owned by a different user");
-         });
-      },
-
-      "Check node locked by user": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(5) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(5, 1, "Upload new version action should be rendered for a node locked by the current user");
-         });
-      },
-
-      "Check node locked by another user": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(6) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(6, 0, "Upload new version action should not be rendered for a node locked by a different user");
-         });
-      },
-
-      "Check node with node lock": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(7) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(7, 0, "Upload new version action should not be rendered for a node with lock type NODE_LOCK");
-         });
-      },
-
-      "Check node without Write permission": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(8) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return checkAction(8, 0, "Upload new version action should not be rendered for a node without user write permissions");
-         });
-      },
-
-      "Upload a new verion": function() {
-         return browser.findByCssSelector("#LIST tr:nth-child(2) .dijitMenuItemLabel > span:first-child")
-            .click()
-         .end()
-         .then(function() {
-            return useAction(2);
-         })
-         .end()
-         // Give the dialog a chance to appear...
-         .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed")
-         .end()
-         // Check this is an update (rather than just upload) dialog...
-         .findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-forms-controls-RadioButtons")
+         .findAllByCssSelector("#REST_ACTIONS_ITEM_0_GROUP tr")
             .then(function(elements) {
-               assert.lengthOf(elements, 1, "Version increment options should be displayed");
+               assert.lengthOf(elements, 10, "Unexpected number of REST API actions rendered");
+            });
+      },
+
+      "Count custom actions": function() {
+
+         return browser.findByCssSelector("#CUSTOM_ACTIONS_ITEM_0_MENU_text")
+            .click()
+         .end()
+         .findAllByCssSelector("#CUSTOM_ACTIONS_ITEM_0_GROUP tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Unexpected number of custom actions rendered");
+            });
+      },
+
+      "Count filtered merged actions": function() {
+
+         return browser.findByCssSelector("#MERGED_ACTIONS_ITEM_0_MENU_text")
+            .click()
+         .end()
+         .findAllByCssSelector("#MERGED_ACTIONS_ITEM_0_GROUP tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "Unexpected number of filtered merged REST API and custom actions rendered");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
@@ -68,7 +68,7 @@ define(["intern!object",
          .end()
          .findAllByCssSelector("#MERGED_ACTIONS_ITEM_0_GROUP tr")
             .then(function(elements) {
-               assert.lengthOf(elements, 4, "Unexpected number of filtered merged REST API and custom actions rendered");
+               assert.lengthOf(elements, 5, "Unexpected number of filtered merged REST API and custom actions rendered");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/actions/UploadNewVersionActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/actions/UploadNewVersionActionTest.js
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+       function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+
+   var checkAction = function(row, count, error) {
+      return browser.findByCssSelector("#LIST tr:nth-child(" + row + ") .dijitMenuBar")
+         .getAttribute("id")
+         .then(function(id) {
+            // NOTE: Uncomment for debugging
+            // console.log("ID is: " + id);
+            return browser.end().findByCssSelector("div.dijitPopup[dijitpopupparent=" + id +"]")
+               // NOTE: Uncomment for debugging
+               // .getAttribute("id")
+               // .then(function(popupId) {
+               //    console.log("Popup id is: " + popupId);
+               // })
+               .findAllByCssSelector(".alfresco-menus-AlfMenuItem .dijitMenuItemLabel")
+                  .then(function(elements) {
+                     // NOTE: Uncomment for debugging
+                     // console.log("Actions found: " + elements.length);
+                     assert.lengthOf(elements, count, error);
+                  });
+         });
+   };
+
+   var useAction = function(row) {
+      return browser.findByCssSelector("#LIST tr:nth-child(" + row + ") .dijitMenuBar")
+         .getAttribute("id")
+         .then(function(id) {
+            // NOTE: Uncomment for debugging
+            // console.log("ID is: " + id);
+            return browser.end().findByCssSelector("div.dijitPopup[dijitpopupparent=" + id +"]")
+               // NOTE: Uncomment for debugging
+               // .getAttribute("id")
+               // .then(function(popupId) {
+               //    console.log("Popup id is: " + popupId);
+               // })
+               .findByCssSelector(".alfresco-menus-AlfMenuItem .dijitMenuItemLabel")
+                  .click();
+         });
+   };
+
+
+   registerSuite({
+      name: "Upload New Version Action Test",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/UploadNewVersionAction", "Upload New Version Action Test").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check folder": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(1) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(1, 0, "Upload new version action shouldn't be rendered for a folder");
+         });
+      },
+
+      "Check basic node": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(2) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(2, 1, "Upload new version action should be rendered for a basic node");
+         });
+      },
+
+      "Check working copy owner by user": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(3) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(3, 1, "Upload new version action should be rendered for working copy owned by the current user");
+         });
+      },
+
+      "Check working copy owner by another user": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(4) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(4, 0, "Upload new version action should not be rendered for a working copy owned by a different user");
+         });
+      },
+
+      "Check node locked by user": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(5) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(5, 1, "Upload new version action should be rendered for a node locked by the current user");
+         });
+      },
+
+      "Check node locked by another user": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(6) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(6, 0, "Upload new version action should not be rendered for a node locked by a different user");
+         });
+      },
+
+      "Check node with node lock": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(7) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(7, 0, "Upload new version action should not be rendered for a node with lock type NODE_LOCK");
+         });
+      },
+
+      "Check node without Write permission": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(8) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return checkAction(8, 0, "Upload new version action should not be rendered for a node without user write permissions");
+         });
+      },
+
+      "Upload a new verion": function() {
+         return browser.findByCssSelector("#LIST tr:nth-child(2) .dijitMenuItemLabel > span:first-child")
+            .click()
+         .end()
+         .then(function() {
+            return useAction(2);
+         })
+         .end()
+         // Give the dialog a chance to appear...
+         .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed")
+         .end()
+         // Check this is an update (rather than just upload) dialog...
+         .findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-forms-controls-RadioButtons")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Version increment options should be displayed");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -188,6 +188,7 @@ define({
       "src/test/resources/alfresco/renderers/XhrActionsTest",
 
       "src/test/resources/alfresco/renderers/actions/ManageAspectsActionTest",
+      "src/test/resources/alfresco/renderers/actions/UploadNewVersionActionTest",
 
       "src/test/resources/alfresco/search/AlfSearchResultTest",
       "src/test/resources/alfresco/search/FacetFiltersTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.desc.xml
@@ -1,0 +1,7 @@
+<webscript>
+  <shortname>Actions Renderer</shortname>
+  <description>Shows examples of action rendering using REST API actions and custom actions</description>
+  <description></description>
+  <family>aikau-unit-tests</family>
+  <url>/ActionsRenderer</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.js
@@ -1,0 +1,151 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            siteId: "site1", 
+            containerId: "documentlibrary", 
+            rootNode: null, 
+            widgets: [
+               {
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgetsForHeader: [
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              label: "REST API Action Only"
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              label: "Custom Actions Only"
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              label: "REST API Actions merged with Custom Actions (filtered)"
+                           }
+                        }
+                     ],
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "REST_ACTIONS",
+                                             name: "alfresco/renderers/Actions"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "CUSTOM_ACTIONS",
+                                             name: "alfresco/renderers/Actions",
+                                             config: {
+                                               customActions: [
+                                                   {
+                                                      id: "CUSTOM1",
+                                                      label: "Custom Action 1",
+                                                      icon: "document-delete",
+                                                      index: "10",
+                                                      publishTopic: "DELETE_ACTION_TOPIC",
+                                                      type: "javascript"
+                                                   },
+                                                   {
+                                                      id: "CUSTOM2",
+                                                      label: "Custom Action 2",
+                                                      icon: "folder-manage-permissions",
+                                                      index: "10",
+                                                      publishTopic: "MANAGE_ACTION_TOPIC",
+                                                      publishPayloadType: "BUILD",
+                                                      publishPayload: {
+                                                         payloadVariable1: {
+                                                            alfType: "item",
+                                                            alfProperty: "variable2"
+                                                         },
+                                                         payloadVariable2: {
+                                                            alfType: "item",
+                                                            alfProperty: "variable1"
+                                                         }
+                                                      },
+                                                      type: "javascript"
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "MERGED_ACTIONS",
+                                             name: "alfresco/renderers/Actions",
+                                             config: {
+                                                filterActions: true,
+                                                mergeCustomActions: true,
+                                                allowedActions: [
+                                                   "folder-manage-rules",
+                                                   "folder-download",
+                                                   "folder-view-details",
+                                                   "CUSTOM3"
+                                                ],
+                                                customActions: [
+                                                   {
+                                                      id: "CUSTOM3",
+                                                      label: "Custom Action 3",
+                                                      icon: "document-delete",
+                                                      index: "10",
+                                                      publishTopic: "DELETE_ACTION_TOPIC",
+                                                      type: "javascript"
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                     
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/FullDocLibMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.js
@@ -109,7 +109,7 @@ model.jsonModel = {
                                              name: "alfresco/renderers/Actions",
                                              config: {
                                                 filterActions: true,
-                                                mergeCustomActions: true,
+                                                mergeActions: true,
                                                 allowedActions: [
                                                    "folder-manage-rules",
                                                    "folder-download",
@@ -124,6 +124,11 @@ model.jsonModel = {
                                                       index: "10",
                                                       publishTopic: "DELETE_ACTION_TOPIC",
                                                       type: "javascript"
+                                                   }
+                                                ],
+                                                widgetsForActions: [
+                                                   {
+                                                      name: "alfresco/renderers/actions/ManageAspects"
                                                    }
                                                 ]
                                              }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.properties
@@ -1,0 +1,1 @@
+surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-361 and https://github.com/Alfresco/Aikau/issues/303 to support the ability to merge the 3 different actions types within the alfresco/renderers/Actions renderer.