### PR TITLE
AKU-472: Search without URL hashing

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -240,7 +240,7 @@ define(["dojo/_base/declare",
                }
                else
                {
-                  this.loadData();
+                  this.onReloadData();
                }
             }
          }
@@ -279,7 +279,7 @@ define(["dojo/_base/declare",
                }
                else
                {
-                  this.loadData();
+                  this.onReloadData();
                }
             }
          }

--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -147,16 +147,30 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfCheckableMenuItem__postCreate() {
-
          if (!this.publishPayload)
          {
             this.publishPayload = {};
          }
 
+         // If configured to use a hashName and that hashName is on the 
          if (this.hashName)
          {
             var currHash = hashUtils.getHash();
-            this.checked = currHash[this.hashName] && currHash[this.hashName] === this.value;
+            if (currHash[this.hashName])
+            {
+               // If the hashName is present in the URL hash, set the checked state based on the URL...
+               this.checked = currHash[this.hashName] === this.value;
+            }
+            else if (this.checked)
+            {
+               // ...but if the hashName is NOT present in the URL hash, but the menu item has been 
+               // configured to be checked then update the URL hash...
+               currHash[this.hashName] = this.value;
+               this.alfPublish("ALF_NAVIGATE_TO_PAGE", {
+                  url: ioQuery.objectToQuery(currHash),
+                  type: "HASH"
+               }, true);
+            }
          }
 
          this.alfLog("log", "Create checkable cell");

--- a/aikau/src/main/resources/alfresco/search/FacetFilter.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilter.js
@@ -70,14 +70,32 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
-       * Indicates that the filter should be hidden. This will be set to "true" if any required data is missing
-       * 
+       * Indicate whether or not the filter is currently applied
+       *
        * @instance
        * @type {boolean}
        * @default false
        */
-      hide: false,
+      applied: false,
       
+      /**
+       * The alt-text to use for the image that indicates that a filter has been applied
+       *
+       * @instance
+       * @type {string} 
+       * @default
+       */
+      appliedFilterAltText: "facet.filter.applied.alt-text",
+
+      /**
+       * The path to use as the source for the image that indicates that a filter has been applied
+       *
+       * @instance
+       * @type {string}
+       * @default "12x12-selected-icon.png"
+       */
+      appliedFilterImageSrc: "12x12-selected-icon.png",
+
       /**
        * The facet qname
        *
@@ -106,32 +124,14 @@ define(["dojo/_base/declare",
       filterData: "",
 
       /**
-       * Indicate whether or not the filter is currently applied
-       *
+       * Indicates that the filter should be hidden. This will be set to "true" if any required data is missing
+       * 
        * @instance
        * @type {boolean}
        * @default false
        */
-      applied: false,
+      hide: false,
       
-      /**
-       * The path to use as the source for the image that indicates that a filter has been applied
-       *
-       * @instance
-       * @type {string}
-       * @default "12x12-selected-icon.png"
-       */
-      appliedFilterImageSrc: "12x12-selected-icon.png",
-
-      /**
-       * The alt-text to use for the image that indicates that a filter has been applied
-       *
-       * @instance
-       * @type {string} 
-       * @default
-       */
-      appliedFilterAltText: "facet.filter.applied.alt-text",
-
       /**
        * When this is set to true the current URL hash fragment will be used to initialise the facet selection
        * and when the facet is selected the hash fragment will be updated with the facet selection.
@@ -205,9 +205,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       onApplyFilter: function alfresco_search_FacetFilter__onApplyFilter() {
-
          var fullFilter = this.facet + "|" + this.filter;
-
          if(this.useHash)
          {
             this._updateHash(fullFilter, "add");

--- a/aikau/src/main/resources/alfresco/search/FacetFilters.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilters.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,9 +18,6 @@
  */
 
 /**
- * This should be used to wrap a set of [AlfDocumentFilters]{@link module:alfresco/documentlibrary/AlfDocumentFilter} 
- * in order to achieve the "twisty" and correct look and feel as expected in a document library.
- * 
  * @module alfresco/search/FacetFilters
  * @extends alfresco/documentlibrary/AlfDocumentFilters
  * @author Dave Draper
@@ -111,7 +108,7 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
 
          // TODO: Commented out and published because it's being developed against QuaddsWidgets...
-         this.alfSubscribe("ALF_WIDGETS_READY", lang.hitch(this, "publishFacets"), true);
+         this.alfSubscribe("ALF_WIDGETS_READY", lang.hitch(this, this.publishFacets), true);
          // this.publishFacets();
       },
 
@@ -132,7 +129,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       publishFacets: function alfresco_search_FacetFilters__publishFacets() {
-         if (this.facetQName != null && this.facetQName !== "")
+         if (this.facetQName)
          {
             // Publish the details of the facet for the SearchService to log for inclusion in search requests
             this.alfPublish("ALF_INCLUDE_FACET", {
@@ -141,7 +138,7 @@ define(["dojo/_base/declare",
             }, true);
 
             // Subscribe to facet property results to add facet properties...
-            this.alfSubscribe("ALF_FACET_RESULTS_" + this.facetQName, lang.hitch(this, "processFacetFilters"));
+            this.alfSubscribe("ALF_FACET_RESULTS_" + this.facetQName, lang.hitch(this, this.processFacetFilters));
          }
          else
          {
@@ -166,13 +163,13 @@ define(["dojo/_base/declare",
 
          // Remove all previous filters...
          var widgets = registry.findWidgets(this.contentNode);
-         array.forEach(widgets, function(widget, i) {
+         array.forEach(widgets, function(widget) {
             widget.destroy();
          });
 
          // Put all the active filters into a list...
          var activeFilters = [];
-         if (payload.activeFilters != null)
+         if (payload.activeFilters)
          {
             activeFilters = payload.activeFilters.split(",");
          }
@@ -181,14 +178,16 @@ define(["dojo/_base/declare",
          var filters = [];
          for (var key in payload.facetResults)
          {
-            var currFilter = payload.facetResults[key];
-            filters.push({
-               label: currFilter.label,
-               value: currFilter.value,
-               hits: currFilter.hits,
-               index: currFilter.index
-            });
-            
+            if (payload.facetResults.hasOwnProperty(key))
+            {
+               var currFilter = payload.facetResults[key];
+               filters.push({
+                  label: currFilter.label,
+                  value: currFilter.value,
+                  hits: currFilter.hits,
+                  index: currFilter.index
+               });
+            }
          }
 
          // Sort the filters...
@@ -199,17 +198,16 @@ define(["dojo/_base/declare",
          var filtersToAdd = this.maxFilters;
 
          // Create widgets for each filter...
-         array.forEach(filters, function(filter, index) {
-
-            if (this.minFilterValueLength != null && filter.value.length < this.minFilterValueLength)
+         array.forEach(filters, function(filter) {
+            if (this.minFilterValueLength && filter.value.length < this.minFilterValueLength)
             {
                // Don't add filters that have a value shorter than the minimum specified length
             }
-            else if (this.hitThreshold == null || this.hitThreshold <= filter.hits)
+            else if (!this.hitThreshold || this.hitThreshold <= filter.hits)
             {
                // Check to see if this is an active filter...
-               var applied = array.some(activeFilters, function(activeFilter, index) {
-                  return activeFilter == this.facetQName.replace(/\.__.u/g, "").replace(/\.__/g, "") + "|" + filter.value;
+               var applied = array.some(activeFilters, function(activeFilter) {
+                  return activeFilter === this.facetQName.replace(/\.__.u/g, "").replace(/\.__/g, "") + "|" + filter.value;
                }, this);
 
                // Keeping adding (visible) filters until we've hit the maximum number...
@@ -223,7 +221,7 @@ define(["dojo/_base/declare",
                   pubSubScope: this.pubSubScope
                });
 
-               if (filtersToAdd != null && filtersToAdd <= 0 && !applied)
+               if (filtersToAdd && filtersToAdd <= 0 && !applied)
                {
                   this.addMoreFilter(filterWidget);
                }
@@ -231,12 +229,15 @@ define(["dojo/_base/declare",
                filterWidget.placeAt(this.showMoreNode, "before");
 
                // Decrement the filter count...
-               if (filtersToAdd != null) filtersToAdd--;
+               if (filtersToAdd) 
+               {
+                  filtersToAdd--;
+               }
             }
 
          }, this);
 
-         if (this.moreFiltersList != null)
+         if (this.moreFiltersList)
          {
             domClass.remove(this.showMoreNode, "hidden");
          }
@@ -258,9 +259,9 @@ define(["dojo/_base/declare",
        * @param {object} filter The filter to test
        * @param {number} index The index of the filter
        */
-      filterFacetFilters: function alfresco_search_FacetFilters__filterFacetFilters(filter, index) {
-         return ((this.hitThreshold == null || this.hitThreshold <= filter.hits) &&
-                 (this.minFilterValueLength == null || filter.value.length >= this.minFilterValueLength));
+      filterFacetFilters: function alfresco_search_FacetFilters__filterFacetFilters(filter, /*jshint unused:false*/ index) {
+         return ((!this.hitThreshold || this.hitThreshold <= filter.hits) &&
+                 (!this.minFilterValueLength || filter.value.length >= this.minFilterValueLength));
       },
 
       /**
@@ -271,7 +272,7 @@ define(["dojo/_base/declare",
        * @returns {array} The sorted filters
        */
       sortFacetFilters: function alfresco_search_FacetFilters__sortFacetFilters(filters) {
-         if (this.sortBy == null || lang.trim(this.sortBy) === "ALPHABETICALLY")
+         if (!this.sortBy || lang.trim(this.sortBy) === "ALPHABETICALLY")
          {
             return filters.sort(this._alphaSort);
          }
@@ -306,11 +307,18 @@ define(["dojo/_base/declare",
        * @returns {number} -1, 0 or 1 according to standard array sorting conventions
        */
       _alphaSort: function alfresco_search_FacetFilters___alphaSort(a,b) {
+         var result = 0;
          var alc = a.label.toLowerCase();
          var blc = b.label.toLowerCase();
-         if(alc < blc) return -1;
-         if(alc > blc) return 1;
-         return 0;
+         if(alc < blc)
+         {
+            result = -1;
+         }
+         if(alc > blc)
+         {
+            result = 1;
+         }
+         return result;
       },
 
       /**
@@ -322,11 +330,18 @@ define(["dojo/_base/declare",
        * @returns {number} -1, 0 or 1 according to standard array sorting conventions
        */
       _reverseAlphaSort: function alfresco_search_FacetFilters___reverseAlphaSort(a, b) {
+         var result = 0;
          var alc = a.label.toLowerCase();
          var blc = b.label.toLowerCase();
-         if(alc > blc) return -1;
-         if(alc < blc) return 1;
-         return 0;
+         if(alc > blc)
+         {
+            result = -1;
+         }
+         if(alc < blc)
+         {
+            result = 1;
+         }
+         return result;
       },
 
       /**
@@ -364,7 +379,7 @@ define(["dojo/_base/declare",
        * @returns {number} -1, 0 or 1 according to standard array sorting conventions
        */
       _indexSort: function alfresco_search_FacetFilter___indexSort(a, b) {
-         if (a.index != null && b.index != null)
+         if ((a.index || a.index === 0) && (b.index || b.index === 0))
          {
             return a.index - b.index;
          }

--- a/aikau/src/main/resources/alfresco/search/FacetFilters.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilters.js
@@ -221,7 +221,7 @@ define(["dojo/_base/declare",
                   pubSubScope: this.pubSubScope
                });
 
-               if (filtersToAdd && filtersToAdd <= 0 && !applied)
+               if ((filtersToAdd || filtersToAdd === 0) && filtersToAdd <= 0 && !applied)
                {
                   this.addMoreFilter(filterWidget);
                }

--- a/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
@@ -45,199 +45,196 @@ define(["intern!object",
          browser.end();
       },
 
-     "Mouse tests": function () {
-         var testname = "FacetFiltersTest - Mouse tests";
+     "Check no facets are shown to begin with": function () {
          // Check no facets are shown to begin with
          return browser.findById("FACET1")
             .getVisibleText()
             .then(function (initialValue) {
-               TestCommon.log(testname,"Check no facets are shown to begin with");
-               expect(initialValue).to.equal("Facet 1", "The only text shown should be 'Facet 1'");
-            })
-            .end()
+               assert.equal(initialValue, "Facet 1", "The only text shown should be 'Facet 1'");
+            });
+         },
 
-         .findAllByCssSelector(".alfresco-search-FacetFilter:not(.hidden)")
+      "Check no facet rows are shown to begin with": function() {
+         return browser.findAllByCssSelector(".alfresco-search-FacetFilter:not(.hidden)")
             .then(function (rows) {
-               TestCommon.log(testname,"Check no facet rows are shown to begin with");
-               expect(rows).to.have.length(0, "There should be no visible rows in the facet display");
-            })
-            .end()
+               assert.lengthOf(rows, 0, "There should be no visible rows in the facet display");
+            });
+         },
 
+      "Check facets are shown after clicking button 1": function() {
          // Click button 1 - 4 rows of facet data should appear
-         .findById("DO_FACET_BUTTON_1")
+         return browser.findById("DO_FACET_BUTTON_1")
             .click()
-            .end()
+         .end()
 
          .findAllByCssSelector(".alfresco-search-FacetFilter:not(.hidden)")
             .then(function (rows) {
-               TestCommon.log(testname,"Check facets are shown after clicking button 1");
-               expect(rows).to.have.length(4, "There should be 4 rows in the facet display");
-            })
-            .end()
+               assert.lengthOf(rows, 4, "There should be 4 rows in the facet display");
+            });
+         },
 
+      "heck the first set of facets have appeared": function() {
          // Check the facet values
-         .findById("FACET1")
+         return browser.findById("FACET1")
             .getVisibleText()
             .then(function (facets) {
-               TestCommon.log(testname,"Check the first set of facets have appeared");
-               expect(facets).to.contain("result 1", "Facets should contain 'result 1'");
-               expect(facets).to.contain("result 2", "Facets should contain 'result 2'");
-               expect(facets).to.contain("result 3", "Facets should contain 'result 3'");
-               expect(facets).to.contain("result 4", "Facets should contain 'result 4'");
-            })
-            .end()
+               assert.include(facets, "result 1", "Facets should contain 'result 1'");
+               assert.include(facets, "result 2", "Facets should contain 'result 2'");
+               assert.include(facets, "result 3", "Facets should contain 'result 3'");
+               assert.include(facets, "result 4", "Facets should contain 'result 4'");
+            });
+         },
 
