### PR TITLE
Remove odd looking gradient from Share License Header warning section.

### DIFF
--- a/aikau/src/main/resources/alfresco/header/css/Warning.css
+++ b/aikau/src/main/resources/alfresco/header/css/Warning.css
@@ -5,20 +5,9 @@
    color: black;
    text-align: center;
    background-color: #F4F4F4;
-   background-image: -webkit-gradient(
-      linear,
-      left top,
-      left bottom,
-      color-stop(0, rgb(242,242,242)),
-      color-stop(1, rgb(250,250,250))
-   );
-   background-image: -moz-linear-gradient(
-      center top,
-      rgb(242,242,242) 0%,
-      rgb(250,250,250) 100%
-   );
    font-size: 108%;
    border-top: 1px solid lightgrey;
+   border-bottom: 1px solid lightgrey;
 }
 
 .alfresco-header-Warning .info


### PR DESCRIPTION
A rarely seen component, but now looks cleaner against the Share header area.