### PR TITLE
Update to ensure that the DocLib tests pass on the first run

### DIFF
--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -34,7 +34,7 @@ define(["intern!object",
    // so the tests are abstracted to their own individual functions for re-use (this is slightly different
    // that other tests)...
    var countInitialBreadcrumbs = function() {
-      return browser.findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
+      return browser.setFindTimeout(10000).findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
          .then(function(elements) {
             assert.lengthOf(elements, 1, "No breadcrumbs were rendered on page load");
          }); 


### PR DESCRIPTION
I noticed that the DocLib tests were failing on Chrome but not Firefox, this seems to be because the page is quite complex and the test needs to wait a little longer than normal for the widgets to appear. This minor update ensures the tests pass.