### PR TITLE
AKU-405: Added support for form controls in tabs

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/ControlColumn.js
+++ b/aikau/src/main/resources/alfresco/forms/ControlColumn.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This extends the [VerticalWidgets]{@link module:alfresco/layout/VerticalWidgets} and mixes in
+ * the [LayoutMixin]{@link module:alfresco/forms/LayoutMixin} to provide a basic layout container
+ * for stacking form controls vertically. This can be used in conjunction with other form control
+ * layout widgets such as [TabbedControls]{@link module:alfresco/forms/TabbedControls} and
+ * [ControlRow]{@link module:alfresco/forms/ControlRow} to create interesting layouts for forms.
+ * 
+ * @module alfresco/forms/ControlColumn
+ * @extends module:alfresco/layout/VerticalWidgets,
+ * @mixes module:alfresco/forms/LayoutMixin
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/layout/VerticalWidgets",
+        "alfresco/forms/LayoutMixin"], 
+        function(declare, VerticalWidgets, LayoutMixin) {
+   return declare([VerticalWidgets, LayoutMixin], {});
+});

--- a/aikau/src/main/resources/alfresco/forms/ControlRow.js
+++ b/aikau/src/main/resources/alfresco/forms/ControlRow.js
@@ -25,18 +25,20 @@
  * [form controls]{@link module:alfresco/forms/controls/BaseFormControl} that it may have processed.
  * 
  * @module alfresco/forms/ControlRow
