### PR TITLE
AKU-445, AKU-446: Document Library upload scoping issues

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -401,6 +401,7 @@ define(["dojo/_base/declare",
          delete object.alfTopic;
          delete object.alfPublishScope;
          delete object.alfOriginScope;
+         delete object.alfCallerName;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -390,6 +390,20 @@ define(["dojo/_base/declare",
       alfSubscriptions: null,
 
       /**
+       * Deletes any automatically added publish attributes from the supplied object. These are attributes that
+       * will have been added to the object by the [alfPublish]{@link module:alfresco/core/Core#alfPublish} function.
+       * 
+       * @instance
+       * @param {object} object The object to remove the attributes from.
+       */
+      alfDeleteFrameworkAttributes: function alfresco_core_Core__alfDeleteFrameworkAttributes(object) {
+         delete object.alfResponseTopic;
+         delete object.alfTopic;
+         delete object.alfPublishScope;
+         delete object.alfOriginScope;
+      },
+
+      /**
        * This function wraps the standard Dojo publish function. It should always be used rather than
        * calling the Dojo implementation directly to allow us to make changes to the implementation or
        * to introduce additional features (such as scoping) or updates to the payload.
@@ -404,7 +418,6 @@ define(["dojo/_base/declare",
        *                               and parentScope are falsy)
        */
       alfPublish: function alfresco_core_Core__alfPublish(topics, payload, global, parentScope, customScope) {
-
          // Allow an array of topics so we can publish multiple ones.
          if (!lang.isArray(topics))
          {
@@ -437,6 +450,7 @@ define(["dojo/_base/declare",
             // Update the payload
             payload.alfPublishScope = publishScope;
             payload.alfTopic = scopedTopic;
+            payload.alfOriginScope = this.pubSubScope;
 
             // Publish...
             PubQueue.getSingleton().publish(scopedTopic, payload, this);

--- a/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
@@ -418,8 +418,7 @@ define(["dojo/_base/declare",
             this.alfUnsubscribe(payload.subscriptionHandle);
             delete payload.subscriptionHandle;
          }
-         delete payload.alfTopic;
-         delete payload.alfPublishScope;
+         this.alfDeleteFrameworkAttributes(payload);
 
          // We should consider whether we actually want to mixin in the updated value
          // or just override it completely. It depends on whether or not we want to be

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateContentMenuBarItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateContentMenuBarItem.js
@@ -31,12 +31,13 @@
  */
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarItem",
+        "alfresco/documentlibrary/_AlfCreateContentMenuItemMixin",
         "alfresco/documentlibrary/_AlfCreateContentPermissionsMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "dojo/_base/lang"], 
-        function(declare, AlfMenuBarItem, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, lang) {
+        function(declare, AlfMenuBarItem, _AlfCreateContentMenuItemMixin, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, lang) {
    
-   return declare([AlfMenuBarItem, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin], {
+   return declare([AlfMenuBarItem, _AlfCreateContentMenuItemMixin, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin], {
       
       /**
        * Extends the [superclass function]{@link module:alfresco/menus/AlfMenuBarItem#postCreate} to subscribe to
@@ -49,6 +50,7 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_documentlibrary_AlfCreateContentMenuBarItem__postCreate() {
          this.alfSubscribe(this.userAccessChangeTopic, lang.hitch(this, this.onUserAcess));
          this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onFilterChange));
+         this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.onCurrentNodeChange));
          this.inherited(arguments);
       }
    });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateContentMenuItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateContentMenuItem.js
@@ -31,12 +31,13 @@
  */
 define(["dojo/_base/declare",
         "alfresco/menus/AlfFilteringMenuItem",
+        "alfresco/documentlibrary/_AlfCreateContentMenuItemMixin",
         "alfresco/documentlibrary/_AlfCreateContentPermissionsMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "dojo/_base/lang"], 
-        function(declare, AlfFilteringMenuItem, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, lang) {
+        function(declare, AlfFilteringMenuItem, _AlfCreateContentMenuItemMixin, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, lang) {
    
-   return declare([AlfFilteringMenuItem, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin], {
+   return declare([AlfFilteringMenuItem, _AlfCreateContentMenuItemMixin, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin], {
 
       /**
        * Set the i18n scope so that labels are picked up from the wrapped toolbar message scope.
@@ -56,6 +57,7 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_documentlibrary_AlfCreateContentMenuBarPopup__postCreate() {
          this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onFilterChange));
          this.alfSubscribe(this.userAccessChangeTopic, lang.hitch(this, this.onUserAcess));
+         this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.onCurrentNodeChange));
          this.inherited(arguments);
       },
    

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -492,7 +492,7 @@ define(["dojo/_base/declare",
          {
             this.alfPublish(this.metadataChangeTopic, {
                node: response.metadata
-            }, true);
+            });
 
             // Publish the details of the permissions for the current user. This will
             // only be available when the a specific node is shown rather than a set

--- a/aikau/src/main/resources/alfresco/documentlibrary/UploadButton.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/UploadButton.js
@@ -28,9 +28,8 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/documentlibrary/AlfCreateContentMenuBarItem",
-        "dojo/_base/lang"], 
-        function(declare, AlfCreateContentMenuBarItem, lang) {
+        "alfresco/documentlibrary/AlfCreateContentMenuBarItem"], 
+        function(declare, AlfCreateContentMenuBarItem) {
 
    return declare([AlfCreateContentMenuBarItem], {
       
@@ -73,26 +72,6 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_documentlibrary_UploadButton__postCreate() {
          this.inherited(arguments);
-         this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.onCurrentNodeChange));
-      },
-
-      /**
-       * This handles publications on the 
-       * [metadataChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#metadataChangeTopic}
-       * topic to set the location of the current folder 
-       * 
-       * @instance
-       * @param {object} payload 
-       */
-      onCurrentNodeChange: function alfresco_documentlibrary_UploadButton__onCurrentNodeChange(payload) {
-         if (payload && payload.node)
-         {
-            this.currentNode = payload.node;
-         }
-         else
-         {
-            this.alfLog("error", "A request was made to update the current NodeRef, but no 'node' property was provided in the payload: ", payload);
-         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentMenuItemMixin.js
@@ -18,7 +18,10 @@
  */
 
 /**
- * 
+ * This mixin module is used by both the [AlfCreateContentMenuBarItem]{@link module:alfresco/documentlibrary/AlfCreateContentMenuBarItem}
+ * and [AlfCreateContentMenuItem]{@link module:alfresco/documentlibrary/AlfCreateContentMenuItem} and provides the basic payload
+ * configuration for requesting dialogs to capture user information for creating content. It also provides tracking for the current
+ * Node in which to create content.
  * 
  * @module alfresco/documentlibrary/_AlfCreateContentMenuItemMixin
  * @extends module:alfresco/core/Core
@@ -127,7 +130,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      onClick: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__onClick(/*jshint unused:false*/ evt) {
+      onClick: function alfresco_documentlibrary__AlfCreateContentMenuItemMixin__onClick(/*jshint unused:false*/ evt) {
          var publishPayload;
          if (!this.publishPayload)
          {
@@ -168,7 +171,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload 
        */
-      onCurrentNodeChange: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__onCurrentNodeChange(payload) {
+      onCurrentNodeChange: function alfresco_documentlibrary__AlfCreateContentMenuItemMixin__onCurrentNodeChange(payload) {
          if (payload && payload.node)
          {
             this.currentNode = payload.node;

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentMenuItemMixin.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * 
+ * @module alfresco/documentlibrary/_AlfCreateContentMenuItemMixin
+ * @extends module:alfresco/core/Core
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core"], 
+        function(declare, AlfCore) {
+   
+   return declare([AlfCore], {
+
+      /**
+       * An array of the i18n files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/_AlfCreateContentMenuItemMixin.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/_AlfCreateContentMenuItemMixin.properties"}],
+
+      /**
+       * This is the type of content that will be created. This defaults to "cm:content" but can be overridden through
+       * configuration.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      contentType: "cm:content",
+
+      /**
+       * The title for the content creation dialog.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       */
+      dialogTitle: "create-content-menu-item.dialog.title",
+
+      /**
+       * The label for the content creation dialog confirmation button.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       */
+      dialogConfirmationLabel: "create-content-menu-item.dialog.confirmation",
+
+      /**
+       * The label for the content creation dialog cancellation button.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       */
+      dialogCancellationLabel: "create-content-menu-item.dialog.cancellation",
+
+      /**
+       * The topic published when the content creation dialog is confirmed.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       */
+      formSubmissionTopic: "ALF_CREATE_CONTENT_REQUEST",
+
+      /**
+       * This is the MIME type of the content that will be created. This defaults to "text/plain" but can be overridden
+       * through configuration.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      mimeType: "text/plain",
+
+      /**
+       * This is the topic that will be published when the menu item is clicked. It defaults to the topic requesting
+       * a form dialog be displayed but can be overridden through configuration.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       */
+      publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+
+      /**
+       * It is expected that upload will require topics to be published globally, however this can be overridden through
+       * configuration.
+       *
+       * @instance
+       * @type {boolean}
+       */
+      publishGlobal: true,
+
+      /**
+       * This should be configured to be an array of form control widgets to be placed into the create content dialog.
+       *
+       * @instance
+       * @type {object[]}
+       * @default null
+       */
+      widgets: null,
+
+      /**
+       * 
+       * @instance
+       */
+      onClick: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__onClick(/*jshint unused:false*/ evt) {
+         var publishPayload;
+         if (!this.publishPayload)
+         {
+            // If no explicit payload has been configured then use a default payload to generate a form dialog request...
+            publishPayload = {
+               contentWidth: "550px",
+               dialogTitle: this.message(this.dialogTitle),
+               dialogConfirmationButtonTitle: this.message(this.dialogConfirmationLabel),
+               dialogCancellationButtonTitle: this.message(this.dialogCancellationLabel),
+               formSubmissionTopic: this.formSubmissionTopic,
+               formSubmissionPayloadMixin: {
+                  type: this.contentType,
+                  prop_mimetype: this.mimeType || "",
+                  currentNode: this.currentNode,
+                  alfResponseScope: this.pubSubScope
+               },
+               fixedWidth: true,
+               widgets: this.widgets
+            };
+         }
+         else
+         {
+            // ...or use the configured payload
+            publishPayload = this.publishPayload;
+         }
+
+         var publishGlobal = this.publishGlobal || false;
+         var publishToParent = this.publishToParent || false;
+         var payload = this.generatePayload(publishPayload, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
+         this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
+      },
+
+      /**
+       * This handles publications on the 
+       * [metadataChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#metadataChangeTopic}
+       * topic to set the location of the current folder 
+       * 
+       * @instance
+       * @param {object} payload 
+       */
+      onCurrentNodeChange: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__onCurrentNodeChange(payload) {
+         if (payload && payload.node)
+         {
+            this.currentNode = payload.node;
+         }
+         else
+         {
+            this.alfLog("error", "A request was made to update the current NodeRef, but no 'node' property was provided in the payload: ", payload);
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentPermissionsMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentPermissionsMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -29,9 +29,8 @@
 define(["dojo/_base/declare",
         "alfresco/core/Core",
         "dojo/on",
-        "dojo/_base/lang",
-        "dijit/popup"], 
-        function(declare, AlfCore, on, lang, popup) {
+        "dojo/_base/lang"], 
+        function(declare, AlfCore, on, lang) {
    
    return declare([AlfCore], {
 
@@ -55,10 +54,10 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the selected files.
        */
       onUserAcess: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__onUserAcess(payload) {
-         if (payload && payload.userAccess && typeof this.permission == "string")
+         if (payload && payload.userAccess && typeof this.permission === "string")
          {
             // Disable the menu bar popup if the user doesn't have permission to create content...
-            this.set('disabled', !this.hasPermission(this.permission, payload.userAccess));
+            this.set("disabled", !this.hasPermission(this.permission, payload.userAccess));
          }
       },
       
@@ -70,6 +69,7 @@ define(["dojo/_base/declare",
        * @param {object} userAccess The user access data
        */
       hasPermission: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__hasPermission(permissionString, userAccess) {
+         // jshint maxcomplexity:false
          // Initially assume that the user has permission...
          var hasPermission = true,
              widgetPermissions, orPermissions, permissionTokens, permission, orMatch, shallMatch;
@@ -87,7 +87,7 @@ define(["dojo/_base/declare",
                {
                   permissionTokens = orPermissions[j].split(":");
                   permission = permissionTokens[0];
-                  shallMatch = permissionTokens.length == 2 ? permissionTokens[1] == "true" : true;
+                  shallMatch = permissionTokens.length === 2 ? permissionTokens[1] === "true" : true;
                   if ((userAccess[permission] && shallMatch) || (!userAccess[permission] && !shallMatch))
                   {
                      orMatch = true;
@@ -104,7 +104,7 @@ define(["dojo/_base/declare",
             {
                permissionTokens = widgetPermissions[i].split(":");
                permission = permissionTokens[0];
-               shallMatch = permissionTokens.length == 2 ? permissionTokens[1] == "true" : true;
+               shallMatch = permissionTokens.length === 2 ? permissionTokens[1] === "true" : true;
                if ((userAccess[permission] && !shallMatch) || (!userAccess[permission] && shallMatch))
                {
                   hasPermission = false;
@@ -125,7 +125,7 @@ define(["dojo/_base/declare",
        */
       onFilterChange: function alfresco_documentlibrary__AlfCreateContentPermissionsMixin__onFilterChange(payload) {
          var path = lang.getObject("path", false, payload);
-         this.set('disabled', (path == null));
-      } 
+         this.set("disabled", !path);
+      }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -402,6 +402,7 @@ define(["dojo/_base/declare",
                this.removeDndHighlight();
                var config = this.getUploadConfig();
                var defaultConfig = {
+                  destination: this._currentNode.nodeRef,
                   siteId: null,
                   containerId: null,
                   uploadDirectory: null,

--- a/aikau/src/main/resources/alfresco/documentlibrary/i18n/_AlfCreateContentMenuItemMixin.properties
+++ b/aikau/src/main/resources/alfresco/documentlibrary/i18n/_AlfCreateContentMenuItemMixin.properties
@@ -1,0 +1,3 @@
+create-content-menu-item.dialog.title=Create Content
+create-content-menu-item.dialog.confirmation=Create
+create-content-menu-item.dialog.cancellation=Cancel

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -642,9 +642,7 @@ define(["dojo/_base/declare",
       setHashFragment: function alfresco_forms_Form__setHashFragment(payload) {
          // Make sure to remove the alfTopic from the payload (this will always be assigned on publications
          // but is not actually part of the form data)...
-         delete payload.alfTopic;
-         delete payload.alfPublishScope;
-         delete payload.alfCallerName;
+         this.alfDeleteFrameworkAttributes(payload);
          
          // Make sure that only the controls with names listed in hashVarsForUpdate are set on the URL hash...
          var updatedHash = {};

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -145,7 +145,7 @@ define(["dojo/_base/declare",
 
          // Call DND upload mixin functions to add support for uploading behaviour...
          this.subscribeToCurrentNodeChanges(this.domNode);
-         // this.addUploadDragAndDrop(this.domNode);
+         this.addUploadDragAndDrop(this.domNode);
 
          if (this.subscribeToDocRequests)
          {

--- a/aikau/src/main/resources/alfresco/menus/AlfFilteringMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfFilteringMenuItem.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -44,9 +44,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuItem__postCreate() {
-         if (this.filterTopic != null)
+         if (this.filterTopic)
          {
-            this.alfSubscribe(this.filterTopic, lang.hitch(this, "filter"));
+            this.alfSubscribe(this.filterTopic, lang.hitch(this, this.filter));
          }
          this.inherited(arguments);
       },

--- a/aikau/src/main/resources/alfresco/menus/AlfFilteringMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfFilteringMenuItem.js
@@ -43,11 +43,8 @@ define(["dojo/_base/declare",
        * Ensures that the supplied menu item label is translated.
        * @instance
        */
-      postCreate: function alfresco_menus_AlfMenuItem__postCreate() {
-         if (this.filterTopic)
-         {
-            this.alfSubscribe(this.filterTopic, lang.hitch(this, this.filter));
-         }
+      postCreate: function alfresco_menus_AlfFilteringMenuItem____postCreate() {
+         this.filterTopic && this.alfSubscribe(this.filterTopic, lang.hitch(this, this.filter));
          this.inherited(arguments);
       },
       

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -393,6 +393,7 @@ define(["dojo/_base/declare",
          {
             this.addUploadDragAndDrop(this.imgNode);
             this.addNodeDropTarget(this.imgNode);
+            this._currentNode = this.currentItem.node;
          }
       },
 

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -524,8 +524,7 @@ define(["dojo/_base/declare",
 
                if (this.query)
                {
-                  delete this.query.alfTopic;
-                  delete this.query.alfPublishScope;
+                  this.alfDeleteFrameworkAttributes(this.query);
 
                   if(typeof this.query === "string")
                   {

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -438,7 +438,6 @@ define(["dojo/_base/declare",
       onFileUploadComplete: function alfresco_services_ContentService__onFileUploadComplete(payload) {
          this.alfLog("log", "Upload complete");
          this.alfUnsubscribeSaveHandles([this._uploadSubHandle]);
-         this.alfPublish(this.reloadDataTopic, {});
          var responseScope = payload.alfResponseScope || "";
          this.alfPublish(responseScope + this.reloadDataTopic, {}, true);
       },

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -144,9 +144,7 @@ define(["dojo/_base/declare",
       clonePayload: function alfresco_services_CrudService__clonePayload(payload) {
          var data = lang.clone(payload);
          delete data.url;
-         delete data.alfResponseTopic;
-         delete data.alfTopic;
-         delete data.alfPublishScope;
+         this.alfDeleteFrameworkAttributes(data);
          return data;
       },
 

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -160,6 +160,7 @@ define(["dojo/_base/declare",
                {
                   switch(key) {
                      case "alfTopic":
+                     case "alfOriginScope":
                      case "alfResponseTopic":
                      case "alfPublishScope":
                      case "alfCallerName":

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -232,6 +232,7 @@ define(["dojo/_base/declare",
             // Store a response topic to publish on when the upload is complete...
             // This allows for scoped responses to be processed without pollution...
             this.currentResponseTopic = payload.alfResponseTopic;
+            this.currentResponseScope = payload.alfResponseScope;
 
             this.filesToUpload = [];
             this.validateRequestedFiles(payload.files);
@@ -825,6 +826,7 @@ define(["dojo/_base/declare",
          if (this.currentResponseTopic !== null && this.currentResponseTopic !== undefined)
          {
             this.alfPublish(this.currentResponseTopic, {
+               alfResponseScope: this.currentResponseScope
             }, true);
          }
       },

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -189,50 +189,38 @@ function generateCreateContentMenuItem(menuItemLabel, dialogTitle, iconClass, mo
       config: {
          label: menuItemLabel,
          iconClass: iconClass,
-         publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
-         publishPayloadType: "PROCESS",
-         publishPayloadModifiers: ["processCurrentItemTokens"],
-         publishPayload: {
-            contentWidth: "550px",
-            dialogTitle: dialogTitle,
-            dialogConfirmationButtonTitle: "Create",
-            dialogCancellationButtonTitle: "Cancel",
-            formSubmissionTopic: "ALF_CREATE_CONTENT_REQUEST",
-            formSubmissionPayloadMixin: {
-               type: modelType,
-               prop_mimetype: mimeType || ""
-            },
-            fixedWidth: true,
-            widgets: [
-               {
-                  name: "alfresco/forms/controls/TextBox",
-                  config: {
-                     label: msg.get("create.content.name.label"),
-                     name: "prop_cm_name",
-                     value: "",
-                     requirementConfig: {
-                        initialValue: true
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/TextBox",
-                  config: {
-                     label: msg.get("create.content.title.label"),
-                     name: "prop_cm_title",
-                     value: ""
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/TextArea",
-                  config: {
-                     label: msg.get("create.content.description.label"),
-                     name: "prop_cm_description",
-                     value: ""
+         dialogTitle: dialogTitle,
+         contentType: modelType,
+         mimeType: mimeType,
+         widgets: [
+            {
+               name: "alfresco/forms/controls/TextBox",
+               config: {
+                  label: msg.get("create.content.name.label"),
+                  name: "prop_cm_name",
+                  value: "",
+                  requirementConfig: {
+                     initialValue: true
                   }
                }
-            ]
-         }
+            },
+            {
+               name: "alfresco/forms/controls/TextBox",
+               config: {
+                  label: msg.get("create.content.title.label"),
+                  name: "prop_cm_title",
+                  value: ""
+               }
+            },
+            {
+               name: "alfresco/forms/controls/TextArea",
+               config: {
+                  label: msg.get("create.content.description.label"),
+                  name: "prop_cm_description",
+                  value: ""
+               }
+            }
+         ]
       }
    };
    // If a content widget name has been specified then define the additional widget
@@ -257,11 +245,11 @@ function generateCreateContentMenuItem(menuItemLabel, dialogTitle, iconClass, mo
             }
          }
       }
-      menuItem.config.publishPayload.widgets.push(contentWidget);
+      menuItem.config.widgets.push(contentWidget);
    }
 
    // Add in any additional widgets requested...
-   menuItem.config.publishPayload.widgets.concat(additionalWidgets || []);
+   menuItem.config.widgets.concat(additionalWidgets || []);
    return menuItem;
 }
 
@@ -1231,8 +1219,6 @@ function getDocLib(options) {
          ]
       }
    };
-   if (options.pubSubScope) {
-      docLibModel.pubSubScope = options.pubSubScope;
-   }
+   
    return docLibModel;
 }


### PR DESCRIPTION
This addresses both https://issues.alfresco.com/jira/browse/AKU-445 and https://issues.alfresco.com/jira/browse/AKU-446 to resolve issues preventing uploading and refreshing Document Libraries when those Document Libraries have been given a specific pubSubScope.