+      "Check facets are shown after clicking button 2": function() {
          // Click button 2 - 2 rows of facet data should appear
-         .findById("DO_FACET_BUTTON_2")
+         return browser.findById("DO_FACET_BUTTON_2")
             .click()
-            .end()
-
+         .end()
          .findAllByCssSelector(".alfresco-search-FacetFilter:not(.hidden)")
             .then(function (rows) {
-               TestCommon.log(testname,"Check facets are shown after clicking button 2");
-               expect(rows).to.have.length(2, "There should be 2 rows in the facet display");
-            })
-            .end()
+               assert.lengthOf(rows, 2, "There should be 2 rows in the facet display");
+            });
+         },
 
+      "Check the second set of facets have appeared": function() {
          // Check the facet values
-         .findById("FACET1")
+         return browser.findById("FACET1")
             .getVisibleText()
             .then(function (facets) {
-               TestCommon.log(testname,"Check the second set of facets have appeared");
-               expect(facets).to.contain("result 5", "Facets should contain 'result 5'");
-               expect(facets).to.contain("result 6", "Facets should contain 'result 6'");
-            })
-            .end()
+               assert.include(facets, "result 5", "Facets should contain 'result 5'");
+               assert.include(facets, "result 6", "Facets should contain 'result 6'");
+            });
+         },
 
