### PR TITLE
AKU-353: Improve PublishingDropDownMenu widget testability

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
@@ -199,6 +199,7 @@ define(["dojo/_base/declare",
             // Create the widget...
             this._dropDownWidget = new Select({
                id: this.id + "_SELECT",
+               additionalCssClasses: this.additionalCssClasses || "",
                pubSubScope: uuid,
                fieldId: fieldId,
                value: this.value,

--- a/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
@@ -74,6 +74,20 @@ define(["intern!object",
              });
       },
 
+      "Test that additional CSS classes are included in the popup": function() {
+         return browser.findAllByCssSelector("#PDM_ITEM_0_SELECT_CONTROL_dropdown.custom-css")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Could not find additional CSS classes on select popup");
+            });
+      },
+
+      "Test that value is included in data attribute of select option": function() {
+         return browser.findAllByCssSelector("#PDM_ITEM_0_SELECT_CONTROL_dropdown tr[data-value='PUBLIC']")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Could not find select option via data-value attribute");
+            });
+      },
+
       "Test menu code not removed on click": function() {
          // Select "Private" (should succeed)...
          return browser.findByCssSelector("tr.dijitMenuItem:nth-of-type(3)")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.js
@@ -54,6 +54,7 @@ var widgets = {
                               id: "PDM",
                               name: "alfresco/renderers/PublishingDropDownMenu",
                               config: {
+                                 additionalCssClasses: "custom-css",
                                  publishTopic: "ALF_PUBLISHING_DROPDOWN_MENU",
                                  publishPayload: {
                                     shortName: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-353 to add additional testing hook points into the PublishingDropDownMenu widget (and its associated Select) widget