### PR TITLE
AKU-267: Repeating form dialog support in DialogService

### DIFF
--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -129,7 +129,7 @@
  * @property {string} [dialogId=null] The ID of the dialog to display. Only one dialog with no dialogId can exist on a page at a time, therefore it is sensible to always include an id for your dialogs to allow stacking.
  * @property {boolean} [dialogRepeats=false] Indicates that an additional button the publishes the current form and then recreates the dialog again
  * @property {string} [dialogConfirmationButtonTitle="OK"] - The label for the dialog confirmation button
- * @property {string} [dialogConfirmAndRepeatButtonId="OK (and repeat)"] The label for the button indicating the dialog should be repeated
+ * @property {string} [dialogConfirmAndRepeatButtonTitle="OK (and repeat)"] The label for the button indicating the dialog should be repeated
  * @property {string} [dialogCancellationButtonTitle="Cancel"] - The label for the dialog cancellation button
  * @property {string} [dialogCloseTopic=null] If this is set the the dialog will not automatically be closed when the confirmation button is pressed. Instead the dialog will remain open until this topic is published on.
  * @property {array} [widgets=null] - An array of form controls to include in the dialog
@@ -707,11 +707,6 @@ define(["dojo/_base/declare",
          {
             var data = {};
             var formData = payload.dialogContent[0].getValue();
-
-            // if (payload.subcriptionTopic)
-            // {
-            //    this.alfUnsubscribe(payload.subcriptionTopic); // Remove the subscription...
-            // }
 
             // Destroy the dialog if a reference is provided...
             if (payload.dialogReference && typeof payload.dialogReference.destroyRecursive === "function")

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -212,7 +212,6 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default
        */
       defaultFormDialogConfig: {
          dialogTitle: "",

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -211,7 +211,7 @@ define(["dojo/_base/declare",
        * The default configuration for form dialogs. This is used as a base when requests are received.
        *
        * @instance
-       * @type {string}
+       * @type {object}
        */
       defaultFormDialogConfig: {
          dialogTitle: "",

--- a/aikau/src/main/resources/alfresco/services/i18n/DialogService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/DialogService.properties
@@ -1,0 +1,3 @@
+dialogService.formDialog.ok.button.label=OK
+dialogService.formDialog.cancel.button.label=Cancel
+dialogService.formDialog.repeat.button.label=OK (and repeat)

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -131,7 +131,8 @@ model.jsonModel = {
                ]
             }
          }
-      }, {
+      }, 
+      {
          name: "alfresco/buttons/AlfButton",
          id: "LAUNCH_CUSTOM_BUTTON_ID_DIALOG",
          config: {
@@ -158,10 +159,60 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_AND_CREATE_ANOTHER_1",
+         config: {
+            label: "Launch repeating dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Repeating dialog (golden path)",
+               dialogId: "CUSTOM_DIALOG",
+               dialogRepeats: true,
+               formSubmissionTopic: "POST_FORM_DIALOG",
+               dialogConfirmationButtonId: "CUSTOM_OK_BUTTON_ID",
+               dialogConfirmAndRepeatButtonId: "CUSTOM_REPEAT_BUTTON_ID",
+               widgets: [
+                  {
+                     id: "GOLDEN_REPEATING_INPUT",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text"
+                     }
+                  }
+               ]
+            }
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_AND_CREATE_ANOTHER_2",
+         config: {
+            label: "Launch repeating dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Repeating dialog (error path)",
+               dialogId: "ERROR_REPEATING",
+               formSubmissionTopic: "POST_FORM_DIALOG",
+               dialogRepeats: true,
+               dialogCloseTopic: "FORM_POST_SUCCESS",
+               dialogConfirmationButtonId: "DIFFERENT_OK_BUTTON_ID",
+               widgets: [
+                  {
+                     id: "ERROR_REPEATING_INPUT",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text",
+                        description: "The service will fail when value is 'fail'"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -171,6 +171,8 @@ model.jsonModel = {
                formSubmissionTopic: "POST_FORM_DIALOG",
                dialogConfirmationButtonId: "CUSTOM_OK_BUTTON_ID",
                dialogConfirmAndRepeatButtonId: "CUSTOM_REPEAT_BUTTON_ID",
+               dialogConfirmationButtonTitle: "Create",
+               dialogConfirmAndRepeatButtonTitle: "Create and create another",
                widgets: [
                   {
                      id: "GOLDEN_REPEATING_INPUT",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-267 to add support for repeating form dialogs (the create and create another paradigm). Unit tests have been updated accordingly. Both golden path and error handling scenarios have been addressed.