### PR TITLE
AKU-400: NotificationUtils fix

### DIFF
--- a/aikau/ReleaseNotes.md
+++ b/aikau/ReleaseNotes.md
@@ -1,7 +1,12 @@
 Aikau 1.0.24 Release Notes
 ==========================
 
-Current deprecations:
+New deprecations: 
+-----------------
+* alfresco/buttons/AlfFormDialogButton.js                        (use alfresco/services/DialogService)
+* alfresco/dialogs/_AlfCreateFormDialogMixin.js                  (use alfresco/services/DialogService)
+
+Previous deprecations:
 ---------------------
 * alfresco/core/NotificationUtils.js                             (use alfresco/services/NotificationService)
 * alfresco/documentlibrary/AlfDocumentListInfiniteScroll.js      (use: alfresco/services/InfiniteScrollService)

--- a/aikau/src/main/resources/alfresco/buttons/AlfFormDialogButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfFormDialogButton.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -47,6 +47,7 @@
  * @extends alfresco/menus/AlfMenuItem
  * @mixes module:alfresco/dialogs/_AlfCreateFormDialogMixin
  * @author Dave Draper
+ * @deprecated Since 1.0.25 - use the [DialogService]{@link module:alfresco/services/DialogService} instead.
  */
 define(["dojo/_base/declare",
         "alfresco/buttons/AlfButton",

--- a/aikau/src/main/resources/alfresco/core/NotificationUtils.js
+++ b/aikau/src/main/resources/alfresco/core/NotificationUtils.js
@@ -49,6 +49,11 @@ define(["dojo/_base/declare",
        * @param msg {String} The message to be displayed.
        */
       displayPrompt: function alfresco_core_Core__displayPrompt(config) {
+         // See AKU-400 - support changes to Dojo dialog following upgrade to 1.10.0
+         if (config.textContent)
+         {
+            config.message = config.textContent;
+         }
          this.alfPublish("ALF_DISPLAY_PROMPT", config);
       }
    });

--- a/aikau/src/main/resources/alfresco/dialogs/_AlfCreateFormDialogMixin.js
+++ b/aikau/src/main/resources/alfresco/dialogs/_AlfCreateFormDialogMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -26,13 +26,14 @@
  * @module alfresco/dialogs/_AlfCreateFormDialogMixin
  * @extends module:alfresco/core/Core
  * @author Dave Draper
+ * @deprecated Since 1.0.25 - use the [DialogService]{@link module:alfresco/services/DialogService} instead.
  */
 define(["dojo/_base/declare",
         "alfresco/core/Core",
         "dojo/_base/lang",
         "alfresco/dialogs/AlfDialog",
         "alfresco/forms/Form"],
-        function(declare, AlfCore, lang, AlfDialog, AlfForm) {
+        function(declare, AlfCore, lang, AlfDialog, /*jshint unused:false*/ AlfForm) {
 
    return declare([AlfCore], {
 
@@ -45,12 +46,12 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_dialogs__CreateFormDialogMixin__postCreate() {
          this.inherited(arguments);
 
-         if (this.dialogConfirmationButtonTitle == null)
+         if (!this.dialogConfirmationButtonTitle)
          {
             this.dialogConfirmationButtonTitle = this.message("services.ActionService.button.ok");
          }
 
-         if (this.dialogCancellationButtonTitle == null)
+         if (!this.dialogCancellationButtonTitle)
          {
             this.dialogCancellationButtonTitle = this.message("services.ActionService.button.cancel");
          }
@@ -119,14 +120,14 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The payload published on the request topic.
        */
-      onCreateFormDialogRequest: function alfresco_dialogs__CreateFormDialogMixin__onCreateFormDialogRequest(payload) {
+      onCreateFormDialogRequest: function alfresco_dialogs__CreateFormDialogMixin__onCreateFormDialogRequest(/*jshint unused:false*/ payload) {
          // Destroy any previously created dialog...
-         if (this.dialog != null)
+         if (this.dialog)
          {
             this.dialog.destroyRecursive();
          }
 
-         if (this.widgets == null)
+         if (!this.widgets)
          {
             this.alfLog("warn", "A request was made to display a dialog but no 'widgets' attribute has been defined", this);
          }
@@ -238,9 +239,9 @@ define(["dojo/_base/declare",
        * @param {object} payload The dialog content
        */
       onDialogConfirmation: function alfresco_dialogs__CreateFormDialogMixin__onDialogConfirmation(payload) {
-         if (payload != null &&
-             payload.dialogContent != null &&
-             payload.dialogContent.length == 1 &&
+         if (payload &&
+             payload.dialogContent &&
+             payload.dialogContent.length === 1 &&
              typeof payload.dialogContent[0].getValue === "function")
          {
             var data = payload.dialogContent[0].getValue();

--- a/aikau/src/test/resources/alfresco/core/NotificationUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/core/NotificationUtilsTest.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "NotificationUtils Mixin Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/NotificationUtils", "NotificationUtils Mixin Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that notification is displayed": function() {
+         return browser.findAllByCssSelector(".alfresco-notifications-AlfNotification__message")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Notification not displayed");
+            });
+      },
+
+      "Check that prompt is displayed": function() {
+         return browser.findAllByCssSelector("#NOTIFICATION_PROMPT")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Notification prompt was not displayed");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -51,6 +51,7 @@ define({
 
       "src/test/resources/alfresco/core/AdvancedVisibilityConfigTest",
       "src/test/resources/alfresco/core/CoreRwdTest",
+      "src/test/resources/alfresco/core/NotificationUtilsTest",
       "src/test/resources/alfresco/core/PublishPayloadMixinTest",
       "src/test/resources/alfresco/core/RenderFilterTest",
       "src/test/resources/alfresco/core/TemporalUtilsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/NotificationUtils.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/NotificationUtils.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>NotificationUtils Mixin</shortname>
+  <description>This page is used to test the now deprecated alfresco/core/NotificationUtils mixin.</description>
+  <family>aikau-unit-tests</family>
+  <url>/NotificationUtils</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/NotificationUtils.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/NotificationUtils.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/NotificationUtils.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/NotificationUtils.get.js
@@ -1,0 +1,23 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/NotificationService",
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         name: "aikauTesting/core/NotificationUtilsInstance"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/core/NotificationUtilsInstance.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/core/NotificationUtilsInstance.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/core/NotificationUtilsInstance
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/core/NotificationUtils
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "dijit/_WidgetBase", 
+        "alfresco/core/Core",
+        "alfresco/core/NotificationUtils",
+        "dojo/text!./templates/NotificationUtilsInstance.html"], 
+        function(declare, _Widget, AlfCore, NotificationUtils) {
+   
+   return declare([_Widget, AlfCore, NotificationUtils], {
+      
+      /**
+       * 
+       * @instance postCreate
+       */
+      postCreate: function aikauTesting_core_NotificationUtilsInstance__postCreate() {
+         this.displayMessage("Test Notification");
+         this.displayPrompt({
+            title: "Test Title",
+            textContent: "Test Prompt"
+         });
+      }
+   });
+});


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-400 to ensure that the deprecated alfresco/core/NotificationUtils is backwards compatible with previous releases.