### PR TITLE
AKU-429: Update gallery view and slider to ensure correct initial column rendering

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfGalleryViewSlider.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfGalleryViewSlider.js
@@ -90,7 +90,7 @@ define(["dojo/_base/declare",
          this.set("value", this.getSliderValueFromColumns(this.columns));
          this.alfPublish(this.getPreferenceTopic, {
             preference: "org.alfresco.share.documentList.galleryColumns",
-            callback: this.setColumns,
+            callback: this.onColumnPreferences,
             callbackScope: this
          });
       },
@@ -105,10 +105,23 @@ define(["dojo/_base/declare",
       columns: 4,
 
       /**
+       * This is called when column user preferences are provided. 
+       * 
        * @instance
        * @param {number} value The number of columns to set.
        */
-      setColumns: function(value) {
+      onColumnPreferences: function alfresco_documentlibrary_AlfGalleryViewSlider__onColumnPreferences(value) {
+         this.setColumns(value);
+         this.alfPublish("ALF_DOCLIST_SET_GALLERY_COLUMNS", {
+            value: value
+         });
+      },
+
+      /**
+       * @instance
+       * @param {number} value The number of columns to set.
+       */
+      setColumns: function alfresco_documentlibrary_AlfGalleryViewSlider__setColumns(value) {
          if (!value || isNaN(value))
          {
             value = 4;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-428. It was observed that the correct number of columns were not being rendered when initially displaying a gallery view. This was because the preferences were not being passed to the gallery view when returned via the XHR request. This resulted in the default display being rendered. Whether or not this completely resolves AKU-428, this change is necessary as Share is also exhibiting the same behavior.