### PR TITLE
AKU-466: Ensure that tab containers are displayed properly in dialogs

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -159,6 +159,7 @@
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @mixes module:alfresco/core/ResizeMixin
  * @author Richard Smith
  * @author Dave Draper
  */
@@ -168,14 +169,16 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/AlfTabContainer.html",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
+        "alfresco/core/ResizeMixin",
         "dijit/layout/TabContainer",
         "dijit/layout/ContentPane",
         "dojo/dom-construct",
         "dojo/_base/lang",
         "dojo/_base/array"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, TabContainer, ContentPane, domConstruct, lang, array) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, ResizeMixin, 
+                 TabContainer, ContentPane, domConstruct, lang, array) {
    
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, ResizeMixin], {
       
       /**
        * An array of the CSS files to use with this widget
@@ -352,6 +355,8 @@ define(["dojo/_base/declare",
          {
             this.alfSubscribe(this.tabDeletionTopic, lang.hitch(this, this.onTabDelete));
          }
+
+         this.alfSetupResizeSubscriptions(this.onResize, this);
       },
 
       /**
@@ -455,6 +460,19 @@ define(["dojo/_base/declare",
          if(forDeletion || forDeletion === 0)
          {
             this._delayedProcessingWidgets.splice(forDeletion, 1);
+         }
+      },
+
+      /**
+       * Resizes the TabContainer on resize events.
+       *
+       * @instance
+       * @param {object} evt The resize event.
+       */
+      onResize: function alfresco_layout_AlfTabContainer__onResize() {
+         if (this.tabContainerWidget && typeof this.tabContainerWidget.resize === "function")
+         {
+            this.tabContainerWidget.resize();
          }
       },
 

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -364,6 +364,19 @@ define(["intern!object",
             });
       },
 
+      "Check tabs in form dialog": function() {
+         return browser.findById("CREATE_FORM_DIALOG_WITH_TABBED_LAYOUT")
+            .click()
+         .end()
+         .findAllByCssSelector("#TABBED_FORM_DIALOG.dialogDisplayed")
+         .end()
+         .findByCssSelector("#TABBED_FORM_DIALOG .dijitTabController")
+            .getSize()
+            .then(function(size) {
+               assert(size.height > 0, "Tabs were not displayed correctly when dialog is initially shown");
+            });
+      },
+
       "Can launch dialog within dialog": function() {
          return closeAllDialogs()
             .then(function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -240,6 +240,63 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_FORM_DIALOG_WITH_TABBED_LAYOUT",
+         config: {
+            label: "Create Tabbed Layout Form Dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "TABBED_FORM_DIALOG",
+               dialogTitle: "Tabs in forms",
+               formSubmissionTopic: "TABBED_FORM",
+               widgets: [
+                  {
+                     id: "TC1",
+                     name: "alfresco/forms/TabbedControls",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/forms/ControlColumn",
+                              title: "Tab 1",
+                              config: {
+                                 widgets: [
+                                    {
+                                       id: "TAB1_TB",
+                                       name: "alfresco/forms/controls/TextBox",
+                                       config: {
+                                          fieldId: "TAB1_TB",
+                                          name: "tab1tb",
+                                          label: "Tab 1 TextBox"
+                                       }
+                                    }
+                                 ]
+                              }
+                           },
+                           {
+                              name: "alfresco/forms/ControlColumn",
+                              title: "Tab 2",
+                              config: {
+                                 widgets: [
+                                    {
+                                       id: "TAB2_TB",
+                                       name: "alfresco/forms/controls/TextBox",
+                                       config: {
+                                          fieldId: "TAB2_TB",
+                                          name: "tab2tb",
+                                          label: "Second text box"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-466 to ensure that the alfresco/forms/TabbedControls (or even the "alfresco/layout/AlfTabContainer" that it extends) will be displayed correctly in dialogs. This was resolved by mixing the "alfresco/core/ResizeMixin" into the "alfresco/layout/AlfTabContainer" and handling the resize events that the "alfresco/dialogs/AlfDialog" was providing when first displayed.

A unit test has been added to prevent regressions.