### PR TITLE
AKU-405: Ensure that tabbed form values are published

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/TabbedControls.js
+++ b/aikau/src/main/resources/alfresco/forms/TabbedControls.js
@@ -99,60 +99,18 @@ define(["alfresco/layout/AlfTabContainer",
       delayProcessingDefault: false,
 
       /**
-       * This is used to track the form controls that exist within the tabs.
-       *
-       * @instance
-       * @type {object[]}
-       * @default null
-       */
-      _tabbedFormControls: null,
-
-      /**
        * Overrides the [mixed in function]{@link module:alfresco/forms/LayoutMixin#getFormLayoutChildren}
-       * to get the [current array of form controls]{@link module:alfresco/forms/TabbedControls#_tabbedFormControls}.
+       * to get the current array of form controls.
        *
        * @instance
        * @return {object[]} An array of the form controls to iterate over.
        */
       getFormLayoutChildren: function alfresco_forms_LayoutMixin__getFormLayoutChildren() {
-         if (!this._tabbedFormControls)
-         {
-            this._tabbedFormControls = [];
-            array.forEach(this.tabContainerWidget.getChildren(), lang.hitch(this, function(contentPane) {
-               this._tabbedFormControls = this._tabbedFormControls.concat(contentPane.getChildren());
-            }));
-         }
-         return this._tabbedFormControls;
-      },
-
-      /**
-       * This extends the [inherited function]{@link module:alfresco/layout/AlfTabContainer#onTabAdd} to
-       * update the list of the currently available form controls.
-       * 
-       * @instance
-       * @param {object} payload Details of the tab to delete
-       */
-      onTabAdd: function alfresco_layout_AlfTabContainer__onTabAdd(/*jshint unused:false*/ payload) {
-         this.inherited(arguments);
-
-         // Reset the current array and then recreate it...
-         this._tabbedFormControls = null;
-         this.getFormLayoutChildren();
-      },
-
-      /**
-       * This extends the [inherited function]{@link module:alfresco/layout/AlfTabContainer#onTabDelete} to
-       * update the list of the currently available form controls.
-       * 
-       * @instance
-       * @param {object} payload Details of the tab to delete
-       */
-      onTabDelete: function alfresco_layout_AlfTabContainer__onTabDelete(/*jshint unused:false*/ payload) {
-         this.inherited(arguments);
-
-         // Reset the current array and then recreate it...
-         this._tabbedFormControls = null;
-         this.getFormLayoutChildren();
+         var _tabbedFormControls = [];
+         array.forEach(this.tabContainerWidget.getChildren(), lang.hitch(this, function(contentPane) {
+            _tabbedFormControls = _tabbedFormControls.concat(contentPane.getChildren());
+         }));
+         return _tabbedFormControls;
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -377,6 +377,28 @@ define(["intern!object",
             });
       },
 
+      "Ensure that all tabbed form values are included in published value": function() {
+         return browser.findByCssSelector("#TAB1_TB .dijitInputContainer input")
+            .type("one")
+         .end()
+         .findByCssSelector("#TABBED_FORM_DIALOG .dijitTab:nth-child(2) .tabLabel")
+            .click()
+         .end()
+         .findByCssSelector("#TAB2_TB .dijitInputContainer input")
+            .type("two")
+         .end()
+         .findByCssSelector("#TABBED_FORM_DIALOG .alfresco-buttons-AlfButton.confirmationButton > span")
+            .click()
+         .end()
+         .findAllByCssSelector("#TABBED_FORM_DIALOG.dialogHidden")
+         .end()
+         .getLastPublish("TABBED_FORM")
+            .then(function(payload) {
+               assert.propertyVal(payload, "tab1tb", "one", "Published form data incorrect (tab1tb)"); 
+               assert.propertyVal(payload, "tab2tb", "two", "Published form data incorrect (tab2tb)");
+            });
+      },
+
       "Can launch dialog within dialog": function() {
          return closeAllDialogs()
             .then(function() {


### PR DESCRIPTION
This is a further update for https://issues.alfresco.com/jira/browse/AKU-405. To absolutely guarantee that all tabbed form values are included in form publications. It's a less efficient solution than I was previously going for, but is more reliable.