### PR TITLE
AKU-379: Ensure that single use items can only be added once via keyboard

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -259,6 +259,12 @@ define(["dojo/_base/declare",
                   addCallback: this.onItemAddedByKeyboard,
                   addCallbackScope: this
                });
+
+               // See AKU-379 - ensure use once items can only be added via the keyboard once...
+               if (this.useItemsOnce)
+               {
+                  this._selectedItem = null;
+               }
             }
          }
       },

--- a/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
@@ -89,6 +89,7 @@ define(["intern!object",
             .click()
          .end()
          .pressKeys(keys.ENTER)
+         .pressKeys(keys.ENTER)
          .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
                   assert.lengthOf(elements, 2, "The dropped item was not found");


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-379 to ensure that single use drag and drop items can only be added to a drop target once when using the keyboard.