-         // Click button 3 - 4 rows of facet data should appear
+      "Check facets are shown after clicking button 3": function() {
+         return browser// Click button 3 - 4 rows of facet data should appear
          .findById("DO_FACET_BUTTON_3")
             .click()
-            .end()
-
+         .end()
          .findAllByCssSelector(".alfresco-search-FacetFilter:not(.hidden)")
             .then(function (rows) {
-               TestCommon.log(testname,"Check facets are shown after clicking button 3");
-               expect(rows).to.have.length(6, "There should be 6 rows in the facet display");
-            })
-            .end()
+               assert.lengthOf(rows, 6, "There should be 6 rows in the facet display");
+            });
+         },
 
-         // Check the facet values
+      "Check the third set of facets have appeared": function() {
+         return browser// Check the facet values
          .findById("FACET1")
             .getVisibleText()
             .then(function (facets) {
-               TestCommon.log(testname,"Check the third set of facets have appeared");
-               expect(facets).to.contain("result 7", "Facets should contain 'result 7'");
-               expect(facets).to.contain("result 8", "Facets should contain 'result 8'");
-               expect(facets).to.contain("result 9", "Facets should contain 'result 9'");
-               expect(facets).to.contain("result 10", "Facets should contain 'result 10'");
-               expect(facets).to.contain("result 11", "Facets should contain 'result 11'");
-               expect(facets).to.contain("Show More", "Facets should contain 'More choices'");
-               expect(facets).to.not.contain("result 12", "Facets should not contain 'result 12'");
-            })
-            .end()
+               assert.include(facets, "result 7", "Facets should contain 'result 7'");
+               assert.include(facets, "result 8", "Facets should contain 'result 8'");
+               assert.include(facets, "result 9", "Facets should contain 'result 9'");
+               assert.include(facets, "result 10", "Facets should contain 'result 10'");
+               assert.include(facets, "result 11", "Facets should contain 'result 11'");
+               assert.include(facets, "Show More", "Facets should contain 'More choices'");
+               assert.notInclude(facets, "result 12", "Facets should not contain 'result 12'");
+            });
+         },
 
-         // Click the more choices button
+      "Check the four set of facets are shown": function() {
+         return browser// Click the more choices button
          .findByCssSelector("li.showMore")
             .click()
-            .end()
+         .end()
 
          // Check the facet values
          .findById("FACET1")
             .getVisibleText()
             .then(function (facets) {
-               TestCommon.log(testname,"Check the four set of facets are shown");
-               expect(facets).to.contain("result 7", "Facets should contain 'result 7'");
-               expect(facets).to.contain("result 8", "Facets should contain 'result 8'");
-               expect(facets).to.contain("result 9", "Facets should contain 'result 9'");
-               expect(facets).to.contain("result 10", "Facets should contain 'result 10'");
-               expect(facets).to.contain("result 11", "Facets should contain 'result 11'");
-               expect(facets).to.contain("Show Fewer", "Facets should contain 'Less choices'");
-               expect(facets).to.contain("result 12", "Facets should contain 'result 12'");
-            })
-            .end()
+               assert.include(facets, "result 7", "Facets should contain 'result 7'");
+               assert.include(facets, "result 8", "Facets should contain 'result 8'");
+               assert.include(facets, "result 9", "Facets should contain 'result 9'");
+               assert.include(facets, "result 10", "Facets should contain 'result 10'");
+               assert.include(facets, "result 11", "Facets should contain 'result 11'");
+               assert.include(facets, "Show Fewer", "Facets should contain 'Less choices'");
+               assert.include(facets, "result 12", "Facets should contain 'result 12'");
+            });
+         },
 
-         // Click the less choices button
+      "Check the fifth set of facets are shown": function() {
+         return browser// Click the less choices button
          .findByCssSelector("li.showLess")
             .click()
-            .end()
+         .end()
 
          // Check the facet values
          .findById("FACET1")
             .getVisibleText()
             .then(function (facets) {
-               TestCommon.log(testname,"Check the fifth set of facets are shown");
-               expect(facets).to.contain("result 7", "Facets should contain 'result 7'");
-               expect(facets).to.contain("result 8", "Facets should contain 'result 8'");
-               expect(facets).to.contain("result 9", "Facets should contain 'result 9'");
-               expect(facets).to.contain("result 10", "Facets should contain 'result 10'");
-               expect(facets).to.contain("result 11", "Facets should contain 'result 11'");
-               expect(facets).to.contain("Show More", "Facets should contain 'More choices'");
-               expect(facets).to.not.contain("result 12", "Facets should not contain 'result 12'");
-            })
-            .end()
+               assert.include(facets, "result 7", "Facets should contain 'result 7'");
+               assert.include(facets, "result 8", "Facets should contain 'result 8'");
+               assert.include(facets, "result 9", "Facets should contain 'result 9'");
+               assert.include(facets, "result 10", "Facets should contain 'result 10'");
+               assert.include(facets, "result 11", "Facets should contain 'result 11'");
+               assert.include(facets, "Show More", "Facets should contain 'More choices'");
+               assert.notInclude(facets, "result 12", "Facets should not contain 'result 12'");
+            });
+         },
 
-         // Click the title - the facet menu should disappear
+      "Check facet menu is hidden when the title is clicked": function() {
+         return browser// Click the title - the facet menu should disappear
          .findByCssSelector("#FACET1 > div.label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#FACET1 > ul.filters")
             .isDisplayed()
             .then(function (displayed) {
-               TestCommon.log(testname,"Check facet menu is hidden when the title is clicked");
-               expect(displayed).to.equal(false, "Facet menu should be hidden when the title is clicked");
-            })
-            .end()
+               assert.isFalse(displayed, "Facet menu should be hidden when the title is clicked");
+            });
+         },
 
