### PR TITLE
AKU-414: AlfSearchList does not work with Paginator

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -284,15 +284,14 @@ define(["dojo/_base/declare",
       onPageChange: function alfresco_lists_AlfSortablePaginatedList__onPageChange(payload) {
          if (payload && payload.value !== null && payload.value !== this.currentPage)
          {
-            this.currentPage = payload.value;
             if (this._readyToLoad === true) 
             {
                if (this.useHash === true)
                {
                   var currHash = ioQuery.queryToObject(hash());
-                  if (this.currentPage)
+                  if (payload.value)
                   {
-                     currHash.currentPage = this.currentPage;
+                     currHash.currentPage = payload.value;
                   }
                   this.alfPublish("ALF_NAVIGATE_TO_PAGE", {
                      url: ioQuery.objectToQuery(currHash),
@@ -301,6 +300,7 @@ define(["dojo/_base/declare",
                }
                else
                {
+                  this.currentPage = payload.value;
                   this.loadData();
                }
             }

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -433,6 +433,8 @@ define(["dojo/_base/declare",
                this._cleanResettableVars();
             }
 
+            var pageOrSizeHasChanged = (this.currentPage !== payload.currentPage || this.currentPageSize !== payload.currentPageSize);
+
             // The facet filters need to be handled directly because they are NOT just passed as
             // a simple string. Create a new object for the filters and then break up the filters
             // based on comma delimition and assign each element as a new key in the filters object
@@ -451,7 +453,7 @@ define(["dojo/_base/declare",
             }
 
             lang.mixin(this, payload);
-            this.resetResultsList();
+            this.resetResultsList(pageOrSizeHasChanged);
             this.loadData();
          }
       },
@@ -480,12 +482,7 @@ define(["dojo/_base/declare",
             }
 
             // InfiniteScroll uses pagination under the covers.
-            var startIndex = 0;
-            if (this.useInfiniteScroll)
-            {
-               // Search API wants startIndex rather than page, so we need to convert here.
-               startIndex = (this.currentPage - 1) * this.currentPageSize;
-            }
+            var startIndex = (this.currentPage - 1) * this.currentPageSize;
 
             if (!this.useInfiniteScroll ||
                 !this.currentData ||
@@ -692,9 +689,11 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      resetResultsList: function alfresco_search_AlfSearchList__resetResultsList() {
-         this.startIndex = 0;
-         this.currentPage = 1;
+      resetResultsList: function alfresco_search_AlfSearchList__resetResultsList(doNotChangePages) {
+         if(!doNotChangePages) {
+            this.startIndex = 0;
+            this.currentPage = 1;
+         }
          this.hideChildren(this.domNode);
          this.clearViews();
       },

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -433,7 +433,7 @@ define(["dojo/_base/declare",
                this._cleanResettableVars();
             }
 
-            var pageOrSizeHasChanged = (this.currentPage !== payload.currentPage || this.currentPageSize !== payload.currentPageSize);
+            var pageOrSizeHasChanged = !this.useInfiniteScroll && (this.currentPage !== payload.currentPage || this.currentPageSize !== payload.currentPageSize);
 
             // The facet filters need to be handled directly because they are NOT just passed as
             // a simple string. Create a new object for the filters and then break up the filters

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/PaginatedSearchList.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/PaginatedSearchList.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>PaginatedSearchList Test</shortname>
+  <description>This test page uses the AlfSearchList widget in pagination, rather than infinite-scroll, mode</description>
+  <family>aikau-unit-tests</family>
+  <url>/PaginatedSearchList</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/PaginatedSearchList.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/PaginatedSearchList.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/PaginatedSearchList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/PaginatedSearchList.get.js
@@ -1,0 +1,74 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService",
+      "alfresco/services/SearchService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [
+      {
+         name: "alfresco/lists/Paginator",
+         config: {
+            documentsLoadedTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS",
+            totalResultsProperty: "response.numberFound",
+            startIndexProperty: "response.startIndex",
+            documentsPerPage: 10,
+            pageSizes: [5, 10, 20]
+         }
+      },
+      {
+         name: "alfresco/search/AlfSearchList",
+         config: {
+            useHash: true,
+            useInfiniteScroll: false,
+            currentPageSize: 10,
+            widgets: [
+               {
+                  name: "alfresco/search/AlfSearchListView",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       width: "16px",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "displayName"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PaginatedSearchListMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginatedSearchListMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginatedSearchListMockXhr.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Provides XHR responses for the Search List
+ * 
+ * @module aikauTesting/mockservices/PaginatedSearchListMockXhr
+ * @author Martin Doyle
+ */
+define(["dojo/_base/declare",
+      "dojo/json",
+      "aikauTesting/MockXhr",
+      "dojo/text!./responseTemplates/PaginatedSearchList/results.json"
+   ],
+   function(declare, JSON, MockXhr, itemsJson) {
+
+      return declare([MockXhr], {
+
+         /**
+          * This sets up the fake server with all the responses it should provide
+          *
+          * @instance
+          */
+         setupServer: function alfresco_testing_PaginatedSearchListMockXhr__setupServer() {
+            try {
+               this.server.respondWith("GET", /.*startIndex=(\d+).*pageSize=(\d+).*/, this.createResponse);
+            } catch (e) {
+               this.alfLog("error", "The following error occurred setting up the mock server", e);
+            }
+         },
+
+         /**
+          * Create the response
+          *
+          * @instance
+          * @param {Object} request The intial request object
+          * @param {int} startIndex Start index
+          * @param {int} pageSize Page size
+          * @returns {String} The JSON response
+          */
+         createResponse: function alfresco_testing_PaginatedSearchListMockXhr__createResponse(request, startIndex, pageSize) {
+            var items = JSON.parse(itemsJson),
+               startNum = parseInt(startIndex, 10),
+               pageSizeNum = parseInt(pageSize, 10),
+               slicedItems = items.slice(startNum, startNum + pageSizeNum),
+               responseObject = {
+                  totalRecords: slicedItems.length,
+                  totalRecordsUpper: items.length,
+                  startIndex: startIndex,
+                  numberFound: items.length,
+                  items: slicedItems
+               };
+
+            request.respond(200, {
+               "Content-Type": "application/json"
+            }, JSON.stringify(responseObject));
+         }
+      });
+   });

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PaginatedSearchList/results.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/PaginatedSearchList/results.json
@@ -1,0 +1,1894 @@
+[
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/f5b0f59f-d4e2-44b2-9b51-4866313e0e1e",
+      "type": "document",
+      "name": "standard-tube-map (1).pdf",
+      "displayName": "standard-tube-map (1).pdf",
+      "title": "Standard Tube map September 2013 revision",
+      "description": "",
+      "modifiedOn": "2014-07-31T14:04:18.854+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 468505,
+      "mimetype": "application\/pdf",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/2e775d69-397e-41cf-b911-86848d150caf",
+      "type": "document",
+      "name": "2013-12-29 10.03.18.jpg",
+      "displayName": "2013-12-29 10.03.18.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:11.477+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1930357,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824244"
+       ,
+       "imgpreview:1404218963243"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/7078bcd2-ceee-42cf-a4cd-3b29a9123aa8",
+      "type": "document",
+      "name": "2013-12-29 09.59.46.jpg",
+      "displayName": "2013-12-29 09.59.46.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:11.630+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3479494,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824661"
+       ,
+       "imgpreview:1404218963204"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4",
+      "type": "document",
+      "name": "2013-12-29 09.58.43.jpg",
+      "displayName": "2013-12-29 09.58.43.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:11.803+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 4327152,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824503"
+       ,
+       "imgpreview:1404218963212"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/7a0b4347-80a8-4bf6-b4de-8f702e598bfb",
+      "type": "document",
+      "name": "2013-12-29 09.58.28.jpg",
+      "displayName": "2013-12-29 09.58.28.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:11.943+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2983824,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824396"
+       ,
+       "imgpreview:1404218963805"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/f25d0976-ab7e-415b-9067-daed99ce4e65",
+      "type": "document",
+      "name": "2013-12-29 09.57.58.jpg",
+      "displayName": "2013-12-29 09.57.58.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.068+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2207456,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218826695"
+       ,
+       "imgpreview:1404218965906"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/7d226089-fec9-4c89-a21c-66afd7585c9f",
+      "type": "document",
+      "name": "2013-12-29 09.56.40.jpg",
+      "displayName": "2013-12-29 09.56.40.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.232+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 4267820,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824448"
+       ,
+       "imgpreview:1404218965370"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/5acbe9f4-855e-4352-bc41-389d03e76725",
+      "type": "document",
+      "name": "2013-12-29 09.53.13.jpg",
+      "displayName": "2013-12-29 09.53.13.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.479+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2825516,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218825937"
+       ,
+       "imgpreview:1404218966106"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/47fab052-5650-43c9-952f-aca1a9a3e34d",
+      "type": "document",
+      "name": "2013-12-29 09.53.21.jpg",
+      "displayName": "2013-12-29 09.53.21.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.352+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2965261,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218825954"
+       ,
+       "imgpreview:1404218966419"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/b83eefbc-2379-476a-a568-d95f6ecdc396",
+      "type": "document",
+      "name": "2013-12-26 11.50.09.jpg",
+      "displayName": "2013-12-26 11.50.09.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.574+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2400442,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824660"
+       ,
+       "imgpreview:1404218963084"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/545567e4-dfd9-45fb-a35b-e11f33546256",
+      "type": "document",
+      "name": "2013-12-26 11.48.37.jpg",
+      "displayName": "2013-12-26 11.48.37.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.697+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2250577,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218826819"
+       ,
+       "imgpreview:1404218963716"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/ff26cb61-8532-49f2-98ef-adba0eacc0ee",
+      "type": "document",
+      "name": "2013-12-26 11.48.30.jpg",
+      "displayName": "2013-12-26 11.48.30.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.811+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2384817,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218826578"
+       ,
+       "imgpreview:1404218965738"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/73d88e4a-4b8e-419a-b5e3-9a1f42d84140",
+      "type": "document",
+      "name": "2013-12-26 11.21.22.jpg",
+      "displayName": "2013-12-26 11.21.22.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:12.921+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3540832,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218828867"
+       ,
+       "imgpreview:1404218968220"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/023dbafd-b29e-4573-bf16-b9328a7aefd6",
+      "type": "document",
+      "name": "2013-12-26 11.21.04.jpg",
+      "displayName": "2013-12-26 11.21.04.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.032+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3341225,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218826538"
+       ,
+       "imgpreview:1404218965531"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/e7af53a8-84c5-4e53-bac3-a452e6698e2c",
+      "type": "document",
+      "name": "2013-12-26 11.20.46.jpg",
+      "displayName": "2013-12-26 11.20.46.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.157+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3589574,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218826515"
+       ,
+       "imgpreview:1404218966323"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/3710ac7f-872b-4bd0-ab4b-0cbbaea87125",
+      "type": "document",
+      "name": "2013-12-08 13.16.59.jpg",
+      "displayName": "2013-12-08 13.16.59.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.272+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3364629,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218828279"
+       ,
+       "imgpreview:1404218965543"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/61e49281-b6aa-4de4-bdf2-8c0ed36783d5",
+      "type": "document",
+      "name": "2013-12-08 13.16.12.jpg",
+      "displayName": "2013-12-08 13.16.12.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.417+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3703028,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218828280"
+       ,
+       "imgpreview:1404218967667"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/14d33ef0-dc80-491d-aec8-d7dc3be4b1f0",
+      "type": "document",
+      "name": "2013-11-23 10.51.36.jpg",
+      "displayName": "2013-11-23 10.51.36.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.674+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2285654,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218828881"
+       ,
+       "imgpreview:1404218968172"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/5844c02a-ced2-4601-9cc5-149b33d5d05f",
+      "type": "document",
+      "name": "2013-12-08 13.14.46.jpg",
+      "displayName": "2013-12-08 13.14.46.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.534+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3542520,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218826826"
+       ,
+       "imgpreview:1404218967837"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/0d111217-c6e2-4a5b-b60b-6b591f61021b",
+      "type": "document",
+      "name": "2013-11-23 10.51.34.jpg",
+      "displayName": "2013-11-23 10.51.34.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.784+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2323882,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218829119"
+       ,
+       "imgpreview:1404218967617"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/1e06cbff-f4ed-43da-aae0-f03aca2c917b",
+      "type": "document",
+      "name": "2013-10-10 08.01.37.jpg",
+      "displayName": "2013-10-10 08.01.37.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:14.031+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1989226,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218829104"
+       ,
+       "imgpreview:1404218968596"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/e1f86086-8a54-4609-86f0-b929aaaebf55",
+      "type": "document",
+      "name": "2013-10-12 18.22.32.jpg",
+      "displayName": "2013-10-12 18.22.32.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:13.892+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1023955,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218829119"
+       ,
+       "imgpreview:1404218968502"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/d0133fbb-eed6-44d0-834a-c9e0b426803e",
+      "type": "document",
+      "name": "2013-10-10 08.01.23.jpg",
+      "displayName": "2013-10-10 08.01.23.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:14.176+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2212228,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218828802"
+       ,
+       "imgpreview:1404218968182"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/5f353d8e-c966-4562-8792-c99b8f038103",
+      "type": "document",
+      "name": "2013-10-10 08.01.11.jpg",
+      "displayName": "2013-10-10 08.01.11.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T13:35:14.293+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2288230,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218840891"
+       ,
+       "imgpreview:1404315390701"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/cde0bb96-25f4-4852-85b6-af6b582f6b9b",
+      "type": "document",
+      "name": "2013-09-25 21.03.06.jpg",
+      "displayName": "2013-09-25 21.03.06.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:09.442+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2446552,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755271"
+       ,
+       "imgpreview:1404221759418"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/5d79cbdd-524c-4858-9605-b407c7878ca2",
+      "type": "document",
+      "name": "2013-09-12 11.48.12.jpg",
+      "displayName": "2013-09-12 11.48.12.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:09.659+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1434246,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221754891"
+       ,
+       "imgpreview:1404221759023"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/d2455424-a04c-4ec5-a7c5-c79efa05203b",
+      "type": "document",
+      "name": "2013-09-12 11.47.38.jpg",
+      "displayName": "2013-09-12 11.47.38.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:09.809+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1053554,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221754703"
+       ,
+       "imgpreview:1404221758828"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/dfd11c96-55c4-4136-8c6f-68c728ff96e4",
+      "type": "document",
+      "name": "2013-09-11 12.23.15.jpg",
+      "displayName": "2013-09-11 12.23.15.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:09.962+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1754739,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221754927"
+       ,
+       "imgpreview:1404221758866"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/aa80ca57-db41-4854-8ddc-c45631f51dec",
+      "type": "document",
+      "name": "2013-09-11 12.23.09.jpg",
+      "displayName": "2013-09-11 12.23.09.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.084+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1732361,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221754950"
+       ,
+       "imgpreview:1404221759272"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/74ebf384-15f9-42ae-975f-3bf857ea4b78",
+      "type": "document",
+      "name": "2013-09-04 16.22.03.jpg",
+      "displayName": "2013-09-04 16.22.03.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.228+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2213228,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755151"
+       ,
+       "imgpreview:1404221759087"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/445dae67-438d-4597-8700-157d58a3262f",
+      "type": "document",
+      "name": "2013-09-04 16.21.57.jpg",
+      "displayName": "2013-09-04 16.21.57.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.370+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2215837,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755191"
+       ,
+       "imgpreview:1404221760143"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/e2f0cd93-0433-4555-b31c-8c8d480acde7",
+      "type": "document",
+      "name": "2013-09-04 16.21.55.jpg",
+      "displayName": "2013-09-04 16.21.55.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.513+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2110779,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755171"
+       ,
+       "imgpreview:1404221759101"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/65513700-63c2-4bbc-a0ca-e43a79338707",
+      "type": "document",
+      "name": "2013-09-04 16.21.53.jpg",
+      "displayName": "2013-09-04 16.21.53.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.649+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2055251,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755618"
+       ,
+       "imgpreview:1404221760157"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/48b0c011-a094-4213-b2aa-3d31c1f337e2",
+      "type": "document",
+      "name": "2013-09-04 16.21.51.jpg",
+      "displayName": "2013-09-04 16.21.51.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.756+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2017921,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755795"
+       ,
+       "imgpreview:1404221759975"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/ca3eab1f-aade-4ac9-b380-80de08a768a4",
+      "type": "document",
+      "name": "2013-09-04 16.21.41.jpg",
+      "displayName": "2013-09-04 16.21.41.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:10.902+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2241546,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404221755832"
+       ,
+       "imgpreview:1404221758887"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/304c3ade-01e5-496e-b425-914935726919",
+      "type": "document",
+      "name": "2013-01-26 22.10.33.jpg",
+      "displayName": "2013-01-26 22.10.33.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:45.217+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1111330,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221765062"
+       ,
+       "doclib:1404221772671"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/55e404e8-f28e-453e-8e96-93df1af7217e",
+      "type": "document",
+      "name": "2013-01-18 20.36.01.jpg",
+      "displayName": "2013-01-18 20.36.01.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:45.405+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1552235,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221764854"
+       ,
+       "doclib:1404221772671"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/002ec3e7-2172-4919-a136-2412dbe205b8",
+      "type": "document",
+      "name": "2013-01-18 09.39.03.jpg",
+      "displayName": "2013-01-18 09.39.03.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:45.654+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 711904,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221764039"
+       ,
+       "doclib:1404221772054"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/55938bd0-582a-40ad-b19a-8b5f5b4c1b73",
+      "type": "document",
+      "name": "2013-01-18 09.39.10.jpg",
+      "displayName": "2013-01-18 09.39.10.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:45.528+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 729394,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221764465"
+       ,
+       "doclib:1404221772289"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/f4f46601-4473-4e1e-8628-95990eb16028",
+      "type": "document",
+      "name": "2013-01-18 09.38.55.jpg",
+      "displayName": "2013-01-18 09.38.55.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:45.808+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 732578,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221764047"
+       ,
+       "doclib:1404221772239"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/120383a6-3601-4967-9180-c102c2b9d334",
+      "type": "document",
+      "name": "2013-01-17 12.14.50.jpg",
+      "displayName": "2013-01-17 12.14.50.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:45.973+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1175986,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221764031"
+       ,
+       "doclib:1404221772237"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/ba98f9d1-c436-4d42-977d-bb3036f779be",
+      "type": "document",
+      "name": "2013-01-17 12.14.19.jpg",
+      "displayName": "2013-01-17 12.14.19.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:46.088+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1429771,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221763827"
+       ,
+       "doclib:1404221772028"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/7762fabe-5c5c-4932-96f3-911e8c076a2f",
+      "type": "document",
+      "name": "2013-01-17 12.13.36.jpg",
+      "displayName": "2013-01-17 12.13.36.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-01T14:35:46.208+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1354482,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "photos",
+         "title": "Photos"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1404221764037"
+       ,
+       "doclib:1404221772019"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/764b95f6-0743-4ca4-91cb-249cdbc2a5ca",
+      "type": "document",
+      "name": "2013-12-29 10.03.40.jpg",
+      "displayName": "2013-12-29 10.03.40.jpg",
+      "description": "",
+      "modifiedOn": "2014-07-31T13:17:58.646+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2743117,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site1",
+         "title": "Site1"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "doclib:1404218824416"
+       ,
+       "imgpreview:1404218963017"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/097d5abf-1a99-4909-83f0-66dfdf3752e0",
+      "type": "document",
+      "name": "2013-11-05 19.50.31.jpg",
+      "displayName": "2013-11-05 19.50.31.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T11:57:26.288+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1182164,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site2",
+         "title": "Site2"
+      },
+      "container": "documentLibrary",
+      "path": "Test1",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407754653907"
+       ,
+       "doclib:1407754657017"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/f03f0998-a118-4298-be72-3907387a9dfe",
+      "type": "document",
+      "name": "2013-11-23 10.51.36.jpg",
+      "displayName": "2013-11-23 10.51.36.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.957+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2285654,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409586"
+       ,
+       "doclib:1407849826629"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/807b6838-6736-4f06-b216-a07820b32781",
+      "type": "document",
+      "name": "2013-12-08 13.14.46.jpg",
+      "displayName": "2013-12-08 13.14.46.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.091+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3542520,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409854"
+       ,
+       "doclib:1407849826849"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/46c5a9af-883b-4480-9759-c57340a75039",
+      "type": "document",
+      "name": "2013-12-08 13.16.12.jpg",
+      "displayName": "2013-12-08 13.16.12.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.260+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3703028,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409747"
+       ,
+       "doclib:1407849827105"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/59eb4088-793e-40fc-a1d3-62b8e5c1f1fe",
+      "type": "document",
+      "name": "2013-12-26 11.20.46.jpg",
+      "displayName": "2013-12-26 11.20.46.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.544+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3589574,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409776"
+       ,
+       "doclib:1407849826786"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/a0476a2d-c459-4af5-948d-168ff800b00d",
+      "type": "document",
+      "name": "2013-12-26 11.21.22.jpg",
+      "displayName": "2013-12-26 11.21.22.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.830+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3540832,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758410083"
+       ,
+       "doclib:1407849827385"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/c4819609-bc1c-4ee3-8498-7c4e2a26cac2",
+      "type": "document",
+      "name": "2013-12-26 11.50.09.jpg",
+      "displayName": "2013-12-26 11.50.09.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.194+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2400442,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758410511"
+       ,
+       "doclib:1407849827187"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/92605daf-966c-475f-b2a2-7b7be48e3b86",
+      "type": "document",
+      "name": "2013-12-29 09.53.13.jpg",
+      "displayName": "2013-12-29 09.53.13.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.345+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2825516,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758410504"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/2895582f-49d0-4056-8190-b4b1bb63edd1",
+      "type": "document",
+      "name": "2013-10-10 08.01.23.jpg",
+      "displayName": "2013-10-10 08.01.23.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.345+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2212228,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758410579"
+       ,
+       "doclib:1407849829264"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/85a3fb84-13bb-4ec6-b1aa-3f276ffb056c",
+      "type": "document",
+      "name": "2013-12-08 13.16.59.jpg",
+      "displayName": "2013-12-08 13.16.59.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.404+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3364629,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758411712"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/4e723eb5-fd37-4e6b-b90a-a8ae604b49aa",
+      "type": "document",
+      "name": "2013-12-26 11.21.04.jpg",
+      "displayName": "2013-12-26 11.21.04.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.682+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3341225,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758411982"
+       ,
+       "doclib:1407849827392"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/7a57e71f-6e64-4247-9d5e-55f1839b011d",
+      "type": "document",
+      "name": "2013-12-26 11.48.30.jpg",
+      "displayName": "2013-12-26 11.48.30.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:58.961+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2384817,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758414866"
+       ,
+       "doclib:1407849827382"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/7b417936-6c54-4c2a-b3b7-1d5190bcdcd0",
+      "type": "document",
+      "name": "2013-12-26 11.48.37.jpg",
+      "displayName": "2013-12-26 11.48.37.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.082+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2250577,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758414064"
+       ,
+       "doclib:1407849829264"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/5af5da23-6411-489c-a353-404fd0cfdaaa",
+      "type": "document",
+      "name": "2013-12-29 09.53.21.jpg",
+      "displayName": "2013-12-29 09.53.21.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.481+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2965261,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758411981"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/bbd350a9-d92a-41d2-b204-f7bd7ab4b2a3",
+      "type": "document",
+      "name": "2013-12-29 09.56.40.jpg",
+      "displayName": "2013-12-29 09.56.40.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.614+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 4267820,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758412505"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/264f9276-44a1-4dad-84b2-fc346771a7bb",
+      "type": "document",
+      "name": "2013-12-29 09.57.58.jpg",
+      "displayName": "2013-12-29 09.57.58.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.751+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2207456,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758410579"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/c3f9222b-95cb-4deb-9de7-ead9c8c9e1cf",
+      "type": "document",
+      "name": "2013-12-29 09.58.28.jpg",
+      "displayName": "2013-12-29 09.58.28.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:59.881+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2983824,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758411581"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/3f2b093b-7b73-4236-aca3-cce68318b189",
+      "type": "document",
+      "name": "2013-12-29 09.58.43.jpg",
+      "displayName": "2013-12-29 09.58.43.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T13:00:00.024+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 4327152,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758414070"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/d1ecbf67-92e0-4ac7-a5e3-625c9adf8b1b",
+      "type": "document",
+      "name": "2013-12-29 10.03.18.jpg",
+      "displayName": "2013-12-29 10.03.18.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T13:00:00.330+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1930357,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758414866"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/bca1a8cf-416a-408c-a331-b28dd3af15a0",
+      "type": "document",
+      "name": "2013-12-29 09.59.46.jpg",
+      "displayName": "2013-12-29 09.59.46.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T13:00:00.199+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 3479494,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758414986"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/b10628d1-5caa-4547-a198-aa1e1cc80348",
+      "type": "document",
+      "name": "2013-12-29 10.03.20.jpg",
+      "displayName": "2013-12-29 10.03.20.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T13:00:00.462+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1854400,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758414665"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/fec1164b-3235-4a0b-ad64-85eba901ccf2",
+      "type": "document",
+      "name": "2013-12-29 10.03.40.jpg",
+      "displayName": "2013-12-29 10.03.40.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T13:00:00.569+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2743117,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758415065"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/16648b5a-075a-4a99-bc0f-d0c044488916",
+      "type": "document",
+      "name": "2013-10-10 08.01.37.jpg",
+      "displayName": "2013-10-10 08.01.37.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.501+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1989226,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758410104"
+       ,
+       "doclib:1407849821290"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/3a265077-deb4-456e-8a36-95a0f3f83b27",
+      "type": "document",
+      "name": "2013-10-10 08.01.11.jpg",
+      "displayName": "2013-10-10 08.01.11.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.196+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2288230,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409128"
+       ,
+       "doclib:1407849821180"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/64b3eacb-b6fc-40c1-b316-fc0b24e4903d",
+      "type": "document",
+      "name": "2013-10-10 08.00.56.jpg",
+      "displayName": "2013-10-10 08.00.56.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.039+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2225456,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409312"
+       ,
+       "doclib:1407849821206"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/178bce27-c14b-474d-8b3b-021859c0edb6",
+      "type": "document",
+      "name": "2013-10-12 18.22.32.jpg",
+      "displayName": "2013-10-12 18.22.32.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.661+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 1023955,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409279"
+       ,
+       "doclib:1407849821240"
+       
+      ],
+      "tags": []
+   },
+   {
+      "nodeRef": "workspace:\/\/SpacesStore\/b633198e-7932-4f00-bbe1-410b4626335b",
+      "type": "document",
+      "name": "2013-11-23 10.51.34.jpg",
+      "displayName": "2013-11-23 10.51.34.jpg",
+      "description": "",
+      "modifiedOn": "2014-08-11T12:59:57.829+01:00",
+      "modifiedByUser": "admin",
+      "modifiedBy": "Administrator ",
+      "size": 2323882,
+      "mimetype": "image\/jpeg",
+      "site":
+      {
+         "shortName": "site3",
+         "title": "Site3"
+      },
+      "container": "documentLibrary",
+      "path": "",
+      "lastThumbnailModification":
+      [
+       "imgpreview:1407758409424"
+       ,
+       "doclib:1407849820729"
+       
+      ],
+      "tags": []
+   }
+]


### PR DESCRIPTION
This addresses issue [AKU-414](https://issues.alfresco.com/jira/browse/AKU-414) which, in response to [a forum post](http://forums.alfresco.com/forum/developer-discussions/alfresco-share-development/extending-aikau-search-page-faceted-search), notes that there are problems using the search list with a paginator.

Here is an example that shows how it can be used:

```javascript
{
   name: "alfresco/lists/Paginator",
   config: {
      documentsLoadedTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS",
      totalResultsProperty: "response.numberFound",
      startIndexProperty: "response.startIndex",
      documentsPerPage: 10,
      pageSizes: [5, 10, 20]
   }
},
{
   name: "alfresco/search/AlfSearchList",
   config: {
      useHash: true,
      useInfiniteScroll: false,
      currentPageSize: 10,
      widgets: [
         {
            name: "alfresco/search/AlfSearchListView",
            config: {
               widgets: [
                  {
                     name: "alfresco/lists/views/layouts/Row",
                     config: {
                        widgets: [
                           {
                              name: "alfresco/lists/views/layouts/Cell",
                              config: {
                                 width: "16px",
                                 widgets: [
                                    {
                                       name: "alfresco/renderers/Property",
                                       config: {
                                          propertyToRender: "displayName"
                                       }
                                    }
                                 ]
                              }
                           }
                        ]
                     }
                  }
               ]
            }
         }
      ]
   }
}
```