### PR TITLE
Ensure that MultipleEntryElementFormControl widgets render in dialogs

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -15,7 +15,7 @@
    max-width: @dialog-control-section;
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-controls-BaseFormControl {
+.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl {
    min-width: @dialog-control-section + 2;
 }
 
@@ -26,7 +26,7 @@
    color: @de-emphasized-font-color;
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-controls-BaseFormControl > .description-row > .description {
+.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .description-row > .description {
    margin: 0 0 @standard-line-height @dialog-label-section + 4;
 }
 
@@ -43,7 +43,7 @@
    display: block;
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-controls-BaseFormControl > .title-row {
+.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .title-row {
    display: inline;
    float: left;
    width: @dialog-label-section - 4;
@@ -57,7 +57,7 @@
    line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-controls-BaseFormControl > .title-row > label:after {
+.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form > .alfresco-forms-controls-BaseFormControl > .title-row > label:after {
    content: ":";
 }
 
@@ -107,7 +107,7 @@
    margin: 0;
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-controls-BaseFormControl > .title-row > .validation-message {
+.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .title-row > .validation-message {
    margin: 7px 0 0 -5px;
 }
 
@@ -115,7 +115,7 @@
    display: inline-block;
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-controls-BaseFormControl > .title-row > .validation-message.display {
+.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .title-row > .validation-message.display {
    display: block;
 }
 

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -417,6 +417,7 @@ define(["dojo/_base/declare",
        * @returns {object} The dialog configuration.
        */
       createDialogConfig: function alfresco_services_DialogService__createDialogConfig(config, formConfig) {
+         // jshint maxcomplexity:false
          var handleOverflow = true;
          if (config.handleOverflow === false)
          {
@@ -488,6 +489,7 @@ define(["dojo/_base/declare",
          var formConfig = {
             name: "alfresco/forms/Form",
             config: {
+               additionalCssClasses: "root-dialog-form",
                displayButtons: false,
                widgets: widgets,
                value: formValue


### PR DESCRIPTION
This update ensures that only form controls that are placed in the "root" form within a dialog have the new form style applied to them. In particular this is important because the MultipleEntryElementFormControl uses forms within forms and this was corrupting the layout when used in the search manager in Share. Therefore root form elements will have the new style applied to them but nested forms will not.