### PR TITLE
AKU-381: Remove white space on dialogs when there are no buttons

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -221,6 +221,10 @@ define(["dojo/_base/declare",
             this.processWidgets(this.widgetsButtons, this.buttonsNode);
             this.creatingButtons = false;
          }
+         else
+         {
+            domClass.add(this.bodyNode, "no-buttons");
+         }
 
          if (this.widgetsContent)
          {

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -44,6 +44,10 @@
    min-width: 560px;
 }
 
+.alfresco-dialog-AlfDialog .dialog-body.no-buttons {
+   margin-bottom: 0;
+}
+
 .alfresco-dialog-AlfDialog.iefooter .dialog-body {
    padding: 12px;
    overflow: hidden;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-381 to ensure that there are is no unnecessary white space at the bottom of dialogs with no buttons. This occurs when an ALF_CREATE_DIALOG topic is used where widgetsButtons is empty, it can be seen in Share when clicking on the More Info link in the faceted search page.