### PR TITLE
AKU-453: Update folder search result links

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -57,12 +57,12 @@ define(["alfresco/core/TemporalUtils",
                name = lang.getObject("name", false, this.currentItem);
                if (site)
                {
-                  payload.url = "site/" + site + "/documentlibrary?path=" + path + "/" + name;
+                  payload.url = "site/" + site + "/documentlibrary?path=" + encodeURIComponent(path) + "%2F" + encodeURIComponent(name);
                }
                else if (path)
                {
                   path = "/" + path.split("/").slice(2).join("/");
-                  payload.url = "repository?path=" + path + "/" + name;
+                  payload.url = "repository?path=" + encodeURIComponent(path) + "%2F" + encodeURIComponent(name);
                }
                break;
 

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -71,11 +71,22 @@ define(["intern!object",
          "Event result opens correct date in calendar": function() {
             return browser.findByCssSelector(".alfresco-search-AlfSearchResult:last-child .nameAndTitleCell .alfresco-renderers-PropertyLink > .inner")
                .click()
-               .end()
+            .end()
 
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload) {
                   assert.deepPropertyVal(payload, "url", "site/eventResult/calendar?date=2015-04-01", "Did not navigate to correct page");
+               });
+         },
+
+         "Click on folder link container ampersand": function() {
+            return browser.findByCssSelector(".alfresco-search-AlfSearchResult:first-child .nameAndTitleCell .alfresco-renderers-PropertyLink > .inner")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2Fone%2Ftwo%2Fthree%2Ffour%2Ftest1%20%26%20test2", "Special characters were not encoded");
                });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -21,6 +21,7 @@ model.jsonModel = {
                   {
                      nodeRef: "dummy://nodeRef/1",
                      type: "folder",
+                     name: "test1 & test2",
                      displayName: "Normal result",
                      title: "Normal result title",
                      modifiedBy: "Barry Smith",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-453 to ensure that search results for folders that contain special characters in their path are encoded so that they can link to the correct location in the repository/document library. The unit test has been updated to prevent regressions.