-         // Click the title again - the facet menu should reappear
+      "Check facet menu is shown when the title is clicked again": function() {
+         return browser// Click the title again - the facet menu should reappear
          .findByCssSelector("#FACET1 > div.label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#FACET1 > ul.filters")
             .isDisplayed()
             .then(function (displayed) {
-               TestCommon.log(testname,"Check facet menu is shown when the title is clicked again");
-               expect(displayed).to.equal(true, "Facet menu should be shown when the title is clicked again");
-            })
-            .end()
+               assert.isTrue(displayed, "Facet menu should be shown when the title is clicked again");
+            });
+         },
 
-         // Click the first facet menu item - it should select
+      "Facet menu item should select when clicked": function() {
+         return browser// Click the first facet menu item - it should select
          .findByCssSelector("#FACET1 > ul.filters > li:first-of-type span.filterLabel")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#FACET1 > ul.filters > li:first-of-type > span.status > span")
             .isDisplayed()
             .then(function (displayed) {
-               TestCommon.log(testname,"Facet menu item should select when clicked");
-               expect(displayed).to.equal(true, "Facet menu item should select when clicked");
-            })
-            .end()
+               assert.isTrue(displayed, "Facet menu item should select when clicked");
+            });
+         },
 
-         .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "alfTopic", "ALF_APPLY_FACET_FILTER"))
+      "Clicking a facet should publish": function() {
+         return browser.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "alfTopic", "ALF_APPLY_FACET_FILTER"))
             .then(
-               function(){TestCommon.log(testname,"Clicking a facet should publish");},
+               function(){},
                function(){assert(false, "The facet did not publish on 'ALF_APPLY_FACET_FILTER'");}
-            )
-           .end()
+            );
+         },
 
-         // Click the first facet menu item again - it should de-select
+      "Facet menu item should de-select when clicked again": function() {
+         return browser// Click the first facet menu item again - it should de-select
          .findByCssSelector("#FACET1 > ul.filters > li:first-of-type span.filterLabel")
             .click()
-            .end()
-
+         .end()
          .findByCssSelector("#FACET1 > ul.filters > li:first-of-type > span.status > span")
             .isDisplayed()
             .then(function (displayed) {
-               TestCommon.log(testname,"Facet menu item should de-select when clicked again");
-               expect(displayed).to.equal(false, "Facet menu item should de-select when clicked again");
-            })
-            .end()
+               assert.isFalse(displayed, "Facet menu item should de-select when clicked again");
+            });
+         },
 
-         .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "alfTopic", "ALF_REMOVE_FACET_FILTER"))
+      "Clicking a facet to deselect should publish": function() {
+         return browser.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "alfTopic", "ALF_REMOVE_FACET_FILTER"))
             .then(
-               function(){TestCommon.log(testname,"Clicking a facet to deselect should publish");},
+               function(){},
                function(){assert(false, "The facet deselection did not publish on 'ALF_REMOVE_FACET_FILTER'");}
             );
       },

--- a/aikau/src/test/resources/alfresco/search/NoHashSearchingTest.js
+++ b/aikau/src/test/resources/alfresco/search/NoHashSearchingTest.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This test generates some variations on AlfSearchResult to test the various if statements in the rendering widgets involved
+ * 
+ * @author Richard Smith
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "No URL Hashing Search Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/NoHashSearching", "No URL Hashing Search Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Check that a scope is selected": function() {
+         // See AKU-475 - because no hashName attribute is set on the AlfCheckableMenuItems the configured checked 
+         // status should result in a scope being set
+         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Repository", "An initial scope was not set");
+            })
+            .clearLog();
+      },
+
+      "Perform a search without setting a hash": function() {
+         // See AKU-472 - with both the SingleComboBoxForm and AlfSearchList configured with useHash to be false
+         // then setting a search term should just perform a search without updating the URL hash
+         return browser.findByCssSelector(".dijitInputInner")
+            .type("hame")
+         .end()
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+         .end()
+         .getLastPublish("SEARCH_RESULTS_SUCCESS")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "response.totalRecords", 10, "Response not published");
+            })
+         .getCurrentUrl()
+            .then(function(url) {
+               assert.notInclude(url, "#", "A hash should not have been set");
+            })
+         .clearLog();
+      },
+
+      "Check search results for alternative search": function() {
+         // Searching for "hame" will actually generate an alternative search for "home"
+         return browser.findByCssSelector(".searched-for-term .search-term-link")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "home", "Did not perform the alternative search");
+            });
+      },
+
+      "Change the scope without setting a hash": function() {
+         // Switching from Repository to All Sites scope should initiate a new search search without setting the hash
+         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+            .click()
+         .end()
+         .findById("FCTSRCH_SET_ALL_SITES_SCOPE_text")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", false, "The search scope was not updated");
+            })
+            .clearLog();
+      },
+
+      "Use original search term without setting hash": function() {
+         // The AlternativeSearchLabel should present the original search term of "hame" - clicking on this
+         // should perform that search and the hash should remain unchanged
+         return browser.findByCssSelector(".searched-for-term .search-term-link")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "term", "home", "The search request was not updated");
+            })
+         .getCurrentUrl()
+            .then(function(url) {
+               assert.notInclude(url, "#", "A hash should not have been set");
+            })
+         .clearLog();
+      },
+      
+      "Apply a facet filter without setting hash": function() {
+         // Applying a facet filter should trigger another search without the AlfSearchList updating the URL hash
+         return browser.findByCssSelector(".filters li:first-child .filterLabel")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "filters", "{http://www.alfresco.org/model/content/1.0}created|NOW/DAY-7DAYS\"..\"NOW/DAY+1DAY", "The search request was not updated");
+            })
+         .getCurrentUrl()
+            .then(function(url) {
+               assert.notInclude(url, "#", "A hash should not have been set");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/search/SearchSuggestionsTest.js
+++ b/aikau/src/test/resources/alfresco/search/SearchSuggestionsTest.js
@@ -31,72 +31,34 @@ define(["intern!object",
 
    var browser;
    registerSuite({
-      name: "Search Suggestions Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/SearchSuggestions", "Search Suggestions Tests").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Test Initial Rendering": function () {
-         var testname = "Search Suggestions - test initial rendering";
-         // Check that alternative suggestion isn't displayed
-         return browser.findByCssSelector(".alfresco-search-AlternativeSearchLabel")
-            .then(
-               function() {
-                  TestCommon.log(testname, "Found the AlternativeSearchLabel widget...");
-               },
-               function() {
-                  assert(false, "Test #1a - Couldn't find the AlternativeSearchLabel widget");
-               }
-            )
-            .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the AlternativeSearchLabel is initially hidden...");
-               assert(result === false, "Test #1b - The AlternativeSearchLabel was not initially hidden");
-            })
-         .end()
-
-         // Check that search suggestions aren't displayed
-         .findByCssSelector("#SEARCHED_ON")
-            .then(
-               function() {
-                  TestCommon.log(testname, "Found the search suggestions list...");
-               },
-               function() {
-                  assert(false, "Test #1c - Couldn't find the search suggestions list widget");
-               }
-            )
-            .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the search suggestions list is initially hidden...");
-               assert(result === false, "Test #1d - The search suggestions list was not initially hidden");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   });
-
-   registerSuite({
       name: "Search Suggestions Tests (Alternative Searches)",
 
       setup: function() {
          browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/SearchSuggestions", "Search Suggestions Tests (Alternative Searches)").end();
+         return TestCommon.loadTestWebScript(this.remote, "/SearchSuggestions#searchTerm=test", "Search Suggestions Tests (Alternative Searches)").end();
       },
 
       beforeEach: function() {
          browser.end();
       },
 
-      "Test Alternative Search": function () {
-         var testname = "Search Suggestions - test alternative search";
+      "Check alternative search label": function () {
+         return browser.findByCssSelector(".alfresco-search-AlternativeSearchLabel")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The AlternativeSearchLabel was not initially hidden");
+            });
+      },
+
+      "Check search suggestions aren't initially displayed": function() {
+         return browser.findByCssSelector("#SEARCHED_ON")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The search suggestions list was not initially hidden");
+            });
+      },
+
+      "Check that the alternative search label is revealed": function () {
          // Click the button to simulate a search result that used an alternative search term
          return browser.findByCssSelector("#SIM_ALT_SEARCH_label")
             .click()
@@ -105,51 +67,48 @@ define(["intern!object",
          // Check that the alternative suggestion widget is displayed
          .findByCssSelector(".alfresco-search-AlternativeSearchLabel")
             .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the AlternativeSearchLabel has been revealed...");
-               assert(result === true, "Test #2a - The AlternativeSearchLabel was not revealed");
-            })
-         .end()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The AlternativeSearchLabel was not revealed");
+            });
+      },
 
