### PR TITLE
AKU-380: Resolved DND nested drag over/out issue

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -161,7 +161,7 @@ define(["dojo/_base/declare",
          this.sourceTarget = new Source(this.paletteNode, {
             copyOnly: !this.useItemsOnce,
             selfCopy: false,
-            accept: this.acceptTypes || [],
+            accept: lang.clone(this.acceptTypes) || [],
             selfAccept: this.selfAccept,
             creator: lang.hitch(this, this.creator),
             withHandles: this.dragWithHandles

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -142,7 +142,7 @@ define(["dojo/_base/declare",
          }
          
          this.previewTarget = new Source(this.previewNode, { 
-            accept: this.acceptTypes,
+            accept: lang.clone(this.acceptTypes),
             creator: lang.hitch(this, this.creator),
             withHandles: this.withHandles,
             horizontal: this.horizontal
@@ -167,8 +167,8 @@ define(["dojo/_base/declare",
 
          if (this.previewTarget)
          {
-            this.previewTarget.onDraggingOut = lang.hitch(this, this.onItemDraggedOut);
-            this.previewTarget.onDraggingOver = lang.hitch(this, this.onItemDraggedOver);
+            aspect.after(this.previewTarget, "onOutEvent", lang.hitch(this, this.onItemDraggedOut), true);
+            aspect.after(this.previewTarget, "onOverEvent", lang.hitch(this, this.onItemDraggedOver), true);
          }
          
          // Listen for widgets requesting to be deleted...
@@ -366,7 +366,7 @@ define(["dojo/_base/declare",
          {
             array.forEach(value, function(item) {
                var data = {
-                  type: this.acceptTypes,
+                  type: lang.clone(this.acceptTypes),
                   value: item
                };
                var createdItem = this.creator(data);

--- a/aikau/src/main/resources/alfresco/services/LoggingService.js
+++ b/aikau/src/main/resources/alfresco/services/LoggingService.js
@@ -469,7 +469,7 @@ define(["dojo/_base/declare",
             // If the filter is mapped (or if there is no filter) output the log...
             if (this.passesLoggingFilter(payload.callerName))
             {
-               payload.messageArgs[0] = (payload.callerName || "") + payload.messageArgs[0];
+               payload.messageArgs[0] = (payload.callerName || "") + " >> " + payload.messageArgs[0];
                var logFunc = (typeof console[payload.severity] === "function" && payload.severity) || "log";
                console[logFunc].apply(console, payload.messageArgs);
             }


### PR DESCRIPTION
This PR finally (hopefully) resolves https://issues.alfresco.com/jira/browse/AKU-380. The issue was that we were implementing the dojo/dnd/Source extension points "onDraggingOut" and "onDraggingOver"... however those extension points were only being fired if the targetState was NOT disabled, e.g.

```JAVASCRIPT
if(this.isDragging && this.targetState != "Disabled"){
  this.onDraggingOut();
}
```

This meant that the updates we'd added to notify the dojo/dnd/Manager of a change of current target were only being fired when the current target was NOT disabled. This meant that as soon as a target was marked as disabled (e.g. when passing over a nested drop target that accepted a different type) the new target was not set when leaving that nested target.

The solution is to use an aspect to chain to the "onOutEvent" and "onOverEvent" to handle all drag out and over events.

There are no tests for this because unfortunately we're not able to get the unit tests to handle the nested targets properly at the moment.