### PR TITLE
Add dedicated CSS resource for NumberSpinner control

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
@@ -26,11 +26,21 @@ define(["alfresco/forms/controls/BaseFormControl",
         "alfresco/forms/controls/utilities/TextBoxValueChangeMixin",
         "dojo/_base/declare",
         "dojo/_base/lang",
+        "dojo/dom-class",
         "dijit/form/NumberSpinner",
         "alfresco/core/ObjectTypeUtils"], 
-        function(BaseFormControl, TextBoxValueChangeMixin, declare, lang, NumberSpinner, ObjectTypeUtils) {
+        function(BaseFormControl, TextBoxValueChangeMixin, declare, lang, domClass, NumberSpinner, ObjectTypeUtils) {
    
    return declare([BaseFormControl, TextBoxValueChangeMixin], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/NumberSpinner.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/NumberSpinner.css"}],
       
       /**
        * This is the amount the value will be changed when using the "spin" controls
@@ -175,6 +185,13 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        */
       createFormControl: function alfresco_forms_controls_NumberSpinner__createFormControl(config, /*jshint unused:false*/ domNode) {
+         var additionalCssClasses = "";
+         if (this.additionalCssClasses !== null)
+         {
+            additionalCssClasses = this.additionalCssClasses;
+         }
+         domClass.add(this.domNode, "alfresco-forms-controls-NumberSpinner " + additionalCssClasses);
+         
          var ns = new NumberSpinner(config);
          // We'll take care of the validation thanks very much!
          ns.isValid = function() {

--- a/aikau/src/main/resources/alfresco/forms/controls/css/NumberSpinner.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/NumberSpinner.css
@@ -1,0 +1,28 @@
+.alfresco-forms-controls-NumberSpinner {
+   .dijitSpinner.dijitSpinnerFocused .dijitArrowButton {
+      background-color: #efefef; /* .claro .dijitSpinner .dijitArrowButton - until we style this ourselves in the future */
+   }
+   
+   .dijitNumberTextBox .dijitButtonNode.dijitSpinnerButtonContainer,
+   .dijitNumberTextBoxHover .dijitButtonNode.dijitSpinnerButtonContainer {
+      border-color: @standard-border-color;
+      transition: none;
+      width: 14px;
+      
+      .dijitUpArrowButton, .dijitDownArrowButton {
+         background-image: none;
+         transition: none;
+         border-color: @standard-button-border-color;
+         > .dijitArrowButtonInner {
+            border: none;
+            margin: 0;
+         }
+      }
+      
+      .dijitUpArrowButton.dijitUpArrowButtonHover, .dijitDownArrowButton.dijitDownArrowButtonHover {
+         background-image: none;
+         border-color: @standard-border-color;
+         background-color: #efefef; /* .claro .dijitSpinner .dijitArrowButton - until we style this ourselves in the future */
+      }
+   }
+}


### PR DESCRIPTION
Styles to remove the default dijit transitions, gradients and border colours that we don't use in other Alfresco Form controls.