### PR TITLE
AKU-450: Initial update pending testing

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -82,6 +82,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
+       * @default
        */
       additionalDocumentAndFolderActions: null,
 
@@ -93,6 +94,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
+       * @default
        */
       additionalOtherNodeActions: null,
 
@@ -104,7 +106,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string[]}
-       * @default null
+       * @default
        */
       documentAndFolderActions: null,
 
@@ -113,7 +115,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {boolean}
-       * @default false
+       * @default
        */
       enableContextMenu: false,
 
@@ -126,7 +128,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string[]}
-       * @default null
+       * @default
        */
       otherNodeActions: null,
 
@@ -146,7 +148,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object[]}
-       * @default null
+       * @default
        */
       widgetsAbove: null,
 
@@ -156,7 +158,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object[]}
-       * @default null
+       * @default
        */
       widgetsBelow: null,
 

--- a/aikau/src/main/resources/alfresco/search/i18n/AlfSearchResult.properties
+++ b/aikau/src/main/resources/alfresco/search/i18n/AlfSearchResult.properties
@@ -1,0 +1,5 @@
+faceted-search.doc-lib.value-prefix.description=Description:
+faceted-search.doc-lib.unavailable.description=No Description
+faceted-search.doc-lib.value-prefix.site=Site
+faceted-search.doc-lib.value-prefix.path=In folder
+faceted-search.doc-lib.value-prefix.size=Size:

--- a/aikau/src/main/resources/alfresco/search/templates/AlfSearchResult.html
+++ b/aikau/src/main/resources/alfresco/search/templates/AlfSearchResult.html
@@ -1,6 +1,7 @@
 <tr class="alfresco-search-AlfSearchResult" data-dojo-attach-point="containerNode" data-dojo-attach-event="onclick:onFocusClick" tabindex="0">
    <td class="thumbnailCell"><div data-dojo-attach-point="thumbnailNode"></div></td>
    <td class="propertiesCell">
+      <div class="aboveCell"><span data-dojo-attach-point="aboveNode"></span></div>
       <div class="nameAndTitleCell">
          <span data-dojo-attach-point="nameNode"></span>
          <span data-dojo-attach-point="titleNode"></span>
@@ -11,6 +12,7 @@
       <div class="siteCell" data-dojo-attach-point="siteRow"><span data-dojo-attach-point="siteNode"></span></div>
       <div class="pathCell" data-dojo-attach-point="pathRow"><span data-dojo-attach-point="pathNode"></span></div>
       <div class="sizeCell" data-dojo-attach-point="sizeRow"><span data-dojo-attach-point="sizeNode"></span></div>
+      <div class="belowCell"><span data-dojo-attach-point="belowNode"></span></div>
    </td>
    <td class="actionsCell"><div data-dojo-attach-point="actionsNode"/></td>
 </tr>

