### PR TITLE
AKU-451: Updates to ensure form controls are rendered in tab containers

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -375,6 +375,7 @@ define(["dojo/_base/declare",
 
             // Add the widget to the ContentPane
             cp.addChild(w);
+            this._tabWidgetProcessingComplete();
          }
          // Otherwise record the widget for processing later on
          else
@@ -417,6 +418,8 @@ define(["dojo/_base/declare",
 
                // Add the widget to the ContentPane
                newTab.addChild(w);
+               this._tabWidgetProcessingComplete();
+
                forDeletion = i;
                break;
             }
@@ -455,6 +458,7 @@ define(["dojo/_base/declare",
          {
             this.alfLog("warn", "Attempt made to select a TabController tab with an inapproriate payload", this);
          }
+         this._tabWidgetProcessingComplete();
       },
 
       /**
@@ -498,6 +502,7 @@ define(["dojo/_base/declare",
          {
             array.forEach(payload.widgets, lang.hitch(this, this.addWidget));
          }
+         this._tabWidgetProcessingComplete();
       },
 
       /**
@@ -528,6 +533,16 @@ define(["dojo/_base/declare",
          {
             this.alfLog("warn", "Attempt made to remove a TabController tab with an inapproriate payload", this);
          }
+      },
+
+      /**
+       * It is necessary to publish a topic to ensure that all widgets know that processing is complete,
+       * this is particularly important for form controls to ensure that they are properly rendered.
+       *
+       * @instance
+       */
+      _tabWidgetProcessingComplete: function alfresco_layout_AlfTabContainer___tabWidgetProcessingComplete() {
+         this.alfPublish("ALF_WIDGET_PROCESSING_COMPLETE", {}, true);
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -57,7 +57,7 @@ define(["intern!object",
          return browser.findAllByCssSelector("div.dijitTabListWrapper > div.dijitTabContainerTop-tabs > div.dijitTab")
             .then(
                function (tabs) {
-                  expect(tabs.length).to.equal(9, "There are not 9 tabs");
+                  expect(tabs.length).to.equal(11, "There are not 11 tabs");
                }
             );
       },
@@ -66,7 +66,7 @@ define(["intern!object",
          return browser.findAllByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper")
             .then(
                function (panels) {
-                  expect(panels.length).to.equal(9, "There are not 9 panels");
+                  expect(panels.length).to.equal(11, "There are not 11 panels");
                }
             );
       },
@@ -85,7 +85,7 @@ define(["intern!object",
          return browser.findAllByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper.dijitHidden")
             .then(
                function (panels) {
-                  expect(panels.length).to.equal(8, "There are not 8 panels");
+                  expect(panels.length).to.equal(10, "There are not 10 panels");
                }
             );
       },
@@ -501,7 +501,7 @@ define(["intern!object",
          return browser.findAllByCssSelector("div.dijitTabListWrapper > div.dijitTabContainerTop-tabs > div.dijitTab")
             .then(
                function (tabs) {
-                  expect(tabs.length).to.equal(9, "There are not 9 tabs");
+                  expect(tabs.length).to.equal(11, "There are not 11 tabs");
                }
             );
       },
@@ -514,7 +514,7 @@ define(["intern!object",
          .findAllByCssSelector("div.dijitTabListWrapper > div.dijitTabContainerTop-tabs > div.dijitTab")
             .then(
                function (tabs) {
-                  expect(tabs.length).to.equal(8, "There are not 8 tabs");
+                  expect(tabs.length).to.equal(10, "There are not 10 tabs");
                }
             );
       },
@@ -527,7 +527,7 @@ define(["intern!object",
          .findAllByCssSelector("div.dijitTabListWrapper > div.dijitTabContainerTop-tabs > div.dijitTab")
             .then(
                function (tabs) {
-                  expect(tabs.length).to.equal(7, "There are not 7 tabs");
+                  expect(tabs.length).to.equal(9, "There are not 9 tabs");
                }
             );
       },
@@ -540,10 +540,33 @@ define(["intern!object",
          .findAllByCssSelector("div.dijitTabListWrapper > div.dijitTabContainerTop-tabs > div.dijitTab")
             .then(
                function (tabs) {
-                  expect(tabs.length).to.equal(6, "There are not 6 tabs");
+                  expect(tabs.length).to.equal(8, "There are not 8 tabs");
                }
             );
       },
+
+      "Check that delayed processing form control is displayed correctly": function() {
+         return browser.findById("dijit_layout_TabContainer_0_tablist_dijit_layout_ContentPane_9")
+            .click()
+         .end()
+         .findByCssSelector("#FormControl1 .label")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Select...", "The form control was not displayed correctly");
+            });
+      },
+
+       "Check that non-delayed processing form control is displayed correctly": function() {
+         return browser.findById("dijit_layout_TabContainer_0_tablist_dijit_layout_ContentPane_10")
+            .click()
+         .end()
+         .findByCssSelector("#FormControl2 .label")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Select...", "The form control was not displayed correctly");
+            });
+      },
+
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
@@ -594,6 +617,14 @@ define(["intern!object",
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "One", "The new tab content was rendered correctly");
+            });
+      },
+
+      "Check that the form control in the new panel has rendered correctly": function() {
+         return browser.findByCssSelector("#SELECT_FOR_One .label")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Select...", "The form control was not displayed correctly");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfTabContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfTabContainer.get.js
@@ -103,6 +103,48 @@ model.jsonModel = {
                                     config: {
                                        logoClasses: "alfresco-logo-only"
                                     }
+                                 },
+                                 {
+                                    id: "FormControl1",
+                                    name: "alfresco/forms/controls/Select",
+                                    title: "DP Form Control",
+                                    // tabId: "FORM_CONTROL_TAB_1",
+                                    delayProcessing: true,
+                                    config: {
+                                       fieldId: "SELECT",
+                                       name: "select",
+                                       label: "Select...",
+                                       value: "One",
+                                       description: "An example select form control",
+                                       optionsConfig: {
+                                          fixed: [
+                                             {label: "One", value: "One"},
+                                             {label: "Two", value: "Two"},
+                                             {label: "Three", value: "Three"}
+                                          ]
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "FormControl2",
+                                    name: "alfresco/forms/controls/Select",
+                                    tabId: "FORM_CONTROL_TAB_2",
+                                    title: "Non-DP Form Control",
+                                    delayProcessing: false,
+                                    config: {
+                                       fieldId: "SELECT",
+                                       name: "select",
+                                       label: "Select...",
+                                       value: "One",
+                                       description: "An example select form control",
+                                       optionsConfig: {
+                                          fixed: [
+                                             {label: "One", value: "One"},
+                                             {label: "Two", value: "Two"},
+                                             {label: "Three", value: "Three"}
+                                          ]
+                                       }
+                                    }
                                  }
                               ]
                            }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase.get.js
@@ -67,12 +67,37 @@ model.jsonModel = {
                                                                   publishPayload: {
                                                                      widgets: [
                                                                         {
-                                                                           name: "alfresco/html/Label",
+                                                                           name: "alfresco/layout/VerticalWidgets",
                                                                            title: "{name}",
                                                                            closable: true,
                                                                            selected: true,
                                                                            config: {
-                                                                              label: "{name}"
+                                                                              widgets: [
+                                                                                 {
+                                                                                    name: "alfresco/html/Label",
+                                                                                    config: {
+                                                                                       label: "{name}"
+                                                                                    }
+                                                                                 },
+                                                                                 {
+                                                                                    id: "SELECT_FOR_{name}",
+                                                                                    name: "alfresco/forms/controls/Select",
+                                                                                    config: {
+                                                                                       fieldId: "SELECT",
+                                                                                       name: "select",
+                                                                                       label: "Select...",
+                                                                                       value: "{name}",
+                                                                                       description: "An example select form control",
+                                                                                       optionsConfig: {
+                                                                                          fixed: [
+                                                                                             {label: "One", value: "One"},
+                                                                                             {label: "Two", value: "Two"},
+                                                                                             {label: "Three", value: "Three"}
+                                                                                          ]
+                                                                                       }
+                                                                                    }
+                                                                                 }
+                                                                              ]
                                                                            }
                                                                         }
                                                                      ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-451. The issue was again related to form controls waiting for notification that widget processing has been completed and to address the issue an update has been made such that the required topic is published after adding and selecting tabs. The unit test has been updated to reproduce scenarios of form controls being included in tabs with and without delayed processing and when tabs are dynamically added.