### PR TITLE
AKU-441 - Add an option to all form controls (BaseFormControl) to all…

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -210,6 +210,16 @@ define(["dojo/_base/declare",
       description: "",
 
       /**
+       * Inline help for the field. If this is not empty it will cause a help icon to show which, when clicked, will 
+       * launch a dialog containing the additional help content.
+       * 
+       * @instance
+       * @type {string}
+       * @default ""
+       */
+      inlineHelp: "",
+
+      /**
        * The value to submit as the name for the data captured by this field when the form is submitted.
        *
        * @instance
@@ -1169,13 +1179,31 @@ define(["dojo/_base/declare",
       validationInProgressImg: "ajax_anim.gif",
 
       /**
-       * The alt-text label to use for the validation in progress indicator
-       *
+       * The alt-text label to use for the validation in progress indicator.
+       * 
        * @instance
        * @type {string}
        * @default "validation.inprogress.alttext"
        */
       validationInProgressAltText: "validation.inprogress.alttext",
+
+      /**
+       * The local image to use for the inline help indicator.
+       * 
+       * @instance
+       * @type {string}
+       * @default "help.png"
+       */
+      inlineHelpImg: "help.png",
+
+      /**
+       * The alt-text label to use for the inline help indicator.
+       * 
+       * @instance
+       * @type {string}
+       * @default "inlinehelp.alttext"
+       */
+      inlineHelpAltText: "inlinehelp.alttext",
 
       /**
        * Processes the image source for indicating validation is in progress and its alt-text label.
@@ -1193,6 +1221,12 @@ define(["dojo/_base/declare",
             this.validationInProgressImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.validationInProgressImg;
          }
          this.validationInProgressAltText = this.message(this.validationInProgressAltText);
+
+         if (!this.inlineHelpImgSrc)
+         {
+            this.inlineHelpImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.inlineHelpImg;
+         }
+         this.inlineHelpAltText = this.message(this.inlineHelpAltText) + " " + this.label;
       },
 
       /**
@@ -1220,6 +1254,11 @@ define(["dojo/_base/declare",
          if (this.additionalCssClasses)
          {
             domClass.add(this.domNode, this.additionalCssClasses);
+         }
+
+         if (this.inlineHelp)
+         {
+            domClass.remove(this._inlineHelpIndicator, "hidden");
          }
 
          this.wrappedWidget = this.createFormControl(this.initialConfig);
@@ -1927,6 +1966,30 @@ define(["dojo/_base/declare",
          if (this.publishValue && typeof this.publishValue === "function")
          {
             this.validate();
+         }
+      },
+
+      /**
+       * This function is attached to the click event of the inline help icon and will display a dialog containing 
+       * inline help when called.
+       * 
+       * @instance
+       */
+      showInlineHelp: function alfresco_forms_controls_BaseFormControl__showInlineHelp() {
+         if (this.inlineHelp)
+         {
+            this.alfPublish("ALF_CREATE_DIALOG_REQUEST", {
+               dialogId: "BASE_FORM_CONTROL_INLINE_HELP",
+               dialogTitle: this.label,
+               widgetsContent: [
+                  {
+                     name: "dijit/layout/ContentPane",
+                     config: {
+                        content: this.inlineHelp.replace(/\n/g, "<br />")
+                     }
+                  }
+               ]
+            }, true);
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -90,6 +90,18 @@
    display: none;
 }
 
+.alfresco-forms-controls-BaseFormControl > .title-row > img.inlineHelp {
+   width: 16px;
+   height: 16px;
+   margin: 2px 0;
+   vertical-align: top;
+   cursor: pointer;
+}
+
+.alfresco-forms-controls-BaseFormControl > .title-row > img.inlineHelp.hidden {
+   display: none;
+}
+
 .alfresco-forms-controls-BaseFormControl > .title-row > .validation-error {
    background: url("./images/error-16.png");
    display: inline-block;

--- a/aikau/src/main/resources/alfresco/forms/controls/i18n/BaseFormControl.properties
+++ b/aikau/src/main/resources/alfresco/forms/controls/i18n/BaseFormControl.properties
@@ -1,2 +1,3 @@
 validation.control.invalid=invalid
 validation.inprogress.alttext=Validating
+inlinehelp.alttext=Help for:

--- a/aikau/src/main/resources/alfresco/forms/controls/templates/BaseFormControl.html
+++ b/aikau/src/main/resources/alfresco/forms/controls/templates/BaseFormControl.html
@@ -2,6 +2,7 @@
    <div data-dojo-attach-point="_titleRowNode" class="title-row">
       <img class="validationInProgress hidden" src="${validationInProgressImgSrc}" alt="${validationInProgressAltText}" title="${validationInProgressAltText}" data-dojo-attach-point="_validationInProgressIndicator">
       <span class="validation" data-dojo-attach-point="_validationIndicator">&nbsp;</span>
+      <img class="inlineHelp hidden" src="${inlineHelpImgSrc}" alt="${inlineHelpAltText}" title="${inlineHelpAltText}" data-dojo-attach-point="_inlineHelpIndicator" data-dojo-attach-event="ondijitclick:showInlineHelp">
       <label class="label" data-dojo-attach-point="_labelNode"></label>
       <span class="requirementIndicator" data-dojo-attach-point="_requirementIndicator">*</span>
       <span class="validation-message" data-dojo-attach-point="_validationMessage"></span>

--- a/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
@@ -354,6 +354,18 @@ define(["intern!object",
             .isDisplayed();
       },
 
+      "Check textbox with help is displayed": function() {
+         return browser.findByCssSelector("#FORM_FIELD_WITH_HELP img.inlineHelp")
+            .then(
+               function() {
+                  // No action;
+               }, 
+               function() {
+                  assert(false, "Textbox with help is not displayed");
+               }
+            );
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextBox.get.js
@@ -11,7 +11,8 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/ErrorReporter",
+      "alfresco/services/DialogService"
    ],
    widgets: [
       {
@@ -388,6 +389,16 @@ model.jsonModel = {
                      validationConfig: {
                         regExObj: null
                      }
+                  }
+               },
+               {
+                  id: "FORM_FIELD_WITH_HELP",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     name: "control2",
+                     label: "Form field with help",
+                     value: "Text2",
+                     inlineHelp: "Once upon a time there was, a little white bull.\n\nVery sad because he was, a little white bull."
                   }
                }
             ]


### PR DESCRIPTION
…ow additional help copy to be provided

 - New optional functionality added to base form control that shows a help icon when inlineHelp config is provided
 - Help icon, when clicked, opens a dialog showing the content of the inlineHelp
 - Simple test included