### PR TITLE
InfiniteScroll issue with Share

### DIFF
--- a/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
+++ b/aikau/src/main/resources/alfresco/services/InfiniteScrollService.js
@@ -131,7 +131,7 @@ define(["dojo/_base/declare",
             clientHeight,
             scrollTop;
          if(scrollNode === window) {
-            scrollHeight = document.body.offsetHeight;
+            scrollHeight = document.body.scrollHeight;
             clientHeight = window.innerHeight;
             scrollTop = window.pageYOffset || (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop;
          } else {


### PR DESCRIPTION
Fix bug whereby InfiniteScrollService was not correctly calculating nearBottom when using `window` as the scrollNode.