### PR TITLE
AKU-421: Invalid alfPublishScope set by InlineEditPropertyLink

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -36,10 +36,11 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojox/uuid/generateRandomUuid", 
         "dojox/html/entities", 
-        "dojo/Deferred"], 
-        function(declare, CoreData, PubSubLog, AlfConstants, pubSub, PubQueue, array, lang, uuid, htmlEntities, Deferred) {
+        "dojo/Deferred",
+        "alfresco/core/TopicsMixin"], 
+        function(declare, CoreData, PubSubLog, AlfConstants, pubSub, PubQueue, array, lang, uuid, htmlEntities, Deferred, TopicsMixin) {
 
-   return declare(null, {
+   return declare([TopicsMixin], {
 
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/main/resources/alfresco/core/TopicsMixin.js
+++ b/aikau/src/main/resources/alfresco/core/TopicsMixin.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This mixin is intended to contain ALL topics used by the Aikau framework. It is a mixin rather than
+ * a constants file, because occasionally it is necessary to override certain values due to the manner
+ * in which certain files have been constructed, however it is strongly discouraged to do so.<br />
+ * <br />
+ * NOTE: The TOPIC_ prefix is used because these items will be referenced as instance variables, and
+ * so makes it easier to effortlessly determine what the variable is when reading code.
+ * 
+ * @module alfresco/core/TopicsMixin
+ * @author Martin Doyle
+ */
+define(["dojo/_base/declare"],
+   function(declare) {
+
+      // NOTE: Please keep every value alphabetically sorted, in order
+      //       to help manage the large number of topics used in Aikau
+      return declare(null, {
+
+         /**
+          * This topic is fired automatically whenever a notification is destroyed.
+          *
+          * @instance
+          * @type {string}
+          * @default
+          */
+         TOPIC_NOTIFICATION_CLOSED: "ALF_NOTIFICATION_CLOSED"
+      });
+   });

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -83,7 +83,7 @@ define(["dojo/_base/declare",
             // If no topic has been provided then assume this to be a standard document/folder link...
             this.linkPublishPayload = {};
             var publishTopic = this.generateFileFolderLink(this.linkPublishPayload);
-            this.alfPublish(publishTopic, this.linkPublishPayload, publishGlobal, publishToParent);
+            this.alfServicePublish(publishTopic, this.linkPublishPayload);
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -64,6 +64,7 @@ define(["dojo/_base/declare",
                });
                newNotification.startup();
                newNotification.display().then(lang.hitch(this, function() {
+                  this.alfPublish(this.TOPIC_NOTIFICATION_CLOSED, {}, true);
                   if (payload.publishTopic) {
                      this.alfPublish(payload.publishTopic, payload.publishPayload || {}, payload.publishGlobal, payload.publishToParent);
                   }

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -48,12 +48,15 @@ define(["intern!object",
             return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
                .getVisibleText()
                .then(function(text) {
-                  assert.equal(text, "Test", "Value not rendered correctly");
+                  assert.equal(text, "Test item (topic, no scope)", "Value not rendered correctly");
                });
          },
 
          "Edit widget not initially created": function() {
-            return browser.findAllByCssSelector("#INLINE_EDIT_ITEM_0 > .editWidgetNode > *")
+            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 [data-dojo-attach-point=\"formWidgetNode\"]") // Make sure placeholder is present
+               .end()
+
+            .findAllByCssSelector("#INLINE_EDIT_ITEM_0 .alfresco-forms-Form")
                .then(function(elements) {
                   assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
                });
@@ -125,10 +128,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
-               .then(null, function() {
-                  assert(false, "Clicking edit icon did not create the validation text box");
-               });
+            .findByCssSelector("#INLINE_EDIT_ITEM_0 .alfresco-forms-Form");
          },
 
          "Read property is hidden when editing": function() {
@@ -171,9 +171,9 @@ define(["intern!object",
                .click()
                .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("TEST_PROPERTY_LINK_CLICK", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Property link topic not published on click");
+            .getLastPublish("TEST_PROPERTY_LINK_CLICK")
+               .then(function(payload) {
+                  assert.isNotNull(payload, "Property link topic not published on click");
                });
          },
 
@@ -243,21 +243,12 @@ define(["intern!object",
                .click()
                .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATE", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Property update not requested");
-               })
-               .end()
-
-            .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "name", "New"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "New value didn't publish correctly");
-               })
-               .end()
-
-            .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "hiddenData", "hidden_update"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Hidden value didn't get included");
+            .getLastPublish("ALF_CRUD_UPDATE", true)
+               .then(function(payload) {
+                  assert.isNotNull(payload, "Property update not requested");
+                  assert.propertyVal(payload, "name", "New", "New value didn't publish correctly");
+                  assert.propertyVal(payload, "hiddenData", "hidden_update", "Hidden value didn't get included");
+                  assert.propertyVal(payload, "alfResponseScope", "", "Unscoped property link generated alfResponseScope");
                });
          },
 
@@ -271,6 +262,64 @@ define(["intern!object",
             .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "New", "Read-only value not updated correctly");
+               });
+         },
+
+         "Scoped property link update has response scoped": function() {
+            return browser.findByCssSelector("#LIST_TOPIC_SCOPED .editIcon")
+               .click()
+               .end()
+
+            .findByCssSelector("#LIST_TOPIC_SCOPED .alfresco-forms-controls-TextBox:first-child .dijitInputContainer input")
+               .type("New2")
+               .end()
+
+            .findByCssSelector("#LIST_TOPIC_SCOPED .save")
+               .clearLog()
+               .click()
+               .end()
+
+            .getLastPublish("ALF_CRUD_UPDATE", true)
+               .then(function(payload) {
+                  assert.isNotNull(payload, "Property update not requested");
+                  assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "Scoped property link generated incorrect alfResponseScope");
+               });
+         },
+
+         "Property links publish correct payloads": function() {
+            return browser.findByCssSelector("#LIST_TOPIC_NOSCOPE .alfresco-renderers-InlineEditProperty .alfresco-renderers-Property")
+               .clearLog()
+               .click()
+               .end()
+
+            .getLastPublish("TEST_PROPERTY_LINK_CLICK", true)
+               .then(function(payload) {
+                  assert.isNotNull(payload, "'Test item (topic, no scope)' did not publish correct topic");
+                  assert.propertyVal(payload, "alfResponseScope", "", "'Test item (topic, no scope)' generated incorrect alfResponseScope");
+               })
+               .end()
+
+            .findByCssSelector("#LIST_TOPIC_SCOPED .alfresco-renderers-InlineEditProperty .alfresco-renderers-Property")
+               .clearLog()
+               .click()
+               .end()
+
+            .getLastPublish("SCOPED_TEST_PROPERTY_LINK_CLICK", true)
+               .then(function(payload) {
+                  assert.isNotNull(payload, "'Test item (topic, scoped)' did not publish correct topic");
+                  assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "'Test item (topic, scoped)' generated incorrect alfResponseScope");
+               })
+               .end()
+
+            .findByCssSelector("#LIST_NOTOPIC_SCOPED .alfresco-renderers-InlineEditProperty .alfresco-renderers-Property")
+               .clearLog()
+               .click()
+               .end()
+
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE", true)
+               .then(function(payload) {
+                  assert.isNotNull(payload, "'Test item (no topic, scoped)' did not publish correct topic");
+                  assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "'Test item (no topic, scoped)' generated incorrect alfResponseScope");
                });
          },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest"
+      "src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest"
    ],
 
    /**

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -217,7 +217,7 @@ define({
       "src/test/resources/alfresco/services/NotificationServiceTest",
       "src/test/resources/alfresco/services/SearchServiceTest",
       "src/test/resources/alfresco/services/ServiceFilteringTest",
-      "src/test/resources/alfresco/services/SiteServiceTest",
+      // "src/test/resources/alfresco/services/SiteServiceTest", - NO TESTS IN THIS SUITE THAT DO ANYTHING!
       "src/test/resources/alfresco/services/UserServiceTest",
 
       "src/test/resources/alfresco/services/actions/CopyMoveTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
@@ -1,3 +1,82 @@
+var propertyLinkWidgets = [
+      {
+         name: "alfresco/lists/views/layouts/Row",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/lists/views/layouts/Cell",
+                  config: {
+                     widgets: [
+                        {
+                           id: "INLINE_EDIT",
+                           name: "alfresco/renderers/InlineEditPropertyLink",
+                           config: {
+                              propertyToRender: "name",
+                              linkPublishTopic: "TEST_PROPERTY_LINK_CLICK",
+                              linkPublishPayload: {},
+                              publishTopic: "ALF_CRUD_UPDATE",
+                              publishPayloadType: "PROCESS",
+                              publishPayloadModifiers: ["processCurrentItemTokens"],
+                              publishPayloadItemMixin: true,
+                              publishPayload: {
+                                 url: "api/solr/facet-config/{name}"
+                              },
+                              hiddenDataRules: [
+                                 {
+                                    name: "hiddenData",
+                                    rulePassValue: "hidden_update",
+                                    ruleFailValue: "",
+                                    is: ["New"]
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   ],
+   propertyLinkWidgetsNoTopic = [
+      {
+         name: "alfresco/lists/views/layouts/Row",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/lists/views/layouts/Cell",
+                  config: {
+                     widgets: [
+                        {
+                           id: "INLINE_EDIT",
+                           name: "alfresco/renderers/InlineEditPropertyLink",
+                           config: {
+                              propertyToRender: "name",
+                              publishTopic: "ALF_CRUD_UPDATE",
+                              publishPayloadType: "PROCESS",
+                              publishPayloadModifiers: ["processCurrentItemTokens"],
+                              publishPayloadItemMixin: true,
+                              publishPayload: {
+                                 url: "api/solr/facet-config/{name}"
+                              },
+                              hiddenDataRules: [
+                                 {
+                                    name: "hiddenData",
+                                    rulePassValue: "hidden_update",
+                                    ruleFailValue: "",
+                                    is: ["New"]
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   ];
+
 model.jsonModel = {
    services: [
       {
@@ -15,64 +94,50 @@ model.jsonModel = {
    widgets:[
       {
          name: "alfresco/lists/views/AlfListView",
+         id: "LIST_TOPIC_NOSCOPE",
          config: {
-            id: "LIST",
             currentData: {
                items: [
                   {
-                     name: "Test",
-                     option: "1"
+                     name: "Test item (topic, no scope)"
                   }
                ]
             },
-            widgets:[
-               {
-                  name: "alfresco/lists/views/layouts/Row",
-                  config: {
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/layouts/Cell",
-                           config: {
-                              widgets: [
-                                 {
-                                    id: "INLINE_EDIT",
-                                    name: "alfresco/renderers/InlineEditPropertyLink",
-                                    config: {
-                                       propertyToRender: "name",
-                                       linkPublishTopic: "TEST_PROPERTY_LINK_CLICK",
-                                       linkPublishPayload: {},
-                                       publishTopic: "ALF_CRUD_UPDATE",
-                                       publishPayloadType: "PROCESS",
-                                       publishPayloadModifiers: ["processCurrentItemTokens"],
-                                       publishPayloadItemMixin: true,
-                                       publishPayload: {
-                                          url: "api/solr/facet-config/{name}"
-                                       },
-                                       hiddenDataRules: [
-                                          {
-                                             name: "hiddenData",
-                                             rulePassValue: "hidden_update",
-                                             ruleFailValue: "",
-                                             is: ["New"]
-                                          }
-                                       ]
-                                    }
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  }
-               }
-            ]
-
+            widgets: propertyLinkWidgets
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/lists/views/AlfListView",
+         id: "LIST_TOPIC_SCOPED",
+         config: {
+            pubSubScope: "SCOPED_",
+            currentData: {
+               items: [
+                  {
+                     name: "Test item (topic, scoped)"
+                  }
+               ]
+            },
+            widgets: propertyLinkWidgets
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/lists/views/AlfListView",
+         id: "LIST_NOTOPIC_SCOPED",
+         config: {
+            pubSubScope: "SCOPED_",
+            currentData: {
+               items: [
+                  {
+                     name: "Test item (no topic, scoped)"
+                  }
+               ]
+            },
+            widgets: propertyLinkWidgetsNoTopic
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-421](https://issues.alfresco.com/jira/browse/AKU-421), which is about invalid scoping when using the InlineEditPropertyLink. Additionally, NotificationService has been updated to always publish when notifications are closed, and the SiteServices test has been removed from testing because it's pointless.