### PR TITLE
AKU-407: AvatarThumbnail add support for link

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/AvatarThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/AvatarThumbnail.js
@@ -19,8 +19,9 @@
 
 /**
  * <p>This extends the standard [thumbnail widget]{@link module:alfresco/renderers/Thumbnail} to render user avatar
- * thumbnails. In this current implementation click events are suppressed, however in the future this widget is likely
- * to be enhanced to support configurable previews or navigation actions.</p>
+ * thumbnails. By default, it has no click action, however it is possible to specify a custom publishTopic which
+ * will then render the thumbnail clickable. For more information, please see the example below.</p>
+ * 
  * <p>The Alfresco REST APIs greatly vary in the attribute that user names are assigned to so it is important when
  * using this widget to set the [userNameProperty]{@link module:alfresco/renderers/AvatarThumbnail#userNameProperty}
  * for the context in which the thumbnail is to be used. If the REST API supports it you should also look to set the
@@ -35,14 +36,31 @@
  *    }
  * }
  * 
+ * @example <caption>Example configuration with click/publish:</caption>
+ * {
+ *    name: "alfresco/renderers/AvatarThumbnail",
+ *    id: "GUEST_THUMBNAIL",
+ *    config: {
+ *       currentItem: {
+ *          userName: "guest"
+ *       },
+ *       publishTopic: "ALF_DISPLAY_NOTIFICATION",
+ *       publishPayload: {
+ *          message: "You clicked on the guest thumbnail"
+ *       },
+ *       publishGlobal: true
+ *    }
+ * }
+ *
  * @module alfresco/renderers/AvatarThumbnail
  * @extends module:alfresco/renderers/Thumbnail
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
         "alfresco/renderers/Thumbnail",
+        "dojo/dom-style",
         "dojo/_base/event"], 
-        function(declare, Thumbnail, event) {
+        function(declare, Thumbnail, domStyle, event) {
 
    return declare([Thumbnail], {
       
@@ -87,7 +105,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      postMixInProperties: function alfresco_renderers_Thumbnail__postMixInProperties() {
+      postMixInProperties: function alfresco_renderers_AvatarThumbnail__postMixInProperties() {
          if (!this.thumbnailUrlTemplate)
          {
             this.thumbnailUrlTemplate = "slingshot/profile/avatar/{" + this.userNameProperty + "}/thumbnail/avatar";
@@ -96,14 +114,24 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Called after widget has been created.
+       *
+       * @instance
+       */
+      postCreate: function alfresco_renderers_AvatarThumbnail__postCreate(){
+         this.inherited(arguments);
+         this.publishTopic && domStyle.set(this.clickNode, "cursor", "pointer");
+      },
+
+      /**
        * Overrides the [inherited function]{@link module:alfresco/renderers/Thumbnail#onLinkClick} to prevent
-       * click actions from having any effect. In the future this is likely to be updated to support previewing
-       * the user data or navigating to a configurable user details page.
+       * click actions from having any effect unless a publishTopic has been specified.
        * 
        * @param  {object} evt The click event
        */
       onLinkClick: function alfresco_renderers_AvatarThumbnail__onLinkClick(evt) {
          evt && event.stop(evt);
+         this.publishTopic && this.alfPublish(this.publishTopic, this.getGeneratedPayload(), this.publishGlobal, this.publishToParent);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/templates/Thumbnail.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/Thumbnail.html
@@ -1,7 +1,7 @@
 <span class="alfresco-renderers-Thumbnail ${customClasses}" data-dojo-attach-point="thumbnailNode">
    <span class="link hidden" data-dojo-attach-point="linkNode"></span>
    <span class="droppable hidden" data-dojo-attach-point="droppableNode"></span>
-   <span class="inner" data-dojo-attach-event="ondijitclick:onLinkClick">
+   <span class="inner" data-dojo-attach-point="clickNode" data-dojo-attach-event="ondijitclick:onLinkClick">
       <img data-dojo-attach-point="imgNode" id="${imgId}" src="${thumbnailUrl}" alt="${imgAltText}" title="${imgTitle}"/>
    </span>
 </span>

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -187,14 +187,14 @@ define(["intern/dojo/node!fs",
             return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
                .click();
          };
-         command.session.getLastPublish = function(topicName) {
+         command.session.getLastPublish = function(topicName, isGlobal) {
             return this.getLogEntries({
                type: "PUBLISH",
                topic: topicName,
                pos: "last"
-            });
+            }, null, isGlobal);
          };
-         command.session.getLogEntries = function(filter, waitPeriod) {
+         command.session.getLogEntries = function(filter, waitPeriod, isGlobal) {
 
             // Normalise arguments
             filter = filter || {};
@@ -203,7 +203,11 @@ define(["intern/dojo/node!fs",
             // Build the selector
             var selectorBits = [".alfresco_logging_DebugLog__entry"];
             filter.type && selectorBits.push("[data-aikau-log-type=\"" + filter.type + "\"]"); // Type is "..."
-            filter.topic && selectorBits.push("[data-aikau-log-topic$=\"" + filter.topic + "\"]"); // Topic ends with "..."
+            if(isGlobal) {
+               filter.topic && selectorBits.push("[data-aikau-log-topic=\"" + filter.topic + "\"]"); // Topic is "..."
+            } else {
+               filter.topic && selectorBits.push("[data-aikau-log-topic$=\"" + filter.topic + "\"]"); // Topic ends with "..."
+            }
             filter.object && selectorBits.push("[data-aikau-log-object=\"" + filter.object + "\"]"); // Object is "..."
             if (filter.debug) {
                console.log("Log entry selector: \"" + selectorBits.join("") + "\"");

--- a/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "require",
+      "alfresco/TestCommon",
+      "intern/dojo/node!leadfoot/keys"
+   ],
+   function(registerSuite, assert, require, TestCommon, keys) {
+
+      var browser;
+      registerSuite({
+         name: "Avatar Thumbnail Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AvatarThumbnail", "Avatar Thumbnail Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Image src is correct": function() {
+            return browser.findByCssSelector("#ADMIN_THUMBNAIL .inner img")
+               .getAttribute("src")
+               .then(function(src) {
+                  assert.match(src, /\/aikau\/proxy\/alfresco\/slingshot\/profile\/avatar\/admin\/thumbnail\/avatar/, "Avatar thumbnail src incorrect");
+               });
+         },
+
+         "Publishes topic when clicked": function() {
+            return browser.findByCssSelector("#GUEST_THUMBNAIL .inner")
+               .click()
+               .getLastPublish("ALF_DISPLAY_NOTIFICATION", true)
+               .then(function(payload) {
+                  assert.isNotNull(payload, "Did not publish correct topic when clicked");
+                  assert.propertyVal(payload, "message", "You clicked on the guest thumbnail", "Did not publish correct payload");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
@@ -109,29 +109,4 @@ define(["intern!object",
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });
-
-   registerSuite({
-      name: "Avatar Thumbnail Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AvatarThumbnail", "Avatar Thumbnail Tests").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Check avatar img src attribute": function () {
-         return browser.findByCssSelector(".alfresco-renderers-Thumbnail .inner img")
-            .getAttribute("src")
-            .then(function (src){
-               assert(src.indexOf("/aikau/proxy/alfresco/slingshot/profile/avatar/admin/thumbnail/avatar") !== -1, "Avatar thumbnail src attribute wrong: " + src);
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   });
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,8 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/SitePickerTest"
+      "src/test/resources/alfresco/renderers/AvatarThumbnailTest",
+      "src/test/resources/alfresco/renderers/ThumbnailTest"
    ],
 
    /**
@@ -178,6 +179,7 @@ define({
 
       "src/test/resources/alfresco/renderers/ActionsTest",
       "src/test/resources/alfresco/renderers/ActivitySummaryTest",
+      "src/test/resources/alfresco/renderers/AvatarThumbnailTest",
       "src/test/resources/alfresco/renderers/BannerTest",
       "src/test/resources/alfresco/renderers/BooleanTest",
       "src/test/resources/alfresco/renderers/CategoryTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/AvatarThumbnail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/AvatarThumbnail.get.js
@@ -9,13 +9,12 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/DocumentService",
-      "alfresco/services/DialogService",
-      "alfresco/services/CrudService"
+      "alfresco/services/NotificationService"
    ],
    widgets:[
       {
          name: "alfresco/renderers/AvatarThumbnail",
+         id: "ADMIN_THUMBNAIL",
          config: {
             currentItem: {
                userName: "admin"
@@ -23,10 +22,25 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/renderers/AvatarThumbnail",
+         id: "GUEST_THUMBNAIL",
+         config: {
+            currentItem: {
+               userName: "guest"
+            },
+            generatePubSubScope: true,
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "You clicked on the guest thumbnail"
+            },
+            publishGlobal: true
+         }
+      },
+      {
          name: "aikauTesting/mockservices/ThumbnailsMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-407](https://issues.alfresco.com/jira/browse/AKU-407) and provides the ability to publish when clicking on an Avatar Thumbnail.