### PR TITLE
AKU-455: Embedded DateTextBox validations display errors

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -380,7 +380,7 @@ define(["dojo/_base/declare",
       visibilityConfig: null,
 
       /**
-       * Defines the visibility behaviour of the widget. It is possible for the widget to dynamically be required
+       * Defines the requirement behaviour of the widget. It is possible for the widget to dynamically be required
        * to have a value provided based on the value of one or more other widgets. See [processConfig]{@link module:alfresco/forms/controls/BaseFormControl#processConfig}
        * for the structure to use when configuring the rules</p>
        *
@@ -391,7 +391,7 @@ define(["dojo/_base/declare",
       requirementConfig: null,
 
       /**
-       * Defines the visibility behaviour of the widget. It is possible for the widget to dynamically be disabled
+       * Defines the disablement behaviour of the widget. It is possible for the widget to dynamically be disabled
        * or enabled based on the value of one or more other widgets. See [processConfig]{@link module:alfresco/forms/controls/BaseFormControl#processConfig}
        * for the structure to use when configuring the rules</p>
        *

--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -72,11 +72,42 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @returns {object} The configuration for the form control
        */
       getWidgetConfig: function alfresco_forms_controls_DateTextBox__getWidgetConfig() {
+         this.configureValidation();
          return {
             id : this.id + "_CONTROL",
             name: this.name,
             options: (this.options !== null) ? this.options : []
          };
+      },
+
+      /**
+       * This function is used to set or update the validationConfig
+       * 
+       * @instance
+       */
+      configureValidation: function alfresco_forms_controls_DateTextBox__configureValidation() {
+         if (!this.validationConfig || ObjectTypeUtils.isObject(this.validationConfig)) {
+            this.validationConfig = [];
+         }
+         this.validationConfig.push({
+            validation: "customValidator",
+            errorMessage: this.message("formValidation.date.error")
+         });
+      },
+
+      /**
+       * Ensure value is a date
+       *
+       * @instance
+       * @param {object} validationConfig The configuration for this validator
+       */
+      customValidator: function alfresco_forms_controls_DateTextBox__customValidator(validationConfig){
+         var currentValue = this.getValue(),
+            isValid = typeof currentValue === "string";
+         if(!isValid && !this._required) {
+            isValid = this.wrappedWidget.get("displayedValue") === "";
+         }
+         this.reportValidationResult(validationConfig, isValid);
       },
 
       /**
@@ -98,7 +129,12 @@ define(["alfresco/forms/controls/BaseFormControl",
        */
       createFormControl: function alfresco_forms_controls_DateTextBox__createFormControl(config) {
          domClass.add(this.domNode, "alfresco-forms-controls-DateTextBox");
-         return new DateTextBox(config);
+         var dateTextBox = new DateTextBox(config);
+         dateTextBox.validate = lang.hitch(this, function(){
+            setTimeout(lang.hitch(this, this.validate), 0);
+            return true;
+         });
+         return dateTextBox;
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -177,16 +177,3 @@
 .alfresco-forms-controls-BaseFormControl div.control .dijitFocused {
    border-color: @focused-border-color;
 }
-
-/* AKU-455 Fix validation display errors */
-/*.alfresco-forms-controls-BaseFormControl {
-   .dijitSelectError,
-   .dijitSelectError .dijitButtonContents,
-   .dijitTextBoxError,
-   .dijitTextBoxError .dijitButtonNode {
-      border-color: #d3d3d3;
-   }
-   .dijitValidationContainer {
-      display: none;
-   }
-}*/

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -177,3 +177,16 @@
 .alfresco-forms-controls-BaseFormControl div.control .dijitFocused {
    border-color: @focused-border-color;
 }
+
+/* AKU-455 Fix validation display errors */
+/*.alfresco-forms-controls-BaseFormControl {
+   .dijitSelectError,
+   .dijitSelectError .dijitButtonContents,
+   .dijitTextBoxError,
+   .dijitTextBoxError .dijitButtonNode {
+      border-color: #d3d3d3;
+   }
+   .dijitValidationContainer {
+      display: none;
+   }
+}*/

--- a/aikau/src/main/resources/alfresco/forms/controls/i18n/FormControlValidationMixin.properties
+++ b/aikau/src/main/resources/alfresco/forms/controls/i18n/FormControlValidationMixin.properties
@@ -5,3 +5,4 @@ formValidation.numerical.error=Enter a number
 formValidation.numerical.decimalPlaces0.error=Number should be whole number
 formValidation.numerical.decimalPlaces1.error=Number should use no more than 1 decimal place
 formValidation.numerical.decimalPlacesN.error=Number should use no more than {0} decimal places
+formValidation.date.error=Enter a valid date

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -52,17 +52,38 @@ define(["intern!object",
       },
 
       "Test initial invalid values": function() {
-         return browser.findByCssSelector("#INVALID_DATES_FORM .confirmationButton .dijitButtonNode")
-            .click()
-            .getLastPublish("INVALID_DATES_FORM_SUBMIT")
-            .then(function(payload) {
-               assert.propertyVal(payload, "lettersDate", null, "Invalid starting date-value (arbitrary letters) was not published with null value");
-               assert.propertyVal(payload, "emptyDate", null, "Invalid starting date-value (empty) was not published with null value");
-               assert.propertyVal(payload, "nullDate", null, "Invalid starting date-value (null) was not published with null value");
-               assert.propertyVal(payload, "undefinedDate", null, "Invalid starting date-value (undefined) was not published with null value");
+         return browser.findById("LETTERS_DATE_VALUE_CONTROL")
+            .getProperty("value")
+            .then(function(value){
+               assert.equal(value, "", "Initial value of letters should present empty date box");
+            })
+            .end()
+            
+         .findById("EMPTY_DATE_VALUE_CONTROL")
+            .getProperty("value")
+            .then(function(value){
+               assert.equal(value, "", "Initial value of empty should present empty date box");
+            })
+            .end()
+
+         .findById("NULL_DATE_VALUE_CONTROL")
+            .getProperty("value")
+            .then(function(value){
+               assert.equal(value, "", "Initial value of null should present empty date box");
+            })
+            .end()
+
+         .findById("UNDEFINED_DATE_VALUE_CONTROL")
+            .getProperty("value")
+            .then(function(value){
+               assert.equal(value, "", "Initial value of undefined should present empty date box");
             });
       },
 
+      "Ensure invalid form is disabled": function() {
+         return browser.findByCssSelector("#INVALID_DATES_FORM .dijitButtonDisabled");
+      },
+      
       "Changed date publishes correct value": function() {
          return browser.findByCssSelector("#VALID_DATE_VALUE_2 .dijitArrowButton") // Click down arrow
             .clearLog()
@@ -79,6 +100,23 @@ define(["intern!object",
             .then(function(payload) {
                assert.propertyVal(payload, "validDate1", "2012-12-12", "Incorrect date value retrieved from control after other control updated");
                assert.propertyVal(payload, "validDate2", "2015-07-14", "Incorrect date value retrieved from control after this control updated");
+            });
+      },
+
+      "Entering invalid date produces correct error": function() {
+         return browser.findById("VALID_DATE_VALUE_1_CONTROL")
+            .clearValue()
+            .type("foo")
+            .end()
+
+         .findByCssSelector("#VALID_DATE_VALUE_1 .validation-message")
+            .isDisplayed()
+            .then(function(isDisplayed) {
+               assert.isTrue(isDisplayed, "Did not display error message");
+            })
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "Enter a valid date", "Did not display correct error text");
             });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest"
+      "src/test/resources/alfresco/forms/controls/DateTextBoxTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -28,7 +28,8 @@ model.jsonModel = {
                            config: {
                               name: "validDate1",
                               value: "2012-12-12",
-                              label: "Valid date #1"
+                              label: "Valid date",
+                              description: "Preset with the value \"2012-12-12\""
                            }
                         },
                         {
@@ -37,7 +38,11 @@ model.jsonModel = {
                            config: {
                               name: "validDate2",
                               value: "2015-07-07",
-                              label: "Valid date #2"
+                              label: "Valid date (mandatory)",
+                              description: "Preset with the value \"2015-07-07\"",
+                              requirementConfig: {
+                                 initialValue: true
+                              }
                            }
                         }
                      ]
@@ -55,7 +60,11 @@ model.jsonModel = {
                            config: {
                               name: "lettersDate",
                               value: "letters",
-                              label: "Letters date"
+                              label: "Letters date (mandatory)",
+                              description: "Preset with the value \"letters\"",
+                              requirementConfig: {
+                                 initialValue: true
+                              }
                            }
                         },
                         {
@@ -64,7 +73,8 @@ model.jsonModel = {
                            config: {
                               name: "emptyDate",
                               value: "",
-                              label: "Empty date"
+                              label: "Empty date",
+                              description: "Preset with the value \"\""
                            }
                         },
                         {
@@ -73,7 +83,8 @@ model.jsonModel = {
                            config: {
                               name: "nullDate",
                               value: null,
-                              label: "Null date"
+                              label: "Null date",
+                              description: "Preset with the value null"
                            }
                         },
                         {
@@ -82,7 +93,8 @@ model.jsonModel = {
                            config: {
                               name: "undefinedDate",
                               value: undefined,
-                              label: "Undefined date"
+                              label: "Undefined date",
+                              description: "Preset with the value undefined"
                            }
                         }
                      ]


### PR DESCRIPTION
This addresses issue [AKU-455](https://issues.alfresco.com/jira/browse/AKU-455) which is reporting poor validation errors in the DateTextBox control. The control now has fully-implemented validation, as per the rest of the controls in Aikau.