### PR TITLE
AKU-388: Ensure that PROCESS payload types can be used with menu items

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -295,7 +295,7 @@ define(["dojo/_base/declare",
 
             // TODO: DD: Not keen on the fact that somehow this "document" specific stuff has crept in here...
             //           Ideally it shouldn't be there...
-            var payload = this.generatePayload((this.publishPayload) ? this.publishPayload : {document: this.currentItem}, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin);
+            var payload = this.generatePayload((this.publishPayload) ? this.publishPayload : {document: this.currentItem}, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
             this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
          }
          else

--- a/aikau/src/main/resources/alfresco/renderers/_PublishPayloadMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_PublishPayloadMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -25,38 +25,88 @@
  * <li>the current item</li>
  * <li>the configured payload processed through one or more modifier functions</li>
  * <li>a new payload built from properties in the current item or a triggering publication payload</li>
- * <li>any of the above with the current item "mixed in"</li></ul>
- * 
- * <p>In the following example one variable called shortName is defined as being sourced from the shortName 
- * property of the currentItem. A second variable called visibility is defined as being the value property 
- * found within the payload.</p>
- * 
- * <p>Example model configuration:</p>
- * 
- * <p><pre>publishTopic: "ALF_DO_SOMETHING",
- * publishPayload: {
- *    shortName: {
- *       alfType: "item",
- *       alfProperty: "shortName"
- *    },
- *    visibility: {
- *       alfType: "payload",
- *       alfProperty: "value"
+ * <li>any of the above with the current item "mixed in"</li></ul></p>
+ *
+ * @example <caption>Standard configured payload</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuItem",
+ *   config: {
+ *     label: "Configured payload",
+ *     publishTopic: "CUSTOM_TOPIC",
+ *     publishPayloadType: "CONFIGURED",
+ *     publishPayload: {
+ *       value: "one"
+ *     }
+ *   }
+ * }
+ *
+ * @example <caption>Standard configured payload with current item mixed in</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuItem",
+ *   config: {
+ *     label: "Configured payload with current item data",
+ *     publishTopic: "CUSTOM_TOPIC",
+ *     publishPayloadType: "CONFIGURED",
+ *     publishPayload: {
+ *       value: "one"
+ *     },
+ *     publishPayloadItemMixin: true
+ *   }
+ * }
+ *
+ * @example <caption>Current item payload</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuItem",
+ *   config: {
+ *     label: "Current item as payload",
+ *     publishTopic: "CUSTOM_TOPIC",
+ *     publishPayloadType: "CURRENT_ITEM"
+ *   }
+ * }
+ *
+ * @example <caption>Processed payload using values from current item</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuItem",
+ *   config: {
+ *     label: "Configured payload with current item data",
+ *     publishTopic: "CUSTOM_TOPIC",
+ *     publishPayloadType: "PROCESS",
+ *     publishPayload: {
+ *       value: "{value.on.currentItem}"
+ *     },
+ *     publishPayloadModifiers: ["processCurrentItemTokens"]
+ *   }
+ * }
+ *
+ * @example <caption>Build payload (using data from both the currentItem and the received payload)</caption>
+ * {
+ *   name: "alfresco/menus/AlfMenuItem",
+ *   config: {
+ *     label: "Configured payload with current item data",
+ *     publishTopic: "CUSTOM_TOPIC",
+ *     publishPayloadType: "BUILD",
+ *     publishPayload: {
+ *       shortName: {
+ *         alfType: "item",
+ *         alfProperty: "shortName"
+ *       },
+ *       visibility: {
+ *         alfType: "payload",
+ *         alfProperty: "value"
+ *      }
  *    }
- * }</pre></p>
- * 
- * <p>Widgets mixing in the _PublishPayloadMixin will support the model configuration shown.</p>
+ * }
  * 
  * @module alfresco/renderers/_PublishPayloadMixin
+ * @extends alfresco/core/ObjectProcessingMixin
  * @auther Dave Draper
  * @author Richard Smith
  */
 define(["dojo/_base/declare",
-        "alfresco/core/Core",
         "alfresco/core/ObjectProcessingMixin",
         "dojo/_base/lang",
         "alfresco/core/ObjectTypeUtils"], 
-        function(declare, AlfCore, ObjectProcessingMixin, lang, ObjectTypeUtils) {
+        function(declare, ObjectProcessingMixin, lang, ObjectTypeUtils) {
    
    return declare([ObjectProcessingMixin], {
 

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuItemTest.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "AlfMenuItem Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AlfMenuItem", "AlfMenuItem Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check processed payload": function() {
+         return browser.findByCssSelector("#MENU_BAR_POPUP_text")
+            .click()
+         .end()
+         .findByCssSelector("#PROCESS_PAYLOAD_MENU_ITEM_text")
+            .click()
+         .end()
+         .getLastPublish("PROCESSED_PAYLOAD")
+         .then(function(payload) {
+            assert.propertyVal(payload, "value", "test", "Processed payload not generated correctly");
+         });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -148,6 +148,7 @@ define({
       "src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest",
       "src/test/resources/alfresco/menus/AlfMenuBarSelectTest",
       "src/test/resources/alfresco/menus/AlfMenuBarToggleTest",
+      "src/test/resources/alfresco/menus/AlfMenuItemTest",
       "src/test/resources/alfresco/menus/AlfMenuItemWrapperTest",
       "src/test/resources/alfresco/menus/AlfMenuTextForClipboardTest",
       "src/test/resources/alfresco/menus/AlfVerticalMenuBarTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfMenuItems</shortname>
+  <description>Demonstrates the basic alfresco/menus/AlfMenuItem widget</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfMenuItem</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.js
@@ -1,0 +1,53 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "MENU_BAR",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "MENU_BAR_POPUP",
+                  name: "alfresco/menus/AlfMenuBarPopup",
+                  config: {
+                     label: "Drop down menu",
+                     widgets: [
+                        {
+                           id: "PROCESS_PAYLOAD_MENU_ITEM",
+                           name: "alfresco/menus/AlfMenuItem",
+                           config: {
+                              currentItem: {
+                                 some: {
+                                    data: "test"
+                                 }
+                              },
+                              label: "Processed Payload",
+                              publishTopic: "PROCESSED_PAYLOAD",
+                              publishPayloadType: "PROCESS",
+                              publishPayloadModifiers: ["processCurrentItemTokens"],
+                              publishPayload: {
+                                 value: "{some.data}"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-388. As this is a bug I've just added a test to prevent regressions on the reported issue, but we can use the test to handle any additional bugs reported in the future. I've also updated the JSDoc to give examples of the various types of payload that can be configured.