### PR TITLE
AKU-447: Address action scoping issues

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateTemplateContentMenu.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateTemplateContentMenu.js
@@ -327,8 +327,7 @@ define(["dojo/_base/declare",
          if (targetNodeRef)
          {
             payload.action.params.targetNodeRef = this.currentNode.parent.nodeRef;
-            payload.responseScope = this.pubSubScope;
-            this.alfPublish(this.templatePublishTopic, payload, true);
+            this.alfServicePublish(this.templatePublishTopic, payload);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateTemplateContentMenu.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateTemplateContentMenu.js
@@ -55,12 +55,14 @@ define(["dojo/_base/declare",
       
       /**
        * This is the topic that is published by each menu item created within the cascade. It should not
-       * be necessary to reconfigure it.
+       * be reconfigured it as it is automatically generated to be a unique value so that only menu items 
+       * added to this cascading menu will use it.
        *
        * @instance
        * @type {String}
+       * @default null
        */
-      _menuItemToParentTopic: "ALF_CREATE_TEMPLATED_CONTENT",
+      _menuItemToParentTopic: null,
 
       /**
        * Indicates whether the templates have been loaded yet.

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateTemplateContentMenu.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateTemplateContentMenu.js
@@ -30,6 +30,7 @@
  */
 define(["dojo/_base/declare",
         "alfresco/menus/AlfCascadingMenu",
+        "alfresco/documentlibrary/_AlfCreateContentMenuItemMixin",
         "alfresco/documentlibrary/_AlfCreateContentPermissionsMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/core/CoreXhr",
@@ -38,10 +39,10 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "service/constants/Default"], 
-        function(declare, AlfCascadingMenu, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, AlfCoreXhr, 
-                 AlfMenuGroup, AlfMenuItem, lang, array, AlfConstants) {
+        function(declare, AlfCascadingMenu, _AlfCreateContentMenuItemMixin, _AlfCreateContentPermissionsMixin, 
+                 _AlfDocumentListTopicMixin, AlfCoreXhr, AlfMenuGroup, AlfMenuItem, lang, array, AlfConstants) {
    
-   return declare([AlfCascadingMenu, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, AlfCoreXhr], {
+   return declare([AlfCascadingMenu, _AlfCreateContentMenuItemMixin, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, AlfCoreXhr], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -52,6 +53,59 @@ define(["dojo/_base/declare",
        */
       i18nRequirements: [{i18nFile: "./i18n/AlfCreateTemplateContentMenu.properties"}],
       
+      /**
+       * This is the topic that is published by each menu item created within the cascade. It should not
+       * be necessary to reconfigure it.
+       *
+       * @instance
+       * @type {String}
+       */
+      _menuItemToParentTopic: "ALF_CREATE_TEMPLATED_CONTENT",
+
+      /**
+       * Indicates whether the templates have been loaded yet.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      _templatesAlreadyLoaded: false,
+      
+      /**
+       * A URL to override the default. Primarily provided for the test harness.
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      _templatesUrl: null,
+      
+      /**
+       * The iconClass to use on each template content menu item
+       * 
+       * @instance
+       * @type {string}
+       * @default "alf-textdoc-icon"
+       */
+      templateIconClass: "alf-textdoc-icon",
+      
+      /**
+       * The topic to publish on when requesting to create templated content
+       * 
+       * @instance
+       * @type {string} 
+       * @default "ALF_CREATE_CONTENT"
+       */
+      templatePublishTopic: "ALF_CREATE_CONTENT",
+      
+      /**
+       * The type of template to be created. Either "node" or "folder".
+       *
+       * @instance
+       * @type {string}
+       * @default "node"
+       */
+      templateType: "node",
+
       /**
        * This defines the default widgets to display in the menu which is initially just a loading
        * message which should be replaced when the XHR request returns with some data.
@@ -76,9 +130,16 @@ define(["dojo/_base/declare",
        *  
        * @instance
        */
-      postCreate: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu__postCreate() {
+      postCreate: function alfresco_documentlibrary_AlfCreateTemplateContentMenu__postCreate() {
          this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onFilterChange));
          this.alfSubscribe(this.userAccessChangeTopic, lang.hitch(this, this.onUserAcess));
+         this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.onCurrentNodeChange));
+
+         // Create a unique topic for each menu item in the cascade to publish to in order for the 
+         // current node to be added to the payload...
+         this._menuItemToParentTopic = this.generateUuid();
+         this.alfSubscribe(this._menuItemToParentTopic, lang.hitch(this, this.onCreateTemplatedContent), true);
+         
          this.inherited(arguments);
          if (this.label)
          {
@@ -101,31 +162,13 @@ define(["dojo/_base/declare",
          }
       },
       
-      
-      /**
-       * A URL to override the default. Primarily provided for the test harness.
-       * @instance
-       * @type {string}
-       * @default null
-       */
-      _templatesUrl: null,
-      
-      /**
-       * Indicates whether the templates have been loaded yet.
-       * 
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      _templatesAlreadyLoaded: false,
-      
       /**
        * This function is called when the user clicks on the "Templates" cascading menu item to asynchronously
        * load the available content templates.
        * 
        * @instance
        */
-      loadTemplates: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu__loadTemplates() {
+      loadTemplates: function alfresco_documentlibrary_AlfCreateTemplateContentMenu__loadTemplates() {
          if (this._templatesAlreadyLoaded)
          {
             this.alfLog("log", "Templates already loaded");
@@ -153,7 +196,7 @@ define(["dojo/_base/declare",
        * @param {object} response The response from the request
        * @param {object} originalRequestConfig The configuration passed on the original request
        */
-      _templatesLoaded: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu___templatesLoaded(response, originalRequestConfig) {
+      _templatesLoaded: function alfresco_documentlibrary_AlfCreateTemplateContentMenu___templatesLoaded(response, /*jshint unused:false*/ originalRequestConfig) {
          this.alfLog("log", "Templates data loaded successfully", response);
          this._templatesAlreadyLoaded = true;
          
@@ -198,7 +241,7 @@ define(["dojo/_base/declare",
        * @param {object} response The response from the request
        * @param {object} originalRequestConfig The configuration passed on the original request
        */
-      _templatesLoadFailed: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu___templatesLoadFailed(response, originalRequestConfig) {
+      _templatesLoadFailed: function alfresco_documentlibrary_AlfCreateTemplateContentMenu___templatesLoadFailed(response, /*jshint unused:false*/ originalRequestConfig) {
          this.alfLog("error", "Could not load templates menu items", response);
          
          // Remove the loading templates item...
@@ -215,7 +258,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      addNoTemplatesMessageItem: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu__addNoTemplatesMessageItem() {
+      addNoTemplatesMessageItem: function alfresco_documentlibrary_AlfCreateTemplateContentMenu__addNoTemplatesMessageItem() {
          this._templatesMessageItem = new AlfMenuItem({
             label: "no.templates.label"
          });
@@ -230,49 +273,13 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      addTemplatesFailMessageItem: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu__addTemplatesFailMessageItem() {
+      addTemplatesFailMessageItem: function alfresco_documentlibrary_AlfCreateTemplateContentMenu__addTemplatesFailMessageItem() {
          this._templatesMessageItem = new AlfMenuItem({
             label: "templates.load.error"
          });
          this.popup.addChild(this._templatesMessageItem);
       },
       
-      /**
-       * The topic to publish on when requesting to create templated content
-       * 
-       * @instance
-       * @type {string} 
-       * @default "ALF_CREATE_CONTENT"
-       */
-      templatePublishTopic: "ALF_CREATE_CONTENT",
-      
-      /**
-       * The iconClass to use on each template content menu item
-       * 
-       * @instance
-       * @type {string}
-       * @default "alf-textdoc-icon"
-       */
-      templateIconClass: "alf-textdoc-icon",
-      
-      /**
-       * The type of template to be created. Either "node" or "folder".
-       *
-       * @instance
-       * @type {string}
-       * @default "node"
-       */
-      templateType: "node",
-
-      /**
-       * An optional NodeRef in which to create the template.
-       *
-       * @instance
-       * @type {string}
-       * @default null
-       */
-      targetNodeRef: null,
-
       /**
        * Adds an individual menu item.
        * 
@@ -281,25 +288,50 @@ define(["dojo/_base/declare",
        * @param {object} widget The menu item to add
        * @param {integer} index The index to add the menu item at.
        */
-      _addMenuItem: function alf_menus_documentlibrary_AlfCreateTemplateContentMenu___addMenuItem(group, widget, index) {
+      _addMenuItem: function alfresco_documentlibrary_AlfCreateTemplateContentMenu___addMenuItem(group, widget, /*jshint unused:false*/ index) {
          var label = (widget.title !== "") ? widget.title : widget.name;
          var item = new AlfMenuItem({
             label: label,
             iconClass: this.templateIconClass,
-            publishTopic: this.templatePublishTopic,
+            publishTopic: this._menuItemToParentTopic,
             publishPayload: {
-               type: "template",
-               params: {
-                  sourceNodeRef: widget.nodeRef,
-                  targetNodeRef: this.targetNodeRef,
-                  templateType: this.templateType,
-                  name: widget.name,
-                  title: widget.title,
-                  description: widget.description
+               action: {
+                  type: "template",
+                  params: {
+                     sourceNodeRef: widget.nodeRef,
+                     targetNodeRef: null,
+                     templateType: this.templateType,
+                     name: widget.name,
+                     title: widget.title,
+                     description: widget.description
+                  }
                }
-            }
+            },
+            publishGlobal: true
+
          });
          group.addChild(item);
+      },
+
+      /**
+       * Adds the current node in which to create the templated content to the received payload and then publishes
+       * on to the [ActionService]{@link module:alfresco/services/ActionService} to create the templated content.
+       *
+       * @instance
+       * @param {object} payload The payload relating to the template to create.
+       */
+      onCreateTemplatedContent: function alfresco_documentlibrary_AlfCreateTemplateContentMenu__onCreateTemplatedContent(payload) {
+         var targetNodeRef = lang.getObject("currentNode.parent.nodeRef", false, this);
+         if (targetNodeRef)
+         {
+            payload.action.params.targetNodeRef = this.currentNode.parent.nodeRef;
+            payload.responseScope = this.pubSubScope;
+            this.alfPublish(this.templatePublishTopic, payload, true);
+         }
+         else
+         {
+            this.alfLog("warn", "No current node has been provided in which to create templated content", payload, this);
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentActionMenuItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentActionMenuItem.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -79,6 +79,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload published on the filter topic 
        */
       filter: function alfresco_menus_AlfDocumentActionMenuItem__filter(payload) {
+         // jshint maxcomplexity:false
          this.alfLog("log", "Filtering request received: ", payload);
          
          // Defaulting to show
@@ -86,7 +87,7 @@ define(["dojo/_base/declare",
              i, ii;
          if (payload && payload.userAccess && payload.commonAspects && payload.allAspects)
          {
-            if (this.permission != "")
+            if (this.permission)
             {
                var actionPermissions = this.permission.split(",");
                for (i = 0, ii = actionPermissions.length; i < ii; i++)
@@ -102,12 +103,12 @@ define(["dojo/_base/declare",
             
             // Check required aspects.
             // Disable if any node DOES NOT have ALL required aspects
-            if (this.hasAspect != "")
+            if (this.hasAspect)
             {
                var hasAspects = this.hasAspect.split(",");
                for (i = 0, ii = hasAspects.length; i < ii; i++)
                {
-                  if (array.indexOf(payload.commonAspects, hasAspects[i]) == -1)
+                  if (array.indexOf(payload.commonAspects, hasAspects[i]) === -1)
                   {
                      hide = true;
                      break;
@@ -117,12 +118,12 @@ define(["dojo/_base/declare",
             
             // Check forbidden aspects.
             // Disable if any node DOES have ANY forbidden aspect
-            if (this.notAspect != "")
+            if (this.notAspect)
             {
                var notAspects = this.notAspect.split(",");
                for (i = 0, ii = notAspects.length; i < ii; i++)
                {
-                  if (array.indexOf(payload.allAspects, notAspects[i]) != -1)
+                  if (array.indexOf(payload.allAspects, notAspects[i]) !== -1)
                   {
                      hide = true;
                      break;

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -238,7 +238,7 @@ define(["dojo/_base/declare",
             }
          }
          payload.documents = selectedItems;
-         this.alfPublish("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", payload, true);
+         this.alfServicePublish("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", payload);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -36,13 +36,13 @@ define(["dojo/_base/declare",
       
       /**
        * Controls whether or not this widget actively tracks the selected items or passively subscribes
-       * to topics that indicate the items that have been selected. It is passive by default.
+       * to topics that indicate the items that have been selected. It is NOT passive by default.
        *
        * @instance
        * @type {boolean}
-       * @default true
+       * @default
        */
-      passive: true,
+      passive: false,
 
       /**
        * Overrides the default to initialise as disabled.
@@ -104,6 +104,7 @@ define(["dojo/_base/declare",
             this.alfSubscribe(this.documentSelectedTopic, lang.hitch(this, this.onItemSelected));
             this.alfSubscribe(this.documentDeselectedTopic, lang.hitch(this, this.onItemDeselected));
             this.alfSubscribe("ALF_CLEAR_SELECTED_ITEMS", lang.hitch(this, this.onItemSelectionCleared));
+            this.alfSubscribe("ALF_SELECTED_DOCUMENTS_ACTION_REQUEST", lang.hitch(this, this.onSelectedDocumentsAction));
          }
          this.inherited(arguments);
       },
@@ -218,6 +219,26 @@ define(["dojo/_base/declare",
        */
       onFilesSelected: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onFilesSelected(payload) {
          this.set("disabled", (payload && payload.selectedFiles && payload.selectedFiles.length === 0));
+      },
+
+      /**
+       * This function handles requests to perform actions on the currently selected documents. It takes the 
+       * provided payload and updates it with the 
+       *
+       * @instance
+       * @param {object} payload The payload containing the details of the action being requested
+       */
+      onSelectedDocumentsAction: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onSelectedDocumentsAction(payload) {
+         var selectedItems = [];
+         for (var nodeRef in this.currentlySelectedItems)
+         {
+            if (this.currentlySelectedItems.hasOwnProperty(nodeRef))
+            {
+               selectedItems.push(this.currentlySelectedItems[nodeRef]);
+            }
+         }
+         payload.documents = selectedItems;
+         this.alfPublish("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", payload, true);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
@@ -254,11 +254,7 @@ define(["alfresco/lists/views/layouts/Row",
          }, {
             _attachPoint: "actions",
             id: "DETAILED_VIEW_ACTIONS",
-            name: "alfresco/renderers/Actions",
-            config: {
-               publishGlobal: false,
-               publishToParent: true
-            }
+            name: "alfresco/renderers/Actions"
          }]
       });
    });

--- a/aikau/src/main/resources/alfresco/menus/AlfSelectedItemsMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfSelectedItemsMenuItem.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -56,9 +56,9 @@ define(["dojo/_base/declare",
        * @param {object} payload A publication payload containing the details of the selected items.
        */
       onItemsSelected: function alfresco_menus_AlfSelectedItemsMenuItem__onItemsSelected(payload) {
-         if (payload.selectedItems != null)
+         if (payload.selectedItems)
          {
-            if (this.publishPayload == null)
+            if (!this.publishPayload)
             {
                this.publishPayload = {};
             }
@@ -84,7 +84,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onClick: function alfresco_menus_AlfSelectedItemsMenuItem__onClick(evt) {
+      onClick: function alfresco_menus_AlfSelectedItemsMenuItem__onClick(/*jshint unused:false*/ evt) {
          this.inherited(arguments);
          if (this.clearSelectedItemsOnClick === true)
          {

--- a/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
@@ -264,6 +264,14 @@ define(["dojo/_base/declare",
 
             var id = action.id ? (this.id + "_" + action.id) : null;
             var payload = (action.publishPayload) ? action.publishPayload : {document: this.currentItem, action: action};
+            payload = this.generatePayload(payload, this.currentItem, null, action.publishPayloadType, action.publishPayloadItemMixin, action.publishPayloadModifiers);
+
+            // It's expected that an Actions renderere will be used inside a row of Document List view, and that
+            // the row will typically have its own scope. However, we know that some actions will require that the
+            // list is refreshed (e.g. when items are deleted, moved or copied) in which case the responseScope
+            // should be addressed at the list (i.e. the parent scope) not this renderer...
+            payload.responseScope = this.parentPubSubScope;
+
             var menuItem = new AlfMenuItem({
                id: id,
                label: action.label,
@@ -272,9 +280,9 @@ define(["dojo/_base/declare",
                pubSubScope: this.pubSubScope,
                parentPubSubScope: this.parentPubSubScope,
                publishTopic: action.publishTopic || this.singleDocumentActionTopic,
-               publishPayload: this.generatePayload(payload, this.currentItem, null, action.publishPayloadType, action.publishPayloadItemMixin, action.publishPayloadModifiers),
-               publishGlobal: this.publishGlobal,
-               publishToParent: this.publishToParent
+               publishPayload: payload,
+               publishGlobal: true,
+               publishToParent: false
             });
             this.actionsGroup.addChild(menuItem);
          }

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -581,7 +581,7 @@ define(["dojo/_base/declare",
             // NOTE: Ideally we want to be avoid using a contextual _currentNode, we should be providing 
             //       all the data required by the service in the request, but this remains for legacy support
             var node = lang.clone(this._currentNode.parent);
-            payload.documentdocument = {
+            payload.document = {
                nodeRef: node.nodeRef,
                node: node,
                jsNode: new JsNode(node)
@@ -775,7 +775,7 @@ define(["dojo/_base/declare",
        */
       onActionEditOffline: function alfresco_services_ActionService__onActionEditOffline(payload) {
          // Document might be an array.
-         var document = (lang.isArray(payload.document))? payload.document[0] : payload.document;
+         var document = (ObjectTypeUtils.isArray(payload.document))? payload.document[0] : payload.document;
          if (document && document.node && document.node.nodeRef)
          {
             var data = {

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -216,7 +216,7 @@ define(["dojo/_base/declare",
                if (typeof this[payload.action] === "function")
                {
                   // Then check the actions provided by this service...
-                  this[payload.action](payload.document);
+                  this[payload.action](payload);
                }
                else
                {
@@ -480,14 +480,14 @@ define(["dojo/_base/declare",
             {
                if (action.params.sourceNodeRef)
                {
-                  var targetNodeRef = action.params.targetNodeRef || lang.getObject("_currentNode.parent.nodeRef", false, this);
                   this.alfPublish("ALF_CREATE_TEMPLATE_CONTENT", {
                      sourceNodeRef: action.params.sourceNodeRef,
-                     targetNodeRef: targetNodeRef,
+                     targetNodeRef: action.params.targetNodeRef,
                      templateType: action.params.templateType || "node",
                      name: action.params.name || "",
                      title: action.params.title || "",
-                     description: action.params.description || ""
+                     description: action.params.description || "",
+                     responseScope: payload.alfResponseScope
                   });
                }
                else
@@ -906,7 +906,7 @@ define(["dojo/_base/declare",
        */
       onActionAssignWorkflow: function alfresco_services_ActionService__onActionAssignWorkflow(payload) {
          this.alfPublish("ALF_ASSIGN_WORKFLOW", {
-            nodes: payload.documents,
+            nodes: payload.documents || [payload.document],
             currentTarget: this.currentTarget
          });
       },
@@ -990,7 +990,9 @@ define(["dojo/_base/declare",
        * @param {object} item The item to perform the action on
        */
       onActionLocate: function alfresco_services_ActionService__onActionLocate(payload) {
-         this.alfPublish("ALF_LOCATE_DOCUMENT", { item: payload.document });
+         this.alfPublish("ALF_LOCATE_DOCUMENT", {
+            node: payload.document
+         });
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -152,6 +152,7 @@ define(["dojo/_base/declare",
          var responseTopic = this.generateUuid();
          this._actionDeleteHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onActionDeleteConfirmation), true);
 
+         var nodes = payload.documents || [payload.document];
          this.alfPublish("ALF_CREATE_DIALOG_REQUEST", {
             dialogId: "ALF_DELETE_CONTENT_DIALOG",
             dialogTitle: this.message("contentService.delete.dialog.title"),
@@ -161,7 +162,7 @@ define(["dojo/_base/declare",
                   config: {
                      additionalCssClasses: "no-highlight",
                      currentData: {
-                        items: payload.nodes
+                        items: nodes
                      },
                      widgets: [
                         {
@@ -224,7 +225,8 @@ define(["dojo/_base/declare",
                      label: this.message("contentService.delete.confirmation"),
                      publishTopic: responseTopic,
                      publishPayload: {
-                        nodes: payload.nodes
+                        nodes: nodes,
+                        responseScope: payload.alfResponseScope
                      }
                   }
                },
@@ -256,6 +258,7 @@ define(["dojo/_base/declare",
 
          this.serviceXhr({
             alfTopic: responseTopic,
+            responseScope: payload.alfResponseScope,
             subscriptionHandle: subscriptionHandle,
             url: AlfConstants.PROXY_URI + "slingshot/doclib/action/files?alf_method=delete",
             method: "POST",
@@ -280,7 +283,7 @@ define(["dojo/_base/declare",
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message("contentService.delete.success.message")
          });
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, payload.requestConfig.responseScope);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -502,61 +502,72 @@ define(["dojo/_base/declare",
        * @param {object} node The node to display the metadata for
        */
       onEditBasicMetadata: function alfresco_services_ContentService__onEditBasicMetadata(payload) {
-         var node = payload.document.node || payload.response.item.node;
-         var dialogTitle = this.message("contentService.basicMetadata.dialog.title", {
-            0: node.properties["cm:name"]
-         });
+         var node = lang.getObject("document.node", false, payload);
+         if (!node)
+         {
+            node = lang.getObject("response.item.node", false, payload);
+         }
+         if (node)
+         {
+            var dialogTitle = this.message("contentService.basicMetadata.dialog.title", {
+               0: node.properties["cm:name"]
+            });
 
-         this.alfPublish("ALF_CREATE_FORM_DIALOG_REQUEST", {
-            dialogId: "ALF_BASIC_METADATA_DIALOG",
-            dialogTitle: dialogTitle,
-            dialogConfirmationButtonTitle: "contentService.basicMetadata.confirmation",
-            dialogCancellationButtonTitle: "contentService.basicMetadata.cancellation",
-            formSubmissionTopic: "ALF_UPDATE_CONTENT_REQUEST",
-            responseScope: payload.alfResponseScope,
-            widgets: [
-               {
-                  name: "alfresco/forms/controls/TextBox",
-                  config: {
-                     name: "nodeRef",
-                     value: node.nodeRef,
-                     visibilityConfig: {
-                        initialValue: false
+            this.alfPublish("ALF_CREATE_FORM_DIALOG_REQUEST", {
+               dialogId: "ALF_BASIC_METADATA_DIALOG",
+               dialogTitle: dialogTitle,
+               dialogConfirmationButtonTitle: "contentService.basicMetadata.confirmation",
+               dialogCancellationButtonTitle: "contentService.basicMetadata.cancellation",
+               formSubmissionTopic: "ALF_UPDATE_CONTENT_REQUEST",
+               responseScope: payload.alfResponseScope,
+               widgets: [
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "nodeRef",
+                        value: node.nodeRef,
+                        visibilityConfig: {
+                           initialValue: false
+                        }
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        label: "contentService.basicMetadata.name.label",
+                        description: "contentService.basicMetadata.name.description",
+                        name: "prop_cm_name",
+                        value: node.properties["cm:name"],
+                        requirementConfig: {
+                           initialValue: true
+                        }
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        label: "contentService.basicMetadata.title.label",
+                        description: "contentService.basicMetadata.title.description",
+                        name: "prop_cm_title",
+                        value: node.properties["cm:title"]
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextArea",
+                     config: {
+                        label: "contentService.basicMetadata.description.label",
+                        description: "contentService.basicMetadata.description.description",
+                        name: "prop_cm_description",
+                        value: node.properties["cm:description"]
                      }
                   }
-               },
-               {
-                  name: "alfresco/forms/controls/TextBox",
-                  config: {
-                     label: "contentService.basicMetadata.name.label",
-                     description: "contentService.basicMetadata.name.description",
-                     name: "prop_cm_name",
-                     value: node.properties["cm:name"],
-                     requirementConfig: {
-                        initialValue: true
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/TextBox",
-                  config: {
-                     label: "contentService.basicMetadata.title.label",
-                     description: "contentService.basicMetadata.title.description",
-                     name: "prop_cm_title",
-                     value: node.properties["cm:title"]
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/TextArea",
-                  config: {
-                     label: "contentService.basicMetadata.description.label",
-                     description: "contentService.basicMetadata.description.description",
-                     name: "prop_cm_description",
-                     value: node.properties["cm:description"]
-                  }
-               }
-            ]
-         });
+               ]
+            });
+         }
+         else
+         {
+            this.alfLog("warn", "Node data not provided for editing metdata", payload, this);
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -66,7 +66,6 @@ define(["dojo/_base/declare",
          this.alfSubscribe("ALF_CREATE_CONTENT_REQUEST", lang.hitch(this, this.onCreateContent));
          this.alfSubscribe("ALF_UPDATE_CONTENT_REQUEST", lang.hitch(this, this.onUpdateContent));
          this.alfSubscribe("ALF_DELETE_CONTENT_REQUEST", lang.hitch(this, this.onDeleteContent));
-
          this.alfSubscribe("ALF_EDIT_BASIC_METADATA_REQUEST", lang.hitch(this, this.onEditBasicMetadataRequest));
          this.alfSubscribe("ALF_BASIC_METADATA_SUCCESS", lang.hitch(this, this.onEditBasicMetadataReceived));
          
@@ -137,7 +136,7 @@ define(["dojo/_base/declare",
             this.serviceXhr({url : url,
                              data: payload,
                              method: "POST",
-                             successCallback: this.contentCreationSuccess,
+                             successCallback: this.onContentCreationSuccess,
                              callbackScope: this});
          }
       },
@@ -388,9 +387,18 @@ define(["dojo/_base/declare",
          var parentNodeRef = lang.getObject("parent.nodeRef", false, payload);
          if (!parentNodeRef)
          {
+            parentNodeRef = lang.getObject("document.parent.nodeRef", false, payload);
+         }
+         if (!parentNodeRef)
+         {
             parentNodeRef = lang.getObject("parent.nodeRef", false, this._currentNode);
          }
          var updateNodeRef = lang.getObject("node.nodeRef", false, payload);
+         if (!updateNodeRef)
+         {
+            updateNodeRef = lang.getObject("document.node.nodeRef", false, payload);
+         }
+
          this.alfPublish("ALF_CREATE_FORM_DIALOG_REQUEST", {
             dialogTitle: (updateNodeRef ? "contentService.updater.dialog.title" : "contentService.uploader.dialog.title"),
             dialogConfirmationButtonTitle: "contentService.uploader.dialog.confirmation",
@@ -450,19 +458,20 @@ define(["dojo/_base/declare",
        * @param {object} payload An object containing the node to edit
        */
       onEditBasicMetadataRequest: function alfresco_services_ContentService__onEditBasicMetadataRequest(payload) {
-         if (payload.node && payload.node.node)
+         var node = lang.getObject("document.node", false, payload);
+         if (node)
          {
-            var node = payload.node.node;
             // Check to see if properties are already available (this would be expected when used with
             // some Alfresco APIs but not others, e.g. Document Library APIs, but not Search APIs)...
             if (node.properties)
             {
-               this.onEditBasicMetadata(node);
+               this.onEditBasicMetadata(payload);
             }
             else if (node.nodeRef)
             {
                this.alfPublish("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST", {
                   alfResponseTopic: "ALF_BASIC_METADATA",
+                  responseScope: payload.alfResponseScope,
                   nodeRef: node.nodeRef,
                   rawData: true
                });
@@ -483,9 +492,8 @@ define(["dojo/_base/declare",
       onEditBasicMetadataReceived: function alfresco_services_ContentService__onEditBasicMetadataReceived(payload) {
          if (lang.exists("response.item.node", payload)) 
          {
-            this.onEditBasicMetadata(payload.response.item.node);
+            this.onEditBasicMetadata(payload);
          }
-         this.alfLog("Error", "This method hasn't been implemented yet.");
       },
 
       /**
@@ -493,7 +501,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} node The node to display the metadata for
        */
-      onEditBasicMetadata: function alfresco_services_ContentService__onEditBasicMetadata(node) {
+      onEditBasicMetadata: function alfresco_services_ContentService__onEditBasicMetadata(payload) {
+         var node = payload.document.node || payload.response.item.node;
          var dialogTitle = this.message("contentService.basicMetadata.dialog.title", {
             0: node.properties["cm:name"]
          });
@@ -504,6 +513,7 @@ define(["dojo/_base/declare",
             dialogConfirmationButtonTitle: "contentService.basicMetadata.confirmation",
             dialogCancellationButtonTitle: "contentService.basicMetadata.cancellation",
             formSubmissionTopic: "ALF_UPDATE_CONTENT_REQUEST",
+            responseScope: payload.alfResponseScope,
             widgets: [
                {
                   name: "alfresco/forms/controls/TextBox",

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -637,12 +637,16 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload supplied when the event was triggered.
        */
       onCancelEdit: function alfresco_services_DocumentService__onCancelEdit(payload) {
-         if (!payload.documents) {
-            this.alfLog("error", "Uable to cancel editing: documents missing from payload.");
+         if (!payload.document) 
+         {
+            this.alfLog("error", "Uable to cancel editing: document missing from payload", payload, this);
          }
-
-         var nodes = NodeUtils.nodeRefArray(payload.documents);
-         array.forEach(nodes, lang.hitch(this, this.onCancelEditNode));
+         else
+         {
+            var nodes = NodeUtils.nodeRefArray(payload.document);
+            array.forEach(nodes, lang.hitch(this, this.onCancelEditNode));
+            this.onCancelEditNode(payload.document);
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
@@ -119,7 +119,8 @@ define(["dojo/_base/declare",
             nodes = NodeUtils.nodeRefArray(documents),
             publishPayload = {
                nodes: nodes,
-               documents: documents
+               documents: documents,
+               responseScope: payload.alfResponseScope
             };
 
          var fileName = (nodes.length === 1)? documents[0].fileName : this.message("services.ActionService.copyMoveTo.multipleFiles");
@@ -186,7 +187,7 @@ define(["dojo/_base/declare",
          else
          {
             var nodeRefs = NodeUtils.nodeRefArray(documents);
-            array.forEach(locations, lang.hitch(this, this.performAction, nodeRefs, urlPrefix, copy));
+            array.forEach(locations, lang.hitch(this, this.performAction, nodeRefs, urlPrefix, copy, payload.alfResponseScope));
          }
       },
 
@@ -199,7 +200,7 @@ define(["dojo/_base/declare",
        * @param {boolean} copy A boolean indicating if this is a copy action or not
        * @param {array} location  The location to move or copy the documents to
        */
-      performAction: function alfresco_services_actions_CopyMoveService__performAction(nodeRefs, urlPrefix, copy, location) {
+      performAction: function alfresco_services_actions_CopyMoveService__performAction(nodeRefs, urlPrefix, copy, responseScope, location) {
          var responseTopic = this.generateUuid();
          var successSubscription = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onActionSuccess), true);
          var failureSubscription = this.alfSubscribe(responseTopic + "_FAILURE", lang.hitch(this, this.onActionFailure), true);
@@ -207,6 +208,7 @@ define(["dojo/_base/declare",
             alfTopic: responseTopic,
             subscriptionHandles: [successSubscription,failureSubscription],
             copy: copy,
+            responseScope: responseScope,
             url: AlfConstants.PROXY_URI + urlPrefix + location.nodeRef.replace("://", "/"),
             method: "POST",
             data: {
@@ -259,7 +261,7 @@ define(["dojo/_base/declare",
                message: message
             });
          }
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, payload.requestConfig.responseScope);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/actions/CreateTemplateContentService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CreateTemplateContentService.js
@@ -108,6 +108,7 @@ define(["dojo/_base/declare",
                subscriptionHandle: subscriptionHandle,
                urlSuffix: "folder-templates"
             },
+            responseScope: payload.alfResponseScope,
             widgets: [
                {
                   id: "FOLDER_TEMPLATE_NAME",
@@ -172,6 +173,11 @@ define(["dojo/_base/declare",
             sourceNodeRef: payload.sourceNodeRef
          };
 
+         // Initialise the override data, the request will fail without it...
+         data.prop_cm_name = "";
+         data.prop_cm_title = "";
+         data.prop_cm_description = "";
+
          // Add in any additional data provided through user overrides...
          if (payload.name)
          {
@@ -190,6 +196,7 @@ define(["dojo/_base/declare",
          this.serviceXhr({url : url,
                           node: payload.sourceNodeRef,
                           data: data,
+                          responseScope: payload.alfResponseScope,
                           method: "POST",
                           successCallback: this.templateContentCreateSuccess,
                           failureCallback: this.templateContentCreateFailure,
@@ -201,7 +208,7 @@ define(["dojo/_base/declare",
        * @param {object} response The response from the request
        * @param {object} originalRequestConfig The configuration passed on the original request
        */
-      templateContentCreateSuccess: function alfresco_services_ActionService__templateContentCreateSuccess(response, /*jshint unused:false*/ originalRequestConfig) {
+      templateContentCreateSuccess: function alfresco_services_ActionService__templateContentCreateSuccess(response, originalRequestConfig) {
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message("create.template.content.success", {
                0: response.name
@@ -212,7 +219,7 @@ define(["dojo/_base/declare",
             parentNodeRef: originalRequestConfig.data.parentNodeRef,
             highlightFile: response.name
          });
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, originalRequestConfig.responseScope);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/actions/NodeLocationService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/NodeLocationService.js
@@ -107,10 +107,10 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onLocateDocumentRequest: function alfresco_services_actions_NodeLocationService__onLocateDocumentRequest(payload) {
-         if (payload && payload.item)
+         if (payload && payload.node)
          {
-            var path = lang.getObject("item.location.path", false, payload);
-            var recordSiteName = lang.getObject("item.location.site.name", false, payload);
+            var path = lang.getObject("node.location.path", false, payload);
+            var recordSiteName = lang.getObject("node.location.site.name", false, payload);
             var useSiteUrl = (recordSiteName && this.siteUrl);
 
             var page = useSiteUrl ? this.siteUrl : this.nonSiteUrl;

--- a/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
@@ -148,7 +148,7 @@ define(["dojo/_base/declare",
       onApproveSimpleWorkflow: function alfresco_services_actions_WorkflowService__onApproveSimpleWorkflow(payload) {
          if (payload && payload.items)
          {
-            array.forEach(payload.items, lang.hitch(this, this.performAction, "accept-simpleworkflow", this.onApproveSuccess, this.onApproveFailure, payload.action));
+            array.forEach(payload.items, lang.hitch(this, this.performAction, "accept-simpleworkflow", this.onApproveSuccess, this.onApproveFailure, payload));
          }
       },
 
@@ -160,7 +160,7 @@ define(["dojo/_base/declare",
       onRejectSimpleWorkflow: function alfresco_services_actions_WorkflowService__onRejectSimpleWorkflow(payload) {
          if (payload && payload.items)
          {
-            array.forEach(payload.items, lang.hitch(this, this.performAction, "reject-simpleworkflow", this.onRejectSuccess, this.onRejectFailure, payload.action));
+            array.forEach(payload.items, lang.hitch(this, this.performAction, "reject-simpleworkflow", this.onRejectSuccess, this.onRejectFailure, payload));
          }
       },
 
@@ -174,11 +174,12 @@ define(["dojo/_base/declare",
        * @param {object} action Additional action configuration. This can be included to override success and failure messages
        * @param {object} item The item to perform the action on. This is expecte to have a "nodeRef" attribute.
        */
-      performAction: function alfresco_services_actions_WorkflowService__performAction(actionName, successCallback, failureCallback, action, item) {
+      performAction: function alfresco_services_actions_WorkflowService__performAction(actionName, successCallback, failureCallback, payload, item) {
          this.serviceXhr({
             url: AlfConstants.PROXY_URI + "api/actionQueue",
             method: "POST",
-            action: action,
+            action: actionName,
+            responseScope: payload.alfResponseScope,
             data: {
                actionedUponNode: item.nodeRef,
                actionDefinitionName: actionName
@@ -192,24 +193,25 @@ define(["dojo/_base/declare",
        * Called when an approval was completed successfully.
        * 
        * @instance
-       * @param {object} payload
+       * @param {object} response
+       * @param {object} originalRequestConfig The configuration used for the XHR request
        */
-      onApproveSuccess: function alfresco_services_actions_WorkflowService__onApproveSuccess(payload) {
-         var message = lang.getObject("requestConfig.action.successMessage", false, payload);
+      onApproveSuccess: function alfresco_services_actions_WorkflowService__onApproveSuccess(response, originalRequestConfig) {
+         var message = lang.getObject("requestConfig.action.successMessage", false, response);
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message(message || this.approveSuccessMessage)
          });
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, originalRequestConfig.responseScope);
       },
 
       /**
        * Called when an approval could not be completed.
        * 
        * @instance
-       * @param {object} payload
+       * @param {object} response
        */
-      onApproveFailure: function alfresco_services_actions_WorkflowService__onApproveFailure(payload) {
-         var message = lang.getObject("requestConfig.action.failureMessage", false, payload);
+      onApproveFailure: function alfresco_services_actions_WorkflowService__onApproveFailure(response) {
+         var message = lang.getObject("requestConfig.action.failureMessage", false, response);
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message(message || this.approveFailureMessage)
          });
@@ -219,24 +221,25 @@ define(["dojo/_base/declare",
        * Called when a rejection was completed successfully.
        * 
        * @instance
-       * @param {object} payload
+       * @param {object} response
+       * @param {object} originalRequestConfig The configuration used for the XHR request
        */
-      onRejectSuccess: function alfresco_services_actions_WorkflowService__onRejectSuccess(payload) {
-         var message = lang.getObject("requestConfig.action.successMessage", false, payload);
+      onRejectSuccess: function alfresco_services_actions_WorkflowService__onRejectSuccess(response, originalRequestConfig) {
+         var message = lang.getObject("requestConfig.action.successMessage", false, response);
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message(message || this.rejectSuccessMessage)
          });
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, originalRequestConfig.responseScope);
       },
 
       /**
        * Called when a rejection could not be completed.
        * 
        * @instance
-       * @param {object} payload
+       * @param {object} response
        */
-      onRejectFailure: function alfresco_services_actions_WorkflowService__onRejectFailure(payload) {
-         var message = lang.getObject("requestConfig.action.failureMessage", false, payload);
+      onRejectFailure: function alfresco_services_actions_WorkflowService__onRejectFailure(response) {
+         var message = lang.getObject("requestConfig.action.failureMessage", false, response);
          this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
             message: this.message(message || this.rejectFailureMessage)
          });

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -781,7 +781,7 @@ function getSelectedItemsActions(selectedItemsActions) {
                href: (action.href || "").toString(),
                hasAspect: (action.hasAspect || "").toString(),
                notAspect: (action.notAspect || "").toString(),
-               publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+               publishTopic: "ALF_SELECTED_DOCUMENTS_ACTION_REQUEST",
                publishPayload: {
                   action: (action.id || "").toString()
                }

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -264,7 +264,7 @@ createContent.splice(0, 0, folder, plainText, html, xml);
 var createContentByTemplateEnabled = true;
 if (docLibXmlConfig["create-content-by-template"] && docLibXmlConfig["create-content-by-template"].value)
 {
-   createContentByTemplateEnabled = docLibXmlConfig["create-content-by-template"].value.toString() === "true" || false;
+   createContentByTemplateEnabled = docLibXmlConfig["create-content-by-template"].value.toString().equals("true") || false;
 }
 if (createContentByTemplateEnabled)
 {

--- a/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
@@ -309,14 +309,16 @@ define(["intern!object",
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "Node 1", "Node wasn't rendered correctly");
-            })
-            .click();
+            });
       },
 
       "Check that create template topic was published correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("ALF_CREATE_CONTENT", "params", "sourceNodeRef", "workspace://SpacesStore/0e56c7a3-67d0-4a35-b2ce-4c2038897a66"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Create template topic not published correctly");
+         return browser.findByCssSelector("#CREATE_TEMPLATES_dropdown tbody tr:first-child td:nth-child(2)")
+            .click()
+         .end()
+         .getLastPublish("ALF_CREATE_CONTENT")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "action.params.sourceNodeRef", "workspace://SpacesStore/0e56c7a3-67d0-4a35-b2ce-4c2038897a66", "Create template topic not published correctly");
             });
       },
 
@@ -370,15 +372,17 @@ define(["intern!object",
          .findByCssSelector("#ALF_CREATE_FOLDER_TEMPLATE_NODE .confirmationButton > span")
             .click()
          .end()
-         .findByCssSelector(".mx-row:nth-child(3) .mx-payload")
+         .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogHidden")
+         .end()
+         .findByCssSelector(".mx-row:nth-child(4) .mx-payload")
             .getVisibleText()
             .then(function(payload) {
                // NOTE: Checking payload elements individually because order is not guaranteed...
-               assert(payload.indexOf("\"parentNodeRef\":\"some://dummy/node\"") !== -1, "Parent NodeRef incorrect");
-               assert(payload.indexOf("\"sourceNodeRef\":\"workspace://SpacesStore/c90aa137-2c57-4a36-8681-b0b207cbee91\"") !== -1, "Source NodeRef incorrect");
-               assert(payload.indexOf("\"prop_cm_name\":\"Name\"") !== -1, "Name incorrect");
-               assert(payload.indexOf("\"prop_cm_title\":\"Title\"") !== -1, "Title incorrect");
-               assert(payload.indexOf("\"prop_cm_description\":\"Description\"") !== -1, "Description incorrect");
+               assert.include(payload, "\"parentNodeRef\":\"some://dummy/node\"", "Parent NodeRef incorrect");
+               assert.include(payload, "\"sourceNodeRef\":\"workspace://SpacesStore/c90aa137-2c57-4a36-8681-b0b207cbee91\"", "Source NodeRef incorrect");
+               assert.include(payload, "\"prop_cm_name\":\"Name\"", "Name incorrect");
+               assert.include(payload, "\"prop_cm_title\":\"Title\"", "Title incorrect");
+               assert.include(payload, "\"prop_cm_description\":\"Description\"", "Description incorrect");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/CreateContent.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/CreateContent.get.js
@@ -81,7 +81,12 @@ model.jsonModel = {
                                     id: "CREATE_TEMPLATES",
                                     name: "alfresco/documentlibrary/AlfCreateTemplateContentMenu",
                                     config: {
-                                       label: "Create content from node template"
+                                       label: "Create content from node template",
+                                       currentNode: {
+                                          parent: {
+                                             nodeRef: "some://dummy/node"
+                                          }
+                                       }
                                     }
                                  },
                                  {
@@ -91,7 +96,11 @@ model.jsonModel = {
                                        label: "Create content from folder template",
                                        _templatesUrl: "slingshot/doclib/folder-templates",
                                        templateType: "folder",
-                                       targetNodeRef: "some://dummy/node"
+                                       currentNode: {
+                                          parent: {
+                                             nodeRef: "some://dummy/node"
+                                          }
+                                       }
                                     }
                                  }
                               ]
@@ -163,10 +172,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/CreateContentMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/NodeLocation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/NodeLocation.get.js
@@ -76,7 +76,7 @@ model.jsonModel = {
             pubSubScope: "CUSTOM_",
             publishTopic: "ALF_LOCATE_DOCUMENT",
             publishPayload: {
-               item: {
+               node: {
                   location: {
                      path: "/some/random/path",
                      site: {
@@ -97,7 +97,7 @@ model.jsonModel = {
             pubSubScope: "CUSTOM_",
             publishTopic: "ALF_LOCATE_DOCUMENT",
             publishPayload: {
-               item: {
+               node: {
                   location: {
                      path: "/another/random/path"
                   },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-447 (the JIRA issue contains detailed information on the changes) but this is a substantial PR to rework the scoping of action handling to allow multiple Document Libraries to co-exist without actions (especially those relating to current node and selecte items) from bleeding into one another. It also ensures that the correctly scoped Document Library will be refreshed only by actions relating to it.