### PR TITLE
AKU-392: Correction to infinite scroll reload behaviour

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -158,7 +158,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       setupSubscriptions: function alfresco_lists_AlfList__setupSubscriptions() {
-         this.alfSubscribe(this.reloadDataTopic, lang.hitch(this, this.loadData));
+         this.alfSubscribe(this.reloadDataTopic, lang.hitch(this, this.onReloadData));
          this.alfSubscribe(this.viewSelectionTopic, lang.hitch(this, this.onViewSelected));
          this.alfSubscribe(this.loadDataPublishTopic + "_SUCCESS", lang.hitch(this, this.onDataLoadSuccess));
          this.alfSubscribe(this.loadDataPublishTopic + "_FAILURE", lang.hitch(this, this.onDataLoadFailure));
@@ -796,6 +796,18 @@ define(["dojo/_base/declare",
 
          // Tell the view that it's now on display...
          view.onViewShown();
+      },
+
+      /**
+       * Handles requests to reload the current list data by clearing all the previous data and then calling
+       * [loadData]{@link module:alfresco/lists/AlfList#loadData}.
+       * 
+       * @instance
+       */
+      onReloadData: function alfresco_lists_AlfList__onReloadData() {
+         this.hideChildren(this.domNode);
+         this.clearViews();
+         this.loadData();
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -390,6 +390,20 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#onReloadData} to reset the
+       * current page size on a reload request when [infinite scroll]{@link module:alfresco/lists/AlfList#useInfiniteScroll}
+       * is enabled.
+       * 
+       * @instance
+       */
+      onReloadData: function alfresco_lists_AlfSortablePaginatedList__onReloadData() {
+         if (this.useInfiniteScroll) {
+            this.currentPage = 1;
+         }
+         this.inherited(arguments);
+      },
+
+      /**
        * Overrides the [inherited function]{@link module:alfresco/lists/AlfList#onScrollNearBottom} to request
        * more data when the user scrolls to the bottom of the browser page.
        *

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -154,6 +154,24 @@ define(["intern!object",
             });
       },
 
+      "Simulate a reload request": function() {
+         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+            .click()
+         .end()
+         .findByCssSelector("#SIMULATE_RELOAD_label")
+            .click()
+         .end()
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED")
+            .then(function(payload) {
+               assert.isNotNull(payload, "More results not loaded");
+            })
+         .end()
+         .findAllByCssSelector("#INFITE_SCROLL_LIST tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 10, "Old data not cleared when data filter request applied");
+            });
+      },
+
       "Simulate a path change": function() {
          return browser.then(function() {
             return testClearingDocumentList("#SIMULATE_PATH_CHANGE_label", "Old data not cleared when path change request applied");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
@@ -110,6 +110,14 @@ model.jsonModel = {
                                           name: "simulated"
                                        }
                                     }
+                                 },
+                                 {
+                                    id: "SIMULATE_RELOAD",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Simulate reload",
+                                       publishTopic: "ALF_DOCLIST_RELOAD_DATA"
+                                    }
                                  }
                               ],
                               widgets: [


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-392 to ensure that issuing a reload request to a list (when the list has infinite scroll enabled) will clear the previous results.