### PR TITLE
AKU-497: Paging broken in list when using hash

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -123,13 +123,8 @@ define(["dojo/_base/declare",
                return !!dataFilter.value;
             });
 
-            // Update the filter fields and reload the data
-            if (this._readyToLoad) {
-               this._updateFilterFieldsFromHash();
-               this.loadData();
-            } else {
-               this.alfLog("info", "Hash change not updating filter as ready-to-load check failed");
-            }
+            // Update the filter fields
+            this._updateFilterFieldsFromHash();
          }
 
          // Call inherited

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -281,9 +281,9 @@ define(["dojo/_base/declare",
       /**
        * @instance
        * @type {number}
-       * @default 250
+       * @default
        */
-      _filterDelay: 250,
+      _filterDelay: 1000,
 
       /**
        * An array of the topics to subscribe to that when published provide data that the indicates how the

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -367,11 +367,11 @@ define(["dojo/_base/declare",
        * @instance
        * @overrideable
        */
-      onFiltersUpdated: function(){
+      onFiltersUpdated: function alfresco_lists_AlfList__onFiltersUpdated() {
          this.clearViews();
          this.loadData();
       },
-
+      
       /**
        * This indicates that the instance should wait for all widgets on the page to finish rendering before
        * making any attempt to load data. If this is set to true then loading can begin as soon as this instance

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -187,14 +187,14 @@ define(["intern/dojo/node!fs",
             return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
                .click();
          };
-         command.session.getLastPublish = function(topicName, isGlobal) {
+         command.session.getLastPublish = function(topicName, isGlobal, waitPeriod) {
             return this.getLogEntries({
                type: "PUBLISH",
                topic: topicName,
                pos: "last"
-            }, null, isGlobal);
+            }, isGlobal, waitPeriod);
          };
-         command.session.getLogEntries = function(filter, waitPeriod, isGlobal) {
+         command.session.getLogEntries = function(filter, isGlobal, waitPeriod) {
 
             // Normalise arguments
             filter = filter || {};

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -160,7 +160,7 @@ define(["intern!object",
          .findByCssSelector("#SIMULATE_FILTER_label")
             .click()
          .end()
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED")
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
             .then(function(payload) {
                assert.isNotNull(payload, "More results not loaded");
             })

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -54,7 +54,7 @@ define(["intern!object",
             .end()
 
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
             .end()
 
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
@@ -70,7 +70,7 @@ define(["intern!object",
             .type(keys.BACKSPACE)
             .end()
 
-         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
             .end()
 
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
@@ -89,7 +89,7 @@ define(["intern!object",
             .click()
             .end()
 
-         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
             .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
@@ -105,7 +105,7 @@ define(["intern!object",
             .end()
 
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
             .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")


### PR DESCRIPTION
This addresses issue [AKU-497](https://issues.alfresco.com/jira/browse/AKU-497) which is about paging no longer working in a list when using hash. The fix was to remove a superfluous loadData request. Additionally, the filterDelay has been increased, as per a request in the last Sprint review meeting, in order to avoid pauses in typing causing irritating syncing issues in the filter value. Tests have been updated accordingly.