### PR TITLE
AKU-459: Ability to Set a New User Default Page Preference Via Publish

### DIFF
--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -163,8 +163,13 @@ define(["dojo/_base/declare",
             // Set the remote preference...
             var preferenceObj = {};
             lang.setObject(payload.preference, payload.value, preferenceObj);
+            var responseTopic = payload.alfTopic;
+            if (payload.alfResponseTopic)
+            {
+               responseTopic = payload.alfResponseTopic;
+            }
             this.serviceXhr({url : url,
-                             alfTopic: payload.alfTopic,
+                             alfTopic: responseTopic,
                              data: preferenceObj,
                              method: "POST"});
 

--- a/aikau/src/main/resources/alfresco/services/UserService.js
+++ b/aikau/src/main/resources/alfresco/services/UserService.js
@@ -23,7 +23,7 @@
  * @mixes module:alfresco/core/CoreXhr
  * @mixes module:alfresco/core/NotificationUtils
  * @mixes module:alfresco/services/_UserServiceTopicMixin
-@mixes module:alfresco/services/_PreferenceServiceTopicMixin
+ * @mixes module:alfresco/services/_PreferenceServiceTopicMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",

--- a/aikau/src/main/resources/alfresco/services/_UserServiceTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_UserServiceTopicMixin.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2005-2013 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module alfresco/services/_UserServiceTopicMixin
+ * @author Dave Draper
+ * @author Ray Gauss II
+ */
+define(["dojo/_base/declare"], 
+        function(declare) {
+   
+   return declare(null, {
+      
+      /**
+       * This topic is used to set the status for the user
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_UPDATE_USER_STATUS"
+       */
+      updateUserStatusTopic: "ALF_UPDATE_USER_STATUS",
+      
+      /**
+       * This topic is used to indicate that the user's status was saved successfully.
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_USER_STATUS_UPDATED"
+       */
+      updateUserStatusSuccessTopic: "ALF_USER_STATUS_UPDATED",
+      
+      /**
+       * This topic is used to indicate that the user's status could not be saved.
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_USER_STATUS_UPDATE_FAILURE"
+       */
+      updateUserStatusFailureTopic: "ALF_USER_STATUS_UPDATE_FAILURE",
+      
+      /**
+       * This topic is used to set the default page for the user
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_SET_USER_DEFAULT_PAGE"
+       */
+      setUserDefaultPageTopic: "ALF_SET_USER_DEFAULT_PAGE",
+      
+      /**
+       * This topic is used to indicate that the user's default page was saved successfully.
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_SET_USER_DEFAULT_PAGE_SUCCESS"
+       */
+      setUserDefaultPageSuccessTopic: "ALF_SET_USER_DEFAULT_PAGE_SUCCESS",
+      
+      /**
+       * This topic is used to indicate that the user's default page could not be saved.
+       * 
+       * @instance
+       * @type {string}
+       * @default "ALF_SET_USER_DEFAULT_PAGE_FAILURE"
+       */
+      setUserDefaultPageFailureTopic: "ALF_SET_USER_DEFAULT_PAGE_FAILURE"
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/i18n/UserService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/UserService.properties
@@ -1,2 +1,4 @@
 message.status.failure=Couldn't update status.
 message.status.success=Status successfully updated.
+message.defaultPage.success=Default page successfully updated.
+message.defaultPage.failure=We couldn't update the default page.

--- a/aikau/src/test/resources/alfresco/services/UserServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/UserServiceTest.js
@@ -25,9 +25,10 @@
  */
 define(["intern!object",
         "intern/chai!expect",
+        "intern/chai!assert",
         "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, require, TestCommon) {
+        function (registerSuite, expect, assert, require, TestCommon) {
 
    var browser;
    registerSuite({
@@ -128,6 +129,45 @@ define(["intern!object",
                expect(text).to.equal("Last updated: over 4 years ago", "The 'last updated' should read 'Last updated: over 4 years ago' to finish");
             })
          .end();
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+   
+   registerSuite({
+      name: "User Service Default Page Test",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/UserServiceDefaultPage", "User Service Default Page Test").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+      
+      "Check setting the default page": function() {
+         return browser.findByCssSelector("#HEADER_USER_SET_DEFAULT_PAGE_label")
+            .click()
+         .end()
+         .getLastPublish("ALF_SET_USER_DEFAULT_PAGE")
+            .then(function(payload) {
+               assert.isNotNull(payload, "Set user default page not published");
+            })
+         .getLastPublish("ALF_PREFERENCE_SET")
+            .then(function(payload) {
+               assert.isNotNull(payload, "Set user default page preference not published");
+               if (payload) {
+                  assert.propertyVal(payload, "preference", "org.alfresco.share.user.defaultPage", "The user default page preference key was incorrect");
+                  assert.propertyVal(payload, "value", "NewDefaultPage", "The user default page value was incorrect");
+               }
+            })
+         .getLastPublish("ALF_SET_USER_DEFAULT_PAGE_SUCCESS")
+            .then(function(payload) {
+               assert.isNotNull(payload, "Set user default page success not published");
+            });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/UserServiceDefaultPage.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/UserServiceDefaultPage.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>UserServiceDefaultPage Test</shortname>
+  <description>This WebScript defines the UserServiceDefaultPage test</description>
+  <family>aikau-unit-tests</family>
+  <url>/UserServiceDefaultPage</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/UserServiceDefaultPage.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/UserServiceDefaultPage.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/UserServiceDefaultPage.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/UserServiceDefaultPage.get.js
@@ -1,0 +1,36 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      {
+         name: "alfresco/services/UserService"
+      },
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets:[
+      {
+         id: "HEADER_USER_SET_DEFAULT_PAGE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set Default Page",
+            publishTopic: "ALF_SET_USER_DEFAULT_PAGE",
+            publishPayload: {
+               defaultPage: "NewDefaultPage"
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
  - Added _UserServiceTopicMixin which contains all UserService topics
  - Updated UserService to use topics from mixing
  - Updated UserService with onSetUserDefaultPage method and related
success and failure methods
  - Added check for optional alfResponseTopic in
PreferenceService.setPreference
  - Added UserServiceDefaultPage test webscript
  - Added User Service Default Page Test suite to UserServiceTest