- * @extends module:alfresco/layout/HorizontalWidgets
+ * @extends module:alfresco/layout/HorizontalWidgets,
+ * @mixes module:alfresco/forms/LayoutMixin
  * @author Dave Draper
  */
 define(["alfresco/layout/HorizontalWidgets",
+        "alfresco/forms/LayoutMixin",
         "dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class"], 
-        function(HorizontalWidgets, declare, lang, array, domConstruct, domClass) {
+        function(HorizontalWidgets, LayoutMixin, declare, lang, array, domConstruct, domClass) {
    
-   return declare([HorizontalWidgets], {
+   return declare([HorizontalWidgets, LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -114,102 +116,6 @@ define(["alfresco/layout/HorizontalWidgets",
                innerHTML: this.title,
                className: "title" + (hasDescription ? "" : " border")
             }, this.domNode, "first");
-         }
-      },
-
-      /**
-       * Iterates over the array of processed widgets and adds the value of each to the supplied object
-       *
-       * @instance
-       * @param {object} values The object to set with the values from each form control
-       */
-      addFormControlValue: function alfresco_forms_ControlRow__addFormControlValue(values) {
-         array.forEach(this._processedWidgets, lang.hitch(this, this.addChildFormControlValue, values));
-      },
-
-      /**
-       * 
-       * @instance
-       * @param {object} values The object to set with the value of the supplied widget
-       * @param {object} widget The widget to get the value from
-       * @param {number} index The index of the widget
-       */
-      addChildFormControlValue: function alfresco_forms_ControlRow__addChildFormControlValue(values, widget, /*jshint unused:false*/ index) {
-         if (typeof widget.addFormControlValue === "function")
-         {
-            widget.addFormControlValue(values);
-         }
-      },
-
-      /**
-       * 
-       * @instance
-       * @param {object} values The object to set the each form control value from
-       */
-      updateFormControlValue: function alfresco_forms_ControlRow__addFormControlValue(values) {
-         array.forEach(this._processedWidgets, lang.hitch(this, this.updateChildFormControlValue, values));
-      },
-
-      /**
-       * 
-       * @instance
-       * @param {object} values The object to set with the value of the supplied widget
-       * @param {object} widget The widget to get the value from
-       * @param {number} index The index of the widget
-       */
-      updateChildFormControlValue: function alfresco_forms_ControlRow__updateChildFormControlValue(values, widget, /*jshint unused:false*/ index) {
-         if (typeof widget.addFormControlValue === "function")
-         {
-            widget.updateFormControlValue(values);
-         }
-      },
-
-      /**
-       * Iterates over the child form controls and validates each one.
-       * 
-       * @instance
-       */
-      validateFormControlValue: function alfresco_forms_ControlRow__validateFormControlValue() {
-         array.forEach(this._processedWidgets, lang.hitch(this, this.validateChildFormControlValue));
-      },
-
-      /**
-       *
-       * @instance
-       * @param {object} widget The widget to validate
-       * @param {number} index The index of the widget to validate
-       */
-      validateChildFormControlValue: function alfresco_forms_ControlRow__validateChildFormControlValue(widget, /*jshint unused:false*/ index) {
-         if (typeof widget.validateFormControlValue === "function")
-         {
-            widget.validateFormControlValue();
-         }
-      },
-
-      /**
-       * Iterates over the child form controls and publishes the value of each one.
-       * 
-       * @instance
-       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
-       */
-      publishValue: function alfresco_forms_ControlRow__publishValue(deferred) {
-         array.forEach(this._processedWidgets, lang.hitch(this, this.publishChildValue, deferred));
-      },
-
-      /**
-       * This is called by the [publishValue]{@link module:alfresco/forms/ControlRow#publishValue} function for each
-       * of the child form controls in the row and calls its 
-       * [publishValue]{@link module:alfresco/forms/controls/BaseFormControl#publishValue} function.
-       * 
-       * @instance
-       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
-       * @param {object} widget The widget to validate
-       * @param {number} index The index of the widget to validate
-       */
-      publishChildValue: function alfresco_forms_ControlRow__publishChildValue(deferred, widget, /*jshint unused:false*/ index) {
-         if (typeof widget.publishValue === "function")
-         {
-            widget.publishValue(deferred);
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -34,6 +34,12 @@
  * [autoSavePublishTopic]{@link module:alfresco/forms/Form#autoSavePublishTopic} is specified, 
  * then the OK and Cancel buttons are automatically hidden.</p>
  *
+ * <p><b>PLEASE NOTE:</b> If you want to layout your form controls in a specific manner (e.g. in a horizontal 
+ * line or within tabs) then you should use dedicated form control layout widgets such as 
+ * [ControlRow]{@link module:alfresco/forms/ControlRow} or
+ * [TabbedControls]{@link module:alfresco/forms/TabbedControls} as the basic layout widgets 
+ * do not provide all the required functionality.</p>
+ * 
  * @example <caption>Example configuration for auto-publishing (including invalid) form:</caption>
  * {
  *    name: "alfresco/forms/Form",

--- a/aikau/src/main/resources/alfresco/forms/LayoutMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/LayoutMixin.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This module can be mixed into modules that extend layout controls such as 
+ * [AlfTabContainer]{@link module:alfresco/layout/AlfTabContainer} to create layout widgets that can
+ * be used in forms. It aliases the functions that a [Form]{@link module:alfresco/forms/Form} expects
+ * to find in immediate descendent widgets and makes the necessary calls to its children. By default
+ * the children are expected to be found in the 
+ * [_processedWidgets]{@link module:alfresco/core/CoreWidgetProcessing#_processedWidgets} attribute
+ * but if this is not the case then the 
+ * [getFormLayoutChildren]{@link module:alfresco/forms/LayoutMixin#getFormLayoutChildren} should be overridden
+ * to return the form controls that the layout widget contains.
+ * 
+ * @module alfresco/forms/LayoutMixin
+ * @extends module:alfresco/core/Core
+ * @author Dave Draper
+ */
+define(["alfresco/core/Core",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/_base/array"], 
+        function(AlfCore, declare, lang, array) {
+   
+   return declare([AlfCore], {
+      
+      /**
+       * Iterates over the array of processed widgets and adds the value of each to the supplied object
+       *
+       * @instance
+       * @param {object} values The object to set with the values from each form control
+       */
+      addFormControlValue: function alfresco_forms_LayoutMixin__addFormControlValue(values) {
+         array.forEach(this.getFormLayoutChildren(), lang.hitch(this, this.addChildFormControlValue, values));
+      },
+
+      /**
+       * 
+       * @instance
+       * @param {object} values The object to set with the value of the supplied widget
+       * @param {object} widget The widget to get the value from
+       * @param {number} index The index of the widget
+       */
+      addChildFormControlValue: function alfresco_forms_LayoutMixin__addChildFormControlValue(values, widget, /*jshint unused:false*/ index) {
+         if (typeof widget.addFormControlValue === "function")
+         {
+            widget.addFormControlValue(values);
+         }
+      },
+
+      /**
+       * Returns the children to iterate over. Each child is expected to be a form control.
+       *
+       * @instance
+       * @return {object[]} An array of the form controls to iterate over.
+       */
+      getFormLayoutChildren: function alfresco_forms_LayoutMixin__getFormLayoutChildren() {
+         return this._processedWidgets;
+      },
+
+      /**
+       * Iterates over the child form controls and publishes the value of each one.
+       * 
+       * @instance
+       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
+       */
+      publishValue: function alfresco_forms_LayoutMixin__publishValue(deferred) {
+         array.forEach(this.getFormLayoutChildren(), lang.hitch(this, this.publishChildValue, deferred));
+      },
+
+      /**
+       * This is called by the [publishValue]{@link module:alfresco/forms/ControlRow#publishValue} function for each
+       * of the child form controls in the row and calls its 
+       * [publishValue]{@link module:alfresco/forms/controls/BaseFormControl#publishValue} function.
+       * 
+       * @instance
+       * @param {Deferred} [deferred] A deferred object can optionally be passed. This will only be resolved as widget value
+       * @param {object} widget The widget to validate
+       * @param {number} index The index of the widget to validate
+       */
+      publishChildValue: function alfresco_forms_LayoutMixin__publishChildValue(deferred, widget, /*jshint unused:false*/ index) {
+         if (typeof widget.publishValue === "function")
+         {
+            widget.publishValue(deferred);
+         }
+      },
+
+      /**
+       * 
+       * @instance
+       * @param {object} values The object to set the each form control value from
+       */
+      updateFormControlValue: function alfresco_forms_LayoutMixin__addFormControlValue(values) {
+         array.forEach(this.getFormLayoutChildren(), lang.hitch(this, this.updateChildFormControlValue, values));
+      },
+
+      /**
+       * 
+       * @instance
+       * @param {object} values The object to set with the value of the supplied widget
+       * @param {object} widget The widget to get the value from
+       * @param {number} index The index of the widget
+       */
+      updateChildFormControlValue: function alfresco_forms_LayoutMixin__updateChildFormControlValue(values, widget, /*jshint unused:false*/ index) {
+         if (typeof widget.addFormControlValue === "function")
+         {
+            widget.updateFormControlValue(values);
+         }
+      },
+
+      /**
+       * Iterates over the child form controls and validates each one.
+       * 
+       * @instance
+       */
+      validateFormControlValue: function alfresco_forms_LayoutMixin__validateFormControlValue() {
+         array.forEach(this.getFormLayoutChildren(), lang.hitch(this, this.validateChildFormControlValue));
+      },
+
+      /**
+       *
+       * @instance
+       * @param {object} widget The widget to validate
+       * @param {number} index The index of the widget to validate
+       */
+      validateChildFormControlValue: function alfresco_forms_LayoutMixin__validateChildFormControlValue(widget, /*jshint unused:false*/ index) {
+         if (typeof widget.validateFormControlValue === "function")
+         {
+            widget.validateFormControlValue();
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/forms/TabbedControls.js
+++ b/aikau/src/main/resources/alfresco/forms/TabbedControls.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This extends the [AlfTabContainer]{@link module:alfresco/layout/AlfTabContainer} and mixes in
+ * the [LayoutMixin]{@link module:alfresco/forms/LayoutMixin} to provide a tab container that form
+ * controls can be placed. Each tab should be added as a
+ * [ControlColumn]{@link module:alfresco/forms/ControlColumn} widget on which the tab title can
+ * be configured.
+ *
+ * @example <caption>Example of form containing tabbed controls</caption>
+ * {
+ *   name: "alfresco/forms/Form",
+ *   config: {
+ *     okButtonPublishTopic: "SAVE_FORM",
+ *     widgets: [
+ *       {
+ *         name: "alfresco/forms/TabbedControls",
+ *         config: {
+ *           widgets: [
+ *             {
+ *               name: "alfresco/forms/ControlColumn",
+ *               title: "Tab 1",
+ *               config: {
+ *                 widgets: [
+ *                   {
+ *                     name: "alfresco/forms/controls/TextBox",
+ *                     config: {
+ *                       fieldId: "TB1",
+ *                       name: "tb1",
+ *                       label: "Text box in tab 1"
+ *                     }
+ *                   }
+ *                 ]
+ *               }
+ *             },
+ *             {
+ *               name: "alfresco/forms/ControlColumn",
+ *               title: "Tab 2",
+ *               config: {
+ *                 widgets: [
+ *                   {
+ *                     name: "alfresco/forms/controls/TextBox",
+ *                     config: {
+ *                       fieldId: "TB2",
+ *                       name: "tb2",
+ *                       label: "Text box in tab 2"
+ *                     }
+ *                   }
+ *                 ]
+ *               }
+ *             }
+ *           ]
+ *         }
+ *       }
+ *     ]
+ *   }
+ * }
+ * 
+ * @module alfresco/forms/TabbedControls
+ * @extends module:alfresco/layout/AlfTabContainer,
+ * @mixes module:alfresco/forms/LayoutMixin
+ * @author Dave Draper
+ */
+define(["alfresco/layout/AlfTabContainer",
+        "alfresco/forms/LayoutMixin",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/_base/array"], 
+        function(HorizontalWidgets, LayoutMixin, declare, lang, array) {
+   
+   return declare([HorizontalWidgets, LayoutMixin], {
+      
+      /**
+       * Overrides the [default]{@link module:alfresco/layout/AlfTabContainer#delayProcessingDefault} 
+       * delayed processing setting so that all form fields will be created immediately so that their
+       * validity can be processed.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      delayProcessingDefault: false,
+
+      /**
+       * This is used to track the form controls that exist within the tabs.
+       *
+       * @instance
+       * @type {object[]}
+       * @default null
+       */
+      _tabbedFormControls: null,
+
+      /**
+       * Overrides the [mixed in function]{@link module:alfresco/forms/LayoutMixin#getFormLayoutChildren}
+       * to get the [current array of form controls]{@link module:alfresco/forms/TabbedControls#_tabbedFormControls}.
+       *
+       * @instance
+       * @return {object[]} An array of the form controls to iterate over.
+       */
+      getFormLayoutChildren: function alfresco_forms_LayoutMixin__getFormLayoutChildren() {
+         if (!this._tabbedFormControls)
+         {
+            this._tabbedFormControls = [];
+            array.forEach(this.tabContainerWidget.getChildren(), lang.hitch(this, function(contentPane) {
+               this._tabbedFormControls = this._tabbedFormControls.concat(contentPane.getChildren());
+            }));
+         }
+         return this._tabbedFormControls;
+      },
+
+      /**
+       * This extends the [inherited function]{@link module:alfresco/layout/AlfTabContainer#onTabAdd} to
+       * update the list of the currently available form controls.
+       * 
+       * @instance
+       * @param {object} payload Details of the tab to delete
+       */
+      onTabAdd: function alfresco_layout_AlfTabContainer__onTabAdd(/*jshint unused:false*/ payload) {
+         this.inherited(arguments);
+
+         // Reset the current array and then recreate it...
+         this._tabbedFormControls = null;
+         this.getFormLayoutChildren();
+      },
+
+      /**
+       * This extends the [inherited function]{@link module:alfresco/layout/AlfTabContainer#onTabDelete} to
+       * update the list of the currently available form controls.
+       * 
+       * @instance
+       * @param {object} payload Details of the tab to delete
+       */
+      onTabDelete: function alfresco_layout_AlfTabContainer__onTabDelete(/*jshint unused:false*/ payload) {
+         this.inherited(arguments);
+
+         // Reset the current array and then recreate it...
+         this._tabbedFormControls = null;
+         this.getFormLayoutChildren();
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -270,6 +270,18 @@ define(["dojo/_base/declare",
       tabDeletionTopic: null,
 
       /**
+       * This is the default delayed processing behaviour of tabs. By default a tabs content
+       * will not be created until it is displayed (unless the tab is configured to request
+       * otherwise). However, this can be overridden to switch the default so that all tab
+       * content will be created as soon as the container is created.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      delayProcessingDefault: true,
+
+      /**
        * @instance
        */
       postCreate: function alfresco_layout_AlfTabContainer__postCreate() {
@@ -290,12 +302,24 @@ define(["dojo/_base/declare",
             // we'll ensure that the first tab is both selected and will be immediately rendered
             var tabSelected = false;
             array.forEach(this.widgets, function(widget) {
-               if (widget.delayProcessing !== false && !widget.selected)
+               if ((widget.delayProcessing === true && !widget.selected) || 
+                   widget.delayProcessing === false)
                {
-                  widget.delayProcessing = true;
+                  // No action, use the explicit configuration
+               }
+               else if (widget.delayProcessing === true && widget.selected)
+               {
+                  // Silly configuration, if the tab is to be initially selected, processing can't be delayed...
+                  widget.delayProcessingDefault = false;
+               }
+               else
+               {
+                  // Use the default if no configuration is provided...
+                  widget.delayProcessing = this.delayProcessingDefault;
                }
                tabSelected = tabSelected || widget.selected;
-            });
+            }, this);
+
             if (this.widgets.length && !tabSelected)
             {
                this.widgets[0].selected = true;

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -31,6 +31,10 @@
  * [delete]{@link module:alfresco/layout/AlfTabContainer#tabDeletionTopic} tabs then you will need to
  * configure the topics to subscribe to. Subscriptions will be made at the configured 
  * [pubSubScope]{@link module:alfresco/core/Core#pubSubScope} of the widget.</p>
+ * 
+ * <p><b>PLEASE NOTE:</b> It is not possible to use this module to control the layout of controls within a form. If you wish
+ * to create a form containing tabbed controls then you should use the 
+ * [TabbedControls]{@link module:alfresco/forms/TabbedControls} widget</p>
  *
  * @example <caption>Basic configuration (first tab will be selected):</caption>
  * {

--- a/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
@@ -30,6 +30,10 @@
  * [widgetMarginRight]{@link module:alfresco/layout/HorizontalWidgets#widgetMarginRight} attributes (but you should bear
  * in mind that if using both attributes then the gap between 2 widgets will be the <b>combination</b> of both values).</p>
  * 
+ * <p><b>PLEASE NOTE:</b> It is not possible to use this module to control the layout of controls within a form. If you wish
+ * to create a form containing horizontally aligned controls then you should use the 
+ * [ControlRow]{@link module:alfresco/forms/ControlRow} widget</p>
+ *
  * <p><b>PLEASE NOTE: Resize operations are not currently handled - this will be addressed in the future</b></p>
  * 
  * @example <caption>Sample usage:</caption>

--- a/aikau/src/test/resources/alfresco/forms/TabsInFormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/TabsInFormsTest.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "TabbedControls Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/TabsInForms", "TabbedControls Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that values are set": function() {
+         // This checks that values assigned to the form are passed onto the form controls
+         return browser.findByCssSelector("#TB1 .dijitInputContainer input")
+            .getProperty("value")
+            .then(function(text) {
+               assert.equal(text, "data", "The initial value was not set correctly for the field on Tab 1");
+            })
+         .end()
+         .findByCssSelector("#TB2 .dijitInputContainer input")
+            .getProperty("value")
+            .then(function(text) {
+               assert.equal(text, "fail", "The initial value was not set correctly for the field on Tab 2");
+            });
+      },
+
+      "Check that form is initially disabled": function() {
+         // The form should be initially disabled because the value of the text box on tab 2 does not
+         // meet minimum length requirements
+         return browser.findAllByCssSelector(".alfresco-buttons-AlfButton.confirmationButton.dijitButtonDisabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The form confirmation button was not initially disabled");
+            });
+      },
+
+      "Check that resolving control validation enables form submission": function() {
+         // Check that updating the value of the text box on tab 2 to meet the minimum length requirements
+         // will enable the confirmation button on the form
+         return browser.findByCssSelector(".dijitTab:nth-child(2) .tabLabel")
+            .click()
+         .end()
+         .findByCssSelector("#TB2 .dijitInputContainer input")
+            .clearValue()
+            .type("LongEnough")
+         .end()
+         .findAllByCssSelector(".alfresco-buttons-AlfButton.confirmationButton.dijitButtonDisabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The form confirmation button was not enabled");
+            });
+      },
+
+      "Check form post value": function() {
+         // Check that posting the form submits all of the correct values
+         return browser.findByCssSelector(".alfresco-buttons-AlfButton.confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("FORM1_SAVE_FORM")
+            .then(function(payload) {
+               assert.propertyVal(payload, "tb1", "data", "Published form data incorrect (tb1)"); 
+               assert.propertyVal(payload, "tb2", "LongEnough", "Published form data incorrect (tb2)");
+               assert.propertyVal(payload, "tb3", "", "Published form data incorrect (tb3)");
+            });
+      },
+
+      "Check requirement rule disables form": function() {
+         // Setting the text box on tab 1 to be "break" should make the text box on tab 3 required and as 
+         // it has no data this should result in the confirmation button on the form being disabled
+         return browser.findByCssSelector(".dijitTab:nth-child(1) .tabLabel")
+            .click()
+         .end()
+         .findByCssSelector("#TB1 .dijitInputContainer input")
+            .clearValue()
+            .type("break")
+         .end()
+         .findAllByCssSelector(".alfresco-buttons-AlfButton.confirmationButton.dijitButtonDisabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The form confirmation button was not disabled");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -99,6 +99,7 @@ define({
       "src/test/resources/alfresco/forms/FormValidationTest",
       "src/test/resources/alfresco/forms/HashFormTest",
       "src/test/resources/alfresco/forms/SingleTextFieldFormTest",
+      "src/test/resources/alfresco/forms/TabsInFormsTest",
 
       "src/test/resources/alfresco/forms/controls/AutoSetTest",
       "src/test/resources/alfresco/forms/controls/BaseFormTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Tabs in Forms</shortname>
+  <description>Demonstrates a form that includes controls in multiple tabs</description>
+  <family>aikau-unit-tests</family>
+  <url>/TabsInForms</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.js
@@ -1,0 +1,113 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "FORM1",
+         name: "alfresco/forms/Form",
+         config: {
+            pubSubScope: "FORM1_",
+            okButtonPublishTopic: "SAVE_FORM",
+            value: {
+               tb1: "data",
+               tb2: "fail",
+               tb3: ""
+            },
+            widgets: [
+               {
+                  id: "TC1",
+                  name: "alfresco/forms/TabbedControls",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/forms/ControlColumn",
+                           title: "Tab 1",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "TB1",
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       fieldId: "TB1",
+                                       name: "tb1",
+                                       label: "First text box",
+                                       description: "Setting this field value to 'break' will make the text box in tab 3 required"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/ControlColumn",
+                           title: "Tab 2",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "TB2",
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       fieldId: "TB2",
+                                       name: "tb2",
+                                       label: "Second text box",
+                                       description: "This is a text box that should be displayed on tab 2",
+                                       validationConfig: [
+                                          {
+                                             validation: "minLength",
+                                             length: 5,
+                                             errorMessage: "Too short"
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/ControlColumn",
+                           title: "Tab 3",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "TB3",
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       fieldId: "TB3",
+                                       name: "tb3",
+                                       label: "Third text box",
+                                       description: "This will because required when the field on tab 1 is set to break",
+                                       requirementConfig: {
+                                          initialValue: false,
+                                          rules: [
+                                             {
+                                                targetId: "TB1",
+                                                is: ["break"]
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-405 to add a new mixin module "alfresco/forms/LayoutMixin" that can be applied to layout controls to create layout widgets to be used inside forms. This has been abstracted and applied to the "alfresco/forms/ControlRow" widget and used to create the "alfresco/forms/TabbedControls" and "alfresco/forms/ControlColumn" modules.

Unit tests have been added to support the new modules.