### PR TITLE
AKU-436: Notifications show off screen if scrolled

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -93,6 +93,13 @@
 @dashlet-body-background: @primary-background-color;
 @dashlet-body-border-radius: 0; // This gives rounding at the top of the dashlet only
 
+// Notifications
+@notification-background: #666;
+@notification-foreground: @highlighted-font-color;
+@notification-foreground-dimmed: @de-emphasized-font-color;
+@notification-width: 400px;
+@notification-border-radius: 0 0 5px 5px;
+
 // Lists
 @list-header-border-color: #e5e5e5;
 @list-header-background-color: #f5f5f5;

--- a/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
+++ b/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
@@ -128,8 +128,20 @@ define(["alfresco/core/Core",
           * @private
           */
          _hide: function alfresco_notifications_AlfNotification___hide() {
-            domClass.remove(this.domNode, "alfresco-notifications-AlfNotification--visible");
-            setTimeout(lang.hitch(this, this.destroy), this.destroyAfterHideMs);
+            if(this.domNode && this.domNode.parentNode === document.body) {
+               domClass.remove(this.domNode, "alfresco-notifications-AlfNotification--visible");
+               setTimeout(lang.hitch(this, this.destroy), this.destroyAfterHideMs);
+            }
+         },
+
+         /**
+          * Handle clicks on the close button
+          *
+          * @instance
+          * @param {Object} evt Dojo-normalised event object
+          */
+         _onCloseClick: function alfresco_notifications_AlfNotification___onCloseClick(/*jshint unused:false*/ evt) {
+            this._hide();
          },
 
          /**

--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -5,7 +5,7 @@
    position: fixed;
    right: 0;
    top: 52.5%;
-   transition: opacity .2s ease-out, top .2s ease-out;
+   transition: all .2s ease-out;
    z-index: 9999; /* This isn't ideal, but searching all z-indexes is even worse (better solution possible?) */
    &__container {
       background: #666;
@@ -13,10 +13,22 @@
       box-shadow: @standard-box-shadow;
       box-sizing: border-box;
       margin: 0 auto;
-      padding: 20px;
+      padding: 20px 30px 20px 20px;
       position: relative;
       top: -50%;
       width: 400px;
+   }
+   &__close {
+      color: #aaa;
+      cursor: pointer;
+      font-size: 25px;
+      position: absolute;
+      right: 10px;
+      top: 0;
+      transition: all .1s ease-out;
+      &:hover {
+         color: #fff;
+      }
    }
    &__message {
       color: #fff;

--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -4,22 +4,20 @@
    opacity: 0;
    position: fixed;
    right: 0;
-   top: 52.5%;
+   top: 22.5%;
    transition: all .2s ease-out;
    z-index: 9999; /* This isn't ideal, but searching all z-indexes is even worse (better solution possible?) */
    &__container {
-      background: #666;
-      border-radius: 0 0 5px 5px;
+      background: @notification-background;
+      border-radius: @notification-border-radius;
       box-shadow: @standard-box-shadow;
       box-sizing: border-box;
       margin: 0 auto;
       padding: 20px 30px 20px 20px;
-      position: relative;
-      top: -50%;
-      width: 400px;
+      width: @notification-width;
    }
    &__close {
-      color: #aaa;
+      color: @notification-foreground-dimmed;
       cursor: pointer;
       font-size: 25px;
       position: absolute;
@@ -27,17 +25,17 @@
       top: 0;
       transition: all .1s ease-out;
       &:hover {
-         color: #fff;
+         color: @notification-foreground;
       }
    }
    &__message {
-      color: #fff;
+      color: @notification-foreground;
       font-family: @standard-font;
       font-size: @normal-font-size;
       line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
    }
    &--visible {
       opacity: 1;
-      top: 50%;
+      top: 20%;
    }
 }

--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -2,7 +2,7 @@
 .alfresco-notifications-AlfNotification {
    left: 0;
    opacity: 0;
-   position: absolute;
+   position: fixed;
    right: 0;
    top: 52.5%;
    transition: opacity .2s ease-out, top .2s ease-out;

--- a/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
+++ b/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
@@ -1,5 +1,6 @@
 <div class="alfresco-notifications-AlfNotification">
    <div class="alfresco-notifications-AlfNotification__container">
+      <div class="alfresco-notifications-AlfNotification__close" data-dojo-attach-event="click:_onCloseClick">&times;</div>
       <span class="alfresco-notifications-AlfNotification__message" data-dojo-attach-point="messageNode" aria-live="assertive" role="status">${message}</span>
    </div>
 </div>

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -21,10 +21,10 @@
  * @author Martin Doyle
  */
 define(["intern!object",
-        "intern/chai!expect", 
-        "intern/chai!assert", 
-        "require", 
-        "alfresco/TestCommon"], 
+        "intern/chai!expect",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
         function(registerSuite, expect, assert, require, TestCommon) {
 
    var browser;

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -21,10 +21,10 @@
  * @author Martin Doyle
  */
 define(["intern!object",
-        "intern/chai!expect",
-        "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon"],
+        "intern/chai!expect", 
+        "intern/chai!assert", 
+        "require", 
+        "alfresco/TestCommon"], 
         function(registerSuite, expect, assert, require, TestCommon) {
 
    var browser;
@@ -55,15 +55,13 @@ define(["intern!object",
             });
       },
 
-      "Notification hides after displaying": function() {
-         return browser.setFindTimeout(5000)
-            .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message");
-      },
-
       "Topic publishes after notification hidden": function() {
-         return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_NOTIFICATION_DESTROYED", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Post-notification topic not published");
+         return browser.setFindTimeout(5000)
+            .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message")
+
+         .getLastPublish("ALF_NOTIFICATION_DESTROYED")
+            .then(function(payload) {
+               assert.isNotNull(payload, "Post-notification topic not published");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -81,7 +81,24 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "500px"
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "NOTIFICATION_BUTTON_SCROLLED",
+         config: {
+            label: "Display notification (use when scrolled)",
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "This is another test notification message."
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       },
       {
          name: "aikauTesting/TestCoverageResults"


### PR DESCRIPTION
This addresses issue [AKU-436](https://issues.alfresco.com/jira/browse/AKU-436) which fixes the notifications showing off screen when scrolled by changing positioning from absolute to fixed. Have also added a requested close button on the notification.