### PR TITLE
AKU-395: Code updates and test page for infinite scroll in dashlet

### DIFF
--- a/aikau/src/main/resources/alfresco/core/_EventsMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_EventsMixin.js
@@ -82,7 +82,7 @@ define(["alfresco/core/Core",
           *                        [functionUtils debounce method]{@link module:alfresco/util/functionUtils#debounce}
           * @return {Object} An object containing a remove() function which will clear any outstanding publish
           */
-          debouncedPublish: function alfresco_core_Core__debouncedPublish(topic, payload, global, parentScope, args) {
+          debouncedPublish: function alfresco_core__EventsMixin__debouncedPublish(topic, payload, global, parentScope, args) {
             var publishFunc = lang.hitch(this, this.alfPublish, topic, payload, global, parentScope),
                debounceArgs = lang.mixin({
                   name: topic,
@@ -103,7 +103,7 @@ define(["alfresco/core/Core",
           *                        [functionUtils throttle method]{@link module:alfresco/util/functionUtils#throttle}
           * @return {Object} An object containing a remove() function which will clear any outstanding publish
           */
-         throttledPublish: function(topic, payload, global, parentScope, args) {
+         throttledPublish: function alfresco_core__EventsMixin__throttledPublish(topic, payload, global, parentScope, args) {
             var publishFunc = lang.hitch(this, this.alfPublish, topic, payload, global, parentScope),
                throttleArgs = lang.mixin({
                   name: topic,
@@ -120,7 +120,7 @@ define(["alfresco/core/Core",
           * @param {Object} [scrollNode=window] The scroll node
           * @return {Object} The scroll-listener, which contains a remove() function which can be called to release the listener
           */
-         publishScrollEvents: function(scrollNode) {
+         publishScrollEvents: function alfresco_core__EventsMixin__publishScrollEvents(scrollNode) {
             var nodeToMonitor = scrollNode || window,
                scrollListener = on(nodeToMonitor, "scroll", lang.hitch(this, this.debouncedPublish, this.eventsScrollTopic, {
                   node: nodeToMonitor
@@ -136,7 +136,7 @@ define(["alfresco/core/Core",
           * @instance
           * @return {Object} The resize-listener, which contains a remove() function which can be called to release the listener
           */
-         publishResizeEvents: function() {
+         publishResizeEvents: function alfresco_core__EventsMixin__publishResizeEvents() {
             var resizeListener = on(window, "resize", lang.hitch(this, this.debouncedPublish, this.eventsResizeTopic));
             this.own && this.own(resizeListener);
             return resizeListener;

--- a/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
+++ b/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
@@ -289,7 +289,7 @@ define(["dojo/_base/declare",
             this.processContainer(this.widgetsForToolbar, this.toolbarNode);
             this.processContainer(this.widgetsForToolbar2, this.toolbar2Node);
             if (this.bodyHeight) {
-               domStyle.set(this.bodyNode, "height", this.bodyHeight + "px");
+               domStyle.set(this.bodyWidgetsNode, "height", this.bodyHeight + "px");
             }
             this.processContainer(this.widgetsForBody, this.bodyWidgetsNode);
             if (this.componentId && !this.resizeDisabled) {

--- a/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
+++ b/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
@@ -91,7 +91,6 @@
    }
    &__body {
       background-color: #fff;
-      overflow: hidden;
       padding-bottom: 15px; /* This is referenced within Dashlet.js! */
       position: relative;
       a {
@@ -115,7 +114,12 @@
             line-height: 1.5;
          }
       }
+
+      .alfresco-dashlets-Dashlet__body__widgets {
+         overflow: auto;
+      }
    }
+   
    /* Same-level classes */
    &.smallpad {
       .alfresco-dashlets-Dashlet__body__widgets {

--- a/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
+++ b/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
@@ -115,7 +115,7 @@
          }
       }
 
-      .alfresco-dashlets-Dashlet__body__widgets {
+      &__widgets {
          overflow: auto;
       }
    }

--- a/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
@@ -93,10 +93,10 @@ define(["alfresco/TestCommon",
          },
 
          "Dashlet with pre-configured height is set appropriately": function() {
-            return browser.findByCssSelector("#VALID_ID_DASHLET .alfresco-dashlets-Dashlet__body")
+            return browser.findByCssSelector("#VALID_ID_DASHLET .alfresco-dashlets-Dashlet__body__widgets")
                .getSize()
                .then(function(size) {
-                  assert.equal(size.height, (300 + 15), "Body not equal to set height (300) plus padding");
+                  assert.equal(size.height, (300 + 20), "Body not equal to set height (300) plus padding");
                });
          },
 
@@ -111,7 +111,7 @@ define(["alfresco/TestCommon",
 
             .getLastPublish("VALID_ID_ALF_STORE_DASHLET_HEIGHT_SUCCESS")
                .then(function(payload) {
-                  assert.deepPropertyVal(payload, "requestConfig.data.height", 250, "Did not publish new height");
+                  assert.deepPropertyVal(payload, "requestConfig.data.height", 270, "Did not publish new height");
                });
          },
 

--- a/aikau/src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Test class for the Dashlet widget.
+ * 
+ * @author Dave Draper
+ */
+define(["alfresco/TestCommon",
+        "intern/chai!assert",
+        "intern!object",
+        "intern/dojo/node!leadfoot/keys"],
+        function(TestCommon, assert, registerSuite, keys) {
+
+   var browser;
+   registerSuite({
+      name: "Infinite Scrolling Dashlet Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollDashlet", "Infinite Scrolling Dashlet Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Scroll to bottom of first dashlet body": function() {
+         // Click on the first row to give it focus...
+         return browser.findByCssSelector("#INFITE_SCROLL_LIST_1 tr:nth-child(1) .alfresco-renderers-Property")
+            .click()
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+         .end()
+         .getLastPublish("BELOW_ALF_EVENTS_SCROLL")
+            .then(function(payload) {
+               assert.isNotNull(payload, "List scroll event not registered");
+            })
+         .end()
+         .findAllByCssSelector("#INFITE_SCROLL_LIST_1 tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 20, "Additional rows were not loaded when the bottom of the list was reached");
+            });
+      },
+
+      "Scroll to bottom of second dashlet body": function() {
+         // Click on the first row to give it focus...
+         return browser.findByCssSelector("#INFITE_SCROLL_LIST_2 tr:nth-child(1) .alfresco-renderers-Property")
+            .click()
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+            .pressKeys(keys.ARROW_DOWN)
+         .end()
+         .getLastPublish("ABOVE_ALF_EVENTS_SCROLL")
+            .then(function(payload) {
+               assert.isNotNull(payload, "List scroll event not registered");
+            })
+         .end()
+         .findAllByCssSelector("#INFITE_SCROLL_LIST_2 tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 40, "Additional rows were not loaded when the bottom of the list was reached");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -62,6 +62,7 @@ define({
       "src/test/resources/alfresco/debug/WidgetInfoTest",
 
       "src/test/resources/alfresco/dashlets/DashletTest",
+      "src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest",
 
       "src/test/resources/alfresco/dnd/AlternateEditorTest",
       "src/test/resources/alfresco/dnd/DndTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/InfiniteScrollDashlet.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/InfiniteScrollDashlet.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Infinite Scroll Dashlet</shortname>
+  <description>This page shows a dashlet containing a list configured with infinite scrolling</description>
+  <family>aikau-unit-tests</family>
+  <url>/InfiniteScrollDashlet</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/InfiniteScrollDashlet.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/InfiniteScrollDashlet.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/InfiniteScrollDashlet.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/InfiniteScrollDashlet.get.js
@@ -58,11 +58,65 @@ model.jsonModel = {
             "widgets": [
                {
                   name: "alfresco/dashlets/Dashlet",
-                  id: "NO_ID_DASHLET",
+                  id: "BELOW_DASHLET",
                   config: {
                      additionalCssClasses: "smallpad",
-                     pubSubScope: "NO_ID_",
-                     title: "Dashlet (no ID)",
+                     pubSubScope: "BELOW_",
+                     title: "Dashlet (height BELOW scroll tolerance)",
+                     bodyHeight: 200,
+                     widgetsForTitleBarActions: [
+                        {
+                           name: "alfresco/html/Label",
+                           config: {
+                              label: "Title-bar actions"
+                           }
+                        }
+                     ],
+                     widgetsForToolbar: [
+                        {
+                           name: "alfresco/html/Label",
+                           config: {
+                              label: "Toolbar"
+                           }
+                        }
+                     ],
+                     widgetsForToolbar2: [
+                        {
+                           name: "alfresco/html/Label",
+                           config: {
+                              label: "Toolbar2"
+                           }
+                        }
+                     ],
+                     widgetsForBody: [
+                        {
+                           name: "alfresco/layout/InfiniteScrollArea",
+                           config: {
+                              scrollTolerance: 300,
+                              widgets: [
+                                 {
+                                    id: "INFITE_SCROLL_LIST_1",
+                                    name: "alfresco/lists/AlfSortablePaginatedList",
+                                    config: {
+                                       useHash: false,
+                                       useInfiniteScroll: true,
+                                       currentPageSize: 10,
+                                       widgets: [view]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/dashlets/Dashlet",
+                  id: "ABOVE_DASHLET",
+                  config: {
+                     additionalCssClasses: "smallpad",
+                     pubSubScope: "ABOVE_",
+                     title: "(height ABOVE scroll tolerance)",
                      bodyHeight: 500,
                      widgetsForTitleBarActions: [
                         {
@@ -95,54 +149,16 @@ model.jsonModel = {
                               scrollTolerance: 300,
                               widgets: [
                                  {
-                                    id: "INFITE_SCROLL_LIST",
+                                    id: "INFITE_SCROLL_LIST_2",
                                     name: "alfresco/lists/AlfSortablePaginatedList",
                                     config: {
                                        useHash: false,
                                        useInfiniteScroll: true,
                                        currentPageSize: 20,
-                                       filteringTopics: ["FILTER_THIS"],
                                        widgets: [view]
                                     }
                                  }
                               ]
-                           }
-                        }
-                     ]
-                  }
-               },
-               {
-                  name: "alfresco/dashlets/Dashlet",
-                  id: "VALID_ID_DASHLET",
-                  config: {
-                     additionalCssClasses: "mediumpad",
-                     pubSubScope: "VALID_ID_",
-                     title: "Dashlet (valid ID, presized)",
-                     componentId: "component.valid-dashlet",
-                     bodyHeight: 300,
-                     widgetsForBody: [
-                        {
-                           name: "alfresco/html/Label",
-                           config: {
-                              label: "Objectively innovate empowered manufactured products whereas parallel platforms. Holisticly predominate extensible testing procedures for reliable supply chains. Dramatically engage top-line web services vis-a-vis cutting-edge deliverables. Proactively envisioned multimedia based expertise and cross-media growth strategies. Seamlessly visualize quality intellectual capital without superior collaboration and idea-sharing. Holistically pontificate installed base portals after maintainable products. Phosfluorescently engage worldwide methodologies with web-enabled technology. Interactively coordinate proactive e-commerce via process-centric 'outside the box' thinking. Completely pursue scalable customer service through sustainable potentialities."
-                           }
-                        }
-                     ]
-                  }
-               },
-               {
-                  name: "alfresco/dashlets/Dashlet",
-                  id: "INVALID_ID_DASHLET",
-                  config: {
-                     additionalCssClasses: "largepad",
-                     pubSubScope: "INVALID_ID_",
-                     title: "Dashlet (invalid ID)",
-                     componentId: "component.invalid-dashlet",
-                     widgetsForBody: [
-                        {
-                           name: "alfresco/html/Label",
-                           config: {
-                              label: "Collaboratively administrate turnkey channels whereas virtual e-tailers. Objectively seize scalable metrics whereas proactive e-services. Seamlessly empower fully researched growth strategies and interoperable internal or 'organic' sources. Credibly innovate granular internal or 'organic' sources whereas high standards in web-readiness. Energistically scale future-proof core competencies vis-a-vis impactful experiences. Dramatically synthesize integrated schemas with optimal networks. Interactively procrastinate high-payoff content without backward-compatible data. Quickly cultivate optimal processes and tactical architectures. Completely iterate covalent strategic theme areas via accurate e-markets."
                            }
                         }
                      ]


### PR DESCRIPTION
This PR addresses (in part) https://issues.alfresco.com/jira/browse/AKU-395. I've attempted to reproduce the issues that the customer was having with infinite scroll inside a dashlet (now possible with the pure Aikau dashlet). I've had to make some minor tweaks to get it working and I've added a test page, but no test yet... this might be worth pulling into 1.0.24 though and completing the test work in the next sprint (alternatively I'll try and get the test in before end of sprint)