### PR TITLE
AKU-399: DND preset value typing issues

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/Constants.js
+++ b/aikau/src/main/resources/alfresco/dnd/Constants.js
@@ -152,6 +152,17 @@ define([],function() {
        * @type {String}
        * @default "ALF_DND_DROPPED_ITEM_DELETED"
        */
-      itemDeletedTopic: "ALF_DND_DROPPED_ITEM_DELETED"
+      itemDeletedTopic: "ALF_DND_DROPPED_ITEM_DELETED",
+
+      /**
+       * This topic is published by a [DragAndDropTarget]{@link module:alfresco/dnd/DragAndDropTarget} whenever a 
+       * dropped item is inserted into a target. This topic is subscribed to by [DragAndDropItems]{@link module:alfresco/dnd/DragAndDropItems}
+       * that are configured to only allow an item to be used so that the deleted item can be reinstated.
+       *
+       * @instance
+       * @type {String}
+       * @default "ALF_DND_ITEM_ADDED"
+       */
+      itemAddedTopic: "ALF_DND_ITEM_ADDED"
    };
 });

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -144,6 +144,7 @@ define(["dojo/_base/declare",
          if (this.useItemsOnce === true)
          {
             this.alfSubscribe(Constants.itemDeletedTopic, lang.hitch(this, this.onItemDeleted));
+            this.alfSubscribe(Constants.itemAddedTopic, lang.hitch(this, this.onItemAdded));
          }
       },
 
@@ -188,6 +189,34 @@ define(["dojo/_base/declare",
                   if (a === b)
                   {
                      this.sourceTarget.insertNodes(false, [item]);
+                     return true;
+                  }
+                  return false;
+               }, this);
+            }
+         }
+      },
+
+      /**
+       * Handles items being deleted. If the item deleted is a deleted item from this widget then it will
+       * be re-instated.
+       *
+       * @instance
+       * @param  {object} payload A payload containing a deleted item
+       */
+      onItemAdded: function alfresco_dnd_DragAndDropItems__onItemAdded(payload) {
+         if (payload && payload.value && this.useItemsOnceComparisonKey)
+         {
+            var a = lang.getObject(this.useItemsOnceComparisonKey, false, payload.value);
+            if (a)
+            {
+               // NOTE: Using some to exit as soon as match is found
+               array.some(this.items, function(item) {
+                  var b = lang.getObject(this.useItemsOnceComparisonKey, false, item.value);
+                  if (a === b)
+                  {
+                     this.sourceTarget.delItem(b);
+                     // console.info("Remove this node", item);
                      return true;
                   }
                   return false;

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -39,12 +39,13 @@ define(["dojo/_base/declare",
         "dojo/dnd/Source",
         "dojo/_base/lang",
         "dojo/_base/array",
+        "dojo/dom",
         "dojo/on",
         "dojo/string",
         "dojo/dom-construct",
         "dojo/dom-class"], 
         function(declare, _Widget, _Templated, CoreWidgetProcessing, ObjectProcessingMixin, template, AlfCore, Constants, 
-                 Source, lang, array, on, stringUtil, domConstruct, domClass) {
+                 Source, lang, array, dom, on, stringUtil, domConstruct, domClass) {
    
    return declare([_Widget, _Templated, CoreWidgetProcessing, ObjectProcessingMixin, AlfCore], {
       
@@ -215,8 +216,10 @@ define(["dojo/_base/declare",
                   var b = lang.getObject(this.useItemsOnceComparisonKey, false, item.value);
                   if (a === b)
                   {
-                     this.sourceTarget.delItem(b);
-                     // console.info("Remove this node", item);
+                     this.sourceTarget.forInItems(function(i, id, map) {
+                        map.delItem(id);
+                        domConstruct.destroy(dom.byId(id));
+                     });
                      return true;
                   }
                   return false;

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropNestedTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropNestedTarget.js
@@ -147,6 +147,7 @@ define(["dojo/_base/declare",
             config: {
                label: "{label}",
                value: "{value}",
+               type: "{type}",
                widgets: [
                   {
                      name: "alfresco/dnd/DragAndDropNestedTarget",

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -375,7 +375,10 @@ define(["dojo/_base/declare",
                };
                var createdItem = this.creator(data);
                this.previewTarget.insertNodes(true, [createdItem.data]);
+               this.alfPublish(Constants.itemAddedTopic, createdItem.data);
             }, this);
+
+            this.previewTarget.selectNone();
          }
       },
       

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -194,6 +194,7 @@ define(["dojo/_base/declare",
             config: {
                label: "{label}",
                value: "{value}",
+               type: "{type}",
                widgets: "{widgets}"
             }
          }
@@ -236,6 +237,7 @@ define(["dojo/_base/declare",
          var promise = new Deferred();
          promise.then(lang.hitch(this, this.createDroppedItemsWidgets, item, node));
          this.alfPublish(Constants.requestWidgetsForDisplayTopic, {
+            type: item.type,
             value: item.value,
             promise: promise
          });
@@ -260,6 +262,7 @@ define(["dojo/_base/declare",
             this.currentItem = {};
             this.currentItem.label = item.label || item.value.label; // If no label is provided on the item, check the value (See AKU-318)
             this.currentItem.value = item.value;
+            this.currentItem.type = item.type;
             this.processObject(["processCurrentItemTokens"], widgetModel);
             
             // Create the widgets...
@@ -296,6 +299,7 @@ define(["dojo/_base/declare",
                // Set the value to be processed...
                this.currentItem.value = clonedItem.value;
                this.currentItem.label = clonedItem.label || clonedItem.value.label;
+               this.currentItem.type = clonedItem.type;
 
                // Check to see if a specific widget model has been requested for rendering the dropped item...
                // TODO Not sure that we actually care about this yet? If at all... shouldn't everything be part of the value?
@@ -366,7 +370,7 @@ define(["dojo/_base/declare",
          {
             array.forEach(value, function(item) {
                var data = {
-                  type: lang.clone(this.acceptTypes),
+                  type: lang.clone(item.type),
                   value: item
                };
                var createdItem = this.creator(data);

--- a/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
@@ -209,6 +209,7 @@ define(["dojo/_base/declare",
             if (this.value)
             {
                this.value.label = this.label;
+               this.value.type = this.type;
             }
          }
          if (this.widgets !== null && this.widgets !== undefined)

--- a/aikau/src/main/resources/alfresco/services/DragAndDropModellingService.js
+++ b/aikau/src/main/resources/alfresco/services/DragAndDropModellingService.js
@@ -45,6 +45,7 @@
  *          config: {
  *             label: "{label}",
  *             value: "{value}",
+ *             type: "{type}",
  *             widgets: [
  *                {
  *                   name: "alfresco/dnd/DroppedItemWidgets"
@@ -113,6 +114,7 @@ define(["dojo/_base/declare",
             showEditButton: false,
             label: "{label}",
             value: "{value}",
+            type: "{type}",
             widgets: [{
                name: "alfresco/dnd/DroppedItem"
             }]

--- a/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
@@ -249,4 +249,51 @@ define(["intern!object",
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });
+
+   registerSuite({
+
+      name: "Multi-source DND tests (test preset value loading)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/multi-source-dnd?preset=true", "Multi-source DND tests (test preset value loading)")
+            .end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that the single use item has been removed (as it has been used)": function() {
+         return browser.findAllByCssSelector("#DRAG_PALETTE2 .alfresco-dnd-DragAndDropItem")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The single use item was not removed");
+            });
+      },
+
+      "Check that all items are present and correct": function() {
+         return browser.findAllByCssSelector(".alfresco-dnd-DroppedItemWrapper")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "Not all the items were recreated");
+            });
+      },
+
+      "Drag a preset item and check only one item is selected": function() {
+         return browser.findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DroppedItemWrapper:first-child .dojoDndHandle")
+            .moveMouseTo()
+            .click()
+            .pressMouseButton()
+            .moveMouseTo(1, 1)
+            .moveMouseTo(1, 50)
+         .end()
+         .findAllByCssSelector(".alfresco-dnd-DroppedItemWrapper")
+            .then(function(elements) {
+               assert.lengthOf(elements, 5, "The wrong number of items were pre-selected for dragging");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/multi-source.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/multi-source.get.js
@@ -28,6 +28,7 @@ model.jsonModel = {
                            showEditButton: false,
                            label: "{label}",
                            value: "{value}",
+                           type: "{type}",
                            widgets: [
                               {
                                  name: "alfresco/dnd/DragAndDropNestedTarget",
@@ -56,6 +57,7 @@ model.jsonModel = {
                            showEditButton: false,
                            label: "{label}",
                            value: "{value}",
+                           type: "{type}",
                            widgets: [
                               {
                                  name: "alfresco/dnd/DroppedItem"
@@ -108,6 +110,22 @@ model.jsonModel = {
                               label: "Data",
                               name: "data",
                               value: null,
+                              // value: [
+                              //    {
+                              //       name: "bob",
+                              //       label: "Item 1",
+                              //       type: ["widget"],
+                              //       config: {
+                              //          widgets: [
+                              //             {
+                              //                name: "ted",
+                              //                label: "Item 2",
+                              //                type: ["not_a_widget"]
+                              //             }
+                              //          ]
+                              //       }
+                              //    }
+                              // ],
                               acceptTypes: ["widget"],
                               useModellingService: true,
                               clearTopic: "BRUTAL_CLEAR",
@@ -153,7 +171,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/multi-source.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/multi-source.get.js
@@ -1,3 +1,30 @@
+/* global page */
+var value = null;
+if (page.url.args.preset)
+{
+   value = [
+      {
+         name:"bob",
+         label:"Item 1",
+         type: ["widget"],
+         config:{
+            widgets:[
+               {
+                  name:"ted",
+                  label:"Item 2",
+                  type: ["not_a_widget"]
+               }
+            ]
+         }
+      },
+      {
+         name:"bob",
+         label:"Item 1",
+         type: ["widget"]
+      }
+   ];
+}
+
 model.jsonModel = {
    services: [
       {
@@ -36,7 +63,7 @@ model.jsonModel = {
                                     useModellingService: true,
                                     label: "Widgets",
                                     targetProperty: "config.widgets",
-                                    acceptTypes: [ "not_a_widget" ]
+                                    acceptTypes: [ "not_a_widget", "something_else" ]
                                  }
                               }
                            ]
@@ -84,7 +111,7 @@ model.jsonModel = {
                   config: {
                      items: [
                         {
-                           type: [ "widget" ],
+                           type: [ "widget"],
                            label: "Item 1",
                            value: {
                               name: "bob"
@@ -109,24 +136,8 @@ model.jsonModel = {
                            config: {
                               label: "Data",
                               name: "data",
-                              value: null,
-                              // value: [
-                              //    {
-                              //       name: "bob",
-                              //       label: "Item 1",
-                              //       type: ["widget"],
-                              //       config: {
-                              //          widgets: [
-                              //             {
-                              //                name: "ted",
-                              //                label: "Item 2",
-                              //                type: ["not_a_widget"]
-                              //             }
-                              //          ]
-                              //       }
-                              //    }
-                              // ],
-                              acceptTypes: ["widget"],
+                              value: value,
+                              acceptTypes: ["widget", "something_else"],
                               useModellingService: true,
                               clearTopic: "BRUTAL_CLEAR",
                               clearDroppedItemsTopic: "NICE_CLEAR"


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-399 to resolve an issue whereby the acceptance types for drop targets was being incorrectly set. In fact the types were not being set at all and this has now been corrected. Additionally I've fixed the issue where all dropped items created from a preset value are initially selected on the first drag and ensured that single use items that are used by a preset value are removed from the palette.