### PR TITLE
AKU-378: Only show validation when forms lose focus

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -22,12 +22,17 @@
  * [BaseFormControl]{@link module:alfresco/forms/controls/BaseFormControl} and handles setting and 
  * getting there values as well as creating and controlling the behaviour of buttons that can be
  * used to publish the overall value of the controls that the form contains.</p>
+ *
+ * <p>By default forms will show error messages against any fields that contain invalid data when the 
+ * form is first displayed. If you'd prefer to give the user a chance to enter or change the data before
+ * validation errors are displayed then this can be achieved by configuring the 
+ * [showValidationErrorsImmediately]{@link module:alfresco/forms/Form#showValidationErrorsImmediately}
+ * to be false.</p>
  * 
- * <p>Auto-publishing forms:<br />
- * It is also possible to setup a form to automatically publish itself whenever its values change,
- * and optionally to also do so if any of its values are invalid (see example below).<br />
- * NOTE: If the autoSavePublishTopic is specified, then the OK and Cancel buttons are automatically
- * disabled.</p>
+ * <p>It is also possible to setup a form to automatically publish itself whenever its values change,
+ * and optionally to also do so if any of its values are invalid. If the 
+ * [autoSavePublishTopic]{@link module:alfresco/forms/Form#autoSavePublishTopic} is specified, 
+ * then the OK and Cancel buttons are automatically hidden.</p>
  *
  * @example <caption>Example configuration for auto-publishing (including invalid) form:</caption>
  * {
@@ -42,6 +47,28 @@
  *             config: {
  *                name: "control",
  *                label: "Autosave form control (even invalid)",
+ *                requirementConfig: {
+ *                   initialValue: true
+ *                }
+ *             }
+ *           }
+ *        ]
+ *     }
+ *  }
+ *
+ * @example <caption>Example configuration for form that does not show validation errors on initial display:</caption>
+ * {
+ *    name: "alfresco/forms/Form",
+ *    config: {
+ *       okButtonPublishTopic: "SAVE_FORM",
+ *       okButtonLabel: "Save",
+ *       showValidationErrorsImmediately: false,
+ *       widgets: [
+ *          {
+ *             name: "alfresco/forms/controls/TextBox",
+ *             config: {
+ *                name: "control",
+ *                label: "Name",
  *                requirementConfig: {
  *                   initialValue: true
  *                }
@@ -211,6 +238,17 @@ define(["dojo/_base/declare",
       setValueTopicParentScope: false,
 
       /**
+       * Indicates that any validation errors that are present on the fields contained within the form will be 
+       * shown immediately when the form is displayed. Validation will still occur if this is configured to be
+       * false (so it will not be possible to submit an invalid form).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default true
+       */
+      showValidationErrorsImmediately: true,
+
+      /**
        * When using the optional auto-saving capability (configured by setting an [autoSavePublishTopic]{@link module:alfresco/forms/Form#autoSavePublishTopic})
        * the form will typically need to wait until page setup is complete before allowing automatic saving to commence. However,
        * if a form (configured to auto-save) is dynamically created after the page has been loaded (e.g. when created within a
@@ -280,6 +318,13 @@ define(["dojo/_base/declare",
          // to this widget. However, this widget will need to be assigned with a pubSubScope... 
          if (this.widgets)
          {
+            array.forEach(this.widgets, function(widget) {
+               if (widget && widget.config)
+               {
+                  widget.config.showValidationErrorsImmediately = this.showValidationErrorsImmediately;
+               }
+            }, this);
+
             this.processWidgets(this.widgets, this._form.domNode);
          }
       },

--- a/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Form Validation Display Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/FormValidation", "Form Validation Display Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that first form does NOT show validation errors on load": function() {
+         return browser.findAllByCssSelector("#TB1 .validation-error")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The error icon should not have been displayed (TB1)");
+            })
+         .end()
+         .findByCssSelector("#TB1 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The error message should not have been displayed (TB1)");
+            })
+         .end()
+         .findAllByCssSelector("#TB2 .validation-error")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The error icon should not have been displayed (TB1)");
+            })
+         .end()
+         .findByCssSelector("#TB2 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The error message should not have been displayed (TB2)");
+            });
+      },
+
+      "Check that first form confirmation button is disabled": function() {
+         return browser.findAllByCssSelector("#NO_INITIAL_VALIDATION .buttons .alfresco-buttons-AlfButton.confirmationButton.dijitButtonDisabled")
+            .then(function(elements) {
+               assert(elements.length === 1, "Confirmation button was not initially disabled");
+            });
+      },
+
+      "Check that seoond form DOES show validation errors on load": function() {
+         return browser.findByCssSelector("#TB3 .validation-error")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB3)");
+            })
+         .end()
+         .findByCssSelector("#TB3 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB3)");
+            })
+         .end()
+         .findByCssSelector("#TB4 .validation-error")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB4)");
+            })
+         .end()
+         .findByCssSelector("#TB4 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB4)");
+            });
+      },
+
+      "Give and remove focus to first text field and verify error message is displayed": function() {
+         return browser.findByCssSelector("#TB1 .dijitInputContainer input")
+            .click()
+         .end()
+         .findByCssSelector("#TB2 .dijitInputContainer input")
+            .click()
+         .end()
+         .findByCssSelector("#TB1 .validation-error")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB1)");
+            })
+         .end()
+         .findByCssSelector("#TB1 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB1)");
+            });
+      },
+
+      "Remove focus from second text field and verify error message is displayed": function() {
+         return browser.findByCssSelector("#TB3 .dijitInputContainer input")
+            .click()
+         .end()
+         .findByCssSelector("#TB2 .validation-error")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB2)");
+            })
+         .end()
+         .findByCssSelector("#TB2 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB2)");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -95,6 +95,7 @@ define({
       "src/test/resources/alfresco/forms/CrudFormTest",
       "src/test/resources/alfresco/forms/DynamicFormTest",
       "src/test/resources/alfresco/forms/FormsTest",
+      "src/test/resources/alfresco/forms/FormValidationTest",
       "src/test/resources/alfresco/forms/HashFormTest",
       "src/test/resources/alfresco/forms/SingleTextFieldFormTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Form Validation</shortname>
+  <description>This loads a form that contains initially invalid data.</description>
+  <family>aikau-unit-tests</family>
+  <url>/FormValidation</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.js
@@ -1,0 +1,131 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Form Not Validated On Display",
+            widgets: [
+               {
+                  id: "NO_INITIAL_VALIDATION",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     showOkButton: true,
+                     okButtonPublishTopic: "SET_HASH",
+                     okButtonLabel: "Save",
+                     showCancelButton: false,
+                     useHash: false,
+                     setHash: false,
+                     pubSubScope: "FORM1_",
+                     showValidationErrorsImmediately: false,
+                     widgets: [
+                        {
+                           id: "TB1",
+                           name: "alfresco/forms/controls/DojoValidationTextBox",
+                           config: {
+                              fieldId: "FIELD1",
+                              label: "Field 1",
+                              name: "field1",
+                              description: "Needs to be 3 characters or more",
+                              value: "a",
+                              validationConfig: [
+                                 {
+                                    validation: "minLength",
+                                    length: 3,
+                                    errorMessage: "Too short"
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "TB2",
+                           name: "alfresco/forms/controls/DojoValidationTextBox",
+                           config: {
+                              fieldId: "FIELD2",
+                              label: "Field 2",
+                              name: "field2",
+                              description: "Must be a number",
+                              value: "abcde",
+                              validationConfig: {
+                                 regex: "^([0-9]+)$",
+                                 errorMessage: "Value must be a number"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Form Validated On Display",
+            widgets: [
+               {
+                  id: "IMMEDIATELY_VALIDATED",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     okButtonPublishTopic: "PUBLISH_FORM_DATA",
+                     cancelButtonPublishTopic: "CANCEL_FORM_DATA",
+                     pubSubScope: "FORM2_",
+                     showValidationErrorsImmediately: true,
+                     widgets: [
+                        {
+                           id: "TB3",
+                           name: "alfresco/forms/controls/DojoValidationTextBox",
+                           config: {
+                              fieldId: "FIELD3",
+                              label: "Field 3",
+                              name: "field3",
+                              description: "Needs to be 3 characters or more",
+                              value: "a",
+                              validationConfig: [
+                                 {
+                                    validation: "minLength",
+                                    length: 3,
+                                    errorMessage: "Too short"
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "TB4",
+                           name: "alfresco/forms/controls/DojoValidationTextBox",
+                           config: {
+                              fieldId: "FIELD4",
+                              label: "Field 4",
+                              name: "field4",
+                              description: "Must be a number",
+                              value: "abcde",
+                              validationConfig: {
+                                 regex: "^([0-9]+)$",
+                                 errorMessage: "Value must be a number"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-378 to add the ability to configure forms to not show validation errors immediately. This is done by configuring the form with the new attribute "showValidationErrorsImmediately" as false (the default is true).