### PR TITLE
AKU-420: currentPageSize issue

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -18,8 +18,11 @@
  */
 
 /**
- * This extends the [hash list]{@link module:alfresco/lists/AlfHashList} to provide support
- * for common pagination and sorting behaviour.
+ * <p>This extends the [hash list]{@link module:alfresco/lists/AlfHashList} to provide support
+ * for common pagination and sorting behaviour.</p>
+ *
+ * <p>It is possible to specify the [pageSizePreferenceName]{@link module:alfresco/lists/AlfSortablePaginatedList#pageSizePreferenceName}
+ * to be used by this widget (or its descendants), by setting a new value for the property in the model config.</p>
  *
  * @module alfresco/lists/AlfSortablePaginatedList
  * @extends module:alfresco/lists/AlfHashList
@@ -75,6 +78,15 @@ define(["dojo/_base/declare",
       currentPageSize: 25,
 
       /**
+       * The name of the property to access in order to retrieve the page-size preference for this widget
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      pageSizePreferenceName: "org.alfresco.share.documentList.documentsPerPage",
+
+      /**
        * The inital sort order.
        *
        * @instance
@@ -111,7 +123,7 @@ define(["dojo/_base/declare",
          }
 
          this.alfPublish(this.getPreferenceTopic, {
-            preference: "org.alfresco.share.documentList.documentsPerPage",
+            preference: this.pageSizePreferenceName,
             callback: this.setPageSize,
             callbackScope: this
          });

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -78,6 +78,39 @@ define(["intern!object",
          browser.end();
       },
 
+      "Preference names are honoured when retrieving pageSize": function() {
+         return browser.findByCssSelector("body") // Need to create the session
+            .getLogEntries({
+               type: "PUBLISH",
+               topic: "ALF_PREFERENCE_GET",
+               object: "HASH_LIST",
+               pos: "last"
+            })
+            .then(function(payload) {
+               assert.propertyVal(payload, "preference", "org.alfresco.share.documentList.documentsPerPage", "Incorrect preference used for HASH_LIST list");
+            })
+
+         .getLogEntries({
+               type: "PUBLISH",
+               topic: "ALF_PREFERENCE_GET",
+               object: "DOCUMENT_LIST",
+               pos: "last"
+            })
+            .then(function(payload) {
+               assert.propertyVal(payload, "preference", "org.alfresco.share.documentList.documentsPerPage", "Incorrect preference used for DOCUMENT_LIST list");
+            })
+
+         .getLogEntries({
+               type: "PUBLISH",
+               topic: "ALF_PREFERENCE_GET",
+               object: "INFINITE_SCROLL_LIST",
+               pos: "last"
+            })
+            .then(function(payload) {
+               assert.propertyVal(payload, "preference", "custom.pageSize.preference", "Incorrect preference used for INFINITE_SCROLL_LIST list");
+            })
+      },
+
       "Check URL hash controls displayed page": function() {
          // See AKU-293
          return browser.findByCssSelector("#HASH_LIST tr:nth-child(1) .alfresco-renderers-Property .value")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
@@ -133,6 +133,7 @@ model.jsonModel = {
                                                 useHash: false,
                                                 useInfiniteScroll: true,
                                                 currentPageSize: 10,
+                                                pageSizePreferenceName: "custom.pageSize.preference",
                                                 filteringTopics: ["FILTER_THIS"],
                                                 widgets: [view]
                                              }


### PR DESCRIPTION
This addresses issue [AKU-420](https://issues.alfresco.com/jira/browse/AKU-420) by allowing the specification of a custom page-size preference name in AlfSortablePaginatedList and its descendants. Tests have also been added to ensure this works properly.
