### PR TITLE
AKU-431: NumberSpinner cannot be empty

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
@@ -46,7 +46,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        *
        * @instance
        * @type {number}
-       * @default 0
+       * @default
        */
       min: null,
 
@@ -55,9 +55,20 @@ define(["alfresco/forms/controls/BaseFormControl",
        *
        * @instance
        * @type {number}
-       * @default null
+       * @default
        */
       max: null,
+
+      /**
+       * By default, this control can only be valid when it contains a numerical value. If this configuration
+       * property is set to true, then it will be possible to submit a form without any value in this control,
+       * at which point its value will be submitted as null.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      permitEmpty: false,
 
       /**
        * Returns the configuration for the widget ensuring that it is valid, in that
@@ -109,7 +120,7 @@ define(["alfresco/forms/controls/BaseFormControl",
             // See AKU-341 for details of why we handle commas and spaces...
             var value = this.wrappedWidget.textbox.value.replace(",","").replace(" ","");
             var parsedValue = parseFloat(value);
-            var isValid = !isNaN(parsedValue);
+            var isValid = !isNaN(parsedValue) || (lang.trim(value) === "" && this.permitEmpty);
             this.reportValidationResult(validationConfig, isValid);
          }
          catch(e)

--- a/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
@@ -120,7 +120,7 @@ define(["alfresco/forms/controls/BaseFormControl",
             // See AKU-341 for details of why we handle commas and spaces...
             var value = this.wrappedWidget.textbox.value.replace(",","").replace(" ","");
             var parsedValue = parseFloat(value);
-            var isValid = !isNaN(parsedValue) || (lang.trim(value) === "" && this.permitEmpty);
+            var isValid = !isNaN(parsedValue) || (this.permitEmpty && lang.trim(value) === "");
             this.reportValidationResult(validationConfig, isValid);
          }
          catch(e)

--- a/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
@@ -160,6 +160,46 @@ define(["intern!object",
             });
       },
 
+      "Empty values are only permitted when permitEmpty specified": function(){
+         return browser.findByCssSelector("#NS1 .dijitInputContainer input")
+            .clearValue()
+            .end()
+
+         .findAllByCssSelector("#NS1 .validation-error")
+            .then(function(elements){
+               assert.lengthOf(elements, 1, "Standard number spinner should not permit empty values");
+            })
+            .end()
+
+         .findByCssSelector("#NS7 .dijitInputContainer input")
+            .clearValue()
+            .end()
+
+         .findAllByCssSelector("#NS7 .validation-error")
+            .then(function(elements){
+               assert.lengthOf(elements, 0, "'permitEmpty' number spinner should allow empty values");
+            })
+      },
+
+      "Empty value submits null value": function(){
+         return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"RESET_VALUES\"] .dijitButtonNode")
+            .click()
+            .end()
+
+         .findByCssSelector("#NS1 .dijitInputContainer input")
+            .type("0")
+            .end()
+
+         .findByCssSelector(".confirmationButton .dijitButtonNode")
+            .click()
+            .end()
+
+         .getLastPublish("FORM_POST")
+            .then(function(payload){
+               assert.propertyVal(payload, "seven", null, "Did not publish null value for empty number spinner");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
@@ -14,8 +14,33 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "RESET_VALUES",
+         config: {
+            label: "Reset control values",
+            publishTopic: "FORM_VALUE_TOPIC",
+            publishGlobal: true,
+            publishPayload: {
+               one: "",
+               two: 5,
+               three: 0,
+               four: 1,
+               five: 3,
+               six: 1001,
+               seven: ""
+            }
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "20px"
+         }
+      },
+      {
          name: "alfresco/forms/Form",
          config: {
+            setValueTopic: "FORM_VALUE_TOPIC",
             okButtonPublishTopic: "FORM_POST",
             widgets: [
                {
@@ -83,10 +108,22 @@ model.jsonModel = {
                   name: "alfresco/forms/controls/NumberSpinner", 
                   config: {
                      fieldId: "NS6",
-                     name: "five",
+                     name: "six",
                      label: "Handle commas",
                      description: "This is a number spinner initialised to a value over a 1000",
                      value: 1001
+                  }
+               },
+               {
+                  id: "NS7",
+                  name: "alfresco/forms/controls/NumberSpinner", 
+                  config: {
+                     fieldId: "NS7",
+                     name: "seven",
+                     label: "Empty value",
+                     description: "This is a number spinner initialised to an empty string",
+                     value: "",
+                     permitEmpty: true
                   }
                }
             ]


### PR DESCRIPTION
This addresses issue [AKU-431](https://issues.alfresco.com/jira/browse/AKU-431) by allowing a new config option of 'permitEmpty' on the NumberSpinner control and update tests accordingly.