### PR TITLE
AKU-457: NumberSpinner control invisibly rejects decimal points

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -81,6 +81,8 @@ define(["dojo/_base/declare",
        * @callable
        * @instance
        * @param {string} p_messageId The id of the message to be displayed.
+       * @param {...Object} [messageArgs] A single object with integer keys or multiple objects, either of
+       *                                  which can be used to mix into a message string
        * @returns {string} A localized form of the supplied message
        */
       message: function alfresco_core_Core__message(p_messageId) {

--- a/aikau/src/main/resources/alfresco/forms/controls/i18n/FormControlValidationMixin.properties
+++ b/aikau/src/main/resources/alfresco/forms/controls/i18n/FormControlValidationMixin.properties
@@ -2,3 +2,6 @@ formValidation.numericalRange.error=Enter a number that's at least {0} and no mo
 formValidation.numericalRange.min.error=Enter a number that's at least {0}
 formValidation.numericalRange.max.error=Enter a number that's no more than {0}
 formValidation.numerical.error=Enter a number
+formValidation.numerical.decimalPlaces0.error=Number should be whole number
+formValidation.numerical.decimalPlaces1.error=Number should use no more than 1 decimal place
+formValidation.numerical.decimalPlacesN.error=Number should use no more than {0} decimal places

--- a/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
@@ -18,14 +18,14 @@
  */
 
 /**
- * 
+ *
  * @author Dave Draper
  */
 define(["intern!object",
         "intern/chai!assert",
         "require",
-        "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
 
    var browser;
    registerSuite({
@@ -64,8 +64,8 @@ define(["intern!object",
          return browser.findByCssSelector("#NS2 .dijitInputContainer input")
             .clearValue()
             .type("4")
-         .end()
-         .findByCssSelector("#NS2 span.validation-message")
+            .end()
+            .findByCssSelector("#NS2 span.validation-message")
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "Validation error message should be displayed");
@@ -80,8 +80,8 @@ define(["intern!object",
          return browser.findByCssSelector("#NS2 .dijitInputContainer input")
             .clearValue()
             .type("11")
-         .end()
-         .findByCssSelector("#NS2 span.validation-message")
+            .end()
+            .findByCssSelector("#NS2 span.validation-message")
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "Validation error message should be displayed");
@@ -96,8 +96,8 @@ define(["intern!object",
          return browser.findByCssSelector("#NS2 .dijitInputContainer input")
             .clearValue()
             .type("7")
-         .end()
-         .findByCssSelector("#NS2 span.validation-message")
+            .end()
+            .findByCssSelector("#NS2 span.validation-message")
             .isDisplayed()
             .then(function(displayed) {
                assert.isFalse(displayed, "Validation error message should have been removed");
@@ -108,8 +108,8 @@ define(["intern!object",
          return browser.findByCssSelector("#NS4 .dijitInputContainer input")
             .clearValue()
             .type("0")
-         .end()
-         .findByCssSelector("#NS4 span.validation-message")
+            .end()
+            .findByCssSelector("#NS4 span.validation-message")
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "Validation error message should be displayed");
@@ -124,8 +124,8 @@ define(["intern!object",
          return browser.findByCssSelector("#NS5 .dijitInputContainer input")
             .clearValue()
             .type("8")
-         .end()
-         .findByCssSelector("#NS5 span.validation-message")
+            .end()
+            .findByCssSelector("#NS5 span.validation-message")
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "Validation error message should be displayed");
@@ -140,8 +140,8 @@ define(["intern!object",
          return browser.findByCssSelector("#NS1 .dijitInputContainer input")
             .clearValue()
             .type("a")
-         .end()
-         .findByCssSelector("#NS1 span.validation-message")
+            .end()
+            .findByCssSelector("#NS1 span.validation-message")
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "Validation error message should be displayed");
@@ -160,13 +160,13 @@ define(["intern!object",
             });
       },
 
-      "Empty values are only permitted when permitEmpty specified": function(){
+      "Empty values are only permitted when permitEmpty specified": function() {
          return browser.findByCssSelector("#NS1 .dijitInputContainer input")
             .clearValue()
             .end()
 
          .findAllByCssSelector("#NS1 .validation-error")
-            .then(function(elements){
+            .then(function(elements) {
                assert.lengthOf(elements, 1, "Standard number spinner should not permit empty values");
             })
             .end()
@@ -176,12 +176,12 @@ define(["intern!object",
             .end()
 
          .findAllByCssSelector("#NS7 .validation-error")
-            .then(function(elements){
+            .then(function(elements) {
                assert.lengthOf(elements, 0, "'permitEmpty' number spinner should allow empty values");
             })
       },
 
-      "Empty value submits null value": function(){
+      "Empty value submits null value": function() {
          return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"RESET_VALUES\"] .dijitButtonNode")
             .click()
             .end()
@@ -195,10 +195,115 @@ define(["intern!object",
             .end()
 
          .getLastPublish("FORM_POST")
-            .then(function(payload){
+            .then(function(payload) {
                assert.propertyVal(payload, "seven", null, "Did not publish null value for empty number spinner");
             });
       },
+
+      "Trailing decimal point is always invalid": function() {
+         return browser.findByCssSelector("#NS1 .dijitInputContainer input")
+            .clearValue()
+            .type("5.")
+            .end()
+
+         .findByCssSelector("#NS1 span.validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Validation error message should be displayed");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Enter a number", "Validation error message not set correctly");
+            })
+            .end()
+
+         .findByCssSelector("#NS8 .dijitInputContainer input")
+            .clearValue()
+            .type("5.")
+            .end()
+
+         .findByCssSelector("#NS8 span.validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Validation error message should be displayed");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Enter a number", "Validation error message not set correctly");
+            });
+      },
+
+      "Decimal point is only valid when configured properly": function() {
+         return browser.findByCssSelector("#NS1 .dijitInputContainer input")
+            .clearValue()
+            .type("5.5")
+            .end()
+
+         .findByCssSelector("#NS1 span.validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Validation error message should be displayed");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Number should be whole number", "Validation error message not set correctly");
+            })
+            .end()
+
+         .findByCssSelector("#NS8 .dijitInputContainer input")
+            .clearValue()
+            .type("5.5")
+            .end()
+
+         .findByCssSelector("#NS8 span.validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "Validation error message should be displayed");
+            })
+            .end()
+
+         .findByCssSelector("#NS8 .dijitInputContainer input")
+            .type("6")
+            .end()
+
+         .findByCssSelector("#NS8 span.validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Validation error message should be displayed");
+            })
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Number should use no more than 1 decimal place", "Validation error message not set correctly");
+            });
+      },
+
+      // Make sure this is always the final test, and update accordingly
+      "All values publish correctly": function() {
+         return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"RESET_VALUES\"] .dijitButtonNode")
+            .click()
+            .end()
+
+         .findByCssSelector("#NS1 .dijitInputContainer input")
+            .type("0")
+            .end()
+
+         .findByCssSelector(".confirmationButton .dijitButtonNode")
+            .click()
+            .end()
+
+         .getLastPublish("FORM_POST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "one", 0, "Invalid published value for control with ID \"NS1\"");
+               assert.propertyVal(payload, "two", 5, "Invalid published value for control with ID \"NS2\"");
+               assert.propertyVal(payload, "three", 0, "Invalid published value for control with ID \"NS3\"");
+               assert.propertyVal(payload, "four", 1, "Invalid published value for control with ID \"NS4\"");
+               assert.propertyVal(payload, "five", 3, "Invalid published value for control with ID \"NS5\"");
+               assert.propertyVal(payload, "six", 1001, "Invalid published value for control with ID \"NS6\"");
+               assert.propertyVal(payload, "seven", null, "Invalid published value for control with ID \"NS7\"");
+               assert.propertyVal(payload, "eight", 5.5, "Invalid published value for control with ID \"NS8\"");
+            });
+      },
+      // Make sure this is always the final test, and update accordingly
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
@@ -27,7 +27,8 @@ model.jsonModel = {
                four: 1,
                five: 3,
                six: 1001,
-               seven: ""
+               seven: "",
+               eight: 5.5
             }
          }
       },
@@ -44,86 +45,112 @@ model.jsonModel = {
             okButtonPublishTopic: "FORM_POST",
             widgets: [
                {
-                  id: "NS1",
-                  name: "alfresco/forms/controls/NumberSpinner", 
+                  name: "alfresco/forms/ControlRow",
                   config: {
-                     fieldId: "NS1",
-                     name: "one",
-                     label: "Minimum config",
-                     description: "This is a number spinner with the absolute minimum configuration."
+                     widgets: [
+                        {
+                           id: "NS1",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS1",
+                              name: "one",
+                              label: "Minimum config",
+                              description: "This is a number spinner with the absolute minimum configuration."
+                           }
+                        },
+                        {
+                           id: "NS2",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS2",
+                              name: "two",
+                              label: "Min and max",
+                              description: "This is a number spinner with min and max thresholds set",
+                              value: 3,
+                              min: 5,
+                              max: 10
+                           }
+                        },
+                        {
+                           id: "NS3",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS2",
+                              name: "three",
+                              label: "Required",
+                              value: 0,
+                              description: "This is a number spinner that is a required field",
+                              requirementConfig: {
+                                 initialValue: true
+                              }
+                           }
+                        },
+                        {
+                           id: "NS4",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS4",
+                              name: "four",
+                              label: "Just min",
+                              description: "This is a number spinner with just a min threshold",
+                              min: 1
+                           }
+                        }
+                     ]
                   }
                },
                {
-                  id: "NS2",
-                  name: "alfresco/forms/controls/NumberSpinner", 
+                  name: "alfresco/forms/ControlRow",
                   config: {
-                     fieldId: "NS2",
-                     name: "two",
-                     label: "Min and max",
-                     description: "This is a number spinner with min and max thresholds set",
-                     value: 3,
-                     min: 5,
-                     max: 10
-                  }
-               },
-               {
-                  id: "NS3",
-                  name: "alfresco/forms/controls/NumberSpinner", 
-                  config: {
-                     fieldId: "NS2",
-                     name: "three",
-                     label: "Required",
-                     value: 0,
-                     description: "This is a number spinner that is a required field",
-                     requirementConfig: {
-                        initialValue: true
-                     }
-                  }
-               },
-               {
-                  id: "NS4",
-                  name: "alfresco/forms/controls/NumberSpinner", 
-                  config: {
-                     fieldId: "NS4",
-                     name: "four",
-                     label: "Just min",
-                     description: "This is a number spinner with just a min threshold",
-                     min: 1
-                  }
-               },
-               {
-                  id: "NS5",
-                  name: "alfresco/forms/controls/NumberSpinner", 
-                  config: {
-                     fieldId: "NS5",
-                     name: "five",
-                     label: "Just max",
-                     description: "This is a number spinner with just a max threshold",
-                     value: 3,
-                     max: 5
-                  }
-               },
-               {
-                  id: "NS6",
-                  name: "alfresco/forms/controls/NumberSpinner", 
-                  config: {
-                     fieldId: "NS6",
-                     name: "six",
-                     label: "Handle commas",
-                     description: "This is a number spinner initialised to a value over a 1000",
-                     value: 1001
-                  }
-               },
-               {
-                  id: "NS7",
-                  name: "alfresco/forms/controls/NumberSpinner", 
-                  config: {
-                     fieldId: "NS7",
-                     name: "seven",
-                     label: "Empty value",
-                     description: "This is a number spinner initialised to an empty string",
-                     value: "",
-                     permitEmpty: true
+                     widgets: [
+                        {
+                           id: "NS5",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS5",
+                              name: "five",
+                              label: "Just max",
+                              description: "This is a number spinner with just a max threshold",
+                              value: 3,
+                              max: 5
+                           }
+                        },
+                        {
+                           id: "NS6",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS6",
+                              name: "six",
+                              label: "Handle commas",
+                              description: "This is a number spinner initialised to a value over a 1000",
+                              value: 1001
+                           }
+                        },
+                        {
+                           id: "NS7",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS7",
+                              name: "seven",
+                              label: "Empty value",
+                              description: "This is a number spinner initialised to an empty string",
+                              value: "",
+                              permitEmpty: true
+                           }
+                        },
+                        {
+                           id: "NS8",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS8",
+                              name: "eight",
+                              label: "Decimal points",
+                              description: "This number spinner permits numbers to one decimal place",
+                              value: "5.5",
+                              permittedDecimalPlaces: 1
+                           }
+                        }
+                     ]
                   }
                }
             ]


### PR DESCRIPTION
This addresses issue [AKU-457](https://issues.alfresco.com/jira/browse/AKU-457) which is about decimal points on number spinners being invalid without any notification as to why, and also a request to permit decimal places through configuration. Tests have been updated accordingly.