### PR TITLE
AKU-423: DialogService form to allow publish scoping

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -399,8 +399,9 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload to publish on the supplied topic
        * @param {boolean} [global] Indicates that the pub/sub scope should not be applied
        * @param {boolean} [parentScope] Indicates that the pub/sub scope inherited from the parent should be applied
+       * @param {String} [customScope] An optional scope to use for this topic-publish
        */
-      alfPublish: function alfresco_core_Core__alfPublish(topics, payload, global, parentScope) {
+      alfPublish: function alfresco_core_Core__alfPublish(topics, payload, global, parentScope, customScope) {
 
          // Allow an array of topics so we can publish multiple ones.
          if (!lang.isArray(topics))
@@ -418,7 +419,7 @@ define(["dojo/_base/declare",
             payload.alfCallerName = callerName;
 
             var scopedTopic = topic;
-            if (global !== false && global === true)
+            if (global === true)
             {
                // No action required - use global scope
                payload.alfPublishScope = "";
@@ -430,8 +431,8 @@ define(["dojo/_base/declare",
             }
             else
             {
-               scopedTopic = this.pubSubScope + topic;
-               payload.alfPublishScope = this.pubSubScope;
+               scopedTopic = (customScope || this.pubSubScope) + topic;
+               payload.alfPublishScope = (customScope || this.pubSubScope);
             }
             payload.alfTopic = scopedTopic;
 

--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -399,7 +399,8 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload to publish on the supplied topic
        * @param {boolean} [global] Indicates that the pub/sub scope should not be applied
        * @param {boolean} [parentScope] Indicates that the pub/sub scope inherited from the parent should be applied
-       * @param {String} [customScope] An optional scope to use for this topic-publish
+       * @param {String} [customScope] A custom scope to use for this publish (will only be used if both global
+       *                               and parentScope are falsy)
        */
       alfPublish: function alfresco_core_Core__alfPublish(topics, payload, global, parentScope, customScope) {
 
@@ -418,22 +419,22 @@ define(["dojo/_base/declare",
             }
             payload.alfCallerName = callerName;
 
-            var scopedTopic = topic;
-            if (global === true)
-            {
-               // No action required - use global scope
-               payload.alfPublishScope = "";
+            // Calculate the scope to be used and thus the scoped topic
+            var publishScope = "",
+               scopedTopic;
+            if (global === true) {
+               // No action required
+            } else if (parentScope === true) {
+               publishScope = this.parentPubSubScope;
+            } else if (customScope) {
+               publishScope = customScope;
+            } else {
+               publishScope = this.pubSubScope;
             }
-            else if (parentScope === true)
-            {
-               scopedTopic = this.parentPubSubScope + topic;
-               payload.alfPublishScope = this.parentPubSubScope;
-            }
-            else
-            {
-               scopedTopic = (customScope || this.pubSubScope) + topic;
-               payload.alfPublishScope = (customScope || this.pubSubScope);
-            }
+            scopedTopic = publishScope + topic;
+
+            // Update the payload
+            payload.alfPublishScope = publishScope;
             payload.alfTopic = scopedTopic;
 
             // Publish...

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -634,7 +634,6 @@ define(["dojo/_base/declare",
                            formSubmissionTopic: config.formSubmissionTopic,
                            formSubmissionPayloadMixin: config.formSubmissionPayloadMixin,
                            formSubmissionGlobal: config.formSubmissionGlobal,
-                           formSubmissionToParent: config.formSubmissionToParent,
                            formSubmissionScope: config.formSubmissionScope
                         }
                      }
@@ -665,7 +664,6 @@ define(["dojo/_base/declare",
                      formSubmissionTopic: config.formSubmissionTopic,
                      formSubmissionPayloadMixin: config.formSubmissionPayloadMixin,
                      formSubmissionGlobal: config.formSubmissionGlobal,
-                     formSubmissionToParent: config.formSubmissionToParent,
                      formSubmissionScope: config.formSubmissionScope
                   }
                }
@@ -730,7 +728,7 @@ define(["dojo/_base/declare",
             // Publish the topic requested for complete...
             var topic = payload.formSubmissionTopic,
                globalScope = payload.hasOwnProperty("formSubmissionGlobal") ? !!payload.formSubmissionGlobal : true,
-               toParent = payload.hasOwnProperty("formSubmissionToParent") ? !!payload.formSubmissionToParent : false,
+               toParent = false,
                customScope = payload.formSubmissionScope || undefined;
             this.alfPublish(topic, data, globalScope, toParent, customScope);
          }

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -632,7 +632,10 @@ define(["dojo/_base/declare",
                         publishTopic: this._formConfirmationTopic,
                         publishPayload: {
                            formSubmissionTopic: config.formSubmissionTopic,
-                           formSubmissionPayloadMixin: config.formSubmissionPayloadMixin
+                           formSubmissionPayloadMixin: config.formSubmissionPayloadMixin,
+                           formSubmissionGlobal: config.formSubmissionGlobal,
+                           formSubmissionToParent: config.formSubmissionToParent,
+                           formSubmissionScope: config.formSubmissionScope
                         }
                      }
                   },
@@ -660,7 +663,10 @@ define(["dojo/_base/declare",
                   publishTopic: this._formConfirmationRepeatTopic,
                   publishPayload: {
                      formSubmissionTopic: config.formSubmissionTopic,
-                     formSubmissionPayloadMixin: config.formSubmissionPayloadMixin
+                     formSubmissionPayloadMixin: config.formSubmissionPayloadMixin,
+                     formSubmissionGlobal: config.formSubmissionGlobal,
+                     formSubmissionToParent: config.formSubmissionToParent,
+                     formSubmissionScope: config.formSubmissionScope
                   }
                }
             });
@@ -713,16 +719,21 @@ define(["dojo/_base/declare",
                payload.dialogReference.destroyRecursive();
             }
 
-            // Mixin in any additional payload information...
-            if (payload.formSubmissionPayloadMixin)
-            {
-               lang.mixin(data, payload.formSubmissionPayloadMixin);
-            }
+            // Mixin any additional payload information...
+            payload.formSubmissionPayloadMixin && lang.mixin(data, payload.formSubmissionPayloadMixin);
+            lang.mixin(data, {
+               alfPublishScope: payload.formSubmissionScope || ""
+            });
+
             // Using JQuery here in order to support deep merging of dot-notation properties...
             $.extend(true, data, formData);
 
             // Publish the topic requested for complete...
-            this.alfPublish(payload.formSubmissionTopic, data, true);
+            var topic = payload.formSubmissionTopic,
+               globalScope = payload.hasOwnProperty("formSubmissionGlobal") ? !!payload.formSubmissionGlobal : true,
+               toParent = payload.hasOwnProperty("formSubmissionToParent") ? !!payload.formSubmissionToParent : false,
+               customScope = payload.formSubmissionScope || undefined;
+            this.alfPublish(topic, data, globalScope, toParent, customScope);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -719,12 +719,11 @@ define(["dojo/_base/declare",
                payload.dialogReference.destroyRecursive();
             }
 
-            // Mixin any additional payload information...
-            payload.formSubmissionPayloadMixin && lang.mixin(data, payload.formSubmissionPayloadMixin);
-            lang.mixin(data, {
-               alfPublishScope: payload.formSubmissionScope || ""
-            });
-
+            // Mixin in any additional payload information...
+            if (payload.formSubmissionPayloadMixin)
+            {
+               lang.mixin(data, payload.formSubmissionPayloadMixin);
+            }
             // Using JQuery here in order to support deep merging of dot-notation properties...
             $.extend(true, data, formData);
 

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -369,16 +369,46 @@ define(["intern!object",
             .then(function() {
                return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
                   .click()
-               .end()
+                  .end()
 
                .findById("LAUNCH_INNER_DIALOG_BUTTON")
                   .click()
-               .end()
+                  .end()
 
                .getLastPublish("DISPLAYED_INNER_DIALOG")
                   .then(function(payload) {
                      assert.isNotNull(payload, "Inner dialog not displayed");
-                  });
+                  })
+                  .end()
+
+               .findByCssSelector("#INNER_DIALOG .dijitDialogCloseIcon")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#INNER_DIALOG.dialogHidden")
+                  .end()
+
+               .findByCssSelector("#OUTER_DIALOG .dijitDialogCloseIcon")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#OUTER_DIALOG.dialogHidden");
+            });
+      },
+
+      "Can publish form with custom scope information": function() {
+         return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"CREATE_FORM_DIALOG_CUSTOM_SCOPE\"] .dijitButtonNode")
+            .click()
+            .end()
+
+         .findByCssSelector("#SCOPED_FORM.dialogDisplayed .confirmationButton .dijitButtonNode")
+            .click()
+            .end()
+
+         .getLastPublish("CUSTOM_FORM_SCOPE_CUSTOM_FORM_TOPIC", true)
+            .then(function(payload){
+               assert.isNotNull(payload, "Did not publish correctly scoped topic");
+               assert.propertyVal(payload, "text", "This is some sample text", "Did not publish correct form value to scoped topic");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -46,6 +46,33 @@ model.jsonModel = {
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "CREATE_FORM_DIALOG_CUSTOM_SCOPE",
+         config: {
+            label: "Create Form Dialog (with custom scoping)",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "SCOPED_FORM",
+               dialogTitle: "Scoped Form Dialog",
+               formSubmissionTopic: "CUSTOM_FORM_TOPIC",
+               formSubmissionGlobal: false,
+               formSubmissionToParent: false,
+               formSubmissionScope: "CUSTOM_FORM_SCOPE_",
+               widgets: [
+                  {
+                     id: "SCOPED_FORM_TEXTBOX",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text",
+                        value: "This is some sample text"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
          id: "CREATE_FORM_DIALOG",
          config: {
             label: "Create Basic Form Dialog",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -55,7 +55,6 @@ model.jsonModel = {
                dialogTitle: "Scoped Form Dialog",
                formSubmissionTopic: "CUSTOM_FORM_TOPIC",
                formSubmissionGlobal: false,
-               formSubmissionToParent: false,
                formSubmissionScope: "CUSTOM_FORM_SCOPE_",
                widgets: [
                   {


### PR DESCRIPTION
This addresses issue [AKU-423](https://issues.alfresco.com/jira/browse/AKU-423) which requests allowing a custom scope to be passed to DialogService for use when submitting a form. The publishPayload property will now the following config parameters: formSubmissionTopic [existing], formSubmissionPayloadMixin [existing], formSubmissionGlobal and formSubmissionScope. Core.js has also been updated to allow proper use of a custom, one-off scope which will also update the alfPublishScope property in the payload. Tests have all been updated accordingly.