### PR TITLE
Updates to service-filtering.lib.js

### DIFF
--- a/aikau/src/main/resources/webscript-libs/service-filtering.lib.js
+++ b/aikau/src/main/resources/webscript-libs/service-filtering.lib.js
@@ -1,17 +1,21 @@
 // This library file provides a convenient way in which services provided from multiple libraries can be filtered 
 // against each other to ensure that there are no duplicates (e.g. you want to avoid having two DialogServices on a
 // page otherwise you'll get two dialogs for each request!).
-function alfAddUniqueServices(currentServices, servicesToFilter) {
-   // Add the current services into the array that will ultimately be returned...
-   // Unique services not already defined (or that are configured with a different pubSubScope
-   // will be added) as well...
-   var filteredServices = [].concat(currentServices);
-
+function alfAddUniqueServices(currentServices, servicesToFilter, includeCurrentServices) {
+   var filteredServices = [];
+   
    // There's only filtering to do with we have been provided with some services to
    // filter against an array of current services...
    if (servicesToFilter && servicesToFilter.length &&
        currentServices && currentServices.length)
    {
+      // It is possible to request to NOT include the currentServices in the filtered result,
+      // this allows multiple Surf Components using Aikau on a page to avoid duplicating each other
+      if (includeCurrentServices !== false)
+      {
+         filteredServices = [].concat(currentServices);
+      }
+
       // Re-usable function for getting service names (since services can either
       // be defined in an array as Strings or Objects)...
       var getServiceName = function(s) {
@@ -72,6 +76,20 @@ function alfAddUniqueServices(currentServices, servicesToFilter) {
             filteredServices.push(a);
          }
       }
+   }
+   else if (currentServices && currentServices.length === 0 &&
+            servicesToFilter && servicesToFilter.length)
+   {
+      // If there are no currentServices, but there are servicesToFilter, then just return the complete
+      // list of servicesToFilter
+      filteredServices = servicesToFilter;
+   }
+   else if (currentServices && currentServices.length &&
+            servicesToFilter && servicesToFilter.length === 0 &&
+            includeCurrentServices !== false)
+   {
+      // If there ARE currentServices but no servicesToFilter, and we want to include the currentServices
+      // then just return them
    }
    return filteredServices;
 }

--- a/aikau/src/main/resources/webscript-libs/service-filtering.lib.js
+++ b/aikau/src/main/resources/webscript-libs/service-filtering.lib.js
@@ -1,7 +1,7 @@
 // This library file provides a convenient way in which services provided from multiple libraries can be filtered 
 // against each other to ensure that there are no duplicates (e.g. you want to avoid having two DialogServices on a
 // page otherwise you'll get two dialogs for each request!).
-function alfAddUniqueServices(currentServices, servicesToFilter, includeCurrentServices) {
+function alfAddUniqueServices(currentServices, servicesToFilter, excludeCurrentServices) {
    var filteredServices = [];
    
    // There's only filtering to do with we have been provided with some services to
@@ -11,7 +11,7 @@ function alfAddUniqueServices(currentServices, servicesToFilter, includeCurrentS
    {
       // It is possible to request to NOT include the currentServices in the filtered result,
       // this allows multiple Surf Components using Aikau on a page to avoid duplicating each other
-      if (includeCurrentServices !== false)
+      if (!excludeCurrentServices)
       {
          filteredServices = [].concat(currentServices);
       }
@@ -86,10 +86,11 @@ function alfAddUniqueServices(currentServices, servicesToFilter, includeCurrentS
    }
    else if (currentServices && currentServices.length &&
             servicesToFilter && servicesToFilter.length === 0 &&
-            includeCurrentServices !== false)
+            !excludeCurrentServices)
    {
       // If there ARE currentServices but no servicesToFilter, and we want to include the currentServices
       // then just return them
+      filteredServices = currentServices;
    }
    return filteredServices;
 }


### PR DESCRIPTION
I took a look ahead to AKU-410 and realised that some additional service filtering capabilities would be required. In a scenario where there are 2 Surf Components that render Aikau content it will be necessary to not just filter duplicate services defined in libraries, but to eliminate them altogether. This means that a dashlet WebScript can import the share-header.lib.js file and remove all services that it defined (rather than just eliminating duplicates)... because even if duplicates are removed, the Surf Component containing the header will duplicate them anyway. So the service-filtering.lib.js now supports an additional argument that allows duplicates to not just be filtered but removed entirely.