### PR TITLE
AKU-415: AlfFilteredList: support for hash

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -1,3 +1,4 @@
+/*globals Alfresco*/
 /**
  * Copyright (C) 2005-2013 Alfresco Software Limited.
  *

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -82,7 +82,7 @@ define(["dojo/_base/declare",
        * to [onHashChange]{@link module:alfresco/documentlibrary/_AlfHashMixin#onHashChange}.
        * @instance
        */
-      constructor: function() {
+      constructor: function alfresco_documentlibrary_AlfHashMixin__constructor() {
          this.alfSubscribe("/dojo/hashchange", lang.hitch(this, "onHashChange"));
       },
       
@@ -94,7 +94,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {string} hashString An optional string to use as the hash. If not provided the current hash will be
        */
-      initialiseFilter: function(hashString) {
+      initialiseFilter: function alfresco_documentlibrary_AlfHashMixin__intialiseFilter(hashString) {
          if (!hashString)
          {
             this.onHashChange(hash());

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -71,9 +71,8 @@ define(["dojo/_base/declare",
         "alfresco/documentlibrary/_AlfFilterMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "dojo/hash",
-        "dojo/_base/lang",
-        "dojo/io-query"], 
-        function(declare, AlfCore, _AlfFilterMixin, _AlfDocumentListTopicMixin, hash, lang, ioQuery) {
+        "dojo/_base/lang"], 
+        function(declare, AlfCore, _AlfFilterMixin, _AlfDocumentListTopicMixin, hash, lang) {
    
    return declare([AlfCore, _AlfFilterMixin, _AlfDocumentListTopicMixin], {
 

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -258,29 +258,6 @@ define(["dojo/_base/declare",
             }
          }
          return true;
-      },
-
-      /**
-       * Get the current hash value as an object
-       *
-       * @instance
-       * @returns {Object} The hash value as an object
-       */
-      getHashObj: function alfresco_documentlibrary_AlfHashMixin__getHashObj() {
-         var currHash = hash(),
-            hashObj = ioQuery.queryToObject(currHash);
-         return hashObj;
-      },
-
-      /**
-       * Set the current hash value from an object
-       *
-       * @instance
-       * @param {Object} hashObj The new hash object
-       */
-      setHashObj: function alfresco_documentlibrary_AlfHashMixin__setHashObj(hashObj) {
-         var newHash = ioQuery.objectToQuery(hashObj);
-         hash(newHash);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -112,7 +112,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The publication topic. This object needs to contain the attribute 'filter' for
        * anything to happen.
        */
-      onHashChange: function alfresco_documentlibrary__AlfHashMixin__onHashChange(payload) {
+      onHashChange: function alfresco_documentlibrary_AlfHashMixin__onHashChange(payload) {
          var filterObj = this.processFilter(payload);
          this.alfLog("log", "Publishing decoded filter", filterObj);
          this.alfPublish(this.hashChangeTopic, filterObj);
@@ -128,7 +128,7 @@ define(["dojo/_base/declare",
        * @return {boolean}
        * @private
        */
-      doHashVarUpdate: function alfresco_documentlibrary__AlfHashMixin__doHashVarUpdate(payload, updateInstanceValues, updateObject) {
+      doHashVarUpdate: function alfresco_documentlibrary_AlfHashMixin__doHashVarUpdate(payload, updateInstanceValues, updateObject) {
          return this.payloadContainsUpdateableVar(payload, updateInstanceValues, updateObject) && 
                 this.payloadContainsRequiredUpdateableVars(payload) && 
                 this.payloadContainsEqualUpdateableVars(payload);
@@ -147,7 +147,7 @@ define(["dojo/_base/declare",
        * @param {boolean} updateInstanceValues Indicates whether or not the list instance should be updated with the payload values
        * @return {boolean}
        */
-      payloadContainsUpdateableVar: function alfresco_documentlibrary__AlfHashMixin__payloadContainsUpdateableVar(payload, updateInstanceValues, updateObject) {
+      payloadContainsUpdateableVar: function alfresco_documentlibrary_AlfHashMixin__payloadContainsUpdateableVar(payload, updateInstanceValues, updateObject) {
          // jshint maxcomplexity:false
          var containsUpdateableVar = false;
 
@@ -208,7 +208,7 @@ define(["dojo/_base/declare",
        * @return {boolean}
        * @private
        */
-      payloadContainsRequiredUpdateableVars: function alfresco_documentlibrary__AlfHashMixin__payloadContainsRequiredUpdateableVars(payload) {
+      payloadContainsRequiredUpdateableVars: function alfresco_documentlibrary_AlfHashMixin__payloadContainsRequiredUpdateableVars(payload) {
          // No hashVarsForUpdateRequired - return true
          if(!this.hashVarsForUpdateRequired || this.hashVarsForUpdateRequired.length === 0)
          {
@@ -240,7 +240,7 @@ define(["dojo/_base/declare",
        * @return {boolean}
        * @private
        */
-      payloadContainsEqualUpdateableVars: function alfresco_documentlibrary__AlfHashMixin__payloadContainsEqualUpdateableVars(payload) {
+      payloadContainsEqualUpdateableVars: function alfresco_documentlibrary_AlfHashMixin__payloadContainsEqualUpdateableVars(payload) {
          // No hashVarsForUpdateMustEqual - return true
          if(!this.hashVarsForUpdateMustEqual || this.hashVarsForUpdateMustEqual.length === 0)
          {

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -71,8 +71,9 @@ define(["dojo/_base/declare",
         "alfresco/documentlibrary/_AlfFilterMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "dojo/hash",
-        "dojo/_base/lang"], 
-        function(declare, AlfCore, _AlfFilterMixin, _AlfDocumentListTopicMixin, hash, lang) {
+        "dojo/_base/lang",
+        "dojo/io-query"], 
+        function(declare, AlfCore, _AlfFilterMixin, _AlfDocumentListTopicMixin, hash, lang, ioQuery) {
    
    return declare([AlfCore, _AlfFilterMixin, _AlfDocumentListTopicMixin], {
 
@@ -257,6 +258,29 @@ define(["dojo/_base/declare",
             }
          }
          return true;
+      },
+
+      /**
+       * Get the current hash value as an object
+       *
+       * @instance
+       * @returns {Object} The hash value as an object
+       */
+      getHashObj: function alfresco_documentlibrary_AlfHashMixin__getHashObj() {
+         var currHash = hash(),
+            hashObj = ioQuery.queryToObject(currHash);
+         return hashObj;
+      },
+
+      /**
+       * Set the current hash value from an object
+       *
+       * @instance
+       * @param {Object} hashObj The new hash object
+       */
+      setHashObj: function alfresco_documentlibrary_AlfHashMixin__setHashObj(hashObj) {
+         var newHash = ioQuery.objectToQuery(hashObj);
+         hash(newHash);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -201,8 +201,9 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * The widget filters
+       * The filter widgets
        *
+       * @instance
        * @type {Object[]}
        */
       _filterWidgets: null,

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -123,8 +123,11 @@ define(["dojo/_base/declare",
                return !!dataFilter.value;
             });
 
-            // Update the filter fields
+            // Update the filter fields and reload the data
+            if (this._readyToLoad) {
             this._updateFilterFieldsFromHash();
+               this.loadData();
+            }
          }
 
          // Call inherited
@@ -166,13 +169,14 @@ define(["dojo/_base/declare",
        */
       _updateFilterFieldsFromHash: function alfresco_lists_AlfFilteredList___updateFilterFieldsFromHash() {
          var currHash = hashUtils.getHash();
-         for (var widgetName in this._filterWidgets) {
-            if (this._filterWidgets.hasOwnProperty(widgetName)) {
+         array.forEach(Object.keys(this._filterWidgets), function(widgetName){
                var widget = this._filterWidgets[widgetName],
                   filterValue = currHash[widgetName];
-               widget.setValue(filterValue);
-            }
+            if(typeof filterValue === "undefined") {
+               filterValue = null;
          }
+            widget.setValue(filterValue);
+         }, this);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -29,8 +29,10 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
-        "dojo/dom-class"], 
-        function(declare, AlfSortablePaginatedList, ObjectProcessingMixin, lang, array, domConstruct, domClass) {
+        "dojo/dom-class",
+        "dijit/registry",
+        "alfresco/util/hashUtils"], 
+        function(declare, AlfSortablePaginatedList, ObjectProcessingMixin, lang, array, domConstruct, domClass, registry, hashUtils) {
    
    return declare([AlfSortablePaginatedList, ObjectProcessingMixin], {
       
@@ -53,6 +55,18 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/AlfFilteredList.css"}],
 
       /**
+       * Called after properties mixed into instance
+       *
+       * @instance
+       */
+      postMixInProperties: function alfresco_lists_AlfFilteredList__postMixInProperties() {
+         this.inherited(arguments);
+         if (this.useHash) {
+            this.mapHashVarsToPayload = true;
+         }
+      },
+
+      /**
        * @instance
        */
       postCreate: function alfresco_lists_AlfFilteredList__postCreate() {
@@ -66,7 +80,7 @@ define(["dojo/_base/declare",
             this.processWidgets(filtersModel, this.filtersNode);
 
             // Setup the filtering topics based on the filter widgets configured...
-            array.forEach(this.widgetsForFilters, lang.hitch(this, this.setupFilteringTopics, this.filteringTopics));
+            array.forEach(this.widgetsForFilters, this.setupFilteringTopics, this);
          }
          this.inherited(arguments);
       },
@@ -83,24 +97,111 @@ define(["dojo/_base/declare",
          domClass.remove(this.filtersNode, "share-hidden");
       },
 
+      // /**
+      //  * We need to make sure any filters in the hash are populated into the dataFilters property
+      //  * 
+      //  * @instance
+      //  * @override
+      //  * @param {object} payload The publication topic
+      //  */
+      // onHashChange: function alfresco_documentlibrary_AlfHashMixin__onHashChange( /*jshint unused:false*/ payload) {
+
+      //    // Only do this when we are mirroring the filters in the hash
+      //    if (this.mapHashVarsToPayload) {
+
+      //       // Initialise the data-filters to be all of the filters we have specified, without values
+      //       this.dataFilters = array.map(this._widgetFilterNames, function(filterName) {
+      //          return {
+      //             name: filterName
+      //          };
+      //       });
+
+      //       // Filter to only include items currently in the hash and update values
+      //       var currHash = hashUtils.getHash();
+      //       this.dataFilters = array.filter(this.dataFilters, function(dataFilter) {
+      //          dataFilter.value = currHash[dataFilter.name];
+      //          return !!dataFilter.value;
+      //       }, this);
+
+      //       // Update the filter fields
+      //       this._updateFilterFieldsFromHash();
+      //    }
+
+      //    // Call inherited
+      //    this.inherited(arguments);
+      // },
+
+      // /**
+      //  * Widget has started
+      //  *
+      //  * @instance
+      //  * @override
+      //  */
+      // startup: function alfresco_lists_AlfFilteredList__startup() {
+      //    this.inherited(arguments);
+      //    this._storeFilterWidgets();
+      //    this._updateFilterFieldsFromHash();
+      // },
+
+      // /**
+      //  * Build a collection of filter widgets as a property on this instance
+      //  *
+      //  * @instance
+      //  */
+      // _storeFilterWidgets: function alfresco_lists_AlfFilteredList___storeFilterWidgets() {
+      //    var childWidgets = registry.findWidgets(this.domNode);
+      //    this._widgetFilters = {};
+      //    array.forEach(this.widgetsForFilters, function(filterDef) {
+      //       var filterName = filterDef.config.name;
+      //       this._widgetFilters[filterName] = array.filter(childWidgets, function(childWidget) {
+      //          return childWidget.name === filterName;
+      //       })[0];
+      //    }, this);
+      // },
+
+      // /**
+      //  * Update the filter form fields using the filter values in the hash
+      //  *
+      //  * @instance
+      //  */
+      // _updateFilterFieldsFromHash: function alfresco_lists_AlfFilteredList___updateFilterFieldsFromHash() {
+      //    var currHash = hashUtils.getHash();
+      //    for (var widgetName in this._widgetFilters) {
+      //       if (this._widgetFilters.hasOwnProperty(widgetName)) {
+      //          var widget = this._widgetFilters[widgetName],
+      //             filterValue = currHash[widgetName];
+      //          widget.setValue(filterValue);
+      //       }
+      //    }
+      // },
+
       /**
        * Setups up the [filteringTopics]{@link module:alfresco/lists/AlfList#filteringTopics} for the encapsulated
        * [list]{@link module:alfresco/lists/AlfSortablePaginatedList}.
        *
        * @instance
-       * @param {type} filteringTopics The array that each topic will be added to
        * @param {object} filter The widget to find a topic from (expected to be a form control)
        */
-      setupFilteringTopics: function alfresco_lists_AlfFilteredList__setupFilteringTopics(filteringTopics, filter) {
+      setupFilteringTopics: function alfresco_lists_AlfFilteredList__setupFilteringTopics(filter) {
          if (filter && filter.config && filter.config.fieldId)
          {
-            filteringTopics.push("_valueChangeOf_" + filter.config.fieldId);
+            this.filteringTopics.push("_valueChangeOf_" + filter.config.fieldId);
+            if(this.mapHashVarsToPayload) {
+               this.hashVarsForUpdate.push(filter.config.name);
+            }
          }
          else
          {
             this.alfLog("warn", "A configured filter control did not have a fieldId attribute configured", filter, this);
          }
       },
+
+      /**
+       * The widget filters
+       *
+       * @type {Object[]}
+       */
+      _widgetFilters: null,
 
       /**
        * If the [widgetsForFilters]{@link module:alfresco/lists/AlfFilteredList#widgetsForFilters} attribute is not overridden

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -110,9 +110,9 @@ define(["dojo/_base/declare",
          if (this.mapHashVarsToPayload) {
 
             // Initialise the data-filters to be all of the filters we have specified, without values
-            this.dataFilters = array.map(this._widgetFilters, function(filterWidget) {
+            this.dataFilters = array.map(Object.keys(this._filterWidgets), function(filterName){
                return {
-                  name: filterWidget.name
+                  name: filterName
                };
             });
 
@@ -121,7 +121,7 @@ define(["dojo/_base/declare",
             this.dataFilters = array.filter(this.dataFilters, function(dataFilter) {
                dataFilter.value = currHash[dataFilter.name];
                return !!dataFilter.value;
-            }, this);
+            });
 
             // Update the filter fields
             this._updateFilterFieldsFromHash();
@@ -150,10 +150,10 @@ define(["dojo/_base/declare",
        */
       _storeFilterWidgets: function alfresco_lists_AlfFilteredList___storeFilterWidgets() {
          var childWidgets = registry.findWidgets(this.domNode);
-         this._widgetFilters = {};
+         this._filterWidgets = {};
          array.forEach(this.widgetsForFilters, function(filterDef) {
             var filterName = filterDef.config.name;
-            this._widgetFilters[filterName] = array.filter(childWidgets, function(childWidget) {
+            this._filterWidgets[filterName] = array.filter(childWidgets, function(childWidget) {
                return childWidget.name === filterName;
             })[0];
          }, this);
@@ -166,9 +166,9 @@ define(["dojo/_base/declare",
        */
       _updateFilterFieldsFromHash: function alfresco_lists_AlfFilteredList___updateFilterFieldsFromHash() {
          var currHash = hashUtils.getHash();
-         for (var widgetName in this._widgetFilters) {
-            if (this._widgetFilters.hasOwnProperty(widgetName)) {
-               var widget = this._widgetFilters[widgetName],
+         for (var widgetName in this._filterWidgets) {
+            if (this._filterWidgets.hasOwnProperty(widgetName)) {
+               var widget = this._filterWidgets[widgetName],
                   filterValue = currHash[widgetName];
                widget.setValue(filterValue);
             }
@@ -201,7 +201,7 @@ define(["dojo/_base/declare",
        *
        * @type {Object[]}
        */
-      _widgetFilters: null,
+      _filterWidgets: null,
 
       /**
        * If the [widgetsForFilters]{@link module:alfresco/lists/AlfFilteredList#widgetsForFilters} attribute is not overridden

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -92,7 +92,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} targetNode The node to hide the children of
        */
-      hideChildren: function alfresco_lists_AlfList__hideChildren(/*jshint unused:false*/targetNode) {
+      hideChildren: function alfresco_lists_AlfFilteredList__hideChildren(/*jshint unused:false*/targetNode) {
          this.inherited(arguments);
          domClass.remove(this.filtersNode, "share-hidden");
       },
@@ -104,7 +104,7 @@ define(["dojo/_base/declare",
        * @override
        * @param {object} payload The publication topic
        */
-      onHashChange: function alfresco_documentlibrary_AlfHashMixin__onHashChange( /*jshint unused:false*/ payload) {
+      onHashChange: function alfresco_lists_AlfFilteredList__onHashChange( /*jshint unused:false*/ payload) {
 
          // Only do this when we are mirroring the filters in the hash
          if (this.mapHashVarsToPayload) {

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -97,83 +97,83 @@ define(["dojo/_base/declare",
          domClass.remove(this.filtersNode, "share-hidden");
       },
 
-      // /**
-      //  * We need to make sure any filters in the hash are populated into the dataFilters property
-      //  * 
-      //  * @instance
-      //  * @override
-      //  * @param {object} payload The publication topic
-      //  */
-      // onHashChange: function alfresco_documentlibrary_AlfHashMixin__onHashChange( /*jshint unused:false*/ payload) {
+      /**
+       * We need to make sure any filters in the hash are populated into the dataFilters property
+       * 
+       * @instance
+       * @override
+       * @param {object} payload The publication topic
+       */
+      onHashChange: function alfresco_documentlibrary_AlfHashMixin__onHashChange( /*jshint unused:false*/ payload) {
 
-      //    // Only do this when we are mirroring the filters in the hash
-      //    if (this.mapHashVarsToPayload) {
+         // Only do this when we are mirroring the filters in the hash
+         if (this.mapHashVarsToPayload) {
 
-      //       // Initialise the data-filters to be all of the filters we have specified, without values
-      //       this.dataFilters = array.map(this._widgetFilterNames, function(filterName) {
-      //          return {
-      //             name: filterName
-      //          };
-      //       });
+            // Initialise the data-filters to be all of the filters we have specified, without values
+            this.dataFilters = array.map(this._widgetFilters, function(filterWidget) {
+               return {
+                  name: filterWidget.name
+               };
+            });
 
-      //       // Filter to only include items currently in the hash and update values
-      //       var currHash = hashUtils.getHash();
-      //       this.dataFilters = array.filter(this.dataFilters, function(dataFilter) {
-      //          dataFilter.value = currHash[dataFilter.name];
-      //          return !!dataFilter.value;
-      //       }, this);
+            // Filter to only include items currently in the hash and update values
+            var currHash = hashUtils.getHash();
+            this.dataFilters = array.filter(this.dataFilters, function(dataFilter) {
+               dataFilter.value = currHash[dataFilter.name];
+               return !!dataFilter.value;
+            }, this);
 
-      //       // Update the filter fields
-      //       this._updateFilterFieldsFromHash();
-      //    }
+            // Update the filter fields
+            this._updateFilterFieldsFromHash();
+         }
 
-      //    // Call inherited
-      //    this.inherited(arguments);
-      // },
+         // Call inherited
+         this.inherited(arguments);
+      },
 
-      // /**
-      //  * Widget has started
-      //  *
-      //  * @instance
-      //  * @override
-      //  */
-      // startup: function alfresco_lists_AlfFilteredList__startup() {
-      //    this.inherited(arguments);
-      //    this._storeFilterWidgets();
-      //    this._updateFilterFieldsFromHash();
-      // },
+      /**
+       * Widget has started
+       *
+       * @instance
+       * @override
+       */
+      startup: function alfresco_lists_AlfFilteredList__startup() {
+         this.inherited(arguments);
+         this._storeFilterWidgets();
+         this._updateFilterFieldsFromHash();
+      },
 
-      // /**
-      //  * Build a collection of filter widgets as a property on this instance
-      //  *
-      //  * @instance
-      //  */
-      // _storeFilterWidgets: function alfresco_lists_AlfFilteredList___storeFilterWidgets() {
-      //    var childWidgets = registry.findWidgets(this.domNode);
-      //    this._widgetFilters = {};
-      //    array.forEach(this.widgetsForFilters, function(filterDef) {
-      //       var filterName = filterDef.config.name;
-      //       this._widgetFilters[filterName] = array.filter(childWidgets, function(childWidget) {
-      //          return childWidget.name === filterName;
-      //       })[0];
-      //    }, this);
-      // },
+      /**
+       * Build a collection of filter widgets as a property on this instance
+       *
+       * @instance
+       */
+      _storeFilterWidgets: function alfresco_lists_AlfFilteredList___storeFilterWidgets() {
+         var childWidgets = registry.findWidgets(this.domNode);
+         this._widgetFilters = {};
+         array.forEach(this.widgetsForFilters, function(filterDef) {
+            var filterName = filterDef.config.name;
+            this._widgetFilters[filterName] = array.filter(childWidgets, function(childWidget) {
+               return childWidget.name === filterName;
+            })[0];
+         }, this);
+      },
 
-      // /**
-      //  * Update the filter form fields using the filter values in the hash
-      //  *
-      //  * @instance
-      //  */
-      // _updateFilterFieldsFromHash: function alfresco_lists_AlfFilteredList___updateFilterFieldsFromHash() {
-      //    var currHash = hashUtils.getHash();
-      //    for (var widgetName in this._widgetFilters) {
-      //       if (this._widgetFilters.hasOwnProperty(widgetName)) {
-      //          var widget = this._widgetFilters[widgetName],
-      //             filterValue = currHash[widgetName];
-      //          widget.setValue(filterValue);
-      //       }
-      //    }
-      // },
+      /**
+       * Update the filter form fields using the filter values in the hash
+       *
+       * @instance
+       */
+      _updateFilterFieldsFromHash: function alfresco_lists_AlfFilteredList___updateFilterFieldsFromHash() {
+         var currHash = hashUtils.getHash();
+         for (var widgetName in this._widgetFilters) {
+            if (this._widgetFilters.hasOwnProperty(widgetName)) {
+               var widget = this._widgetFilters[widgetName],
+                  filterValue = currHash[widgetName];
+               widget.setValue(filterValue);
+            }
+         }
+      },
 
       /**
        * Setups up the [filteringTopics]{@link module:alfresco/lists/AlfList#filteringTopics} for the encapsulated

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -212,7 +212,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload
        */
-      updateLocallyStoredHash: function alfresco_lists_AlfHashList__onHashChanged(/*jshint unused:false*/payload) {
+      updateLocallyStoredHash: function alfresco_lists_AlfHashList__updateLocallyStoredHash(/*jshint unused:false*/payload) {
          // Save the hash to local storage if required...
          if(this.useLocalStorageHashFallback === true && 
             ("localStorage" in window && window.localStorage !== null))

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -197,7 +197,7 @@ define(["dojo/_base/declare",
          if (this.mapHashVarsToPayload)
          {
             var currHash = hashUtils.getHash();
-            array.forEach(this.hashVarsForUpdate, function(hashName, index){
+            array.forEach(this.hashVarsForUpdate, function(hashName){
                var hashValue;
                if(currHash.hasOwnProperty(hashName)) {
                   hashValue = currHash[hashName];

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -304,6 +304,7 @@ define(["dojo/_base/declare",
             });
             hashUtils.updateHash(filterValues);
          } else {
+            this.clearViews();
             this.loadData();
          }
       }

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -31,10 +31,11 @@
 define(["dojo/_base/declare",
         "alfresco/lists/AlfList", 
         "alfresco/documentlibrary/_AlfHashMixin",
+        "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/hash",
         "dojo/io-query"], 
-        function(declare, AlfList, _AlfHashMixin, lang, hash, ioQuery) {
+        function(declare, AlfList, _AlfHashMixin, array, lang, hash, ioQuery) {
    
    return declare([AlfList, _AlfHashMixin], {
       
@@ -273,6 +274,30 @@ define(["dojo/_base/declare",
             this.alfPublish("ALF_BRING_ITEM_INTO_VIEW", {
                item: currHash.currentItem
             });
+         }
+      },
+
+      /**
+       * Handle filters being updated
+       *
+       * @instance
+       * @override
+       */
+      onFiltersUpdated: function() {
+         if (this.useHash) {
+            var hashObj = this.getHashObj();
+            array.forEach(this.dataFilters, function(filter){
+               var filterName = filter.name,
+                  filterValue = "" + filter.value;
+               if(lang.trim(filterValue)) {
+                  hashObj[filterName] = filterValue;
+               } else {
+                  delete hashObj[filterName];
+               }
+            }, this);
+            this.setHashObj(hashObj);
+         } else {
+            this.loadData();
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -196,15 +196,18 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          if (this.mapHashVarsToPayload)
          {
-            var hashString = hash();
-            var currHash = ioQuery.queryToObject(hashString);
-            for(var i=0; i < this.hashVarsForUpdate.length; i++)
-            {
-               if(this.hashVarsForUpdate[i] in currHash)
-               {
-                  payload[this.hashVarsForUpdate[i]] = currHash[this.hashVarsForUpdate[i]];
+            var currHash = hashUtils.getHash();
+            array.forEach(this.hashVarsForUpdate, function(hashName, index){
+               var hashValue;
+               if(currHash.hasOwnProperty(hashName)) {
+                  hashValue = currHash[hashName];
+                  if(hashValue !== null && typeof hashValue !== "undefined") {
+                     payload[hashName] = hashValue;
+                  } else {
+                     delete payload[hashName];
                }
             }
+            }, this);
          }
       },
 
@@ -284,11 +287,20 @@ define(["dojo/_base/declare",
        * @instance
        * @override
        */
-      onFiltersUpdated: function() {
+      onFiltersUpdated: function alfresco_lists_AlfHashList__onFiltersUpdated() {
          if (this.useHash) {
             var filterValues = {};
             array.forEach(this.dataFilters, function(dataFilter){
-               filterValues[dataFilter.name] = dataFilter.value;
+               var filterValue = dataFilter.value;
+               if(filterValue !== null && typeof filterValue !== "undefined") {
+                  if(typeof filterValue === "string") {
+                     filterValue = lang.trim(filterValue);
+                     if(!filterValue.length) {
+                        filterValue = null; // Remove empty strings from hash
+                     }
+                  }
+               }
+               filterValues[dataFilter.name] = filterValue;
             });
             hashUtils.updateHash(filterValues);
          } else {

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -34,8 +34,9 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/hash",
-        "dojo/io-query"], 
-        function(declare, AlfList, _AlfHashMixin, array, lang, hash, ioQuery) {
+        "dojo/io-query",
+        "alfresco/util/hashUtils"], 
+        function(declare, AlfList, _AlfHashMixin, array, lang, hash, ioQuery, hashUtils) {
    
    return declare([AlfList, _AlfHashMixin], {
       
@@ -285,17 +286,11 @@ define(["dojo/_base/declare",
        */
       onFiltersUpdated: function() {
          if (this.useHash) {
-            var hashObj = this.getHashObj();
-            array.forEach(this.dataFilters, function(filter){
-               var filterName = filter.name,
-                  filterValue = "" + filter.value;
-               if(lang.trim(filterValue)) {
-                  hashObj[filterName] = filterValue;
-               } else {
-                  delete hashObj[filterName];
-               }
-            }, this);
-            this.setHashObj(hashObj);
+            var filterValues = {};
+            array.forEach(this.dataFilters, function(dataFilter){
+               filterValues[dataFilter.name] = dataFilter.value;
+            });
+            hashUtils.updateHash(filterValues);
          } else {
             this.loadData();
          }

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -355,7 +355,6 @@ define(["dojo/_base/declare",
                }
                else
                {
-                  this.clearViews();
                   this.onFiltersUpdated();
                }
             }), this._filterDelay);

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -368,6 +368,7 @@ define(["dojo/_base/declare",
        * @overrideable
        */
       onFiltersUpdated: function(){
+         this.clearViews();
          this.loadData();
       },
 

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -346,23 +346,30 @@ define(["dojo/_base/declare",
                }
             }
 
-            if (this._filterTimeoutHandle)
-            {
-               clearTimeout(this._filterTimeoutHandle);
-            }
-            var _this = this;
-            this._filterTimeoutHandle = setTimeout(function() {
-               if (_this.requestInProgress)
+            // Setup a new timeout (clearing the old one, just in case)
+            clearTimeout(this._filterTimeoutHandle);
+            this._filterTimeoutHandle = setTimeout(lang.hitch(this, function() {
+               if (this.requestInProgress)
                {
-                  _this.pendingLoadRequest = true;
+                  this.pendingLoadRequest = true;
                }
                else
                {
-                  _this.clearViews();
-                  _this.loadData();
+                  this.clearViews();
+                  this.onFiltersUpdated();
                }
-            }, this._filterDelay);
+            }), this._filterDelay);
          }
+      },
+
+      /**
+       * Handle filters being updated
+       *
+       * @instance
+       * @overrideable
+       */
+      onFiltersUpdated: function(){
+         this.loadData();
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -246,7 +246,7 @@ define(["alfresco/core/ObjectTypeUtils",
           *
           * @instance
           */
-         _clearFilter: function alfresco_logging_DebugLog___applyFilter() {
+         _clearFilter: function alfresco_logging_DebugLog___clearFilter() {
             this.filter.value = "";
             this._applyFilter();
          },

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -236,7 +236,7 @@ define(["alfresco/core/ObjectTypeUtils",
          _applyFilter: function alfresco_logging_DebugLog___applyFilter() {
             var filterValue = this.filter.value;
             array.forEach(this._entries, function(entry) {
-               var matchesTopic = entry.topic.toLowerCase().indexOf(filterValue) !== -1;
+               var matchesTopic = entry.topic.toLowerCase().indexOf(filterValue.toLowerCase()) !== -1;
                domClass[matchesTopic ? "remove" : "add"](entry.node, this.rootClass + "__log__entry--hidden");
             }, this);
          },

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -242,6 +242,16 @@ define(["alfresco/core/ObjectTypeUtils",
          },
 
          /**
+          * Clear the filter
+          *
+          * @instance
+          */
+         _clearFilter: function alfresco_logging_DebugLog___applyFilter() {
+            this.filter.value = "";
+            this._applyFilter();
+         },
+
+         /**
           * Given a variable, make it safe for being JSON.stringified. This means avoiding
           * circular references and respecting maximum sibling quantity and maximum depth.
           *

--- a/aikau/src/main/resources/alfresco/logging/css/DebugLog.css
+++ b/aikau/src/main/resources/alfresco/logging/css/DebugLog.css
@@ -4,7 +4,6 @@
       display: inline-block;
       font-size: 12px;
       line-height: 24px;
-      margin-right: 30px;
    }
    &__header {
       font-family: @bold-font;
@@ -30,7 +29,10 @@
          outline: 0;
       }
    }
-   &__checkbox-publications, &__checkbox-subscriptions {
+   &__clear-button {
+      margin-left: 10px;
+   }
+   &__checkbox {
       display: none;
       &:checked {
          + .alfresco_logging_DebugLog__label {
@@ -65,6 +67,7 @@
       border-radius: 3px;
       color: #a00;
       cursor: pointer;
+      margin-left: 2px;
       opacity: .5;
       padding: 0 10px;
       position: relative;
@@ -74,12 +77,16 @@
          top: 1px;
       }
    }
+   &__label-publications {
+      margin-left: 50px;
+   }
    &__filter {
       border: 1px solid #aaa;
       border-radius: 3px;
       box-shadow: inset 1px 1px 2px rgba(0,0,0,.2);
-      margin-right: 2px;
+      margin-left: 50px;
       padding-left: 6px;
+      width: 150px;
    }
    &__log {
       display: block;

--- a/aikau/src/main/resources/alfresco/logging/templates/DebugLog.html
+++ b/aikau/src/main/resources/alfresco/logging/templates/DebugLog.html
@@ -1,11 +1,12 @@
 <div class="${rootClass}">
    <h3 class="${rootClass}__header">Subscription Log</h3>
    <button class="${rootClass}__clear-button" data-dojo-attach-event="click:_onClearButtonClick">Clear</button>
-   <input type="checkbox" id="display-publications" class="${rootClass}__checkbox-publications" checked="checked" />
-   <label for="display-publications" class="${rootClass}__label">Publications</label>
-   <input type="checkbox" id="display-subscriptions" class="${rootClass}__checkbox-subscriptions" checked="checked" />
-   <label for="display-subscriptions" class="${rootClass}__label">Subscriptions</label>
+   <input type="checkbox" id="display-publications" class="${rootClass}__checkbox ${rootClass}__checkbox-publications" checked="checked" />
+   <label for="display-publications" class="${rootClass}__label ${rootClass}__label-publications">Publications</label>
+   <input type="checkbox" id="display-subscriptions" class="${rootClass}__checkbox ${rootClass}__checkbox-subscriptions" checked="checked" />
+   <label for="display-subscriptions" class="${rootClass}__label ${rootClass}__label-subscriptions">Subscriptions</label>
    <input type="text" class="${rootClass}__filter" data-dojo-attach-point="filter" data-dojo-attach-event="keyup:_applyFilter" placeholder="Type to filter by topic ..." value="" />
-   <button class="${rootClass}__filter-button" data-dojo-attach-event="click:_applyFilter">Filter</button>
+   <button class="${rootClass}__filter-button" data-dojo-attach-event="click:_applyFilter">Apply</button>
+   <button class="${rootClass}__filter-button" data-dojo-attach-event="click:_clearFilter">Clear</button>
    <ul class="${rootClass}__log" data-dojo-attach-point="logNode"></ul>
 </div>

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -40,36 +40,39 @@ define(["dojo/_base/lang",
       },
 
       // See API below
-      setHash: function alfresco_util_hashUtils__getHash(hashObj, replace) {
+      setHash: function alfresco_util_hashUtils__setHash(hashObj, replace) {
          var newHash = ioQuery.objectToQuery(hashObj);
          hash(newHash, replace);
       },
 
       // See API below
-      updateHash: function alfresco_util_hashUtils__getHash(newValues, replace, force) {
-         var hashObj = this.getHash(),
+      updateHash: function alfresco_util_hashUtils__updateHash(newValues, replace, force) {
+         var currHash = this.getHash(),
+            newHash = lang.mixin({}, currHash),
             hashName,
             newHashValue,
-            oldHashValue,
+            currHashValue,
             hashChanged;
          for (hashName in newValues) {
             if (newValues.hasOwnProperty(hashName)) {
                newHashValue = newValues[hashName];
-               oldHashValue = hashObj[hashName];
-               if ((typeof newHashValue === "undefined" || newHashValue === null) && hashObj.hasOwnProperty(hashName)) {
-                  delete hashObj[hashName];
+               currHashValue = currHash[hashName];
+               if (typeof newHashValue === "undefined" || newHashValue === null) {
+                  delete newHash[hashName];
+                  if (currHash.hasOwnProperty(hashName)) {
                   hashChanged = true;
+                  }
                } else {
                   newHashValue = "" + newHashValue;
-                  if (newHashValue !== oldHashValue) {
-                     hashObj[hashName] = encodeURIComponent(newHashValue);
+                  if (newHashValue !== currHashValue) {
+                     newHash[hashName] = encodeURIComponent(newHashValue);
                      hashChanged = true;
                   }
                }
             }
          }
          if (hashChanged || force) {
-            this.setHash(hashObj, replace);
+            this.setHash(newHash, replace);
          }
       }
    };

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Utility object for hash-related utilities. Note that this is not a Class, and so does
+ * not need to be instantiated before use.
+ *
+ * @module alfresco/util/hashUtils
+ * @author Martin Doyle
+ */
+define(["dojo/_base/lang",
+        "dojo/hash",
+        "dojo/io-query"],
+        function(lang, hash, ioQuery) {
+
+   // The private container for the functionality and properties of the util
+   var util = {
+
+      // See API below
+      getHash: function alfresco_util_hashUtils__getHash() {
+         var currHash = hash(),
+            hashObj = ioQuery.queryToObject(currHash);
+         return hashObj;
+      },
+
+      // See API below
+      setHash: function alfresco_util_hashUtils__getHash(hashObj, replace) {
+         var newHash = ioQuery.objectToQuery(hashObj);
+         hash(newHash, replace);
+      },
+
+      // See API below
+      updateHash: function alfresco_util_hashUtils__getHash(newValues, replace, force) {
+         var hashObj = this.getHash(),
+            hashName,
+            newHashValue,
+            oldHashValue,
+            hashChanged;
+         for (hashName in newValues) {
+            if (newValues.hasOwnProperty(hashName)) {
+               newHashValue = newValues[hashName];
+               oldHashValue = hashObj[hashName];
+               if ((typeof newHashValue === "undefined" || newHashValue === null) && hashObj.hasOwnProperty(hashName)) {
+                  delete hashObj[hashName];
+                  hashChanged = true;
+               } else {
+                  newHashValue = "" + newHashValue;
+                  if (newHashValue !== oldHashValue) {
+                     hashObj[hashName] = encodeURIComponent(newHashValue);
+                     hashChanged = true;
+                  }
+               }
+            }
+         }
+         if (hashChanged || force) {
+            this.setHash(hashObj, replace);
+         }
+      }
+   };
+
+   /**
+    * The public API for this utility class
+    *
+    * @alias module:alfresco/util/hashUtils
+    */
+   return {
+
+      /**
+       * Get the current hash value as an object
+       *
+       * @instance
+       * @returns {Object} The hash value as an object
+       */
+      getHash: lang.hitch(util, util.getHash),
+
+      /**
+       * Set the current hash value from an object
+       *
+       * @instance
+       * @param {Object} hashObj The new hash object
+       * @param {boolean} [replace] Replace the current hash, rather than changing
+       *                            (i.e. do not add to the history)
+       */
+      setHash: lang.hitch(util, util.setHash),
+
+      /**
+       * Update the current hash (by default, this will not do the update if the
+       * values are unchanged). To remove a value from the hash, pass through null
+       * or undefined.
+       *
+       * @instance
+       * @param {Object} newValues The new hash values with hash names as keys and
+       *                           hash values as their values (will only change
+       *                           values for hash names with keys in this object)
+       * @param {boolean} [replace] Replace the current hash, rather than changing
+       *                            (i.e. do not add to the history)
+       * @param {boolean} [force] Force an update, even if the values are unchanged
+       *                          (i.e. will trigger hash-change listeners)
+       */
+      updateHash: lang.hitch(util, util.updateHash)
+   };
+});

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -114,6 +114,35 @@ define(["intern!object",
             });
       },
 
+      "Hash reflects current filter values": function() {
+         return browser.getCurrentUrl()
+            .then(function(url) {
+               var hash = url.split("#")[1],
+                  hashParts = (hash && hash.split("&")) || [],
+                  hashObj = {};
+               hashParts.forEach(function(hashPart) {
+                  var nameValuePair = hashPart.split("=");
+                  hashObj[nameValuePair[0]] = nameValuePair[1];
+               });
+               assert.propertyVal(hashObj, "description", "moo", "Invalid value in hash");
+               assert.propertyVal(hashObj, "name", "t", "Invalid value in hash");
+            });
+      },
+
+      "Changing hash value updates filter": function() {
+         var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#description=moo");
+         return browser.findByCssSelector("body")
+            .clearLog()
+            .get(updatedUrl)
+            .getLastPublish("COMPOSITE_ALF_DOCLIST_REQUEST_FINISHED")
+            .end()
+
+         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "Incorrect results displayed for intended filter");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -24,23 +24,23 @@ define(["intern!object",
         "intern/chai!assert",
         "require",
         "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        "intern/dojo/node!leadfoot/keys"],
+        function(registerSuite, assert, require, TestCommon, keys) {
 
    var browser;
    registerSuite({
       name: "FilteredList Tests",
-      
+
       setup: function() {
          browser = this.remote;
          return TestCommon.loadTestWebScript(this.remote, "/FilteredList", "FilteredList Tests").end();
       },
-      
+
       beforeEach: function() {
          browser.end();
       },
-      
-      "Check that results are loaded initially": function () {
+
+      "Check that results are loaded initially": function() {
          return browser.findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
                assert.lengthOf(elements, 6, "The wrong number of results were displayed");
@@ -49,56 +49,69 @@ define(["intern!object",
 
       "Type a filter": function() {
          return browser.findByCssSelector("#TEXTBOX .dijitInputContainer input")
+            .clearLog()
             .type("one")
-         .end()
+            .end()
+
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "1"))
-         .end()
+         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+            .end()
+
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
-         .then(function(elements) {
-            assert.lengthOf(elements, 1, "Only 1 result should be displayed for filter 'one'");
-         });
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Only 1 result should be displayed for filter 'one'");
+            });
       },
 
       "Delete a couple of characters": function() {
          return browser.findByCssSelector("#TEXTBOX .dijitInputContainer input")
+            .clearLog()
             .type(keys.BACKSPACE)
             .type(keys.BACKSPACE)
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "3"))
-         .end()
+            .end()
+
+         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+            .end()
+
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
-         .then(function(elements) {
-            assert.lengthOf(elements, 3, "3 results should be displayed for filter 'o'");
-         });
+            .then(function(elements) {
+               assert.lengthOf(elements, 3, "3 results should be displayed for filter 'o'");
+            });
       },
 
       "Select a filter from drop down": function() {
          return browser.findByCssSelector("#COMPOSITE_DROPDOWN .dijitArrowButtonInner")
+            .clearLog()
             .click()
-         .end()
+            .end()
+
          .findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL_popup1")
             .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "4"))
-         .end()
+            .end()
+
+         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+            .end()
+
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-         .then(function(elements) {
-            assert.lengthOf(elements, 4, "4 results should be displayed for description 'moo'");
-         });
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "4 results should be displayed for description 'moo'");
+            });
       },
 
       "Apply a 2nd filter": function() {
          return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
+            .clearLog()
             .type("t")
-         .end()
+            .end()
+
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCLIST_DOCUMENTS_LOADED", "totalRecords", "2"))
-         .end()
+         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+            .end()
+
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-         .then(function(elements) {
-            assert.lengthOf(elements, 2, "Only 2 result should be displayed for combined filter");
-         });
+            .then(function(elements) {
+               assert.lengthOf(elements, 2, "Only 2 result should be displayed for combined filter");
+            });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,8 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/AvatarThumbnailTest",
-      "src/test/resources/alfresco/renderers/ThumbnailTest"
+      "src/test/resources/alfresco/lists/FilteredListTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
@@ -87,6 +87,7 @@ model.jsonModel = {
                            name: "alfresco/lists/AlfFilteredList",
                            config: {
                               pubSubScope: "COMPOSITE_",
+                              useHash: true,
                               filteringTopics: ["_valueChangeOf_FILTER"],
                               widgetsForFilters: [
                                  {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
@@ -183,7 +183,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-415](https://issues.alfresco.com/jira/browse/AKU-415) which requests the ability to have useHash set to true on a filtered list and have the hash mirror the filtering controls' values with bidirectional communication between the two and the filtered data updating appropriately as well.