### PR TITLE
AKU-437: DocumentPicker improvements

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/Picker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Picker.js
@@ -61,6 +61,29 @@ define(["alfresco/forms/controls/BaseFormControl",
       itemKey: "name",
 
       /**
+       * Whether to use the currentItem as the initial value of the picker
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      useCurrentItemAsValue: false,
+
+      /**
+       * Run after widget and all children created
+       *
+       * @instance
+       * @override
+       */
+      startup: function alfresco_forms_controls_Picker__startup() {
+         this.inherited(arguments);
+         if (this.useCurrentItemAsValue && this.currentItem) {
+            var newValue = this.currentItem instanceof Array ? this.currentItem : [this.currentItem];
+            this.setValue(newValue);
+         }
+      },
+
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_Picker__getWidgetConfig() {
@@ -155,7 +178,8 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {object} value
        */
       setValue: function alfresco_forms_controls_Picker__setValue(value) {
-         this.setModelPickerWidgetValue(value);
+         var pickedItemsWidget = this.getPickedItemsWidget();
+         pickedItemsWidget && pickedItemsWidget.setPickedItems(value);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest.js
@@ -43,9 +43,21 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    return browser.end().alfPostCoverageResults(browser);
-      // },
+      "Initial set-value is correctly submitted": function(){
+         return browser.findByCssSelector("#FORM .confirmationButton .dijitButtonNode")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("PUBLISH_FORM")
+            .then(function(payload){
+               assert.deepPropertyVal(payload, "document[0]", "workspace://SpacesStore/8285e568-3782-4839-9f53-bf0b6aaacb3c", "Did not publish preset value");
+            })
+            .end()
+
+         .findByCssSelector("#DOCUMENT_PICKER .cancelButton .dijitButtonNode")
+            .click();
+      },
 
       "Test picker dialog can be displayed": function () {
          return browser.findByCssSelector("#DOCUMENT_PICKER .alfresco-layout-VerticalWidgets > span > span > span")

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/lists/FilteredListTest"
+      "src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DocumentPickerSingleItem.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DocumentPickerSingleItem.get.js
@@ -15,30 +15,280 @@ model.jsonModel = {
       "aikauTesting/mockservices/DocumentPickerTestService",
       "alfresco/services/ErrorReporter"
    ],
-   widgets:[
+   widgets: [
       {
-         name: "alfresco/forms/controls/DocumentPicker",
+         name: "alfresco/forms/Form",
+         id: "FORM",
          config: {
-            id: "DOCUMENT_PICKER",
-            label: "Items",
-            configForPicker: {
-               widgetsForPickedItems: [
-                  {
-                     name: "alfresco/pickers/PickedItems",
-                     assignTo: "pickedItemsWidget",
-                     config: {
-                        singleItemMode: true
+            okButtonPublishTopic: "PUBLISH_FORM",
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/DocumentPicker",
+                  config: {
+                     id: "DOCUMENT_PICKER",
+                     name: "document",
+                     label: "Items",
+                     currentItem: getMockImage(),
+                     useCurrentItemAsValue: true,
+                     configForPicker: {
+                        widgetsForPickedItems: [
+                           {
+                              name: "alfresco/pickers/PickedItems",
+                              assignTo: "pickedItemsWidget",
+                              config: {
+                                 singleItemMode: true
+                              }
+                           }
+                        ]
                      }
                   }
-               ]
-            }
+               }
+            ]
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };
+
+function getMockImage() {
+   return {
+      "node": {
+         "mimetype": "image\/jpeg",
+         "isLink": false,
+         "aspects": ["cm:auditable", "cm:thumbnailModification", "sys:referenceable", "exif:exif", "cm:titled", "cm:author", "rn:renditioned", "sys:localized", "cm:versionable"],
+         "permissions": {
+            "roles": ["ALLOWED;GROUP_EVERYONE;Contributor;INHERITED"],
+            "inherited": true,
+            "user": {
+               "ChangePermissions": true,
+               "CancelCheckOut": false,
+               "CreateChildren": true,
+               "Write": true,
+               "Delete": true
+            }
+         },
+         "encoding": "UTF-8",
+         "nodeRef": "workspace:\/\/SpacesStore\/8285e568-3782-4839-9f53-bf0b6aaacb3c",
+         "properties": {
+            "cm:modified": {
+               "value": "Thu Dec 19 12:09:26 GMT 2013",
+               "iso8601": "2013-12-19T12:09:26.689Z"
+            },
+            "exif:pixelYDimension": "269",
+            "cm:content": null,
+            "sys:node-uuid": null,
+            "exif:pixelXDimension": "187",
+            "cm:name": "Brian Griffin.jpg",
+            "cm:lastThumbnailModification": ["doclib:1387454968019"],
+            "sys:store-protocol": null,
+            "sys:locale": null,
+            "cm:autoVersion": "true",
+            "sys:node-dbid": null,
+            "cm:initialVersion": "true",
+            "cm:creator": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "cm:created": {
+               "value": "Thu Dec 19 12:09:26 GMT 2013",
+               "iso8601": "2013-12-19T12:09:26.689Z"
+            },
+            "cm:versionLabel": "1.0",
+            "cm:autoVersionOnUpdateProps": "false",
+            "cm:modifier": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:store-identifier": null
+         },
+         "type": "cm:content",
+         "contentURL": "\/api\/node\/content\/workspace\/SpacesStore\/8285e568-3782-4839-9f53-bf0b6aaacb3c\/Brian%20Griffin.jpg",
+         "isContainer": false,
+         "size": 6775.0,
+         "isLocked": false
+      },
+      "version": "1.0",
+      "webdavUrl": "\/webdav\/Shared\/Brian%20Griffin.jpg",
+      "isFavourite": false,
+      "likes": {
+         "isLiked": false,
+         "totalLikes": 0.0
+      },
+      "location": {
+         "repositoryId": "91d4696a-514e-47cb-a28e-5118e527cc64",
+         "path": "\/",
+         "file": "Brian Griffin.jpg",
+         "parent": {}
+      },
+      "parent": {
+         "isLink": false,
+         "aspects": ["app:uifacets", "cm:auditable", "sys:referenceable", "cm:titled", "sys:localized"],
+         "permissions": {
+            "roles": ["ALLOWED;GROUP_EVERYONE;Contributor;DIRECT"],
+            "inherited": false,
+            "user": {
+               "ChangePermissions": true,
+               "CancelCheckOut": false,
+               "CreateChildren": true,
+               "Write": true,
+               "Delete": true
+            }
+         },
+         "nodeRef": "workspace:\/\/SpacesStore\/3d6fa5ad-1443-446d-b5c0-347710aa8447",
+         "properties": {
+            "cm:modified": {
+               "value": "Thu Dec 19 12:09:26 GMT 2013",
+               "iso8601": "2013-12-19T12:09:26.796Z"
+            },
+            "sys:node-dbid": null,
+            "cm:description": "Folder to store shared stuff ",
+            "cm:creator": {
+               "lastName": "User",
+               "userName": "System",
+               "displayName": "System User",
+               "firstName": "System"
+            },
+            "sys:node-uuid": null,
+            "cm:created": {
+               "value": "Thu Dec 19 11:51:19 GMT 2013",
+               "iso8601": "2013-12-19T11:51:19.215Z"
+            },
+            "cm:name": "Shared",
+            "cm:title": "Shared Folder",
+            "sys:store-protocol": null,
+            "sys:locale": null,
+            "cm:modifier": {
+               "lastName": "User",
+               "userName": "System",
+               "displayName": "System User",
+               "firstName": "System"
+            },
+            "sys:store-identifier": null,
+            "app:icon": "space-icon-default"
+         },
+         "type": "cm:folder",
+         "isContainer": true,
+         "isLocked": false
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/8285e568-3782-4839-9f53-bf0b6aaacb3c",
+      "fileName": "Brian Griffin.jpg",
+      "displayName": "Brian Griffin.jpg",
+      "actionGroupId": "document-browse",
+      "actions": [{
+         "id": "document-download",
+         "icon": "document-download",
+         "type": "link",
+         "label": "actions.document.download",
+         "params": {
+            "href": "{downloadUrl}"
+         },
+         "index": "100"
+      }, {
+         "id": "document-view-content",
+         "icon": "document-view-content",
+         "type": "link",
+         "label": "actions.document.view",
+         "params": {
+            "href": "{viewUrl}"
+         },
+         "index": "110"
+      }, {
+         "id": "document-edit-properties",
+         "icon": "document-edit-properties",
+         "type": "javascript",
+         "label": "actions.document.edit-metadata",
+         "params": {
+            "function": "onActionDetails"
+         },
+         "index": "130"
+      }, {
+         "id": "document-upload-new-version",
+         "icon": "document-upload-new-version",
+         "type": "javascript",
+         "label": "actions.document.upload-new-version",
+         "params": {
+            "function": "onActionUploadNewVersion"
+         },
+         "index": "140"
+      }, {
+         "id": "document-edit-offline",
+         "icon": "document-edit-offline",
+         "type": "javascript",
+         "label": "actions.document.edit-offline",
+         "params": {
+            "function": "onActionEditOffline"
+         },
+         "index": "210"
+      }, {
+         "id": "document-copy-to",
+         "icon": "document-copy-to",
+         "type": "javascript",
+         "label": "actions.document.copy-to",
+         "params": {
+            "function": "onActionCopyTo"
+         },
+         "index": "250"
+      }, {
+         "id": "document-move-to",
+         "icon": "document-move-to",
+         "type": "javascript",
+         "label": "actions.document.move-to",
+         "params": {
+            "function": "onActionMoveTo"
+         },
+         "index": "260"
+      }, {
+         "id": "document-delete",
+         "icon": "document-delete",
+         "type": "javascript",
+         "label": "actions.document.delete",
+         "params": {
+            "function": "onActionDelete"
+         },
+         "index": "270"
+      }, {
+         "id": "document-assign-workflow",
+         "icon": "document-assign-workflow",
+         "type": "javascript",
+         "label": "actions.document.assign-workflow",
+         "params": {
+            "function": "onActionAssignWorkflow"
+         },
+         "index": "280"
+      }],
+      "indicators": [{
+         "id": "exif",
+         "index": "40",
+         "icon": "exif-16.png",
+         "label": "status.exif"
+      }],
+      "metadataTemplate": {
+         "id": "default",
+         "title": null,
+         "banners": [],
+         "lines": [{
+            "index": "10",
+            "template": "{date}{size}",
+            "view": ""
+         }, {
+            "index": "20",
+            "template": "{description}",
+            "view": "detailed"
+         }, {
+            "index": "30",
+            "template": "{tags}",
+            "view": "detailed"
+         }, {
+            "index": "50",
+            "template": "{social}",
+            "view": "detailed"
+         }]
+      }
+   };
+}


### PR DESCRIPTION
This addresses issue [AKU-437](https://issues.alfresco.com/jira/browse/AKU-437) by permitting a simple config parameter (`useCurrentItemAsValue`) that sets the initial value of a picker to the currentItem.