### PR TITLE
AKU-2: Added JUnit reporter for Bamboo

### DIFF
--- a/aikau/src/test/resources/intern_grid.js
+++ b/aikau/src/test/resources/intern_grid.js
@@ -79,7 +79,8 @@ define(["./config/Suites"],
          reporters: [
             // "console",
             // "runner",
-            "reporters/AikauReporter"
+            "reporters/AikauReporter",
+            "JUnit"
          ]
 
       };


### PR DESCRIPTION
report.xml will be created in the aikau folder.

Support for custom configuration of the JUnit reporter is only
available from intern 3.0. (See
https://theintern.github.io/intern/#common-config)

ideally the report.xml file will be located in the aikau/target folder
when we upgrade to intern 3.0+