--- a/aikau/src/test/resources/alfresco/search/CustomSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/CustomSearchResultTest.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Custom Search Result Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/CustomSearchResult", "Custom Search Result Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that MoreInfo widget is not displayed": function() {
+         // The test page configures the "showMoreInfo" to be false so the MoreInfo renderer should
+         // not be displayed...
+         return browser.findAllByCssSelector(".alfresco-renderers-MoreInfo")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The MoreInfo widget should not have been rendered");
+            });
+      },
+
+      "Check that widgets are rendered above": function() {
+         return browser.findAllByCssSelector(".alfresco-search-AlfSearchResult .aboveCell .alfresco-renderers-Banner")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Additional widget was NOT rendered above the main result properties");
+            });
+      },
+
+      "Check that widgets are rendered below": function() {
+         return browser.findAllByCssSelector(".alfresco-search-AlfSearchResult .belowCell .alfresco-renderers-Banner")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Additional widget was NOT rendered below the main result properties");
+            });
+      },
+
+      "Check that right-click actions are enabled": function() {
+         return browser.findByCssSelector(".alfresco-search-AlfSearchResult .aboveCell .alfresco-renderers-Banner")
+            .moveMouseTo()
+            .clickMouseButton(2)
+         .end()
+         .findAllByCssSelector(".alfresco-menus-AlfContextMenu")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Right-click context actions menu not displayed");
+            });
+      },
+
+      "Check that the additional action filter is applied": function() {
+         return browser.findAllByCssSelector(".alfresco-menus-AlfContextMenu .alfresco-menus-AlfMenuItem")
+            .then(function(elements) {
+               assert.lengthOf(elements, 9, "Not enough actions were displayed");
+            })
+         .end()
+         .findByCssSelector(".alfresco-menus-AlfContextMenu .alfresco-menus-AlfMenuItem:last-child .dijitMenuItemLabel")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Test Action");
+            });
+      },
+      
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -207,6 +207,7 @@ define({
       "src/test/resources/alfresco/renderers/actions/UploadNewVersionActionTest",
 
       "src/test/resources/alfresco/search/AlfSearchResultTest",
+      "src/test/resources/alfresco/search/CustomSearchResultTest",
       "src/test/resources/alfresco/search/FacetFiltersTest",
       "src/test/resources/alfresco/search/SearchSuggestionsTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -242,9 +242,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/DebugLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/CustomSearchResult.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/CustomSearchResult.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Customized Search Results</shortname>
+  <description>Demonstrates customization of the standard search result renderer</description>
+  <family>aikau-unit-tests</family>
+  <url>/CustomSearchResult</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/CustomSearchResult.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/CustomSearchResult.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/CustomSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/CustomSearchResult.get.js
@@ -1,0 +1,104 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets:[
+      {
+         name: "alfresco/search/AlfSearchListView",
+         config: {
+            id: "SEARCH_RESULTS",
+            currentData: {
+               items: [
+                  {
+                     nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
+                     type: "folder",
+                     displayName: "Normal result",
+                     title: "Normal result title",
+                     modifiedBy: "Barry Smith",
+                     modifiedOn: "13th December 2010",
+                     modifiedByUser: "bsmith",
+                     description: "Normal result description",
+                     site: {
+                        title: "Normal result site title",
+                        shortName: "normalResult"
+                     },
+                     path: "/one/two/three/four",
+                     size: 283746
+                  }
+               ]
+            },
+            widgetsForHeader: [
+               {
+                  name: "alfresco/lists/views/layouts/HeaderCell",
+                  config: {
+                     id: "THUMBNAIL_HEADER",
+                     label: "Thumbnail column"
+                  }
+               },
+               {
+                  name: "alfresco/lists/views/layouts/HeaderCell",
+                  config: {
+                     id: "DETAIL_HEADER",
+                     label: "Detail column"
+                  }
+               },
+               {
+                  name: "alfresco/lists/views/layouts/HeaderCell",
+                  config: {
+                     id: "ACTIONS_HEADER",
+                     label: "Actions column"
+                  }
+               }
+            ],
+            widgets:[
+               {
+                  name: "alfresco/search/AlfSearchResult",
+                  config: {
+                     pubSubScope: "AlfSearchResultScope",
+                     enableContextMenu: true,
+                     showMoreInfo: false,
+                     additionalDocumentAndFolderActions: [
+                        "dummy-action-for-test"
+                     ],
+                     widgetsAbove: [
+                        {
+                           name: "alfresco/renderers/Banner",
+                           config: {
+                              bannerMessage: "Lookout Below!"
+                           }
+                        }
+                     ],
+                     widgetsBelow: [
+                        {
+                           name: "alfresco/renderers/Banner",
+                           config: {
+                              bannerMessage: "Lookout Above!"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+            
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PdfJsMockXhr",
+         config: {
+            
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/previews/PDF.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/previews/PDF.json
@@ -1,1 +1,289 @@
-{"metadata": {"repositoryId": "3f2ec251-52bc-4ff2-9183-c8cf67be42a6", "custom": {"vtiServer": null, "aos": {"baseUrl": "http:\/\/dave-Latitude-E6530:8080\/alfresco\/aos"}}, "onlineEditing": false, "workingCopyLabel": " (Working Copy)", "shareURL": "http:\/\/localhost:8081\/share", "serverURL": "http:\/\/localhost:8080", "parent": {"permissions": {"user": {}, "roles": []}}}, "item": {"node": {"isLink": false, "aspects": ["cm:auditable", "cm:thumbnailModification", "sys:referenceable", "cm:titled", "cm:author", "rn:renditioned", "sys:localized", "cm:versionable"], "properties": {"cm:modified": {"value": "Fri Jan 09 08:56:25 GMT 2015", "iso8601": "2015-01-09T08:56:25.982Z"}, "cm:content": null, "sys:node-uuid": null, "cm:name": "PDF.pdf", "cm:lastThumbnailModification": ["doclib:1420793786747"], "sys:store-protocol": null, "sys:locale": null, "cm:autoVersion": "true", "sys:node-dbid": null, "cm:initialVersion": "true", "cm:creator": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "cm:created": {"value": "Fri Jan 09 08:56:25 GMT 2015", "iso8601": "2015-01-09T08:56:25.982Z"}, "cm:versionLabel": "1.0", "cm:autoVersionOnUpdateProps": "false", "cm:modifier": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:store-identifier": null}, "type": "cm:content", "isLocked": false, "size": 29009, "mimetypeDisplayName": "Adobe PDF Document", "mimetype": "application\/pdf", "encoding": "UTF-8", "permissions": {"roles": ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;INHERITED"], "inherited": true, "user": {"ChangePermissions": true, "CancelCheckOut": false, "CreateChildren": true, "Write": true, "Delete": true, "Unlock": false}}, "nodeRef": "workspace:\/\/SpacesStore\/26ae500c-91a9-496f-aca6-14101f985c28", "isContainer": false, "contentURL": "\/slingshot\/node\/content\/workspace\/SpacesStore\/26ae500c-91a9-496f-aca6-14101f985c28\/PDF.pdf"}, "parent": {"isLink": false, "aspects": ["cm:auditable", "st:siteContainer", "cm:ownable", "cm:tagscope", "sys:referenceable", "cm:titled", "sys:localized"], "permissions": {"roles": ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;INHERITED"], "inherited": true, "user": {"ChangePermissions": true, "CancelCheckOut": false, "CreateChildren": true, "Write": true, "Delete": true, "Unlock": false}}, "nodeRef": "workspace:\/\/SpacesStore\/a20ba3f3-680e-4ff1-b696-041ba9edb915", "properties": {"cm:modified": {"value": "Fri Jan 09 08:56:26 GMT 2015", "iso8601": "2015-01-09T08:56:26.103Z"}, "sys:node-dbid": null, "cm:description": "Document Library", "cm:creator": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:node-uuid": null, "cm:created": {"value": "Tue Jan 06 14:24:27 GMT 2015", "iso8601": "2015-01-06T14:24:27.036Z"}, "st:componentId": "documentLibrary", "cm:name": "documentLibrary", "sys:store-protocol": null, "cm:owner": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:locale": null, "cm:modifier": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:store-identifier": null}, "type": "cm:folder", "isContainer": true, "isLocked": false}, "version": "1.0", "webdavUrl": "\/webdav\/Sites\/site1\/documentLibrary\/PDF.pdf", "isFavourite": false, "likes": {"isLiked": false, "totalLikes": 0}, "location": {"repositoryId": "3f2ec251-52bc-4ff2-9183-c8cf67be42a6", "site": {"name": "site1", "title": "Site1", "preset": "site-dashboard"}, "container": {"name": "documentLibrary", "type": "cm:folder", "nodeRef": ""}, "path": "\/", "repoPath": "\/Sites\/site1\/documentLibrary", "file": "PDF.pdf", "parent": {}}, "nodeRef": "workspace:\/\/SpacesStore\/26ae500c-91a9-496f-aca6-14101f985c28", "fileName": "PDF.pdf", "displayName": "PDF.pdf", "actionGroupId": "document-browse", "actions": [{"id": "document-download", "icon": "document-download", "type": "link", "label": "actions.document.download", "params": {"href": "{downloadUrl}"}, "index": "100"}, {"id": "document-view-content", "icon": "document-view-content", "type": "link", "label": "actions.document.view", "params": {"href": "{viewUrl}"}, "index": "110"}, {"id": "document-edit-properties", "icon": "document-edit-properties", "type": "javascript", "label": "actions.document.edit-metadata", "params": {"function": "onActionDetails"}, "index": "130"}, {"id": "document-upload-new-version", "icon": "document-upload-new-version", "type": "javascript", "label": "actions.document.upload-new-version", "params": {"function": "onActionUploadNewVersion"}, "index": "140"}, {"id": "document-edit-offline", "icon": "document-edit-offline", "type": "javascript", "label": "actions.document.edit-offline", "params": {"function": "onActionEditOffline"}, "index": "210"}, {"id": "document-copy-to", "icon": "document-copy-to", "type": "javascript", "label": "actions.document.copy-to", "params": {"function": "onActionCopyTo"}, "index": "250"}, {"id": "document-move-to", "icon": "document-move-to", "type": "javascript", "label": "actions.document.move-to", "params": {"function": "onActionMoveTo"}, "index": "260"}, {"id": "document-delete", "icon": "document-delete", "type": "javascript", "label": "actions.document.delete", "params": {"function": "onActionDelete"}, "index": "270"}, {"id": "document-assign-workflow", "icon": "document-assign-workflow", "type": "javascript", "label": "actions.document.assign-workflow", "params": {"function": "onActionAssignWorkflow"}, "index": "280"}, {"id": "document-manage-granular-permissions", "icon": "document-manage-permissions", "type": "link", "label": "actions.document.manage-permissions", "params": {"href": "{managePermissionsUrl}"}, "index": "297"}], "indicators": [], "metadataTemplate": {"id": "default", "title": null, "banners": [], "lines": [{"index": "10", "template": "{date}{size}", "view": ""}, {"index": "20", "template": "{description}", "view": "detailed"}, {"index": "30", "template": "{tags}", "view": "detailed"}, {"index": "50", "template": "{social}", "view": "detailed"}]}}}
+{
+   "metadata": {
+      "repositoryId": "3f2ec251-52bc-4ff2-9183-c8cf67be42a6",
+      "custom": {
+         "vtiServer": null,
+         "aos": {
+            "baseUrl": "http:\/\/dave-Latitude-E6530:8080\/alfresco\/aos"
+         }
+      },
+      "onlineEditing": false,
+      "workingCopyLabel": " (Working Copy)",
+      "shareURL": "http:\/\/localhost:8081\/share",
+      "serverURL": "http:\/\/localhost:8080",
+      "parent": {
+         "permissions": {
+            "user": {},
+            "roles": []
+         }
+      }
+   },
+   "item": {
+      "node": {
+         "isLink": false,
+         "aspects": ["cm:auditable", "cm:thumbnailModification", "sys:referenceable", "cm:titled", "cm:author", "rn:renditioned", "sys:localized", "cm:versionable"],
+         "properties": {
+            "cm:modified": {
+               "value": "Fri Jan 09 08:56:25 GMT 2015",
+               "iso8601": "2015-01-09T08:56:25.982Z"
+            },
+            "cm:content": null,
+            "sys:node-uuid": null,
+            "cm:name": "PDF.pdf",
+            "cm:lastThumbnailModification": ["doclib:1420793786747"],
+            "sys:store-protocol": null,
+            "sys:locale": null,
+            "cm:autoVersion": "true",
+            "sys:node-dbid": null,
+            "cm:initialVersion": "true",
+            "cm:creator": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "cm:created": {
+               "value": "Fri Jan 09 08:56:25 GMT 2015",
+               "iso8601": "2015-01-09T08:56:25.982Z"
+            },
+            "cm:versionLabel": "1.0",
+            "cm:autoVersionOnUpdateProps": "false",
+            "cm:modifier": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:store-identifier": null
+         },
+         "type": "cm:content",
+         "isLocked": false,
+         "size": 29009,
+         "mimetypeDisplayName": "Adobe PDF Document",
+         "mimetype": "application\/pdf",
+         "encoding": "UTF-8",
+         "permissions": {
+            "roles": ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;INHERITED"],
+            "inherited": true,
+            "user": {
+               "ChangePermissions": true,
+               "CancelCheckOut": false,
+               "CreateChildren": true,
+               "Write": true,
+               "Delete": true,
+               "Unlock": false
+            }
+         },
+         "nodeRef": "workspace:\/\/SpacesStore\/26ae500c-91a9-496f-aca6-14101f985c28",
+         "isContainer": false,
+         "contentURL": "\/slingshot\/node\/content\/workspace\/SpacesStore\/26ae500c-91a9-496f-aca6-14101f985c28\/PDF.pdf"
+      },
+      "parent": {
+         "isLink": false,
+         "aspects": ["cm:auditable", "st:siteContainer", "cm:ownable", "cm:tagscope", "sys:referenceable", "cm:titled", "sys:localized"],
+         "permissions": {
+            "roles": ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;INHERITED"],
+            "inherited": true,
+            "user": {
+               "ChangePermissions": true,
+               "CancelCheckOut": false,
+               "CreateChildren": true,
+               "Write": true,
+               "Delete": true,
+               "Unlock": false
+            }
+         },
+         "nodeRef": "workspace:\/\/SpacesStore\/a20ba3f3-680e-4ff1-b696-041ba9edb915",
+         "properties": {
+            "cm:modified": {
+               "value": "Fri Jan 09 08:56:26 GMT 2015",
+               "iso8601": "2015-01-09T08:56:26.103Z"
+            },
+            "sys:node-dbid": null,
+            "cm:description": "Document Library",
+            "cm:creator": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:node-uuid": null,
+            "cm:created": {
+               "value": "Tue Jan 06 14:24:27 GMT 2015",
+               "iso8601": "2015-01-06T14:24:27.036Z"
+            },
+            "st:componentId": "documentLibrary",
+            "cm:name": "documentLibrary",
+            "sys:store-protocol": null,
+            "cm:owner": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:locale": null,
+            "cm:modifier": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:store-identifier": null
+         },
+         "type": "cm:folder",
+         "isContainer": true,
+         "isLocked": false
+      },
+      "version": "1.0",
+      "webdavUrl": "\/webdav\/Sites\/site1\/documentLibrary\/PDF.pdf",
+      "isFavourite": false,
+      "likes": {
+         "isLiked": false,
+         "totalLikes": 0
+      },
+      "location": {
+         "repositoryId": "3f2ec251-52bc-4ff2-9183-c8cf67be42a6",
+         "site": {
+            "name": "site1",
+            "title": "Site1",
+            "preset": "site-dashboard"
+         },
+         "container": {
+            "name": "documentLibrary",
+            "type": "cm:folder",
+            "nodeRef": ""
+         },
+         "path": "\/",
+         "repoPath": "\/Sites\/site1\/documentLibrary",
+         "file": "PDF.pdf",
+         "parent": {}
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/26ae500c-91a9-496f-aca6-14101f985c28",
+      "fileName": "PDF.pdf",
+      "displayName": "PDF.pdf",
+      "actionGroupId": "document-browse",
+      "actions": [{
+         "id": "document-download",
+         "icon": "document-download",
+         "type": "link",
+         "label": "actions.document.download",
+         "params": {
+            "href": "{downloadUrl}"
+         },
+         "index": "100"
+      }, {
+         "id": "document-view-content",
+         "icon": "document-view-content",
+         "type": "link",
+         "label": "actions.document.view",
+         "params": {
+            "href": "{viewUrl}"
+         },
+         "index": "110"
+      }, {
+         "id": "document-edit-properties",
+         "icon": "document-edit-properties",
+         "type": "javascript",
+         "label": "actions.document.edit-metadata",
+         "params": {
+            "function": "onActionDetails"
+         },
+         "index": "130"
+      }, {
+         "id": "document-upload-new-version",
+         "icon": "document-upload-new-version",
+         "type": "javascript",
+         "label": "actions.document.upload-new-version",
+         "params": {
+            "function": "onActionUploadNewVersion"
+         },
+         "index": "140"
+      }, {
+         "id": "document-edit-offline",
+         "icon": "document-edit-offline",
+         "type": "javascript",
+         "label": "actions.document.edit-offline",
+         "params": {
+            "function": "onActionEditOffline"
+         },
+         "index": "210"
+      }, {
+         "id": "document-copy-to",
+         "icon": "document-copy-to",
+         "type": "javascript",
+         "label": "actions.document.copy-to",
+         "params": {
+            "function": "onActionCopyTo"
+         },
+         "index": "250"
+      }, {
+         "id": "document-move-to",
+         "icon": "document-move-to",
+         "type": "javascript",
+         "label": "actions.document.move-to",
+         "params": {
+            "function": "onActionMoveTo"
+         },
+         "index": "260"
+      }, {
+         "id": "document-delete",
+         "icon": "document-delete",
+         "type": "javascript",
+         "label": "actions.document.delete",
+         "params": {
+            "function": "onActionDelete"
+         },
+         "index": "270"
+      }, {
+         "id": "document-assign-workflow",
+         "icon": "document-assign-workflow",
+         "type": "javascript",
+         "label": "actions.document.assign-workflow",
+         "params": {
+            "function": "onActionAssignWorkflow"
+         },
+         "index": "280"
+      }, {
+         "id": "document-manage-granular-permissions",
+         "icon": "document-manage-permissions",
+         "type": "link",
+         "label": "actions.document.manage-permissions",
+         "params": {
+            "href": "{managePermissionsUrl}"
+         },
+         "index": "297"
+      }, {
+         "id": "dummy-action-for-test",
+         "icon": "does-not-matter",
+         "type": "link",
+         "label": "Test Action",
+         "params": {
+            "href": "{managePermissionsUrl}"
+         },
+         "index": "297"
+      }],
+      "indicators": [],
+      "metadataTemplate": {
+         "id": "default",
+         "title": null,
+         "banners": [],
+         "lines": [{
+            "index": "10",
+            "template": "{date}{size}",
+            "view": ""
+         }, {
+            "index": "20",
+            "template": "{description}",
+            "view": "detailed"
+         }, {
+            "index": "30",
+            "template": "{tags}",
+            "view": "detailed"
+         }, {
+            "index": "50",
+            "template": "{social}",
+            "view": "detailed"
+         }]
+      }
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-450 to make the alfresco/search/AlfSearchResult more customizable. The key updates are that you can now replace the filtered actions for documents/folder and other nodes (or just add in additional filters). You can configure the MoreInfo widget to not be rendered and it is possible to configure either "widgetsBefore" or "widgetsAfter" that will appear above or below the main properties in the central column. The widget has also been refactored so that when extending it is possible to just override specific functions that produce each specific renderer.

A unit test has been added for these new capabilities.