### PR TITLE
AKU-382: Form updates to ensure that URL hash setting works properly

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -324,9 +324,9 @@ define(["dojo/_base/declare",
          // it will provide the current form data...
          var formValue = this.getValue();
          array.forEach(this.additionalButtons, function(button) {
-            if (button.publishPayload !== null)
+            if (button._alfOriginalButtonPayload)
             {
-               lang.mixin(button.publishPayload, formValue);
+               lang.mixin(button._alfOriginalButtonPayload, formValue);
             }
             else
             {
@@ -604,7 +604,7 @@ define(["dojo/_base/declare",
 
             // If useHash is set to true then set up a subcription on the publish topic for the OK button which will
             // set the hash fragment with the form contents...
-            if (this.useHash === true)
+            if (this.useHash === true && this.setHash === true)
             {
                if (this.okButtonPublishTopic &&
                    lang.trim(this.okButtonPublishTopic) !== "")
@@ -650,6 +650,18 @@ define(["dojo/_base/declare",
          {
             this.additionalButtons = registry.findWidgets(this.buttonsNode);
          }
+
+         // Iterate over all the buttons and make a copy of the original button payload (before any value is
+         // applied to it). This is required since it is possible for values to be removed from the payload
+         // so the original payload needs to be used rather than the payload as it was after the previous update
+         // (e.g. a field has become disabled since the last payload update and is configured to not have its value
+         // included when it is hidden, therefore we need to ensure its previous value is NOT included in the payload)
+         array.forEach(this.additionalButtons, function(button) {
+            if (button.payload)
+            {
+               button._alfOriginalButtonPayload = lang.clone(button.payload);
+            }
+         });
       },
       
       /**

--- a/aikau/src/test/resources/alfresco/forms/HashFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/HashFormTest.js
@@ -56,6 +56,14 @@ define(["intern!object",
             });
       },
 
+      "Test that disabled field 1 is NOT updated in FORM3": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_7 .dijitInputInner")
+            .getProperty("value")
+            .then(function(value) {
+               assert.equal(value, "", "Field 1 in third form should not have been set");
+            });
+      },
+
       "Update field 1 and field3 and check that only field 1 updates the URL hash": function() {
          return browser.findByCssSelector("#HASH_TEXT_BOX_1 .dijitInputInner")
             .clearValue()
@@ -103,6 +111,38 @@ define(["intern!object",
             .getProperty("value")
             .then(function(value) {
                assert.equal(value, "Update2", "Field 3 in first form should NOT have been updated");
+            });
+      },
+
+      "Check that updating FORM3 does NOT update hash": function() {
+         return browser.findByCssSelector("#HASH_TEXT_BOX_8 .dijitInputInner")
+            .clearValue()
+            .type("NoUpdate")
+         .end()
+         .findByCssSelector("#HASH_FORM3 .confirmationButton > span")
+            .click()
+            .execute("return window.location.hash.toString()")
+            .then(function(hash) {
+               assert.equal(hash, "#field1=Reset1&field2=two&field3=Reset2", "Hash updated when form configured not to");
+            });
+      },
+
+      "Check that updating form configured not to update hash does NOT update hash": function() {
+         // Set a value that won't be updated once the field is disabled...
+         return browser.findByCssSelector("#HASH_TEXT_BOX_5 .dijitInputInner")
+            .clearValue()
+            .type("NoUpdate")
+         .end()
+         // Set a value in another field to dynamically make the test field disabled...
+         .findByCssSelector("#HASH_TEXT_BOX_4 .dijitInputInner")
+            .clearValue()
+            .type("disableField2")
+         .end()
+         .findByCssSelector("#HASH_FORM2 .confirmationButton > span")
+            .click()
+            .execute("return window.location.hash.toString()")
+            .then(function(hash) {
+               assert.equal(hash, "#field1=disableField2&field2=two&field3=Reset2", "Hash updated when form configured not to");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/HashForm.get.js
@@ -40,6 +40,7 @@ model.jsonModel = {
                      okButtonLabel: "Set Hash",
                      showCancelButton: false,
                      useHash: true,
+                     setHash: true,
                      hashVarsForUpdate: ["field1","field2"],
                      pubSubScope: "FORM1_",
                      widgets: [
@@ -90,12 +91,14 @@ model.jsonModel = {
                      okButtonLabel: "Set Hash",
                      showCancelButton: false,
                      useHash: true,
+                     setHash: true,
                      pubSubScope: "FORM2_",
                      widgets: [
                         {
                            id: "HASH_TEXT_BOX_4",
                            name: "alfresco/forms/controls/TextBox",
                            config: {
+                              fieldId: "HASH_TEXT_BOX_4",
                               label: "Field 1",
                               name: "field1",
                               value: ""
@@ -107,11 +110,75 @@ model.jsonModel = {
                            config: {
                               label: "Field 2",
                               name: "field2",
-                              value: ""
+                              value: "",
+                              postWhenHiddenOrDisabled: false,
+                              disablementConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       targetId: "HASH_TEXT_BOX_4",
+                                       is: ["disableField2"]
+                                    }
+                                 ]
+                              }
                            }
                         },
                         {
                            id: "HASH_TEXT_BOX_6",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 3",
+                              name: "field3",
+                              value: ""
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Hash based form (update form, but don't set hash)",
+            widgets: [
+               {
+                  id: "HASH_FORM3",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     showOkButton: true,
+                     okButtonPublishTopic: "SET_HASH",
+                     okButtonLabel: "Set Hash",
+                     showCancelButton: false,
+                     useHash: true,
+                     setHash: false,
+                     pubSubScope: "FORM3_",
+                     widgets: [
+                        {
+                           id: "HASH_TEXT_BOX_7",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 1",
+                              name: "field1",
+                              value: "",
+                              noValueUpdateWhenHiddenOrDisabled: true,
+                              disablementConfig: {
+                                 initialValue: true
+                              }
+                           }
+                        },
+                        {
+                           id: "HASH_TEXT_BOX_8",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              label: "Field 2",
+                              name: "field2",
+                              value: ""
+                           }
+                        },
+                        {
+                           id: "HASH_TEXT_BOX_9",
                            name: "alfresco/forms/controls/TextBox",
                            config: {
                               label: "Field 3",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-382 to correct a few outstanding issues with using the browser URL hash with forms. The "setHash" configuration attribute is properly honoured so that the URL hash is only updated on request. The "postWhenHiddenOrDisabled" and "noValueUpdateWhenHiddenOrDisabled" configuration attributes now have tests to ensure that they're honoured with respect to setting the hash. I've also noted and resolved an unrelated issue where a button payload does not have values that should be hidden removed (e.g. if a field is disabled that shouldn't POST when disabled having previously output its value - the value is NOT removed from the payload - this has now been corrected).