### PR TITLE
AKU-480: InlineEditPropertyLink not scoping when it should

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -83,7 +83,7 @@ define(["dojo/_base/declare",
             // If no topic has been provided then assume this to be a standard document/folder link...
             this.linkPublishPayload = {};
             var publishTopic = this.generateFileFolderLink(this.linkPublishPayload);
-            this.alfServicePublish(publishTopic, this.linkPublishPayload);
+            this.alfPublish(publishTopic, this.linkPublishPayload, publishGlobal, publishToParent);
          }
       }
    });

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -316,7 +316,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("ALF_NAVIGATE_TO_PAGE", true)
+            .getLastPublish("SCOPED_ALF_NAVIGATE_TO_PAGE", true)
                .then(function(payload) {
                   assert.isNotNull(payload, "'Test item (no topic, scoped)' did not publish correct topic");
                   assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "'Test item (no topic, scoped)' generated incorrect alfResponseScope");


### PR DESCRIPTION
This addresses issue [AKU-480](https://issues.alfresco.com/jira/browse/AKU-480) where InlineEditPropertyLink is not scoping when it should. Reverted changes in [AKU-421](https://issues.alfresco.com/jira/browse/AKU-421) and updated test accordingly.