### PR TITLE
NavigationService: allow queryParams and hashParams objects in payload to support encoding

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -30,11 +30,12 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/services/_NavigationServiceTopicMixin",
         "alfresco/util/hashUtils",
+        "alfresco/util/urlUtils",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-construct",
         "service/constants/Default"],
-        function(declare, AlfCore, _NavigationServiceTopicMixin, hashUtils, array, lang, domConstruct, AlfConstants) {
+        function(declare, AlfCore, _NavigationServiceTopicMixin, hashUtils, urlUtils, array, lang, domConstruct, AlfConstants) {
 
    return declare([AlfCore, _NavigationServiceTopicMixin], {
 
@@ -92,7 +93,7 @@ define(["dojo/_base/declare",
 
       /**
        * Builds a URL from the supplied data object.
-       * 
+       *
        * @instance
        * @param  {object} data The data object form which to construct the URL
        * @return {string} The built URL
@@ -123,6 +124,23 @@ define(["dojo/_base/declare",
          {
             this.alfLog("error", "An unknown URL type of '" + data.type + "' was provided for a navigation request", data, this);
          }
+
+         // Encode Parameters?
+         var encodeParams = (typeof data.encodeParams !== "undefined")? data.encodeParams : true;
+
+         // Add parameters supplied
+         if (lang.isObject(data.queryParams)) {
+            array.forEach(Object.keys(data.queryParams), function(prop) {
+               url = urlUtils.addQueryParameter(url, prop, data.queryParams[prop], encodeParams);
+            });
+         }
+
+         if (lang.isObject(data.hashParams)) {
+            array.forEach(Object.keys(data.hashParams), function(prop) {
+               url = urlUtils.addHashParameter(url, prop, data.hashParams[prop], encodeParams);
+            });
+         }
+
          return url;
       },
 

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -129,13 +129,13 @@ define(["dojo/_base/declare",
          var encodeParams = (typeof data.encodeParams !== "undefined")? data.encodeParams : true;
 
          // Add parameters supplied
-         if (lang.isObject(data.queryParams)) {
+         if (data.queryParams && typeof data.queryParams === "object") {
             array.forEach(Object.keys(data.queryParams), function(prop) {
                url = urlUtils.addQueryParameter(url, prop, data.queryParams[prop], encodeParams);
             });
          }
 
-         if (lang.isObject(data.hashParams)) {
+         if (data.hashParams && typeof data.hashParams === "object") {
             array.forEach(Object.keys(data.hashParams), function(prop) {
                url = urlUtils.addHashParameter(url, prop, data.hashParams[prop], encodeParams);
             });

--- a/aikau/src/main/resources/alfresco/util/urlUtils.js
+++ b/aikau/src/main/resources/alfresco/util/urlUtils.js
@@ -77,14 +77,7 @@ define(["dojo/_base/lang",
             var returnUrl,
                safeValue = (encodeValue) ? encodeURIComponent(value) : value;
 
-            if (this._isAbsolute(url)) {
-               var urlObj = this.parseUrl(url);
-
-               urlObj.queryParams[param] = (encodeValue) ? encodeURIComponent(value) : value;
-
-               returnUrl = urlObj.toString();
-            }
-            else if (url.indexOf("#") !== -1) {
+            if (url.indexOf("#") !== -1) {
                var urlParts = url.split("#");
 
                if(url.indexOf("?") !== -1) {
@@ -110,13 +103,7 @@ define(["dojo/_base/lang",
             var returnUrl,
                safeValue = (encodeValue) ? encodeURIComponent(value) : value;
 
-            if (this._isAbsolute(url)) {
-               var urlObj = this.parseUrl(url);
-
-               urlObj.hashParams[param] = safeValue;
-               returnUrl = urlObj.toString();
-            }
-            else if (url.indexOf("#") !== -1) {
+            if (url.indexOf("#") !== -1) {
                returnUrl = url + "&" + param + "=" + safeValue;
 
             }
@@ -125,16 +112,6 @@ define(["dojo/_base/lang",
             }
 
             return returnUrl;
-         },
-
-         /**
-          * Is the URL an absolute one?
-          *
-          * @param url
-          * @returns {boolean}
-          */
-         _isAbsolute: function alfresco_util_urlUtils__isAbsolute(url) {
-            return (url.indexOf("http") === 0);
          }
       };
 

--- a/aikau/src/main/resources/alfresco/util/urlUtils.js
+++ b/aikau/src/main/resources/alfresco/util/urlUtils.js
@@ -23,6 +23,7 @@
  *
  * @module alfresco/util/urlUtils
  * @author Martin Doyle
+ * @author David Webster
  */
 define(["dojo/_base/lang"],
    function(lang) {
@@ -30,18 +31,40 @@ define(["dojo/_base/lang"],
       // The private container for the functionality and properties of the util
       var util = {
 
-         // See API below
-         addQueryParameter: function alfresco_util_urlUtils__addQueryParameter(url, param, value, encodeValue) {
-            var paramPrefix = url.indexOf("?") === -1 ? "?" : "&",
+         addParameter: function alfresco_util_urlUtils__addParameter(type, url, param, value, encodeValue) {
+            var initialChar;
+
+            switch (type) {
+               case "query":
+                  initialChar = "?";
+                  break;
+               case "hash":
+                  initialChar = "#";
+                  break;
+               default:
+                  this.alfLog("warn", "Attempting to add parameter, but param type unknown: " + arguments);
+            }
+
+            var paramPrefix = url.indexOf(initialChar) === -1 ? initialChar : "&",
                paramToUse = paramPrefix + param,
                valueToUse = encodeValue ? encodeURIComponent(value) : value;
             return url + paramToUse + "=" + valueToUse;
+         },
+
+         // See API below
+         addQueryParameter: function alfresco_util_urlUtils__addQueryParameter(url, param, value, encodeValue) {
+            return this.addParameter("query", url, param, value, encodeValue);
+         },
+
+         // See API below
+         addHashParameter: function alfresco_util_urlUtils__addHashParameter(url, param, value, encodeValue) {
+            return this.addParameter("hash", url, param, value, encodeValue);
          }
       };
 
       /**
        * The public API for this utility class
-       * 
+       *
        * @alias module:alfresco/util/urlUtils
        */
       return {
@@ -58,6 +81,21 @@ define(["dojo/_base/lang"],
           * @param {bool} [encodeValue] Whether to URI-encode the value
           * @returns {string} The updated URL
           */
-         addQueryParameter: lang.hitch(util, util.addQueryParameter)
+         addQueryParameter: lang.hitch(util, util.addQueryParameter),
+
+
+         /**
+          * This function can be used to append the supplied parameter name and value onto the hash of the
+          * supplied URL string which is then returned.
+          *
+          * @instance
+          * @function
+          * @param {string} url The url to update
+          * @param {string} param The name of the hash parameter
+          * @param {string} value The value of the hash parameter
+          * @param {bool} [encodeValue] Whether to URI-encode the value
+          * @returns {string} The updated URL
+          */
+         addHashParameter: lang.hitch(util, util.addHashParameter)
       };
    });

--- a/aikau/src/main/resources/alfresco/util/urlUtils.js
+++ b/aikau/src/main/resources/alfresco/util/urlUtils.js
@@ -39,6 +39,11 @@ define(["dojo/_base/lang",
           * @returns {object}
           */
          parseUrl: function alfresco_util_urlUtils__parseUrl(url) {
+            if (!url.indexOf("://"))
+            {
+               this.alfLog("warn", "Attempting to parse a relative URL. This will return an absolute URL");
+            }
+
             var a = document.createElement("a"),
                _sanitizedPathname = function (pathname) {
                   // pathname MUST include leading slash (IE<9: this code is for you).
@@ -69,20 +74,67 @@ define(["dojo/_base/lang",
 
          // See API below
          addQueryParameter: function alfresco_util_urlUtils__addQueryParameter(url, param, value, encodeValue) {
-            var urlObj = this.parseUrl(url);
+            var returnUrl,
+               safeValue = (encodeValue) ? encodeURIComponent(value) : value;
 
-            urlObj.queryParams[param] = (encodeValue)? encodeURIComponent(value) : value;
+            if (this._isAbsolute(url)) {
+               var urlObj = this.parseUrl(url);
 
-            return urlObj.toString();
+               urlObj.queryParams[param] = (encodeValue) ? encodeURIComponent(value) : value;
+
+               returnUrl = urlObj.toString();
+            }
+            else if (url.indexOf("#") !== -1) {
+               var urlParts = url.split("#");
+
+               if(url.indexOf("?") !== -1) {
+                  returnUrl = urlParts[0] + "&" + param + "=" + safeValue + "#" + urlParts[1];
+               }
+               else {
+                  returnUrl = urlParts[0] + "?" + param + "=" + safeValue + "#" + urlParts[1];
+               }
+
+            }
+            else if (url.indexOf("?") !== -1) {
+               returnUrl = url + "&" + param + "=" + safeValue;
+            }
+            else {
+                  returnUrl = url + "?" + param + "=" + safeValue;
+            }
+
+            return returnUrl;
          },
 
          // See API below
          addHashParameter: function alfresco_util_urlUtils__addHashParameter(url, param, value, encodeValue) {
-            var urlObj = this.parseUrl(url);
+            var returnUrl,
+               safeValue = (encodeValue) ? encodeURIComponent(value) : value;
 
-            urlObj.hashParams[param] = (encodeValue) ? encodeURIComponent(value) : value;
+            if (this._isAbsolute(url)) {
+               var urlObj = this.parseUrl(url);
 
-            return urlObj.toString();
+               urlObj.hashParams[param] = safeValue;
+               returnUrl = urlObj.toString();
+            }
+            else if (url.indexOf("#") !== -1) {
+               returnUrl = url + "&" + param + "=" + safeValue;
+
+            }
+            else {
+               returnUrl = url + "#" + param + "=" + safeValue;
+            }
+
+            return returnUrl;
+         },
+
+         /**
+          * Is the URL an absolute one?
+          *
+          * @param url
+          * @returns {boolean}
+          */
+         _isAbsolute: function alfresco_util_urlUtils__isAbsolute(url) {
+            return (url.indexOf("http") === 0);
          }
       };
 

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -124,6 +124,25 @@ define(["intern!object",
          });
       },
 
+      "Post to new page using params": function() {
+         // Clear the current browser log...
+         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+            .click()
+            .end()
+            .getCurrentUrl()
+            .then(function (url) {
+               assert.notInclude(url, "page/tp/ws/NavigationService?bar=scndqryprm&foo=qryprm#baz=hshprm", "Not on the expected page (before nav to new page");
+            })
+            .findByCssSelector("#NAV_TO_PAGE_WITH_PARAMS_label")
+            .click()
+            .end()
+            .getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "page/tp/ws/NavigationService?bar=scndqryprm&foo=qryprm#baz=hshprm", "Not on new page (after nav to new page");
+            })
+            .end();
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/alfresco/util/urlUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/util/urlUtilsTest.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author David Webster
+ */
+define([
+      "alfresco/TestCommon",
+      "intern!object",
+      "intern/chai!assert",
+      "require"
+   ],
+   function (TestCommon, registerSuite, assert, require) {
+
+      var browser;
+      registerSuite({
+         name: "URL Utils Test",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Index", "URL Utils Test").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "URL Utils": function () {
+            return browser.setExecuteAsyncTimeout(5000)
+               .executeAsync(function(callback) {
+                  require(["alfresco/util/urlUtils"], function(urlUtils) {
+                     var url = "http://localhost:8080/alfresco/example?foo=one&bar=two#baz=three",
+                        urlObj = urlUtils.parseUrl(url),
+                        urlHash = urlUtils.addHashParameter(url, "newParam", "four"),
+                        urlParam = urlUtils.addQueryParameter(urlHash, "newQParam", "five"),
+                        testUrl = urlObj.toString();
+
+                     setTimeout(function() {
+                        callback({
+                           url: url,
+                           urlObj: urlObj,
+                           urlHash: urlHash,
+                           urlParam: urlParam,
+                           testUrl: testUrl
+                        });
+                     }, 1000);
+                  });
+               })
+               .then(function(results) {
+                  var url = results.url,
+                     urlObj = results.urlObj,
+                     urlHash = results.urlHash,
+                     urlParam = results.urlParam,
+                     testUrl = results.testUrl;
+
+                  assert.equal(urlObj.protocol, "http:");
+                  assert.equal(urlObj.hostname, "localhost");
+                  assert.equal(urlObj.port, "8080");
+                  assert.equal(urlObj.pathname, "/alfresco/example");
+                  assert.equal(urlObj.queryParams.foo, "one");
+                  assert.equal(urlObj.queryParams.bar, "two");
+                  assert.equal(urlObj.hashParams.baz, "three");
+                  assert.equal(testUrl, url);
+
+                  assert.equal(urlHash, "http://localhost:8080/alfresco/example?foo=one&bar=two#baz=three&newParam=four");
+                  assert.equal(urlParam, "http://localhost:8080/alfresco/example?foo=one&bar=two&newQParam=five#baz=three&newParam=four");
+
+               });
+         }
+      });
+   }
+);

--- a/aikau/src/test/resources/alfresco/util/urlUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/util/urlUtilsTest.js
@@ -49,15 +49,32 @@ define([
                         urlObj = urlUtils.parseUrl(url),
                         urlHash = urlUtils.addHashParameter(url, "newParam", "four"),
                         urlParam = urlUtils.addQueryParameter(urlHash, "newQParam", "five"),
-                        testUrl = urlObj.toString();
+                        testUrl = urlObj.toString(),
+                        relativeUrl = "example/path/",
+                        relativeUrlHash = "example/path/#hash",
+                        relativeUrlQuery = "example/path/?query=param",
+                        relativeUrlTest = urlUtils.addQueryParameter(relativeUrl,  "qpm", "qwerty"),
+                        relativeUrlHashTest = urlUtils.addQueryParameter(relativeUrlHash,  "qpm", "qwerty"),
+                        relativeUrlQueryTest = urlUtils.addHashParameter(
+                           urlUtils.addQueryParameter(relativeUrlQuery, "newQuery", "u%@p", true),
+                           "hash", "already%20encoded", false),
+                        relativeUrlQueryTest2 = urlUtils.addHashParameter(
+                           urlUtils.addQueryParameter(relativeUrlQuery, "newQuery", "u%@p", true),
+                           "hash", "already%20encoded");
 
-                     setTimeout(function() {
+
+                        setTimeout(function() {
                         callback({
                            url: url,
                            urlObj: urlObj,
                            urlHash: urlHash,
                            urlParam: urlParam,
-                           testUrl: testUrl
+                           testUrl: testUrl,
+                           relativeUrl: relativeUrl,
+                           relativeUrlTest: relativeUrlTest,
+                           relativeUrlHashTest: relativeUrlHashTest,
+                           relativeUrlQueryTest: relativeUrlQueryTest,
+                           relativeUrlQueryTest2: relativeUrlQueryTest2
                         });
                      }, 1000);
                   });
@@ -80,6 +97,13 @@ define([
 
                   assert.equal(urlHash, "http://localhost:8080/alfresco/example?foo=one&bar=two#baz=three&newParam=four");
                   assert.equal(urlParam, "http://localhost:8080/alfresco/example?foo=one&bar=two&newQParam=five#baz=three&newParam=four");
+
+                  // Relative URLs:
+                  assert.equal(results.relativeUrlTest, "example/path/?qpm=qwerty");
+                  assert.equal(results.relativeUrlHashTest, "example/path/?qpm=qwerty#hash");
+                  assert.equal(results.relativeUrlQueryTest, "example/path/?query=param&newQuery=u%25%40p#hash=already%20encoded");
+
+                  assert.equal(results.relativeUrlQueryTest, results.relativeUrlQueryTest2);
 
                });
          }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -227,7 +227,8 @@ define({
 
       "src/test/resources/alfresco/upload/UploadTest",
 
-      "src/test/resources/alfresco/util/functionUtilsTest"
+      "src/test/resources/alfresco/util/functionUtilsTest",
+      "src/test/resources/alfresco/util/urlUtilsTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
@@ -83,6 +83,26 @@ model.jsonModel = {
          }
       },
       {
+         id: "NAV_TO_PAGE_WITH_PARAMS",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Navigate with query and hash params",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "tp/ws/NavigationService",
+               type: "PAGE_RELATIVE",
+               target: "CURRENT",
+               queryParams: {
+                  foo: "qryprm",
+                  bar: "scndqryprm"
+               },
+               hashParams: {
+                  baz: "hshprm"
+               }
+            }
+         }
+      },
+      {
          id: "BACK_TO_ORIGINAL_URL",
          name: "alfresco/buttons/AlfButton",
          config: {


### PR DESCRIPTION
This is required to support RM-2465.