### PR TITLE
AKU-396: Update AlfSearchResult to include "Manage Aspects" as an available action

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -111,7 +111,8 @@ define(["dojo/_base/declare",
             "document-assign-workflow",
             "document-cancel-editing",
             "document-approve",
-            "document-reject"
+            "document-reject",
+            "document-manage-aspects"
 
 //            TODO: Needs to use forms runtime or equiv.
 //            "document-edit-properties",
@@ -120,7 +121,6 @@ define(["dojo/_base/declare",
 //            "document-upload-new-version",
 //            "folder-view-details"
 //            
-//            "document-manage-aspects"
 //            "document-cloud-sync"
 //            "document-cloud-unsync"
 //            "document-view-in-cloud"

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -976,8 +976,8 @@ define(["dojo/_base/declare",
        *
        * @param {object} item The item to perform the action on
        */
-      onActionManageAspects: function alfresco_services_ActionService__onActionManageAspects(item) {
-         this.alfPublish("ALF_MANAGE_ASPECTS_REQUEST", item);
+      onActionManageAspects: function alfresco_services_ActionService__onActionManageAspects(payload, documents) {
+         this.alfPublish("ALF_MANAGE_ASPECTS_REQUEST", documents[0]);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
@@ -288,7 +288,7 @@ define(["dojo/_base/declare",
        * 
        * @param {object} payload The payload containing the updated aspects.
        */
-      onActionManageAspectsConfirmation: function alfresco_services_ActionService__onActionManageAspectsConfirmation(payload) {
+      onActionManageAspectsConfirmation: function alfresco_services_actions_ManageAspectsService__onActionManageAspectsConfirmation(payload) {
          // Clean up any subscription handles
          if (payload && payload.subscriptionHandle)
          {

--- a/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
@@ -136,31 +136,39 @@ define(["intern!object",
 
       "Test managing aspects when aspects can't be retrieved": function() {
          // By using a node that the mock service doesn't cater for we can rely on a 404 producing an error...
-         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG.dialogHidden").end()
+         return browser.findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG.dialogHidden")
+            .end()
+
          .findByCssSelector("#MANAGE_ASPECTS3_label")
             .click()
-         .end()
-         .findByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_PROMPT", "message", "It was not possible to retrieve the aspects applied to No Data Node"))
-            .then(null, function() {
-               assert(false, "The error prompt was not requested when failing to retrieve aspects");
+            .end()
+
+         .getLastPublish("ALF_DISPLAY_PROMPT")
+            .then(function(payload) {
+               assert.propertyVal(payload, "message", "It was not possible to retrieve the aspects applied to No Data Node", "The error prompt was not requested when failing to retrieve aspects");
             });
       },
+
 
       "Test failure to save aspect changes": function() {
          // By using a node that the mock service doesn't cater for we can rely on a 404 producing an error...
          return browser.findByCssSelector("#MANAGE_ASPECTS4_label")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG.dialogDisplayed")
-         .end()
+            .end()
+
          .findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .confirmationButton > span")
             .click()
-         .end()
+            .end()
+
          .findAllByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG.dialogHidden")
-         .end()
-         .findByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_PROMPT", "message", "It was not possible to update the aspects applied to Save Fail Node"))
-            .then(null, function() {
-               assert(false, "The error prompt was not requested when failure occurred saving data");
+            .end()
+
+         .getLastPublish("ALF_DISPLAY_PROMPT")
+            .then(function(payload) {
+               assert.propertyVal(payload, "message", "It was not possible to update the aspects applied to Save Fail Node", "The error prompt was not requested when failure occurred saving data");
             });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/dashlets/DashletTest"
+      "src/test/resources/alfresco/services/actions/ManageAspectsTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
@@ -48,7 +48,16 @@ model.jsonModel = {
             label: "Manage Aspects (no aspects in payload)",
             publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
-               action: "onActionManageAspects",
+               action: {
+                  "id": "document-manage-aspects",
+                  "icon": "document-manage-aspects",
+                  "type": "javascript",
+                  "label": "actions.document.manage-aspects",
+                  "params": {
+                     "function": "onActionManageAspects"
+                  },
+                  "index": "300"
+               },
                document: {
                   node: {
                      nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
@@ -65,7 +74,16 @@ model.jsonModel = {
             label: "Manage Aspects (fail on aspect request)",
             publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
-               action: "onActionManageAspects",
+               action: {
+                  "id": "document-manage-aspects",
+                  "icon": "document-manage-aspects",
+                  "type": "javascript",
+                  "label": "actions.document.manage-aspects",
+                  "params": {
+                     "function": "onActionManageAspects"
+                  },
+                  "index": "300"
+               },
                document: {
                   displayName: "No Data Node",
                   node: {
@@ -82,7 +100,16 @@ model.jsonModel = {
             label: "Manage Aspects (fail on save)",
             publishTopic: "ALF_SINGLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
-               action: "onActionManageAspects",
+               action: {
+                  "id": "document-manage-aspects",
+                  "icon": "document-manage-aspects",
+                  "type": "javascript",
+                  "label": "actions.document.manage-aspects",
+                  "params": {
+                     "function": "onActionManageAspects"
+                  },
+                  "index": "300"
+               },
                document: {
                   displayName: "Save Fail Node",
                   node: {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
@@ -96,7 +96,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/ManageAspectsMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-396](https://issues.alfresco.com/jira/browse/AKU-396), which is the addition of ManageAspects to the AlfSearchResult. When this is integrated with Share then further changes will be needed in Share, as documented in the JIRA ticket.