### PR TITLE
AKU-390: Nested DND re-order and delete updates

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/Constants.js
+++ b/aikau/src/main/resources/alfresco/dnd/Constants.js
@@ -47,6 +47,15 @@ define([],function() {
       updateItemsEvent: "onAlfItemsUpdated",
 
       /**
+       * Emitted when an item is moved up or down within its parent
+       *
+       * @instance
+       * @type {String}
+       * @default "onAlfItemsReordered"
+       */
+      reorderItemsEvent: "onAlfItemsReordered",
+
+      /**
        * Emitted when an item value is updated
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropTarget.js
@@ -152,18 +152,9 @@ define(["dojo/_base/declare",
          aspect.after(this.previewTarget, "onMouseDown", lang.hitch(this, this.onWidgetSelected), true);
          
          // Capture widgets being dropped...
-         aspect.after(this.previewTarget, "onDrop", lang.hitch(this, this.onItemsUpdated), true);
-         
-         // We need to make sure that when a previously dropped item is dragged to a new location
-         // that the target it has been dragged out of is updated after a successful relocation
-         aspect.after(this.previewTarget, "onDndDrop", function(source, nodes, copy, target) {
-            var widget = registry.getEnclosingWidget(target.node);
-            widget = registry.getEnclosingWidget(source.node);
-            if (typeof widget.onItemsUpdated === "function")
-            {
-               widget.onItemsUpdated();
-            }
-         }, true);
+         aspect.after(this.previewTarget, "insertNodes", lang.hitch(this, this.onItemsUpdated), true);
+         aspect.after(this.previewTarget, "deleteSelectedNodes", lang.hitch(this, this.onItemsUpdated), true);
+
 
          if (this.previewTarget)
          {
@@ -405,7 +396,12 @@ define(["dojo/_base/declare",
                domClass.remove(this.previewNode, "containsItems");
             }
             // Emit the event to alert wrapping widgets to changes...
-            this.onItemsUpdated();
+            on.emit(this.domNode, Constants.updateItemsEvent, {
+               bubbles: true,
+               cancelable: true,
+               targetWidget: this,
+               deleteIndex: evt.deleteIndex
+            });
          }
       },
 
@@ -425,7 +421,7 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This function is called after a new item is dropped onto the page.
+       * This function is called after a new item is dropped onto the target or when items are deleted from it
        *
        * @instance
        */

--- a/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
@@ -457,10 +457,12 @@ define(["dojo/_base/declare",
             var previousItem = $(this.domNode.parentNode).children().eq(currentIndex -1);
             $(this.domNode).after($(previousItem));
 
-            on.emit(this.domNode, Constants.updateItemsEvent, {
+            on.emit(this.domNode, Constants.reorderItemsEvent, {
                bubbles: true,
                cancelable: true,
-               targetWidget: this
+               targetWidget: this,
+               oldIndex: currentIndex,
+               newIndex: currentIndex - 1 
             });
          }
       },
@@ -470,7 +472,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      onItemDown: function alfresco_dnd_DroppedItemWrapper__onItemonItemDown() {
+      onItemDown: function alfresco_dnd_DroppedItemWrapper__onItemDown() {
          var currentIndex = $(this.domNode).index();
          var itemCount = $(this.domNode.parentNode).children().length;
          if (currentIndex !== itemCount - 1)
@@ -483,10 +485,12 @@ define(["dojo/_base/declare",
             //    $(this).insertAfter(nextItem).slideDown(300);
             // });
 
-            on.emit(this.domNode, Constants.updateItemsEvent, {
+            on.emit(this.domNode, Constants.reorderItemsEvent, {
                bubbles: true,
                cancelable: true,
-               targetWidget: this
+               targetWidget: this,
+               oldIndex: currentIndex,
+               newIndex: currentIndex + 1 
             });
          }
       }

--- a/aikau/src/main/resources/alfresco/dnd/DroppedNestingItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedNestingItemWrapper.js
@@ -29,12 +29,14 @@
 define(["dojo/_base/declare",
         "alfresco/dnd/DroppedItemWrapper",
         "alfresco/dnd/Constants",
+        "alfresco/core/ObjectTypeUtils",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/on",
         "dojo/Deferred",
-        "dijit/registry"], 
-        function(declare, DroppedItemWrapper, Constants, lang, array, on, Deferred, registry) {
+        "dijit/registry",
+        "jquery"], 
+        function(declare, DroppedItemWrapper, Constants, ObjectTypeUtils, lang, array, on, Deferred, registry, $) {
    
    return declare([DroppedItemWrapper], {
       
@@ -55,6 +57,7 @@ define(["dojo/_base/declare",
 
          this.inherited(arguments);
          on(this.domNode, Constants.updateItemsEvent, lang.hitch(this, this.onNestedTargetUpdated));
+         on(this.domNode, Constants.reorderItemsEvent, lang.hitch(this, this.onNestedTargetReordered));
       },
 
       /**
@@ -114,30 +117,109 @@ define(["dojo/_base/declare",
        * @param {object} evt The drop event.
        */
       onNestedTargetUpdated: function alfresco_dnd_DroppedNestingItemWrapper__onNestedTargetUpdated(evt) {
-         if (typeof evt.stopPropagation === "function")
+         if (evt.targetWidget === this)
          {
-            evt.stopPropagation();
-         }
-         if (typeof evt.preventDefault === "function")
-         {
-            evt.preventDefault();
-         }
-
-         // Attempt to mix the updated target value into the wrapped value...
-         if (evt.targetWidget)
-         {
-            if (evt.targetWidget.targetProperty && typeof evt.targetWidget.getValue === "function")
-            {
-               lang.setObject(evt.targetWidget.targetProperty, evt.targetWidget.getValue(), this.value);
-            }
-            else
-            {
-               this.alfLog("warn", "The 'targetWidget' has no 'targetProperty' or no 'getValue' function", evt.targetWidget, this);
-            }
+            // We've managed to catch our own emitted event, allow bubbling to continue...
          }
          else
          {
-            this.alfLog("warn", "The update event contains no 'targetWidget' attribute", evt, this);
+            if (typeof evt.stopPropagation === "function")
+            {
+               evt.stopPropagation();
+            }
+            if (typeof evt.preventDefault === "function")
+            {
+               evt.preventDefault();
+            }
+
+            // Attempt to mix the updated target value into the wrapped value...
+            if (evt.targetWidget)
+            {
+               if (evt.targetWidget.targetProperty && typeof evt.targetWidget.getValue === "function")
+               {
+                  var listToReorder = lang.getObject(evt.targetWidget.targetProperty, false, this.value);
+                  if (!ObjectTypeUtils.isArray(listToReorder))
+                  {
+                     // The target value will usually be an array, but just in case - just set the value as given...
+                     lang.setObject(evt.targetWidget.targetProperty, evt.targetWidget.getValue(), this.value);
+                  }
+                  else if (!isNaN(evt.index))
+                  {
+                     // Set the supplied index...
+                     listToReorder[evt.index] = evt.targetWidget.getValue();
+                  }
+                  else
+                  {
+                     this.alfLog("warn", "Can't determine what to update as no index is provided to update the array", listToReorder, evt, this);
+                  }
+               }
+               else
+               {
+                  this.alfLog("warn", "The 'targetWidget' has no 'targetProperty' or no 'getValue' function", evt.targetWidget, this);
+               }
+            }
+            else
+            {
+               this.alfLog("warn", "The update event contains no 'targetWidget' attribute", evt, this);
+            }
+         }
+      },
+
+      /**
+       * Handles items in a target being reordered
+       * 
+       * @instance
+       * @param {object} evt The drop event.
+       */
+      onNestedTargetReordered: function alfresco_dnd_DroppedNestingItemWrapper__onNestedTargetReordered(evt) {
+         if (evt.targetWidget === this)
+         {
+            // We've managed to catch our own emitted event, allow bubbling to continue...
+         }
+         else
+         {
+            if (typeof evt.stopPropagation === "function")
+            {
+               evt.stopPropagation();
+            }
+            if (typeof evt.preventDefault === "function")
+            {
+               evt.preventDefault();
+            }
+
+            // Attempt to mix the updated target value into the wrapped value...
+            if (evt.targetWidget && evt.targetWidget.targetProperty)
+            {
+               var listToReorder = lang.getObject(evt.targetWidget.targetProperty, false, this.value);
+               if (!ObjectTypeUtils.isArray(listToReorder))
+               {
+                  this.alfLog("warn", "Can't reorder because the targetProperty does not exist or is not an array", evt.targetWidget.targetProperty, this.value, this);
+               }
+               else if (isNaN(evt.oldIndex) || isNaN(evt.newIndex))
+               {
+                  this.alfLog("warn", "Can't reorder because either the oldIndex or the newIndex (or both) are missing or are not numbers", evt, this);
+               }
+               else
+               {
+                  // Do the re-ordering...
+                  var tmp1 = listToReorder[evt.oldIndex];
+                  var tmp2 = listToReorder[evt.newIndex];
+                  listToReorder[evt.oldIndex] = tmp2;
+                  listToReorder[evt.newIndex] = tmp1;
+
+                  // ...then emit an event to capture the new value...
+                  on.emit(this.domNode, Constants.updateItemsEvent, {
+                     bubbles: true,
+                     cancelable: true,
+                     targetWidget: this,
+                     index: $(this.domNode).index()
+                  });
+               }
+            }
+            else
+            {
+               this.alfLog("warn", "The update event contains no 'targetWidget' attribute", evt, this);
+            }
          }
       },
 

--- a/aikau/src/main/resources/alfresco/dnd/DroppedNestingItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedNestingItemWrapper.js
@@ -158,19 +158,19 @@ define(["dojo/_base/declare",
                   {
                      // The target value will usually be an array, but just in case - just set the value as given...
                      lang.setObject(evt.targetWidget.targetProperty, evt.targetWidget.getValue(), this.value);
-                     this.onUpdateParentOfChange();
+                     this.notifyParentOfChange();
                   }
                   else if (!isNaN(evt.index))
                   {
                      // Set the supplied index...
                      listToReorder[evt.index] = evt.targetWidget.getValue();
-                     this.onUpdateParentOfChange();
+                     this.notifyParentOfChange();
                   }
                   else if (!isNaN(evt.deleteIndex))
                   {
                      // Delete an item...
                      listToReorder.splice(evt.deleteIndex, 1);
-                     this.onUpdateParentOfChange();
+                     this.notifyParentOfChange();
                   }
                   else
                   {
@@ -186,7 +186,7 @@ define(["dojo/_base/declare",
                         }
                      }, this);
                      lang.setObject(evt.targetWidget.targetProperty, value, this.value);
-                     this.onUpdateParentOfChange();
+                     this.notifyParentOfChange();
                   }
                }
                else
@@ -244,7 +244,7 @@ define(["dojo/_base/declare",
                   listToReorder[evt.newIndex] = tmp1;
 
                   // ...then emit an event to capture the new value...
-                  this.onUpdateParentOfChange();
+                  this.notifyParentOfChange();
                }
             }
             else
@@ -259,7 +259,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      onUpdateParentOfChange: function alfresco_dnd_DroppedNestingItemWrapper__onUpdateParentOfChange() {
+      notifyParentOfChange: function alfresco_dnd_DroppedNestingItemWrapper__notifyParentOfChange() {
          on.emit(this.domNode, Constants.updateItemsEvent, {
             bubbles: true,
             cancelable: true,

--- a/aikau/src/test/resources/alfresco/dnd/NestedReorderTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/NestedReorderTest.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"], 
+        function (registerSuite, assert, require, TestCommon, keys) {
+
+   var pause = 150;
+   var browser;
+   registerSuite({
+
+      name: "Nested item re-ordering, moving and deleting tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/nested-reorder-dnd", "Nested item re-ordering, moving and deleting tests")
+            .end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Move a deep nested item down a place": function() {
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(1) .innerTestItemWrapper:nth-child(1) .down")
+            .click()
+         .end()
+         .clearLog()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data.0.config.widgets.0.config.widgets.0.name", "E", "E was not saved as first item");
+               assert.deepPropertyVal(payload, "data.0.config.widgets.0.config.widgets.1.name", "D", "D was not saved as second item");
+            });
+      },
+
+      "Delete a deep nested item": function() {
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(1) .innerTestItemWrapper:nth-child(1) .delete")
+            .click()
+         .end()
+         .clearLog()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data.0.config.widgets.0.config.widgets.0.name", "D", "D was not saved as first item");
+               assert.deepPropertyVal(payload, "data.0.config.widgets.0.config.widgets.1.name", "F", "F was not saved as second item");
+               assert.lengthOf(payload.data[0].config.widgets[0].config.widgets, 2, "E was not deleted");
+            });
+      },
+
+      "Move a deep nested item into another target": function() {
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(1) .innerTestItemWrapper:nth-child(1) .dojoDndHandle")
+            .moveMouseTo()
+            .click()
+            .pressMouseButton()
+            .moveMouseTo(1, 1)
+         .end()
+         .findByCssSelector(".middleTestItemWrapper:nth-child(2) .previewPanel > div:first-child")
+            .then(function(element) {
+                  browser.moveMouseTo(element);
+               })
+            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+            .releaseMouseButton()
+         .end()
+         .clearLog()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.lengthOf(payload.data[0].config.widgets[1].config.widgets, 4, "D was not moved between targets");
+               assert.lengthOf(payload.data[0].config.widgets[0].config.widgets, 1, "D was not removed from original source");
+            });
+      },
+
+      "Re-order deep nested item using buttons": function() {
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(2) .innerTestItemWrapper:nth-child(4) .up")
+            .click()
+         .end()
+         .clearLog()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data.0.config.widgets.1.config.widgets.2.name", "D", "D was not moved up");
+               assert.deepPropertyVal(payload, "data.0.config.widgets.1.config.widgets.3.name", "E", "E was not moved down");
+            });
+      },
+
+      "Re-order middle nested item using buttons": function() {
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(1) > .actions > .down")
+            .click()
+         .end()
+         .clearLog()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data.0.config.widgets.0.config.widgets.2.name", "D", "C was not moved up");
+               assert.deepPropertyVal(payload, "data.0.config.widgets.1.config.widgets.0.name", "F", "B was not moved down");
+            });
+      },
+
+      "Delete middle nested item": function() {
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(1) > .actions > .delete")
+            .click()
+         .end()
+         .clearLog()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.lengthOf(payload.data[0].config.widgets, 1, "C was not deleted");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,9 +31,14 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest",
-      "src/test/resources/alfresco/dashlets/DashletTest"
+   baseFunctionalSuites: [
+      "src/test/resources/alfresco/dnd/AlternateEditorTest",
+      "src/test/resources/alfresco/dnd/DndTest",
+      "src/test/resources/alfresco/dnd/FormCreationTest",
+      "src/test/resources/alfresco/dnd/ModelCreationServiceTest",
+      "src/test/resources/alfresco/dnd/MultiSourceTest",
+      "src/test/resources/alfresco/dnd/NestedConfigurationTest",
+      "src/test/resources/alfresco/dnd/NestedReorderTest"
    ],
 
    /**
@@ -42,7 +47,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 
@@ -72,6 +77,7 @@ define({
       "src/test/resources/alfresco/dnd/ModelCreationServiceTest",
       "src/test/resources/alfresco/dnd/MultiSourceTest",
       "src/test/resources/alfresco/dnd/NestedConfigurationTest",
+      "src/test/resources/alfresco/dnd/NestedReorderTest",
 
       "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest",
       "src/test/resources/alfresco/documentlibrary/CreateContentTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,14 +31,9 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   baseFunctionalSuites: [
-      "src/test/resources/alfresco/dnd/AlternateEditorTest",
-      "src/test/resources/alfresco/dnd/DndTest",
-      "src/test/resources/alfresco/dnd/FormCreationTest",
-      "src/test/resources/alfresco/dnd/ModelCreationServiceTest",
-      "src/test/resources/alfresco/dnd/MultiSourceTest",
-      "src/test/resources/alfresco/dnd/NestedConfigurationTest",
-      "src/test/resources/alfresco/dnd/NestedReorderTest"
+   xbaseFunctionalSuites: [
+      "src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest",
+      "src/test/resources/alfresco/dashlets/DashletTest"
    ],
 
    /**
@@ -47,7 +42,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   xbaseFunctionalSuites: [
+   baseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Drag-and-drop (nested item reordering)</shortname>
+  <description>Shows pre-loaded DND data where items nested within an object are reordered</description>
+  <family>aikau-unit-tests</family>
+  <url>/nested-reorder-dnd</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.js
@@ -1,4 +1,3 @@
-/* global page */
 var value = [
  {
    name: "A",
@@ -104,6 +103,7 @@ model.jsonModel = {
                      {
                         name: "alfresco/dnd/DroppedNestingItemWrapper",
                         config: {
+                           additionalCssClasses: "outerTestItemWrapper",
                            showEditButton: false,
                            label: "{label}",
                            value: "{value}",
@@ -112,6 +112,7 @@ model.jsonModel = {
                               {
                                  name: "alfresco/dnd/DragAndDropNestedTarget",
                                  config: {
+                                    additionalCssClasses: "outerTestItemTarget",
                                     useModellingService: true,
                                     label: "Widgets",
                                     targetProperty: "config.widgets",
@@ -133,6 +134,7 @@ model.jsonModel = {
                      {
                         name: "alfresco/dnd/DroppedNestingItemWrapper",
                         config: {
+                           additionalCssClasses: "middleTestItemWrapper",
                            showEditButton: false,
                            label: "{label}",
                            value: "{value}",
@@ -141,6 +143,7 @@ model.jsonModel = {
                               {
                                  name: "alfresco/dnd/DragAndDropNestedTarget",
                                  config: {
+                                    additionalCssClasses: "middleTestItemTarget",
                                     useModellingService: true,
                                     label: "Widgets",
                                     targetProperty: "config.widgets",
@@ -162,13 +165,17 @@ model.jsonModel = {
                      {
                         name: "alfresco/dnd/DroppedNestingItemWrapper",
                         config: {
+                           additionalCssClasses: "innerTestItemWrapper",
                            showEditButton: false,
                            label: "{label}",
                            value: "{value}",
                            type: "{type}",
                            widgets: [
                               {
-                                 name: "alfresco/dnd/DroppedItem"
+                                 name: "alfresco/dnd/DroppedItem",
+                                 config: {
+                                    additionalCssClasses: "innerTestItem"
+                                 }
                               }
                            ]
                         }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.js
@@ -1,0 +1,270 @@
+/* global page */
+var value = [
+ {
+   name: "A",
+   label: "A",
+   type: [
+     "outer"
+   ],
+   config: {
+     widgets: [
+       {
+         name: "B",
+         label: "B",
+         type: [
+           "middle"
+         ],
+         config: {
+           widgets: [
+             {
+               name: "D",
+               label: "D",
+               type: [
+                 "inner"
+               ]
+             },
+             {
+               name: "E",
+               label: "E",
+               type: [
+                 "inner"
+               ]
+             },
+             {
+               name: "F",
+               label: "F",
+               type: [
+                 "inner"
+               ]
+             }
+           ]
+         }
+       },
+       {
+         name: "C",
+         label: "C",
+         type: [
+           "middle"
+         ],
+         config: {
+           widgets: [
+             {
+               name: "F",
+               label: "F",
+               type: [
+                 "inner"
+               ]
+             },
+             {
+               name: "E",
+               label: "E",
+               type: [
+                 "inner"
+               ]
+             },
+             {
+               name: "D",
+               label: "D",
+               type: [
+                 "inner"
+               ]
+             }
+           ]
+         }
+       }
+     ]
+   }
+ }
+];
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      {
+         name: "alfresco/services/DragAndDropModellingService",
+         config: {
+            models: [
+               {
+                  property: "name",
+                  targetValues: ["A"],
+                  widgetsForConfig: [
+                     // No config
+                  ],
+                  widgetsForDisplay: [
+                     {
+                        name: "alfresco/dnd/DroppedNestingItemWrapper",
+                        config: {
+                           showEditButton: false,
+                           label: "{label}",
+                           value: "{value}",
+                           type: "{type}",
+                           widgets: [
+                              {
+                                 name: "alfresco/dnd/DragAndDropNestedTarget",
+                                 config: {
+                                    useModellingService: true,
+                                    label: "Widgets",
+                                    targetProperty: "config.widgets",
+                                    acceptTypes: [ "middle" ]
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  property: "name",
+                  targetValues: ["B","C"],
+                  widgetsForConfig: [
+                     // No config
+                  ],
+                  widgetsForDisplay: [
+                     {
+                        name: "alfresco/dnd/DroppedNestingItemWrapper",
+                        config: {
+                           showEditButton: false,
+                           label: "{label}",
+                           value: "{value}",
+                           type: "{type}",
+                           widgets: [
+                              {
+                                 name: "alfresco/dnd/DragAndDropNestedTarget",
+                                 config: {
+                                    useModellingService: true,
+                                    label: "Widgets",
+                                    targetProperty: "config.widgets",
+                                    acceptTypes: [ "inner" ]
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  property: "name",
+                  targetValues: ["D","E","F"],
+                  widgetsForConfig: [
+                     // No config
+                  ],
+                  widgetsForDisplay: [
+                     {
+                        name: "alfresco/dnd/DroppedNestingItemWrapper",
+                        config: {
+                           showEditButton: false,
+                           label: "{label}",
+                           value: "{value}",
+                           type: "{type}",
+                           widgets: [
+                              {
+                                 name: "alfresco/dnd/DroppedItem"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+
+            ]
+         }
+      },
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "DRAG_PALETTE1",
+                  name: "alfresco/dnd/DragAndDropItems",
+                  config: {
+                     items: [
+                        {
+                           type: [ "outer"],
+                           label: "A",
+                           value: {
+                              name: "A"
+                           }
+                        },
+                        {
+                           type: [ "middle"],
+                           label: "B",
+                           value: {
+                              name: "B"
+                           }
+                        },
+                        {
+                           type: [ "middle"],
+                           label: "C",
+                           value: {
+                              name: "C"
+                           }
+                        },
+                        {
+                           type: [ "inner"],
+                           label: "D",
+                           value: {
+                              name: "D"
+                           }
+                        },
+                        {
+                           type: [ "inner"],
+                           label: "E",
+                           value: {
+                              name: "E"
+                           }
+                        },
+                        {
+                           type: [ "inner"],
+                           label: "F",
+                           value: {
+                              name: "F"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "FORM1",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     scopeFormControls: false,
+                     okButtonLabel: "Save",
+                     okButtonPublishTopic: "FORM1_POST",
+                     okButtonPublishGlobal: true,
+                     showCancelButton: false,
+                     widgets: [
+                        {
+                           id: "ROOT_DROPPED_ITEMS1",
+                           name: "alfresco/forms/controls/DragAndDropTargetControl",
+                           config: {
+                              label: "Data",
+                              name: "data",
+                              value: value,
+                              acceptTypes: ["outer"],
+                              useModellingService: true
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-390 to resolve issues with the DND capabilities in nested items. Previous tests for re-ordering were only looking at root level items so a new test page has been created with items nested within nested items and these are then re-ordered (using the up/down buttons), moved from one target to another and deleted. 

Some significant portions of the DND implementation have required updating to ensure that this now works as it should.