### PR TITLE
Minor change to width of dijitTextArea within Dialogs to line up with width of dijitTextBox

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -124,3 +124,7 @@
    width: 360px;
    border-radius: 3px;
 }
+
+.dialog-body .control .dijitTextArea {
+   width: 356px;
+}


### PR DESCRIPTION
For reasons only known to browser vendors, width of textbox and textarea fields varies by a few pixels when set to the same value. Override the value for textarea to match - in dialogs only.