### PR TITLE
AKU-409: DateTextBox cannot be empty

### DIFF
--- a/aikau/src/main/resources/alfresco/core/TemporalUtils.js
+++ b/aikau/src/main/resources/alfresco/core/TemporalUtils.js
@@ -43,12 +43,13 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/TemporalUtils.properties"}],
 
       /**
-       * @constructs TemporalUtils
-       * @param {object} args modules to mixin
+       * Constructor
+       * 
+       * @param {object} config Config to mixin
        */
-      constructor: function alfresco_core_TemporalUtils__constructor(args) {
+      constructor: function alfresco_core_TemporalUtils__constructor(config) {
 
-         lang.mixin(this, args);
+         lang.mixin(this, config);
          
          this.dateFormats = {};
          this.dateFormats.DAY_NAMES = (this.message("days.medium") + "," + this.message("days.long")).split(",");
@@ -79,11 +80,12 @@ define(["dojo/_base/declare",
        * Generate a relative time between two Date objects.
        *
        * @instance
-       * @param from {Date|String} JavaScript Date object or ISO8601-formatted date string
-       * @param to {Date|String} (Optional) JavaScript Date object or ISO8601-formatted date string, defaults to now if not supplied
+       * @param {Date|String} from JavaScript Date object or ISO8601-formatted date string
+       * @param {Date|String} [to] JavaScript Date object or ISO8601-formatted date string, defaults to now if not supplied
        * @return {String} Relative time description
        */
       getRelativeTime: function alfresco_core_TemporalUtils__getRelativeTime(from, to) {
+         /*jshint maxstatements:false, maxcomplexity:false*/
 
          var originalFrom = from;
 
@@ -97,7 +99,7 @@ define(["dojo/_base/declare",
             return originalFrom;
          }
 
-         if (to === undefined)
+         if (typeof to === "undefined")
          {
             to = new Date();
          }
@@ -117,7 +119,7 @@ define(["dojo/_base/declare",
          {
             return fnTime("relative.seconds", seconds_ago);
          }
-         if (minutes_ago == 1)
+         if (minutes_ago === 1)
          {
             return fnTime("relative.minute");
          }
@@ -164,20 +166,20 @@ define(["dojo/_base/declare",
        * Convert an ISO8601 date string into a native JavaScript Date object
        *
        * @instance
-       * @param date {String} ISO8601 formatted date string
-       * @param ignoreTime {Boolean} Optional. Ignores any time (and therefore timezone) components.
-       * @return {Date|null} JavaScript native Date object
+       * @param {String} date ISO8601 formatted date string
+       * @param {Boolean} [ignoreTime] Ignores any time (and therefore timezone) components.
+       * @return {Date} JavaScript native Date object or null on errors
        */
-      fromISO8601: function alfresco_core_TemporalUtils__fromISO8601(date, ignoreTime) {
+      fromISO8601: function alfresco_core_TemporalUtils__fromISO8601(dateString, ignoreTime) {
 
          if (ignoreTime)
          {
-            date = date.split('T')[0];
+            dateString = dateString.split("T")[0];
          }
 
          try
          {
-            return stamp.fromISOString(date);
+            return stamp.fromISOString(dateString);
          }
          catch(e)
          {
@@ -189,14 +191,14 @@ define(["dojo/_base/declare",
        * Convert a native JavaScript Date object into an ISO8601 date string
        *
        * @instance
-       * @param date {Date} JavaScript native Date object
+       * @param {Date} date JavaScript native Date object
        * @return {String} ISO8601 formatted date string
        */
       toISO8601: function alfresco_core_TemporalUtils__toISO8601(date) {
 
          try
          {
-            return stamp.toISOString.apply(this, arguments);
+            return stamp.toISOString(date);
          }
          catch(e)
          {
@@ -208,25 +210,21 @@ define(["dojo/_base/declare",
        * Formats a date time into a more UI-friendly format
        *
        * @instance
-       * @param date {String|Date} Optional: Date as ISO8601 compatible string or JavaScript Date Object. Today used if missing.
-       * @param format {String} Optional: Mask to use to override default.
+       * @param {String|Date} [date] Date as ISO8601 compatible string or JavaScript Date Object. Today used if missing.
+       * @param {String} [format] Mask to use to override default.
        * @return {String} Date formatted for UI
        */
-      formatDate: function alfresco_core_TemporalUtils__formatDate(date, format) {
+      formatDate: function alfresco_core_TemporalUtils__formatDate(date, /*jshint unused:false*/ format) {
 
+         var dateToUse = date;
          if (lang.isString(date))
          {
             // if we've got a date as an ISO8601 string, convert to date Object before proceeding - otherwise pass it through
-            var dateObj = this.fromISO8601(date);
-            if (dateObj)
-            {
-               arguments[0] = dateObj;
-            }
+            dateToUse = this.fromISO8601(date) || date;
          }
          try
          {
-            // return locale.format.apply(this, arguments);
-            return this.formatDate3rd.apply(this, arguments);
+            return this.formatDate3rd(dateToUse, format);
          }
          catch(e)
          {
@@ -249,6 +247,7 @@ define(["dojo/_base/declare",
        * @return {String}
        */
       formatDate3rd: function alfresco_core_TemporalUtils__formatDate3rd() {
+         /*jshint noarg:false*/
 
          /* dateFormat
           Accepts a date, a mask, or a date and a mask.
@@ -257,7 +256,7 @@ define(["dojo/_base/declare",
           The mask defaults ``"ddd mmm d yyyy HH:MM:ss"``.
           */
          var _this = this,
-             dateFormat = function() {
+             dateFormat = (function() {
             
             var token        = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloZ]|"[^"]*"|'[^']*'/g,
                 timezone     = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,
@@ -274,17 +273,18 @@ define(["dojo/_base/declare",
 
             // Regexes and supporting functions are cached through closure
             return function (date, mask) {
+               /*jshint maxcomplexity:false*/
 
                // Treat the first argument as a mask if it doesn't contain any numbers
-               if (arguments.length == 1 &&
-                  (typeof date == "string" || date instanceof String) &&
+               if (arguments.length === 1 &&
+                  (typeof date === "string" || date instanceof String) &&
                   !/\d/.test(date))
                {
                   mask = date;
                   date = undefined;
                }
 
-               if (typeof date == "string")
+               if (typeof date === "string")
                {
                   date = date.replace(".", "");
                }
@@ -339,7 +339,7 @@ define(["dojo/_base/declare",
                   return ($0 in flags) ? flags[$0] : $0.slice(1, $0.length - 1);
                });
             };
-         }();
+         })();
 
          /**
           * Alfresco wrapper: delegate to wrapped code
@@ -354,16 +354,20 @@ define(["dojo/_base/declare",
        * Only accepts hours and minutes. Seconds are zeroed.
        *
        * @instance
-       * @param timeString {String} User input time
+       * @param {String} timeString User input time
        * @return {Date}
        */
       parseTime: function alfresco_core_TemporalUtils__parseTime(timeString) {
+         /*jshint maxcomplexity:false*/
 
          var d = new Date(); // Today's date
          var time = timeString.toString().match(/^(\d{1,2})(?::?(\d\d))?\s*(a*)([p]?)\.*m?\.*$/i);
 
          // Exit early if we've not got a match, if the hours are greater than 24, or greater than 12 if AM/PM is specified, or minutes are larger than 59.
-         if (time === null || !time[1] || time[1] > 24 || (time[1] > 12 && (time[3]||time[4])) || (time[2] && time[2] > 59)) return null;
+         if (time === null || typeof time === "undefined" || !time[1] || time[1] > 24 || (time[1] > 12 && (time[3]||time[4])) || (time[2] && time[2] > 59))
+         {
+            return null;
+         }
 
          // Add 12?
          var add12 = false;
@@ -377,7 +381,7 @@ define(["dojo/_base/declare",
          // if we've got EITHER AM or PM, the 12th hour behaves different:
          // 12am = 00:00 (which is the same as 24:00 if the date is ignored), 12pm = 12:00
          // if we don't have AM or PM, then default to 12 === noon (i.e. add nothing).
-         if (time[1] == 12 && (time[3] || time[4]))
+         if (time[1] === "12" && (time[3] || time[4]))
          {
             add12 = !add12;
          }
@@ -396,7 +400,7 @@ define(["dojo/_base/declare",
        * (indicated by <span class="relativeTime">{date.iso8601}</span>)
        *
        * @instance
-       * @param id {String} ID of HTML element containing dates for conversion
+       * @param {String} id ID of HTML element containing dates for conversion
        */
       renderRelativeTime: function alfresco_core_TemporalUtils__renderRelativeTime(id) {
          query("span.relativeTime", id).forEach(function(node){

--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -18,6 +18,19 @@
  */
 
 /**
+ * Creates a date-field input box
+ *
+ * @example <caption>Sample usage:</caption>
+ * {
+ *    name: "alfresco/forms/controls/DateTextBox",
+ *    id: "VALID_DATE_VALUE_1",
+ *    config: {
+ *       name: "validDate1",
+ *       value: "2012-12-12",
+ *       label: "Valid date #1"
+ *    }
+ * }
+ * 
  * @module alfresco/forms/controls/DateTextBox
  * @extends module:alfresco/forms/controls/BaseFormControl
  * @author Dave Draper
@@ -41,10 +54,12 @@ define(["alfresco/forms/controls/BaseFormControl",
       cssRequirements: [{cssFile:"./css/DateTextBox.css"}],
 
       /**
+       * Get the configuration for the wrapped widget
+       * 
        * @instance
+       * @returns {object} The configuration for the form control
        */
       getWidgetConfig: function alfresco_forms_controls_DateTextBox__getWidgetConfig() {
-         // Return the configuration for the widget
          var value = null;
          if (this.value instanceof Date)
          {
@@ -61,15 +76,24 @@ define(["alfresco/forms/controls/BaseFormControl",
          };
       },
 
+      /**
+       * Get the value currently assigned to the wrapped widget
+       * 
+       * @instance
+       * @returns {object} The current value of the field
+       */
       getValue: function alfresco_forms_controls_DateTextBox__getValue() {
          var value = this.inherited(arguments);
          return stamp.toISOString(value, { selector: "date" });
       },
 
       /**
+       * Create and return form control instance
+       *
        * @instance
+       * @param {object} config The configuration to use when instantiating the form control
        */
-      createFormControl: function alfresco_forms_controls_DateTextBox__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_DateTextBox__createFormControl(config) {
          domClass.add(this.domNode, "alfresco-forms-controls-DateTextBox");
          return new DateTextBox(config);
       }

--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -84,7 +84,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        */
       getValue: function alfresco_forms_controls_DateTextBox__getValue() {
          var value = this.inherited(arguments);
-         return stamp.toISOString(value, { selector: "date" });
+         return value && stamp.toISOString(value, { selector: "date" });
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/forms/controls/css/DateTextBox.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/DateTextBox.css
@@ -1,19 +1,12 @@
-.alfresco-forms-controls-TextBox .dijitCalendar,
-.alfresco-forms-controls-TextBox .dijitCalendar:hover,
-.alfresco-forms-controls-TextBox .dijitCalendarHover {
-   background-color: #fff !important;
+.alfresco-forms-controls-TextBox {
+   .dijitCalendar, .dijitCalendar:hover, .dijitCalendarHover, .dijitCalendarDateTemplate, .dijitCalendarPreviousMonth, .dijitCalendarNextMonth {
+      background-color: #fff !important;
+   }
+   .dijitCalendarDateTemplate, .dijitCalendarPreviousMonth, .dijitCalendarNextMonth {
+      border-bottom-color: #fff !important;
+   }
+   .dijitCalendarPreviousMonth .dijitCalendarDateLabel, .dijitCalendarNextMonth .dijitCalendarDateLabel {
+      border-color: #fff !important;
+      color: #ccc !important;
+   }
 }
-
-.alfresco-forms-controls-TextBox .dijitCalendarDateTemplate,
-.alfresco-forms-controls-TextBox .dijitCalendarPreviousMonth,
-.alfresco-forms-controls-TextBox .dijitCalendarNextMonth {
-   border-bottom-color: #fff !important;
-   background-color: #fff !important;
-}
-
-.alfresco-forms-controls-TextBox .dijitCalendarPreviousMonth .dijitCalendarDateLabel,
-.alfresco-forms-controls-TextBox .dijitCalendarNextMonth .dijitCalendarDateLabel {
-   color: #cccccc !important;
-   border-color: #fff !important;
-}
-

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -23,10 +23,10 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!assert",
-        "require",
+        "intern/chai!assert", 
+        "require", 
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function(registerSuite, assert, require, TestCommon) {
 
    var browser;
    registerSuite({
@@ -41,45 +41,48 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
-     "Test initial values": function () {
-         return browser.findByCssSelector("#DOJODATETEXTBOX_CONTROL")
-            .getProperty("value")
-            .then(function(value) {
-               assert(value === "12/12/2012", "Unexpected date value found in control");
+      "Test initial valid values": function() {
+         return browser.findByCssSelector("#VALID_DATES_FORM .confirmationButton .dijitButtonNode")
+            .click()
+            .getLastPublish("VALID_DATES_FORM_SUBMIT")
+            .then(function(payload) {
+               assert.propertyVal(payload, "validDate1", "2012-12-12", "Incorrect date value retrieved from control");
+               assert.propertyVal(payload, "validDate2", "2015-07-07", "Incorrect date value retrieved from control");
+            });
+      },
+
+      "Test initial invalid values": function() {
+         return browser.findByCssSelector("#INVALID_DATES_FORM .confirmationButton .dijitButtonNode")
+            .click()
+            .getLastPublish("INVALID_DATES_FORM_SUBMIT")
+            .then(function(payload) {
+               assert.propertyVal(payload, "lettersDate", null, "Invalid starting date-value (arbitrary letters) was not published with null value");
+               assert.propertyVal(payload, "nullDate", null, "Invalid starting date-value (null) was not published with null value");
+               assert.propertyVal(payload, "undefinedDate", null, "Invalid starting date-value (undefined) was not published with null value");
+            });
+      },
+
+      "Changed date publishes correct value": function() {
+         return browser.findByCssSelector("#VALID_DATE_VALUE_2 .dijitArrowButton") // Click down arrow
+            .clearLog()
+            .click()
+            .end()
+
+         .findByCssSelector("#VALID_DATE_VALUE_2_CONTROL_popup tr:nth-child(3) td:nth-child(3)") // Choose third date on third row
+            .click()
+            .end()
+
+         .findByCssSelector("#VALID_DATES_FORM .confirmationButton .dijitButtonNode") // Submit the form
+            .click()
+            .getLastPublish("VALID_DATES_FORM_SUBMIT")
+            .then(function(payload) {
+               assert.propertyVal(payload, "validDate1", "2012-12-12", "Incorrect date value retrieved from control after other control updated");
+               assert.propertyVal(payload, "validDate2", "2015-07-14", "Incorrect date value retrieved from control after this control updated");
             });
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
-
-      // TODO: Can't get this to pass...
-      // TEST 2
-      // .findByCssSelector("#DOJODATETEXTBOX .control .dijitArrowButton input.dijitArrowButtonInner")
-      //    .click()
-      //    .end()
-      // .findByCssSelector("#DOJODATETEXTBOX_CONTROL_popup tbody tr:nth-of-type(3) td:nth-of-type(5) span")
-      //    .click()
-      //    .end()
-      // .findByCssSelector("#DOJODATETEXTBOX_CONTROL")
-      //    .getProperty('value')
-      //    .then(function(value) {
-      //       assert(value == "14/12/2012", "Unexpected date value found in control after date change");
-      //    })
-      //    .end()
-
-      // // TEST 3
-      // .findByCssSelector("#FORM > .buttons > span:nth-of-type(1) > span > span > span:nth-of-type(3)")
-      //    .click()
-      //    .end()
-      // .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "someDate", "2012-12-14"))
-      //    .then(null, function() {
-      //       assert(false, "Form submission did not publish the expected event");
-      //    })
-      //    .end()
    });
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -106,7 +106,7 @@ define({
       "src/test/resources/alfresco/forms/controls/CodeMirrorTest",
       "src/test/resources/alfresco/forms/controls/ComboBoxTest",
       "src/test/resources/alfresco/forms/controls/ContainerPickerTest",
-      "src/test/resources/alfresco/forms/controls/DateTextBoxTest", // TODO: NEEDS FIXING
+      "src/test/resources/alfresco/forms/controls/DateTextBoxTest",
       "src/test/resources/alfresco/forms/controls/DocumentPickerTest",
       "src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest",
       "src/test/resources/alfresco/forms/controls/FormButtonDialogTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -1,9 +1,4 @@
 model.jsonModel = {
-   publishOnReady: [
-      {
-         publishTopic: "GLOBAL_UPDATE_TOPIC"
-      }
-   ],
    services: [
       {
          name: "alfresco/services/LoggingService",
@@ -18,28 +13,77 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         name: "alfresco/forms/Form",
+         name: "alfresco/layout/HorizontalWidgets",
          config: {
-            id: "FORM",
-            okButtonPublishTopic: "TEST_PUBLISH",
             widgets: [
                {
-                  name: "alfresco/forms/controls/DateTextBox",
+                  name: "alfresco/forms/Form",
+                  id: "VALID_DATES_FORM",
                   config: {
-                     id: "DOJODATETEXTBOX",
-                     name: "someDate",
-                     value: "2012-12-12",
-                     label: "Date"
+                     okButtonPublishTopic: "VALID_DATES_FORM_SUBMIT",
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
+                           id: "VALID_DATE_VALUE_1",
+                           config: {
+                              name: "validDate1",
+                              value: "2012-12-12",
+                              label: "Valid date #1"
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
+                           id: "VALID_DATE_VALUE_2",
+                           config: {
+                              name: "validDate2",
+                              value: "2015-07-07",
+                              label: "Valid date #2"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/Form",
+                  id: "INVALID_DATES_FORM",
+                  config: {
+                     okButtonPublishTopic: "INVALID_DATES_FORM_SUBMIT",
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
+                           id: "LETTERS_DATE_VALUE",
+                           config: {
+                              name: "lettersDate",
+                              value: "letters",
+                              label: "Letters date"
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
+                           id: "NULL_DATE_VALUE",
+                           config: {
+                              name: "nullDate",
+                              value: null,
+                              label: "Null date"
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
+                           id: "UNDEFINED_DATE_VALUE",
+                           config: {
+                              name: "undefinedDate",
+                              value: undefined,
+                              label: "Undefined date"
+                           }
+                        }
+                     ]
                   }
                }
             ]
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-409](https://issues.alfresco.com/jira/browse/AKU-409) which is about errors caused when an invalid value is fed into the DateTextBox control. There are also some JSHint and JSDoc updates, and all corresponding tests are updated.