-         // Check that the searchedFor and searchRequest terms are rendered correctly
-         .findByCssSelector(".alfresco-search-AlternativeSearchLabel > .searched-for-term > .search-term-link")
+      "Check the alternative search term rendering": function() {
+         return browser.findByCssSelector(".alfresco-search-AlternativeSearchLabel > .searched-for-term > .search-term-link")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Check the alternative search term rendering...");
-               assert(text === "test", "Test #2b - The alternative search term was not rendered correctly: " + text);
-            })
-         .end()
-         .findByCssSelector(".alfresco-search-AlternativeSearchLabel > .original-term > .search-term-link")
+               assert.equal(text, "test", "The alternative search term was not rendered correctly");
+            });
+      },
+
+      "Check the original search term rendering": function() {
+         return browser.findByCssSelector(".alfresco-search-AlternativeSearchLabel > .original-term > .search-term-link")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Check the original search term rendering...");
-               assert(text === "tast", "Test #2b - The original search term was not rendered correctly: " + text);
-            })
-         .end()
+               assert.equal(text, "tast", "The original search term was not rendered correctly");
+            });
+      },
 
-         // Click the alternative search term
-         .findByCssSelector(".alfresco-search-AlternativeSearchLabel > .searched-for-term > .search-term-link")
+      "Check the URL has been updated correctly when clicking on the alternative search term": function() {
+         return browser.findByCssSelector(".alfresco-search-AlternativeSearchLabel > .searched-for-term > .search-term-link")
             .click()
          .end()
 
          // Check the URL is updated correctly
          .getCurrentUrl()
             .then(function(url) {
-               TestCommon.log(testname, "Check the URL has been updated correctly when clicking on the alternative search term...");
-               assert(url.indexOf("#searchTerm=test") !== -1, "Test #2c - Clicking on the alternative search term did not update the URL correctly: " + url);
-            })
-         .end()
+               assert.include(url, "#searchTerm=test", "Clicking on the alternative search term did not update the URL correctly: " + url);
+            });
+      },
 
-         // Click the original search term
-         .findByCssSelector(".alfresco-search-AlternativeSearchLabel > .original-term > .search-term-link")
+      "Check the URL has been updated correctly when clicking on the original search term": function() {
+         return browser.findByCssSelector(".alfresco-search-AlternativeSearchLabel > .original-term > .search-term-link")
             .click()
          .end()
 
          // Check the URL is updated correctly
          .getCurrentUrl()
             .then(function(url) {
-               TestCommon.log(testname, "Check the URL has been updated correctly when clicking on the original search term...");
-               assert(url.indexOf("#searchTerm=tast") !== -1, "Test #2c - Clicking on the original search term did not update the URL correctly: " + url);
+               assert.include(url, "#searchTerm=tast", "Clicking on the original search term did not update the URL correctly: " + url);
             });
       },
 
@@ -170,8 +129,7 @@ define(["intern!object",
          browser.end();
       },
 
-      "Test Search Suggestions": function () {
-         var testname = "Search Suggestions - check initial rendering";
+      "Check that the search suggestions is revealed": function () {
          // Click the button to simulate a search result containing suggested search terms
          return browser.findByCssSelector("#SIM_SEARCH_SUGGESTIONS_label")
             .click()
@@ -180,35 +138,31 @@ define(["intern!object",
          // Check that search suggestions are displayed
          .findByCssSelector("#SEARCHED_ON")
             .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the search suggestions is revealed...");
-               assert(result === true, "Test #3a - The search suggestions list was not revealed");
-            })
-         .end()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The search suggestions list was not revealed");
+            });
+      },
 
-         // Count the suggestions
-         .findAllByCssSelector("#SEARCHED_ON tr")
+      "Check that there are 3 suggestions": function() {
+         return browser.findAllByCssSelector("#SEARCHED_ON tr")
             .then(function(elements) {
-               TestCommon.log(testname, "Check that there are 3 suggestions...");
-               assert(elements.length === 3, "Test #3b - The wrong number of search suggestions were shown: " + elements.length);
-            })
-         .end()
+               assert.lengthOf(elements, 3, "The wrong number of search suggestions were shown");
+            });
+      },
 
-         // Click on the first suggestion
-         .findByCssSelector("#SEARCHED_ON tr:first-child span.value")
+      "Check that the suggestion is rendered correctly": function() {
+         return browser.findByCssSelector("#SEARCHED_ON tr:first-child span.value")
             .getVisibleText()
             .then(function(text) {
-               TestCommon.log(testname, "Check that the suggestion is rendered correctly...");
-               assert(text === "test", "Test #3c - The search suggestion was rendered incorrectly: " + text);
+               assert.equal(text, "test", "The search suggestion was rendered incorrectly");
             })
-            .click()
-         .end()
+            .click();
+      },
 
-         // Check the URL is updated correctly
-         .getCurrentUrl()
+      "Check the URL has been updated correctly when clicking on the search suggestion": function() {
+         return browser.getCurrentUrl()
             .then(function(url) {
-               TestCommon.log(testname, "Check the URL has been updated correctly when clicking on the search suggestion...");
-               assert(url.indexOf("#searchTerm=test") !== -1, "Test #3d - Clicking on the search suggestion did not update the URL correctly: " + url);
+               assert.include(url, "#searchTerm=test", "Clicking on the search suggestion did not update the URL correctly: " + url);
             });
       },
 
