### PR TITLE
AKU-442: Ensure that path breadcrumbs publish requests globally

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -236,7 +236,7 @@ define(["dojo/_base/declare",
 
             if (this.useHash === true)
             {
-               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged));
+               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged), true);
             }
             else if (this.pathChangeTopic)
             {
@@ -323,7 +323,8 @@ define(["dojo/_base/declare",
          var path = paths.slice(0, index+1).join("/");
          var config = {
             label: folderName,
-            path: path
+            path: path,
+            publishGlobal: true
          };
          if (index < paths.length -1)
          {

--- a/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
@@ -113,7 +113,7 @@ define(["intern!object",
          return browser.findByCssSelector("#HIDE_PATH_label")
             .click()
             .end()
-         .findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail")
+         .findByCssSelector("#FIXED_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail")
             .isDisplayed()
             .then(function(result) {
                assert(result === false, "The breadcrumb trail wasn't hidden");
@@ -124,7 +124,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SHOW_PATH_label")
             .click()
             .end()
-         .findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail")
+         .findByCssSelector("#FIXED_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail")
             .isDisplayed()
             .then(function(result) {
                assert(result === true, "The breadcrumb trail wasn't displayed");
@@ -135,14 +135,14 @@ define(["intern!object",
          return browser.findByCssSelector("#FILTER_SELECTION_label")
             .click()
             .end()
-         .findAllByCssSelector("#HASH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
+         .findAllByCssSelector("#FIXED_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb")
             .then(function(elements) {
                assert(elements.length === 1, "Setting filter didn't remove breadcrumbs");
             });
       },
 
       "Check that filter is displayed correctly": function() {
-         return browser.findByCssSelector("#HASH_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail > ul > li > a")
+         return browser.findByCssSelector("#FIXED_BREADCRUMBS.alfresco-documentlibrary-AlfBreadcrumbTrail > ul > li > a")
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "Simulated Filter", "Filter wasn't displayed correctly");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
@@ -47,6 +47,7 @@ model.jsonModel = {
          id: "HASH_BREADCRUMBS",
          name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
          config: {
+            pubSubScope: "SCOPED_",
             lastBreadcrumbIsCurrentNode: true,
             useHash: true,
             rootLabel: "HOME",
@@ -136,7 +137,7 @@ model.jsonModel = {
          name: "alfresco/buttons/AlfButton",
          config: {
             label: "Change Current NodeRef",
-            publishTopic: "ALF_CURRENT_NODEREF_CHANGED",
+            publishTopic: "SCOPED_ALF_CURRENT_NODEREF_CHANGED",
             publishPayload: {
                node: {
                   parent: {


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-422 to ensure that path breadcrumbs publish globally and hash breadcrumbs subscribe to hash events globally. I've also made some updates to the test page to ensure this works with scoped breadcrumbs.