### PR TITLE
AKU-375: Twister updates

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfGalleryViewSlider.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfGalleryViewSlider.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -25,7 +25,7 @@
  * @extends external:dijit/form/HorizontalSlider
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/lists/views/_AlfAdditionalViewControlMixin
- * @mixed module:alfresco/services/_PreferenceServiceTopicMixin
+ * @mixes module:alfresco/services/_PreferenceServiceTopicMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
@@ -33,9 +33,8 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/lists/views/_AlfAdditionalViewControlMixin",
         "alfresco/services/_PreferenceServiceTopicMixin",
-        "dojo/dom-class",
-        "dojo/dom-style"], 
-        function(declare, HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin, domClass, domStyle) {
+        "dojo/dom-class"], 
+        function(declare, HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin, domClass) {
    
    return declare([HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin], {
       
@@ -110,7 +109,7 @@ define(["dojo/_base/declare",
        * @param {number} value The number of columns to set.
        */
       setColumns: function(value) {
-         if (value == null)
+         if (!value || isNaN(value))
          {
             value = 4;
          }

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -115,18 +115,18 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "alfresco-layout-Twister-open"
+       * @default "alfresco-layout-Twister--open"
        */
-      CLASS_OPEN: "alfresco-layout-Twister-open",
+      CLASS_OPEN: "alfresco-layout-Twister--open",
       
       /**
        * The CSS class applied when the twister is closed (and removed when opened).
        *
        * @instance
        * @type {string}
-       * @default "alfresco-layout-Twister-closed"
+       * @default "alfresco-layout-Twister--closed"
        */
-      CLASS_CLOSED: "alfresco-layout-Twister-closed",
+      CLASS_CLOSED: "alfresco-layout-Twister--closed",
 
       /**
        * Should the generated twister use a heading or div for it's heading?

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -18,9 +18,53 @@
  */
 
 /**
- * <p>This widget provides the means to progressively reveal it's contents via a "twisty" arrow. When
- * the user clicks (or actions via keyboard) the widget label it will reveal or hide the widgets that
- * it contains.</p>
+ * <p>This widget provides the means to dynamically reveal and hide its contents by clicking on its label. The 
+ * open or closed state is indicated by a "twister" icon. The widget can be configured to render any other widget
+ * model as its contents. The twister can be configured to be intially open or closed by setting the 
+ * [initiallyOpen]{@link module:alfresco/layout/Twister#initiallyOpen} attribute to true (for open) or false (for closed).</p>
+ * 
+ * <p>It is also possible for the open or closed state to be stored to a users personal preferences. This can be done 
+ * by configuring a [twisterPreferenceName]{@link module:alfresco/layout/Twister#twisterPreferenceName} attribute
+ * and ensuring that the [PreferenceService]{@link module:alfresco/services/PreferenceService} (or equivilant) is included
+ * on the page. A single [twisterPreferenceName]{@link module:alfresco/layout/Twister#twisterPreferenceName} can be 
+ * shared between multiple widgets but this will result in all those twisters being in the same state when the page loads.
+ * Using user preferences will override whatever [initiallyOpen]{@link module:alfresco/layout/Twister#initiallyOpen} 
+ * attribute has been configured.</p>
+ *
+ * <p>It is also possible to configure an optional [headingLevel]{@link module:alfresco/layout/Twister#headingLevel} to improve
+ * the overall accessibility of the page containing the twisters. The level provided should be a number between 1 and 6
+ * and will control the HTML element that is used for the twister label (e.g. 1 will render an H1 element, etc).</p>
+ *
+ * @example <caption>Example twister that is initially closed</caption>
+ * {
+ *   name: "alfresco/layout/Twister",
+ *   config: {
+ *     label: "Initially Closed Twister",
+ *     headingLevel: 3,
+ *     initiallyOpen: false,
+ *     widgets: [
+ *       {
+ *         id: "LOGO1",
+ *         name: "alfresco/logo/Logo"
+ *       }
+ *     ]
+ *   }
+ * }
+ *
+ * @example <caption>Example twister that uses user preferences to control the open/closed state</caption>
+ * {
+ *   name: "alfresco/layout/Twister",
+ *   config: {
+ *     label: "Twister State Based on User Preference",
+ *     twisterPreferenceName: "Twister1",
+ *     widgets: [
+ *       {
+ *         id: "LOGO1",
+ *         name: "alfresco/logo/Logo"
+ *       }
+ *     ]
+ *   }
+ * }
  * 
  * @module alfresco/layout/Twister
  * @extends external:dijit/_WidgetBase

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -24,9 +24,9 @@
  * [initiallyOpen]{@link module:alfresco/layout/Twister#initiallyOpen} attribute to true (for open) or false (for closed).</p>
  * 
  * <p>It is also possible for the open or closed state to be stored to a users personal preferences. This can be done 
- * by configuring a [twisterPreferenceName]{@link module:alfresco/layout/Twister#twisterPreferenceName} attribute
+ * by configuring a [preferenceName]{@link module:alfresco/layout/Twister#preferenceName} attribute
  * and ensuring that the [PreferenceService]{@link module:alfresco/services/PreferenceService} (or equivilant) is included
- * on the page. A single [twisterPreferenceName]{@link module:alfresco/layout/Twister#twisterPreferenceName} can be 
+ * on the page. A single [preferenceName]{@link module:alfresco/layout/Twister#preferenceName} can be 
  * shared between multiple widgets but this will result in all those twisters being in the same state when the page loads.
  * Using user preferences will override whatever [initiallyOpen]{@link module:alfresco/layout/Twister#initiallyOpen} 
  * attribute has been configured.</p>
@@ -56,7 +56,7 @@
  *   name: "alfresco/layout/Twister",
  *   config: {
  *     label: "Twister State Based on User Preference",
- *     twisterPreferenceName: "Twister1",
+ *     preferenceName: "Twister1",
  *     widgets: [
  *       {
  *         id: "LOGO1",
@@ -139,7 +139,7 @@ define(["dojo/_base/declare",
 
       /**
        * The initial open/closed state of the twister. This value could be overridden by a previously stored user preference
-       * if a [twisterPreferenceName]{@link module:alfresco/layout/Twister#twisterPreferenceName} is configured and the 
+       * if a [preferenceName]{@link module:alfresco/layout/Twister#preferenceName} is configured and the 
        * [PreferenceService]{@link module:alfresco/services/PreferenceService} is included on the page.
        *
        * @instance
@@ -157,7 +157,7 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default null
        */
-      twisterPreferenceName: null,
+      preferenceName: null,
 
       /**
        * This is the prefix that will be applied to all preferences. It can be optionally configured to a different value
@@ -168,7 +168,7 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default "org.alfresco.share.twisters."
        */
-      twisterPreferencePrefix: "org.alfresco.share.twisters.",
+      preferencePrefix: "org.alfresco.share.twisters.",
       
       /**
        * The width to make the twister. This is null by default and the standard width of a twister is controlled
@@ -256,10 +256,10 @@ define(["dojo/_base/declare",
        * @instance
        */
       createTwister: function alfresco_layout_Twister__createTwister() {
-         if (this.twisterPreferencePrefix && this.twisterPreferenceName)
+         if (this.preferencePrefix && this.preferenceName)
          {
             this.alfPublish(this.getPreferenceTopic, {
-               preference: this.twisterPreferencePrefix + this.twisterPreferenceName,
+               preference: this.preferencePrefix + this.preferenceName,
                callback: this.onSetTwistState,
                callbackScope: this
             });
@@ -310,10 +310,10 @@ define(["dojo/_base/declare",
          var open = domClass.contains(this.labelNode, this.CLASS_CLOSED);
          this.onSetTwistState(open);
 
-         if (this.twisterPreferencePrefix && this.twisterPreferenceName)
+         if (this.preferencePrefix && this.preferenceName)
          {
             this.alfPublish(this.setPreferenceTopic, {
-               preference: this.twisterPreferencePrefix + this.twisterPreferenceName,
+               preference: this.preferencePrefix + this.preferenceName,
                value: open
             });
          }

--- a/aikau/src/main/resources/alfresco/layout/css/Twister.css
+++ b/aikau/src/main/resources/alfresco/layout/css/Twister.css
@@ -8,7 +8,7 @@
    right: 1em;
 }
 
-.alfresco-layout-Twister-closed .alfresco-layout-Twister-actions {
+.alfresco-layout-Twister--closed .alfresco-layout-Twister-actions {
    display: none;
 }
 
@@ -19,11 +19,11 @@
    text-decoration: none;
 }
 
-.alfresco-layout-Twister-open {
+.alfresco-layout-Twister--open {
    background: transparent url(./images/expanded.png) no-repeat scroll 0 50%;
 }
 
-.alfresco-layout-Twister-closed {
+.alfresco-layout-Twister--closed {
    background: transparent url(./images/collapsed.png) no-repeat scroll 0 50% !important;
 }
 
@@ -48,12 +48,12 @@
       border: none;
    }
 
-   > div.alfresco-layout-Twister-open {
+   > div.alfresco-layout-Twister--open {
       padding-left: 20px !important; /* Important is only required to override base.css use of important */
       background-position: 0 3px !important;
    }
 
-   > div.alfresco-layout-Twister-closed {
+   > div.alfresco-layout-Twister--closed {
       background-position: 0 3px !important;
       padding-left: 20px !important; /* Important is only required to override base.css use of important */
    }

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -19,15 +19,13 @@
 
 /**
  * @author Dave Draper
- * @author Richard Smith
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
         "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, expect, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, require, TestCommon, keys) {
 
    var browser;
    registerSuite({
@@ -42,66 +40,115 @@ define(["intern!object",
          browser.end();
       },
 
-     "Initial Rendering": function () {
-         var testname = "Initial Rendering";
+      "Check the first twister gets H3 element": function () {
          return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
             .getVisibleText()
             .then(function (text) {
-               TestCommon.log(testname,"Check the first twister gets H3 element");
-               expect(text).to.equal("Twister with heading level", "Test #1a - The 1st twister did not render an H3 element");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_NO_HEADING_LEVEL > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               TestCommon.log(testname,"Check the second twister renders without header element");
-               expect(text).to.equal("Twister with no heading level", "Test #1b - The 2n twister label was rendered incorrectly");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               TestCommon.log(testname,"Check that invalid heading level 'a' does not render invalid element");
-               expect(text).to.equal("Twister with faulty heading level 'a'", "Test #1c -The 3rd twister did not render correctly");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               TestCommon.log(testname,"Check that invalid heading level '0' does not render invalid element");
-               expect(text).to.equal("Twister with heading level 0", "Test #1d -The 4th twister did not render correctly");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_THREE > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               TestCommon.log(testname,"Check that invalid heading level '7' does not render invalid element");
-               expect(text).to.equal("Twister with heading level 7", "Test #1e -The 5th twister did not render correctly");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_NULL_LABEL")
-            .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname,"Check that null label twister is not displayed");
-               assert(result === false, "Test #1f - Twister with null label was unexpectedly displayed");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_EMPTY_LABEL")
-            .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname,"Check that empty string label twister is not displayed");
-               assert(result === false, "Test #1g - Twister with empty string label was unexpectedly displayed");
+               assert.equal(text,"Twister with heading level", "The 1st twister did not render an H3 element");
             });
       },
 
-      "Twister mouse tests": function () {
-         var testname = "Twister mouse tests";
+      "Check the second twister renders without header element": function () {
+         return browser.findByCssSelector("#TWISTER_NO_HEADING_LEVEL > div.label")
+            .getVisibleText()
+            .then(function (text) {
+               assert.equal(text,"Twister with no heading level", "The 2n twister label was rendered incorrectly");
+            });
+      },
+
+      "Check that invalid heading level 'a' does not render invalid element": function () {
+         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
+            .getVisibleText()
+            .then(function (text) {
+               assert.equal(text,"Twister with faulty heading level 'a'", "The 3rd twister did not render correctly");
+            });
+      },
+
+      "Check that invalid heading level '0' does not render invalid element": function () {
+         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO > div.label")
+            .getVisibleText()
+            .then(function (text) {
+               assert.equal(text,"Twister with heading level 0", "The 4th twister did not render correctly");
+            });
+      },
+
+      "Check that invalid heading level '7' does not render invalid element": function () {
+         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_THREE > div.label")
+            .getVisibleText()
+            .then(function (text) {
+               assert.equal(text,"Twister with heading level 7", "The 5th twister did not render correctly");
+            });
+      },
+
+      "Check that null label twister is not displayed": function () {
+         return browser.findByCssSelector("#TWISTER_NULL_LABEL")
+            .isDisplayed()
+            .then(function(result) {
+               assert.isFalse(result, "Twister with null label was unexpectedly displayed");
+            });
+      },
+
+      "Check that empty string label twister is not displayed": function () {
+         return browser.findByCssSelector("#TWISTER_EMPTY_LABEL")
+            .isDisplayed()
+            .then(function(result) {
+               assert.isFalse(result, "Twister with empty string label was unexpectedly displayed");
+            });
+      },
+
+      "Check that first twister is open": function() {
+         return browser.findAllByCssSelector("#TWISTER_HEADING_LEVEL .alfresco-layout-Twister-open")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Twister configured to be open, was closed");
+            })
+         .end()
+         .findByCssSelector("#TWISTER_HEADING_LEVEL .content")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Twister configured to be open is NOT displaying its contents");
+            });
+      },
+
+      "Check that second twister is closed": function() {
+         return browser.findAllByCssSelector("#TWISTER_NO_HEADING_LEVEL .alfresco-layout-Twister-closed")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Twister configured to be closed, was open");
+            })
+         .end()
+         .findByCssSelector("#TWISTER_NO_HEADING_LEVEL .content")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "Twister configured to be closed is displaying its contents");
+            });
+      },
+
+      "Check that third twister is open (using preferences)": function() {
+         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL .alfresco-layout-Twister-open")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Twister preferred to be open, was closed");
+            })
+         .end()
+         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL .content")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Twister preferred to be open is NOT displaying its contents");
+            });
+      },
+
+      "Check that fourth twister is closed (using preferences)": function() {
+         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .alfresco-layout-Twister-closed")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Twister preferred to be closed, was open");
+            })
+         .end()
+         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .content")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "Twister preferred to be closed is displaying its contents");
+            });
+      },
+
+      "Check the first twister title is still visible": function () {
          return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
             .click()
          .end()
@@ -110,21 +157,20 @@ define(["intern!object",
          .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
             .getVisibleText()
             .then(function (text) {
-               TestCommon.log(testname,"Check the first twister title is still visible");
-               expect(text).to.equal("Twister with heading level", "Test #2a - The first twister title is not visible");
-            })
-         .end()
+               assert.equal(text,"Twister with heading level", "The first twister title is not visible");
+            });
+      },
 
-         .findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
+      "Check that logo in the first twister is hidden when the twister is clicked": function() {
+         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
             .isDisplayed()
             .then(function(result) {
-               TestCommon.log(testname,"Check that logo in the first twister is hidden when the twister is clicked");
-               assert(result === false, "Test #2b - The logo was unexpectedly shown");
-            })
-         .end()
-
-         // Click the title of twister 1
-         .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
+               assert.isFalse(result, "The logo was unexpectedly shown");
+            });
+      },
+      
+      "Check the first twister title is still visible (2)": function() {
+         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
             .click()
          .end()
 
@@ -132,16 +178,39 @@ define(["intern!object",
          .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
             .getVisibleText()
             .then(function (text) {
-               TestCommon.log(testname,"Check the first twister title is still visible");
-               expect(text).to.equal("Twister with heading level", "Test #2c - The first twister title is not visible");
-            })
-         .end()
-
-         .findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
+               assert.equal(text,"Twister with heading level", "The first twister title is not visible");
+            });
+      },
+      
+      "Check that logo in the first twister is hidden when the twister is clicked (2)": function() {
+         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
             .isDisplayed()
             .then(function(result) {
-               TestCommon.log(testname,"Check that logo in the first twister is hidden when the twister is clicked");
-               assert(result === true, "Test #2d - The logo was unexpectedly hidden");
+               assert.isTrue(result, "The logo was unexpectedly hidden");
+            });
+      },
+
+      "Check that closing a twister updates its preferences": function() {
+         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
+            .click()
+         .end()
+
+         .findByCssSelector("tr.mx-row:nth-child(1) td.mx-payload")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "{\"org\":{\"alfresco\":{\"share\":{\"twisters\":{\"twister1\":false}}}}}", "Preference not saved on close");
+            });
+      },
+
+      "Check that opending a twister updates its preferences": function() {
+         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
+            .click()
+         .end()
+
+         .findByCssSelector("tr.mx-row:nth-child(2) td.mx-payload")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "{\"org\":{\"alfresco\":{\"share\":{\"twisters\":{\"twister1\":true}}}}}", "Preference not saved on open");
             });
       },
 
@@ -150,8 +219,7 @@ define(["intern!object",
          TestCommon.alfPostCoverageResults(this, browser);
       },
 
-      "Twister keyboard tests": function () {
-         var testname = "Twister keyboard tests";
+      "Check the first twister title is visible after keyboard [RETURN]": function () {
          return browser.refresh()
 
             // Focus the title of twister 1
@@ -164,38 +232,35 @@ define(["intern!object",
             .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
                .getVisibleText()
                .then(function (text) {
-                  TestCommon.log(testname,"Check the first twister title is visible after keyboard [RETURN]");
-                  expect(text).to.equal("Twister with heading level", "Test #3a - The first twister title is not visible after keyboard [RETURN]");
-               })
-            .end()
+                  assert.equal(text,"Twister with heading level", "The first twister title is not visible after keyboard [RETURN]");
+               });
+         },
 
+         "Check that logo in the first twister is hidden after keyboard [RETURN]": function() {
             // Content should be hidden
-            .findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
                .isDisplayed()
                .then(function(result) {
-                  TestCommon.log(testname,"Check that logo in the first twister is hidden after keyboard [RETURN]");
-                  assert(result === false, "Test #3b - The logo was unexpectedly shown");
-               })
-            .end()
+                  assert.isFalse(result, "The logo was unexpectedly shown");
+               });
+         },
 
-            // 'Click' the title with the return key again
-            .pressKeys(keys.RETURN)
+         "Check the first twister title is visible after re-pressing keyboard [RETURN]": function() {
+            return browser.pressKeys(keys.RETURN)
 
             // Title should still be visible
             .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
                .getVisibleText()
                .then(function (text) {
-                  TestCommon.log(testname,"Check the first twister title is visible after re-pressing keyboard [RETURN]");
-                  expect(text).to.equal("Twister with heading level", "Test #3c - The first twister title is not visible after re-pressing keyboard [RETURN]");
-               })
-            .end()
+                  assert.equal(text,"Twister with heading level", "The first twister title is not visible after re-pressing keyboard [RETURN]");
+               });
+         },
 
-            // Facets should not be hidden
-            .findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
+         "Check that logo in the first twister is displayed after re-pressing keyboard [RETURN]": function() {
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
                .isDisplayed()
                .then(function(result) {
-                  TestCommon.log(testname,"Check that logo in the first twister is displayed after re-pressing keyboard [RETURN]");
-                  assert(result === true, "Test #3d - The logo was unexpectedly hidden");
+                  assert.isTrue(result, "The logo was unexpectedly hidden");
                });
       },
 

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -97,7 +97,7 @@ define(["intern!object",
       },
 
       "Check that first twister is open": function() {
-         return browser.findAllByCssSelector("#TWISTER_HEADING_LEVEL .alfresco-layout-Twister-open")
+         return browser.findAllByCssSelector("#TWISTER_HEADING_LEVEL .alfresco-layout-Twister--open")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Twister configured to be open, was closed");
             })
@@ -110,7 +110,7 @@ define(["intern!object",
       },
 
       "Check that second twister is closed": function() {
-         return browser.findAllByCssSelector("#TWISTER_NO_HEADING_LEVEL .alfresco-layout-Twister-closed")
+         return browser.findAllByCssSelector("#TWISTER_NO_HEADING_LEVEL .alfresco-layout-Twister--closed")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Twister configured to be closed, was open");
             })
@@ -123,7 +123,7 @@ define(["intern!object",
       },
 
       "Check that third twister is open (using preferences)": function() {
-         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL .alfresco-layout-Twister-open")
+         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL .alfresco-layout-Twister--open")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Twister preferred to be open, was closed");
             })
@@ -136,7 +136,7 @@ define(["intern!object",
       },
 
       "Check that fourth twister is closed (using preferences)": function() {
-         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .alfresco-layout-Twister-closed")
+         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .alfresco-layout-Twister--closed")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Twister preferred to be closed, was open");
             })

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -60,6 +60,7 @@ model.jsonModel = {
                            name: "alfresco/layout/Twister",
                            config: {
                               label: "Twister with faulty heading level 'a'",
+                              initiallyOpen: false,
                               twisterPreferenceName: "twister1",
                               headingLevel: "a",
                               widgets: [
@@ -76,6 +77,7 @@ model.jsonModel = {
                            config: {
                               label: "Twister with heading level 0",
                               headingLevel: 0,
+                              initiallyOpen: true,
                               twisterPreferenceName: "twister2",
                               widgets: [
                                  {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -9,115 +9,121 @@ model.jsonModel = {
             }
          }
       },
-      {
-         name: "alfresco/services/ActionService"
-      },
-      {
-         name: "alfresco/services/NavigationService"
-      },
-      {
-         name: "alfresco/services/SearchService"
-      },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/ActionService",
+      "alfresco/services/NavigationService",
+      "alfresco/services/SearchService"
    ],
    widgets: [
-      
       {
-         id: "FACETS",
-         name: "alfresco/layout/VerticalWidgets",
+         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
+      },
+      {
+         name: "aikauTesting/WaitForMockXhrService",
          config: {
             widgets: [
                {
-                  id: "TWISTER_HEADING_LEVEL",
-                  name: "alfresco/layout/Twister",
+                  id: "FACETS",
+                  name: "alfresco/layout/VerticalWidgets",
                   config: {
-                     label: "Twister with heading level",
-                     headingLevel: 3,
                      widgets: [
                         {
-                           id: "LOGO1",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ]
-                  }
-               },
-               {
-                  id: "TWISTER_NO_HEADING_LEVEL",
-                  name: "alfresco/layout/Twister",
-                  config: {
-                     label: "Twister with no heading level",
-                     widgets: [
+                           id: "TWISTER_HEADING_LEVEL",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: "Twister with heading level",
+                              headingLevel: 3,
+                              initiallyOpen: true,
+                              widgets: [
+                                 {
+                                    id: "LOGO1",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
+                        },
                         {
-                           id: "LOGO2",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ]
-                  }
-               },
-               {
-                  id: "TWISTER_BAD_HEADING_LEVEL",
-                  name: "alfresco/layout/Twister",
-                  config: {
-                     label: "Twister with faulty heading level 'a'",
-                     headingLevel: "a",
-                     widgets: [
+                           id: "TWISTER_NO_HEADING_LEVEL",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: "Twister with no heading level",
+                              initiallyOpen: false,
+                              widgets: [
+                                 {
+                                    id: "LOGO2",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
+                        },
                         {
-                           id: "LOGO3",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ]
-                  }
-               },
-               {
-                  id: "TWISTER_BAD_HEADING_LEVEL_TWO",
-                  name: "alfresco/layout/Twister",
-                  config: {
-                     label: "Twister with heading level 0",
-                     headingLevel: 0,
-                     widgets: [
+                           id: "TWISTER_BAD_HEADING_LEVEL",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: "Twister with faulty heading level 'a'",
+                              twisterPreferenceName: "twister1",
+                              headingLevel: "a",
+                              widgets: [
+                                 {
+                                    id: "LOGO3",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
+                        },
                         {
-                           id: "LOGO4",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ]
-                  }
-               },
-               {
-                  id: "TWISTER_BAD_HEADING_LEVEL_THREE",
-                  name: "alfresco/layout/Twister",
-                  config: {
-                     label: "Twister with heading level 7",
-                     headingLevel: 7,
-                     widgets: [
+                           id: "TWISTER_BAD_HEADING_LEVEL_TWO",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: "Twister with heading level 0",
+                              headingLevel: 0,
+                              twisterPreferenceName: "twister2",
+                              widgets: [
+                                 {
+                                    id: "LOGO4",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
+                        },
                         {
-                           id: "LOGO5",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ]
-                  }
-               },
-               {
-                  id: "TWISTER_NULL_LABEL",
-                  name: "alfresco/layout/Twister",
-                  config: {
-                     label: null,
-                     widgets: [
+                           id: "TWISTER_BAD_HEADING_LEVEL_THREE",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: "Twister with heading level 7",
+                              headingLevel: 7,
+                              widgets: [
+                                 {
+                                    id: "LOGO5",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
+                        },
                         {
-                           id: "LOGO6",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ]
-                  }
-               },
-               {
-                  id: "TWISTER_EMPTY_LABEL",
-                  name: "alfresco/layout/Twister",
-                  config: {
-                     label: "",
-                     widgets: [
+                           id: "TWISTER_NULL_LABEL",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: null,
+                              widgets: [
+                                 {
+                                    id: "LOGO6",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
+                        },
                         {
-                           id: "LOGO7",
-                           name: "alfresco/logo/Logo"
+                           id: "TWISTER_EMPTY_LABEL",
+                           name: "alfresco/layout/Twister",
+                           config: {
+                              label: "",
+                              widgets: [
+                                 {
+                                    id: "LOGO7",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ]
+                           }
                         }
                      ]
                   }
@@ -126,10 +132,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -61,7 +61,7 @@ model.jsonModel = {
                            config: {
                               label: "Twister with faulty heading level 'a'",
                               initiallyOpen: false,
-                              twisterPreferenceName: "twister1",
+                              preferenceName: "twister1",
                               headingLevel: "a",
                               widgets: [
                                  {
@@ -78,7 +78,7 @@ model.jsonModel = {
                               label: "Twister with heading level 0",
                               headingLevel: 0,
                               initiallyOpen: true,
-                              twisterPreferenceName: "twister2",
+                              preferenceName: "twister2",
                               widgets: [
                                  {
                                     id: "LOGO4",

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PreferenceServiceMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PreferenceServiceMockXhr.js
@@ -64,6 +64,8 @@ define(["dojo/_base/declare",
                                      {"Content-Type":"application/json;charset=UTF-8",
                                      "Content-Length":7962},
                                      Preferences]);
+
+            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
          }
          catch(e)
          {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Preferences/Preferences.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Preferences/Preferences.json
@@ -66,6 +66,10 @@
                      "filter": "activeTasks"
                   }
                }
+            },
+            "twisters": {
+               "twister1": true,
+               "twister2": false
             }
          }
       }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-375 to update the alfresco/layout/Twister widget to support the ability to configure initial open/closed state. It also adds the ability to use the alfresco/services/PreferenceService to retrieve and store the preferred open/closed state of the twister from the current users personal preferences. For good measure I've also updated the JSDoc and fixed up the unit tests.