### PR TITLE
AKU-487: Breadcrumb trail updates

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -161,6 +161,27 @@ define(["dojo/_base/declare",
       lastBreadcrumbPublishPayload: null,
 
       /**
+       * Indicates whether or not the clicking on the last breadcrumb publishes on the gloabl scope. This 
+       * defaults to true because it is expected that the last breadcrumb will be a page navigation and
+       * therefore need to publish to a globally subscribing 
+       * [NavigationService]{@link module:alfresco/services/NavigationServce}.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      lastBreadcrumbPublishGlobal: true,
+
+      /**
+       * Indicates whether or not the clicking on the last breadcrumb publishes on the parent scope
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      lastBreadcrumbPublishToParent: false,
+
+      /**
        * This is the type of payload that is published when the final breadcrumb in the trail is clicked. 
        * By default it will use the 
        * [lastBreadcrumbPublishPayload]{@link module:alfresco/documentlibrary/AlfBreadCrumbTrail#lastBreadcrumbPublishPayload} 
@@ -236,7 +257,10 @@ define(["dojo/_base/declare",
 
             if (this.useHash === true)
             {
-               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged), true);
+               // Subscribe using the widgets own scope (don't assume global) because the topic published
+               // will in practice be published at a share scope (i.e. when used in the context of a 
+               // scoped Document Library the hash change publication will be scoped, not global)...
+               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged));
             }
             else if (this.pathChangeTopic)
             {
@@ -270,6 +294,12 @@ define(["dojo/_base/declare",
          if (payload && payload.node)
          {
             this.currentNode = payload.node;
+
+            // It's necessary to re-render the breadcrumb trail after the current node changes because on initial
+            // page load the current node update will occur after the breadcrumb has been rendered for the first time...
+            // Currently this can result in the breadcrumb rendering twice, but at least it will be accurate (only 
+            // remove this line when verifying initial page loading results)...
+            this.renderPathBreadcrumbTrail();
          }
          else
          {
@@ -323,8 +353,7 @@ define(["dojo/_base/declare",
          var path = paths.slice(0, index+1).join("/");
          var config = {
             label: folderName,
-            path: path,
-            publishGlobal: true
+            path: path
          };
          if (index < paths.length -1)
          {
@@ -336,6 +365,7 @@ define(["dojo/_base/declare",
                   type: "HASH",
                   target: "CURRENT"
                };
+               config.publishGlobal = true;
             }
             else
             {
@@ -349,6 +379,8 @@ define(["dojo/_base/declare",
          {
             config.publishTopic = this.lastBreadcrumbPublishTopic;
             config.publishPayload = this.generatePayload(this.lastBreadcrumbPublishPayload, this.currentItem, null, this.lastBreadcrumbPublishPayloadType, this.lastBreadcrumbPublishPayloadItemMixin, this.lastBreadcrumbPublishPayloadModifiers);
+            config.publishGlobal = this.lastBreadcrumbPublishGlobal;
+            config.publishToParent = this.lastBreadcrumbPublishToParent;
          }
          this.renderBreadcrumb(config);
       },

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -62,6 +62,19 @@ define(["dojo/_base/declare",
       showFolders: true,
 
       /**
+       * This indicates whether or not [clicking on a folder]{@link module:alfresco/documentlibrary/AlfDocumentList#onFolderClick} 
+       * will perform a globally scoped publication. This is true by default as the as the default
+       * [topic for folder clicks]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#pathChangeTopic} is
+       * expected to be subscribed to by the [NavigationService]{@link module:alfresco/services/NavigationService} which
+       * will typically be subscribing globally.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      folderClickPublishGlobal: true,
+
+      /**
        * Indicates whether or not documents should be shown in the document library.
        *
        * @instance
@@ -340,7 +353,7 @@ define(["dojo/_base/declare",
             this.currentFilter = this.processFilter(payload.url);
             if (!this.useHash && this.currentFilter.path)
             {
-               this.alfPublish(this.pathChangeTopic, this.currentFilter);
+               this.alfPublish(this.pathChangeTopic, this.currentFilter, this.folderClickPublishGlobal);
             }
          }
          else

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
@@ -155,7 +155,8 @@ model.jsonModel = {
             publishTopic: "ALF_HASH_CHANGED",
             publishPayload: {
                path: "/different/path"
-            }
+            },
+            pubSubScope: "SCOPED_"
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-487 to make further updates to the alfresco/documentlibrary/AlfBreadcrumbTrail and related widgets to resolve scoping issues.