@@ -229,9 +183,7 @@ define(["intern!object",
          browser.end();
       },
 
-      "Test Standard Search": function () {
-
-         var testname = "Search Suggestions - check initial rendering";
+      "Check that the alternative search label is still hidden": function () {
          // Click the button to simulate a search result containing suggested search terms
          return browser.findByCssSelector("#SIM_NORMAL_SEARCH_label")
             .click()
@@ -240,18 +192,17 @@ define(["intern!object",
          // Check that neither the alternative search nor the search suggestions are displayed...
          .findByCssSelector(".alfresco-search-AlternativeSearchLabel")
             .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the AlternativeSearchLabel is still hidden...");
-               assert(result === false, "Test #4a - The AlternativeSearchLabel did not remain hidden");
-            })
-         .end()
-         .findByCssSelector("#SEARCHED_ON")
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The AlternativeSearchLabel did not remain hidden");
+            });
+      },
+
+      "Check that the search suggestions list is still hidden": function() {
+         return browser.findByCssSelector("#SEARCHED_ON")
             .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the search suggestions list is still hidden...");
-               assert(result === false, "Test #4b - The search suggestions list did not remain hidden");
-            })
-         .end();
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The search suggestions list did not remain hidden");
+            });
       },
 
       "Post Coverage Results": function() {
@@ -271,8 +222,7 @@ define(["intern!object",
          browser.end();
       },
 
-      "Test Visibity Config": function () {
-         var testname = "Search Suggestions - check visibility config";
+      "Check that the AlternativeSearchLabel is hidden": function () {
          // Show both alt search and suggestions...
          return browser.findByCssSelector("#SIM_ALT_SEARCH_label")
             .click()
@@ -289,18 +239,17 @@ define(["intern!object",
          // Check that neither the alternative search nor the search suggestions are displayed...
          .findByCssSelector(".alfresco-search-AlternativeSearchLabel")
             .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the AlternativeSearchLabel is hidden...");
-               assert(result === false, "Test #5a - The AlternativeSearchLabel was not hidden");
-            })
-         .end()
-         .findByCssSelector("#SEARCHED_ON")
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The AlternativeSearchLabel was not hidden");
+            });
+      },
+
+      "Check that the search suggestions list is hidden": function() {
+         return browser.findByCssSelector("#SEARCHED_ON")
             .isDisplayed()
-            .then(function(result) {
-               TestCommon.log(testname, "Check that the search suggestions list is hidden...");
-               assert(result === false, "Test #5b - The search suggestions list was not hidden");
-            })
-         .end();
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The search suggestions list was not hidden");
+            });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -209,6 +209,7 @@ define({
       "src/test/resources/alfresco/search/AlfSearchResultTest",
       "src/test/resources/alfresco/search/CustomSearchResultTest",
       "src/test/resources/alfresco/search/FacetFiltersTest",
+      "src/test/resources/alfresco/search/NoHashSearchingTest",
       "src/test/resources/alfresco/search/SearchSuggestionsTest",
 
       "src/test/resources/alfresco/services/ActionServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/NoHashSearching.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/NoHashSearching.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Searching without URL hashing</shortname>
+  <description>This page demonstrates the search related widgets configured to not use the URL hash</description>
+  <family>aikau-unit-tests</family>
+  <url>/NoHashSearching</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/NoHashSearching.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/NoHashSearching.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/NoHashSearching.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/NoHashSearching.get.js
@@ -1,0 +1,172 @@
+model.jsonModel = {
+   services: [
+       {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "aikauTesting/mockservices/SearchMockService",
+      "alfresco/services/NavigationService"
+   ],
+   widgets: [
+      {
+         id: "FCTSRCH_TOP_MENU_BAR_SCOPE_MENU_BAR",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "FCTSRCH_SCOPE_SELECTION_MENU",
+                  name: "alfresco/menus/AlfMenuBarSelect",
+                  config: {
+                     selectionTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                     widgets: [
+                        {
+                           id: "FCTSRCH_SCOPE_SELECTION_MENU_GROUP",
+                           name: "alfresco/menus/AlfMenuGroup",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "FCTSRCH_SET_ALL_SITES_SCOPE",
+                                    name: "alfresco/menus/AlfCheckableMenuItem",
+                                    config: {
+                                       label: "All Sites",
+                                       value: "all_sites",
+                                       group: "SEARCHLIST_SCOPE",
+                                       publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                                       checked: false,
+                                       publishPayload: {
+                                          label: "All Sites",
+                                          value: "all_sites"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "FCTSRCH_SET_REPO_SCOPE",
+                                    name: "alfresco/menus/AlfCheckableMenuItem",
+                                    config: {
+                                       label: "Repository",
+                                       value: "repo",
+                                       group: "SEARCHLIST_SCOPE",
+                                       publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                                       checked: true,
+                                       publishPayload: {
+                                          label: "Repository",
+                                          value: "repo"
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "FCTSRCH_SEARCH_FORM",
+         name: "alfresco/forms/SingleComboBoxForm",
+         config: {
+            useHash: false,
+            okButtonLabel: "OK",
+            okButtonPublishTopic : "ALF_SET_SEARCH_TERM",
+            okButtonPublishGlobal: true,
+            okButtonIconClass: "alf-white-search-icon",
+            okButtonClass: "call-to-action",
+            textFieldName: "searchTerm",
+            textBoxIconClass: "alf-search-icon",
+            textBoxCssClasses: "long hiddenlabel",
+            textBoxLabel: "Search",
+            queryAttribute: "term",
+            optionsPublishTopic: "ALF_AUTO_SUGGEST_SEARCH",
+            optionsPublishPayload: {
+               resultsProperty: "response.suggestions"
+            }
+         }
+      },
+      {
+         id: "ALTERNATIVE_SEARCH",
+         name: "alfresco/search/AlternativeSearchLabel",
+         config: {
+            useHash: false,
+            visibilityConfig: {
+               initialValue: false,
+               rules: [
+                  {
+                     topic: "ALF_SEARCH_REQUEST",
+                     attribute: "term",
+                     isNot: [""]
+                  },
+                  {
+                     topic: "ALF_SPELL_CHECK_SEARCH_TERM",
+                     attribute: "searchedFor",
+                     is: ["home"]
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "alfresco/search/FacetFilters",
+         config: {
+            additionalCssClasses: "separated",
+            label: "Created",
+            facetQName: "{http://www.alfresco.org/model/content/1.0}created",
+            sortBy: "INDEX",
+            maxFilters: 5,
+            hitThreshold: 1,
+            minFilterValueLength: 4,
+            useHash: false,
+            headingLevel: 3,
+            blockIncludeFacetRequest: false
+         }
+      },
+      {
+         id: "SEARCH_RESULTS_LIST",
+         name: "alfresco/search/AlfSearchList",
+         config: {
+            waitForPageWidgets: true,
+            useHash: false,
+            loadDataPublishTopic: "SEARCH_RESULTS",
+            widgets: [
+               {
+                  id: "SEARCH_RESULTS_VIEW",
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "displayName"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchSugggestions.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchSugggestions.get.js
@@ -93,6 +93,7 @@ model.jsonModel = {
          name: "alfresco/search/AlfSearchList",
          config: {
             waitForPageWidgets: true,
+            useHash: true,
             loadDataPublishTopic: "SEARCH_RESULTS",
             widgets: [
                {
@@ -222,10 +223,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SearchMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SearchMockService.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "dojo/_base/lang",
+        "dojo/text!./responseTemplates/SearchService/alternative.json",
+        "dojo/text!./responseTemplates/SearchService/original.json",
+        "dojo/text!./responseTemplates/SearchService/default.json"],
+        function(declare, AlfCore, lang, alternative, original, base) {
+   
+   return declare([AlfCore], {
+      
+      /**
+       * 
+       * @instance
+       * @param {array} args Constructor arguments
+       */
+      constructor: function alfresco_testing_mockservices_SearchService__constructor(args) {
+         lang.mixin(this, args);
+         this.alfSubscribe("ALF_SEARCH_REQUEST", lang.hitch(this, this.onSearchRequest));
+      },
+
+      /**
+       *
+       * @instance
+       * @param {object} payload The payload defining the document to retrieve the details for.
+       */
+      onSearchRequest: function alfresco_testing_mockservices_SearchService__onSearchRequest(payload) {
+         if (payload.term === "hame" && payload.spellcheck === true)
+         {
+            this.alfPublish("SEARCH_RESULTS_SUCCESS", {
+               response: JSON.parse(alternative)
+            });
+         }
+         else if (payload.term === "hame" && payload.spellcheck === false)
+         {
+            this.alfPublish("SEARCH_RESULTS_SUCCESS", {
+               response: JSON.parse(original)
+            });
+         }
+         else
+         {
+            this.alfPublish("SEARCH_RESULTS_SUCCESS", {
+               response: JSON.parse(base)
+            });
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchService/alternative.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchService/alternative.json
@@ -1,0 +1,335 @@
+{
+   "totalRecords": 10,
+   "totalRecordsUpper": -1,
+   "startIndex": 0,
+   "numberFound": 10,
+   "facets":
+   {
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}created":
+      [
+         {
+         "label": "faceted-search.date.one-month.label",
+         "value": "NOW\/DAY-1MONTH\"..\"NOW\/DAY+1DAY",
+         "hits": 7,
+         "index": 2
+         },
+         {
+         "label": "faceted-search.date.one-week.label",
+         "value": "NOW\/DAY-7DAYS\"..\"NOW\/DAY+1DAY",
+         "hits": 5,
+         "index": 1
+         },
+         {
+         "label": "faceted-search.date.one-year.label",
+         "value": "NOW\/DAY-1YEAR\"..\"NOW\/DAY+1DAY",
+         "hits": 10,
+         "index": 4
+         },
+         {
+         "label": "faceted-search.date.six-months.label",
+         "value": "NOW\/DAY-6MONTHS\"..\"NOW\/DAY+1DAY",
+         "hits": 10,
+         "index": 3
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}creator":
+      [
+         {
+         "label": "Administrator",
+         "value": "admin",
+         "hits": 10,
+         "index": -1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}modified":
+      [
+         {
+         "label": "faceted-search.date.one-month.label",
+         "value": "NOW\/DAY-1MONTH\"..\"NOW\/DAY+1DAY",
+         "hits": 7,
+         "index": 2
+         },
+         {
+         "label": "faceted-search.date.one-year.label",
+         "value": "NOW\/DAY-1YEAR\"..\"NOW\/DAY+1DAY",
+         "hits": 10,
+         "index": 4
+         },
+         {
+         "label": "faceted-search.date.six-months.label",
+         "value": "NOW\/DAY-6MONTHS\"..\"NOW\/DAY+1DAY",
+         "hits": 10,
+         "index": 3
+         },
+         {
+         "label": "faceted-search.date.one-week.label",
+         "value": "NOW\/DAY-7DAYS\"..\"NOW\/DAY+1DAY",
+         "hits": 5,
+         "index": 1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}modifier":
+      [
+         {
+         "label": "Administrator",
+         "value": "admin",
+         "hits": 10,
+         "index": -1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}content.mimetype":
+      [
+         {
+         "label": "JavaScript",
+         "value": "application\/x-javascript",
+         "hits": 5,
+         "index": -1
+         },
+         {
+         "label": "Plain Text",
+         "value": "text\/plain",
+         "hits": 4,
+         "index": -1
+         },
+         {
+         "label": "XML",
+         "value": "text\/xml",
+         "hits": 1,
+         "index": -1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}content.size":
+      [
+         {
+         "label": "faceted-search.size.10-100KB.label",
+         "value": "10240\"..\"102400",
+         "hits": 2,
+         "index": 1
+         },
+         {
+         "label": "faceted-search.size.0-10KB.label",
+         "value": "0\"..\"10240",
+         "hits": 7,
+         "index": 0
+         },
+         {
+         "label": "faceted-search.size.1-16MB.label",
+         "value": "1048576\"..\"16777216",
+         "hits": 1,
+         "index": 3
+         }
+      ]
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/9f37ca25-2574-4973-a7c6-ed92081bdc10",
+         "type": "document",
+         "name": "home.get.desc.xml",
+         "displayName": "home.get.desc.xml",
+         "description": "",
+         "modifiedOn": "2015-07-28T17:05:33.728+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 111,
+         "mimetype": "text\/xml",
+         "path": "\/Company Home\/folder1",
+         "lastThumbnailModification":
+         [
+          "doclib:1438099536076"
+          
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/9000dea9-89d9-474b-b3c4-293bfa9097a3",
+         "type": "document",
+         "name": "home.get-1.js",
+         "displayName": "home.get-1.js",
+         "description": "",
+         "modifiedOn": "2015-07-29T16:35:53.259+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 11367,
+         "mimetype": "application\/x-javascript",
+         "path": "\/Company Home\/Shared\/folder1",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/6e7d9cab-e6c1-4dfe-9362-a635a6a5af22",
+         "type": "document",
+         "name": "home.get-2.js",
+         "displayName": "home.get-2.js",
+         "description": "",
+         "modifiedOn": "2015-07-29T16:40:26.332+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 11367,
+         "mimetype": "application\/x-javascript",
+         "path": "\/Company Home\/Shared\/folder1",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/21b70b47-b235-4687-b78d-89c64e8daf09",
+         "type": "document",
+         "name": "UseCase1.get.js",
+         "displayName": "UseCase1.get.js",
+         "description": "",
+         "modifiedOn": "2015-06-29T10:20:51.372+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 4477,
+         "mimetype": "application\/x-javascript",
+         "path": "\/Company Home\/User Homes\/chris",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/879ea085-fa8c-41f1-a35f-24c28836c49a",
+         "type": "document",
+         "name": "UseCase1.get.js",
+         "displayName": "UseCase1.get.js",
+         "description": "",
+         "modifiedOn": "2015-06-29T15:15:57.422+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 4477,
+         "mimetype": "application\/x-javascript",
+         "site":
+         {
+            "shortName": "site1",
+            "title": "Site1"
+         },
+         "container": "documentLibrary",
+         "path": "",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/84d2b839-032b-40b9-89c3-c0e23001c527",
+         "type": "document",
+         "name": "tmp.js",
+         "displayName": "tmp.js",
+         "description": "",
+         "modifiedOn": "2015-06-29T15:15:57.519+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 4665,
+         "mimetype": "application\/x-javascript",
+         "site":
+         {
+            "shortName": "site1",
+            "title": "Site1"
+         },
+         "container": "documentLibrary",
+         "path": "",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/9512f54b-4af6-4303-b821-3ccece108920",
+         "type": "document",
+         "name": "home.get.html.ftl",
+         "displayName": "home.get.html.ftl",
+         "description": "",
+         "modifiedOn": "2015-07-28T17:05:05.584+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 34,
+         "mimetype": "text\/plain",
+         "path": "\/Company Home\/folder1",
+         "lastThumbnailModification":
+         [
+          "doclib:1438099521681"
+          
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/1a868fd0-7e9c-4404-b258-b57e555c39a4",
+         "type": "document",
+         "name": "home.get.html.ftl",
+         "displayName": "home.get.html.ftl",
+         "description": "",
+         "modifiedOn": "2015-07-29T16:39:55.708+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 34,
+         "mimetype": "text\/plain",
+         "path": "\/Company Home\/Shared\/folder2\/Folder 3",
+         "lastThumbnailModification":
+         [
+          "doclib:1438184408005"
+          
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/4fea4acf-6ee7-4a71-9eb5-f21048f7673e",
+         "type": "document",
+         "name": "home.get.html.ftl",
+         "displayName": "home.get.html.ftl",
+         "description": "",
+         "modifiedOn": "2015-07-29T15:56:02.930+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 34,
+         "mimetype": "text\/plain",
+         "path": "\/Company Home\/Shared\/folder1",
+         "lastThumbnailModification":
+         [
+          "doclib:1438181766772"
+          
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/644a2c13-93d1-4472-8c6d-137c7b9a2aef",
+         "type": "document",
+         "name": "home.get.html.ftl",
+         "displayName": "home.get.html.ftl",
+         "description": "",
+         "modifiedOn": "2015-07-30T10:54:59.153+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 1633309,
+         "mimetype": "text\/plain",
+         "path": "\/Company Home\/Shared",
+         "lastThumbnailModification":
+         [
+          "doclib:1438250102288"
+          ,
+          "imgpreview:1438705092869"
+          
+         ],
+         "tags": []
+      }
+   ],
+   "spellcheck":
+   {
+         "searchRequest": "hame",
+         "searchedFor": "home"
+   }
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchService/default.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchService/default.json
@@ -1,0 +1,161 @@
+{
+   "totalRecords": 3,
+   "totalRecordsUpper": -1,
+   "startIndex": 0,
+   "numberFound": 3,
+   "facets":
+   {
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}created":
+      [
+         {
+         "label": "faceted-search.date.one-month.label",
+         "value": "NOW\/DAY-1MONTH\"..\"NOW\/DAY+1DAY",
+         "hits": 2,
+         "index": 2
+         },
+         {
+         "label": "faceted-search.date.one-week.label",
+         "value": "NOW\/DAY-7DAYS\"..\"NOW\/DAY+1DAY",
+         "hits": 2,
+         "index": 1
+         },
+         {
+         "label": "faceted-search.date.one-year.label",
+         "value": "NOW\/DAY-1YEAR\"..\"NOW\/DAY+1DAY",
+         "hits": 3,
+         "index": 4
+         },
+         {
+         "label": "faceted-search.date.six-months.label",
+         "value": "NOW\/DAY-6MONTHS\"..\"NOW\/DAY+1DAY",
+         "hits": 3,
+         "index": 3
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}creator":
+      [
+         {
+         "label": "Administrator",
+         "value": "admin",
+         "hits": 3,
+         "index": -1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}modified":
+      [
+         {
+         "label": "faceted-search.date.one-month.label",
+         "value": "NOW\/DAY-1MONTH\"..\"NOW\/DAY+1DAY",
+         "hits": 2,
+         "index": 2
+         },
+         {
+         "label": "faceted-search.date.one-year.label",
+         "value": "NOW\/DAY-1YEAR\"..\"NOW\/DAY+1DAY",
+         "hits": 3,
+         "index": 4
+         },
+         {
+         "label": "faceted-search.date.six-months.label",
+         "value": "NOW\/DAY-6MONTHS\"..\"NOW\/DAY+1DAY",
+         "hits": 3,
+         "index": 3
+         },
+         {
+         "label": "faceted-search.date.one-week.label",
+         "value": "NOW\/DAY-7DAYS\"..\"NOW\/DAY+1DAY",
+         "hits": 2,
+         "index": 1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}modifier":
+      [
+         {
+         "label": "Administrator",
+         "value": "admin",
+         "hits": 3,
+         "index": -1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}content.mimetype":
+      [
+         {
+         "label": "Plain Text",
+         "value": "text\/plain",
+         "hits": 1,
+         "index": -1
+         }
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}content.size":
+      [
+         {
+         "label": "faceted-search.size.1-16MB.label",
+         "value": "1048576\"..\"16777216",
+         "hits": 1,
+         "index": 3
+         }
+      ]
+   },
+   "items":
+   [
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/9e1bc0f4-23d9-4283-9312-fb5cc323d828",
+         "type": "folder",
+         "name": "Template",
+         "displayName": "Template",
+         "title": "bob",
+         "description": "moo",
+         "modifiedOn": "2015-07-30T08:56:19.666+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": -1,
+         "mimetype": "application\/octet-stream",
+         "path": "\/Company Home\/Shared\/folder1",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/b325a97b-23c9-49f4-9ee8-d2fafcf4c36a",
+         "type": "folder",
+         "name": "bob@bob",
+         "displayName": "bob@bob",
+         "description": "",
+         "modifiedOn": "2015-06-25T15:25:08.269+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": -1,
+         "mimetype": "application\/octet-stream",
+         "path": "\/Company Home\/User Homes",
+         "lastThumbnailModification":
+         [
+         ],
+         "tags": []
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/644a2c13-93d1-4472-8c6d-137c7b9a2aef",
+         "type": "document",
+         "name": "home.get.html.ftl",
+         "displayName": "home.get.html.ftl",
+         "description": "",
+         "modifiedOn": "2015-07-30T10:54:59.153+01:00",
+         "modifiedByUser": "admin",
+         "modifiedBy": "Administrator ",
+         "fromDate": "",
+         "size": 1633309,
+         "mimetype": "text\/plain",
+         "path": "\/Company Home\/Shared",
+         "lastThumbnailModification":
+         [
+          "doclib:1438250102288"
+          ,
+          "imgpreview:1438705092869"
+          
+         ],
+         "tags": []
+      }
+   ]
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchService/original.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchService/original.json
@@ -1,0 +1,33 @@
+{
+   "totalRecords": 0,
+   "totalRecordsUpper": -1,
+   "startIndex": 0,
+   "numberFound": 0,
+   "facets":
+   {
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}created":
+      [
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}creator":
+      [
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}modified":
+      [
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}modifier":
+      [
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}content.mimetype":
+      [
+      ],
+      "@{http:\/\/www.alfresco.org\/model\/content\/1.0}content.size":
+      [
+      ]
+   },
+   "items":
+   [
+   ],
+   "spellcheck":
+   {
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-472, https://issues.alfresco.com/jira/browse/AKU-475 and https://issues.alfresco.com/jira/browse/AKU-488 to make a number of changes required to enable the search widgets to be used with useHash configured to be false.