### PR TITLE
AKU-430: DateTextBox does not handle empty values normally

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -54,21 +54,24 @@ define(["alfresco/forms/controls/BaseFormControl",
       cssRequirements: [{cssFile:"./css/DateTextBox.css"}],
 
       /**
+       * Run after properties mixed into instance
+       *
+       * @instance
+       */
+      postMixInProperties: function(){
+         if(!this.value || (typeof this.value === "string" && lang.trim(this.value).length === 0)) {
+            this.value = null; // Falsy values and empty strings should be treated as nulls, i.e. no value (see AKU-430)
+         }
+         this.inherited(arguments); // Must 'clean' the empty strings before calling this
+      },
+
+      /**
        * Get the configuration for the wrapped widget
        * 
        * @instance
        * @returns {object} The configuration for the form control
        */
       getWidgetConfig: function alfresco_forms_controls_DateTextBox__getWidgetConfig() {
-         var value = null;
-         if (this.value instanceof Date)
-         {
-            value = this.value;
-         }
-         else if (lang.isString(this.value))
-         {
-            value = stamp.fromISOString(this.value, { selector: "date" });
-         }
          return {
             id : this.id + "_CONTROL",
             name: this.name,

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -57,6 +57,7 @@ define(["intern!object",
             .getLastPublish("INVALID_DATES_FORM_SUBMIT")
             .then(function(payload) {
                assert.propertyVal(payload, "lettersDate", null, "Invalid starting date-value (arbitrary letters) was not published with null value");
+               assert.propertyVal(payload, "emptyDate", null, "Invalid starting date-value (empty) was not published with null value");
                assert.propertyVal(payload, "nullDate", null, "Invalid starting date-value (null) was not published with null value");
                assert.propertyVal(payload, "undefinedDate", null, "Invalid starting date-value (undefined) was not published with null value");
             });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -60,6 +60,15 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/forms/controls/DateTextBox",
+                           id: "EMPTY_DATE_VALUE",
+                           config: {
+                              name: "emptyDate",
+                              value: "",
+                              label: "Empty date"
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
                            id: "NULL_DATE_VALUE",
                            config: {
                               name: "nullDate",


### PR DESCRIPTION
This addresses issue [AKU-430](https://issues.alfresco.com/jira/browse/AKU-430) by treating empty values supplied to DateTextBox as invalid values, rather than epoch date.