### PR TITLE
Fix default label not displaying on UploadButton

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -150,7 +150,7 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_menus__AlfMenuItemMixin__postMixInProperties() {
          if (this.label)
          {
-            this.label = this.encodeHTML(this.message(this.label));
+            this.params.label = this.label = this.encodeHTML(this.message(this.label));
          }
          if (this.title)
          {


### PR DESCRIPTION
Fix default label not displaying on UploadButton, due to dijit superclass replacing with empty string.