### PR TITLE
Minor fixes for committed Sprint code

### DIFF
--- a/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
+++ b/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
@@ -184,15 +184,6 @@ define(["dojo/_base/declare",
          titleConfig: null,
 
          /**
-          * The container that holds the title.
-          * Will be populated by dojo.
-          *
-          * @instance
-          * @type {HTMLElement}
-          */
-         titleNode: null,
-
-         /**
           * Widgets to place as title bar actions.
           *
           * @instance
@@ -223,42 +214,6 @@ define(["dojo/_base/declare",
           * @type {object[]}
           */
          widgetsForBody: null,
-
-         /**
-          * The container that holds the title bar action widgets.
-          * Will be populated by dojo.
-          *
-          * @instance
-          * @type {HTMLElement}
-          */
-         titleBarActionsNode: null,
-
-         /**
-          * The container that holds the first toolbar widgets.
-          * Will be populated by dojo.
-          *
-          * @instance
-          * @type {HTMLElement}
-          */
-         toolbarNode: null,
-
-         /**
-          * The container that holds the title second tollbar widgets.
-          * Will be populated by dojo.
-          *
-          * @instance
-          * @type {HTMLElement}
-          */
-         toolbar2Node: null,
-
-         /**
-          * The container that holds the body widgets.
-          * Will be populated by dojo.
-          *
-          * @instance
-          * @type {HTMLElement}
-          */
-         bodyNode: null,
 
          /**
           * Explicit height in pixels of the dashlet body

--- a/aikau/src/main/resources/alfresco/misc/AlfTooltip.js
+++ b/aikau/src/main/resources/alfresco/misc/AlfTooltip.js
@@ -235,8 +235,8 @@ define(["dojo/_base/declare",
                id: this.id + "_TOOLTIP",
                style: this.tooltipStyle,
                content: this.dialogContent,
-               onMouseEnter: lang.hitch(this, this.onTooltipMouseover),
-               onMouseLeave: lang.hitch(this, this.onTooltipMouseout)
+               onMouseEnter: lang.hitch(this, this.onTooltipMouseEnter),
+               onMouseLeave: lang.hitch(this, this.onTooltipMouseLeave)
             });
          }
          popup.open({
@@ -282,21 +282,41 @@ define(["dojo/_base/declare",
          }
       },
 
-      onMouseover: function(){
+      /**
+       * Handle mousing-over the widget.
+       *
+       * @instance
+       */
+      onMouseover: function alfresco_misc_AlfTooltip__onMouseover() {
          clearTimeout(this._hideTooltipTimeout);
          this._showTooltipTimeout = setTimeout(lang.hitch(this, this.showTooltip), this.mouseoverShowDelay);
       },
 
-      onMouseout: function(){
+      /**
+       * Handle mousing-out of the widget.
+       *
+       * @instance
+       */
+      onMouseout: function alfresco_misc_AlfTooltip__onMouseout() {
          clearTimeout(this._showTooltipTimeout);
          this._hideTooltipTimeout = setTimeout(lang.hitch(this, this.hideTooltip), this.mouseoutHideDelay);
       },
 
-      onTooltipMouseover: function(){
+      /**
+       * Handle mousing-over the tooltip.
+       *
+       * @instance
+       */
+      onTooltipMouseEnter: function alfresco_misc_AlfTooltip__onTooltipMouseEnter() {
          clearTimeout(this._hideTooltipTimeout);
       },
 
-      onTooltipMouseout: function(){
+      /**
+       * Handle mousing-out of the tooltip.
+       *
+       * @instance
+       */
+      onTooltipMouseLeave: function alfresco_misc_AlfTooltip__onTooltipMouseLeave() {
          this._hideTooltipTimeout = setTimeout(lang.hitch(this, this.hideTooltip), this.mouseoutHideDelay);
       }
    });


### PR DESCRIPTION
Remove Dojo attach points from Dashlet code (we don't have them explicitly set anywhere else). Fix naming (and scoped-naming) of methods in AlfTooltip.