### PR TITLE
AKU-413: Ensure that single item mode works with nested items

### DIFF
--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -211,19 +211,16 @@ define(["dojo/_base/declare",
             var a = lang.getObject(this.useItemsOnceComparisonKey, false, payload.value);
             if (a)
             {
-               // NOTE: Using some to exit as soon as match is found
-               array.some(this.items, function(item) {
-                  var b = lang.getObject(this.useItemsOnceComparisonKey, false, item.value);
+               var _this = this;
+               this.sourceTarget.forInItems(function(i, id, map) {
+                  var _item = map.getItem(id);
+                  var b = lang.getObject(_this.useItemsOnceComparisonKey, false, _item.data.value);
                   if (a === b)
                   {
-                     this.sourceTarget.forInItems(function(i, id, map) {
-                        map.delItem(id);
-                        domConstruct.destroy(dom.byId(id));
-                     });
-                     return true;
+                     map.delItem(id);
+                     domConstruct.destroy(dom.byId(id));
                   }
-                  return false;
-               }, this);
+               });
             }
          }
       },

--- a/aikau/src/test/resources/alfresco/creation/WidgetConfigTest.js
+++ b/aikau/src/test/resources/alfresco/creation/WidgetConfigTest.js
@@ -40,10 +40,6 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
       "Test Drag From Palette To Drop Zone": function () {
          return browser.findByCssSelector("#dojoUnique1 > .title")
             .moveMouseTo()
@@ -53,10 +49,11 @@ define(["intern!object",
          .end()
          .findByCssSelector(".alfresco-creation-DropZone > div")
             .then(function(element) {
-               browser.moveMouseTo(element);
+               return browser.moveMouseTo(element)
+                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                  .releaseMouseButton();
             })
-            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-            .releaseMouseButton()
+            
          .end()
          .findByCssSelector(".dojoDndHandle")
             .click()

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -66,10 +66,10 @@ define(["intern!object",
          .end()
          .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
             .then(function(element) {
-               browser.moveMouseTo(element);
+               return browser.moveMouseTo(element)
+                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                  .releaseMouseButton();
             })
-            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-            .releaseMouseButton()
          .end()
          .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
@@ -393,10 +393,10 @@ define(["intern!object",
          .end()
          .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
             .then(function(element) {
-               browser.moveMouseTo(element);
+               return browser.moveMouseTo(element)
+                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                  .releaseMouseButton();
             })
-            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-            .releaseMouseButton()
          .end()
          .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {

--- a/aikau/src/test/resources/alfresco/dnd/FormCreationTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/FormCreationTest.js
@@ -52,10 +52,11 @@ define(["intern!object",
          .end()
          .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
             .then(function(element) {
-               browser.moveMouseTo(element);
+               return browser.moveMouseTo(element)
+                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                  .releaseMouseButton();
             })
-            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-            .releaseMouseButton()
+            
          .end()
          .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {

--- a/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
@@ -75,10 +75,10 @@ define(["intern!object",
          .end()
          .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
             .then(function(element) {
-               browser.moveMouseTo(element);
+               return browser.moveMouseTo(element)
+                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                  .releaseMouseButton();
             })
-            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-            .releaseMouseButton()
          .end()
          .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
@@ -289,7 +289,8 @@ define(["intern!object",
          .findAllByCssSelector(".alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
                assert.lengthOf(elements, 5, "The wrong number of items were pre-selected for dragging");
-            });
+            })
+            .releaseMouseButton();
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/dnd/NestedReorderTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/NestedReorderTest.js
@@ -23,11 +23,9 @@
 define(["intern!object",
         "intern/chai!assert",
         "require",
-        "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
 
-   var pause = 150;
    var browser;
    registerSuite({
 
@@ -41,6 +39,35 @@ define(["intern!object",
 
       beforeEach: function() {
          browser.end();
+      },
+
+      "Check that only 3 items are shown on the palette": function() {
+         // ...as all the others have been used...
+         return browser.findAllByCssSelector("#DRAG_PALETTE1 .dojoDndItem")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "There should only be 3 elements remaining on the palette as the others have been used");
+            });
+      },
+
+      "Drag nested items and check that palette is not cleared": function() {
+         // See AKU-413...
+         return browser.findByCssSelector(".middleTestItemWrapper:nth-child(1) > .dojoDndHandle")
+            .moveMouseTo()
+            .click()
+            .pressMouseButton()
+            .moveMouseTo(1, 1)
+         .end()
+         .findByCssSelector("#DRAG_PALETTE1 .dojoDndItem:first-child > div")
+            .then(function(element) {
+                  return browser.moveMouseTo(element)
+                     .sleep(1000) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                     .releaseMouseButton();
+               })
+         .end()
+         .findAllByCssSelector("#DRAG_PALETTE1 .dojoDndItem")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "There should still be 3 elements remaining on the palette after drag");
+            });
       },
 
       "Move a deep nested item down a place": function() {
@@ -83,10 +110,10 @@ define(["intern!object",
          .end()
          .findByCssSelector(".middleTestItemWrapper:nth-child(2) .previewPanel > div:first-child")
             .then(function(element) {
-                  browser.moveMouseTo(element);
+                  return browser.moveMouseTo(element)
+                     .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                     .releaseMouseButton();
                })
-            .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-            .releaseMouseButton()
          .end()
          .clearLog()
          .findByCssSelector(".confirmationButton > span")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/nested-reorder.get.js
@@ -197,6 +197,8 @@ model.jsonModel = {
                   id: "DRAG_PALETTE1",
                   name: "alfresco/dnd/DragAndDropItems",
                   config: {
+                     useItemsOnce: true,
+                     useItemsOnceComparisonKey: "name",
                      items: [
                         {
                            type: [ "outer"],
@@ -238,6 +240,27 @@ model.jsonModel = {
                            label: "F",
                            value: {
                               name: "F"
+                           }
+                        },
+                        {
+                           type: [ "outer"],
+                           label: "G",
+                           value: {
+                              name: "G"
+                           }
+                        },
+                        {
+                           type: [ "middle"],
+                           label: "H",
+                           value: {
+                              name: "H"
+                           }
+                        },
+                        {
+                           type: [ "inner"],
+                           label: "I",
+                           value: {
+                              name: "I"
                            }
                         }
                      ]


### PR DESCRIPTION
This PR resolves https://issues.alfresco.com/jira/browse/AKU-413 in ensuring that the DragAndDropItems widget only removes the appropriate items in single use mode.