### PR TITLE
AKU-448: Bottom of scrollbar hidden on long dialogs

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -36,10 +36,14 @@
    font-weight: normal;
 }
 
+.alfresco-dialog-AlfDialog .dialog-body, .alfresco-dialog-AlfDialog .footer {
+   box-sizing: border-box;
+}
+
 .alfresco-dialog-AlfDialog .dialog-body {
    padding: 12px;
    overflow: auto;
-   height: ~"calc(100% - 50px)";
+   height: ~"calc(100% - 40px)";
    margin-bottom: 40px;
    min-width: 560px;
 }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -297,6 +297,159 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_LONG_DIALOG",
+         config: {
+            label: "Launch long dialog",
+            publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Long dialog",
+               widgetsContent: [
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        level: 2,
+                        label: "This is a heading"
+                     }
+                  },
+                  {
+                     name: "alfresco/html/Spacer",
+                     config: {
+                        height: "50px"
+                     }
+                  }
+               ],
+               widgetsButtons: [
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     config: {
+                        label: "OK",
+                        additionalCssClasses: "cancellationButton",
+                        publishTopic: "LONG_DIALOG_CLOSED"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This addresses issue [AKU-448](https://issues.alfresco.com/jira/browse/AKU-448) which notes that the bottom of the scrollbar is hidden on long dialogs