### PR TITLE
AKU-467: Re-work list local storage fallback

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -100,6 +100,17 @@ define(["dojo/_base/declare",
       parentNavTopic: "ALF_DOCLIST_PARENT_NAV",
 
       /**
+       * Overrides the [inherited default]{@link module:alfresco/lists/AlfHashList#updateInstanceValues}
+       * to ensure that instance values should be updated from the hash. This only appliees when
+       * [useHash]{@link module:alfresco/lists/AlfHashList#useHash} is configured to be true.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      updateInstanceValues: true,
+
+      /**
        * Extends the [inherited function]{@link module:alfresco/lists/AlfSortablePaginatedListt#postMixInProperties}
        * to set a default filter to be a root path.
        *

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -130,6 +130,9 @@ define(["dojo/_base/declare",
                var locallyStoredHash = localStorage.getItem(this.useLocalStorageHashFallbackKey);
                hashString = (locallyStoredHash !== null) ? locallyStoredHash : "";
                this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.updateLocallyStoredHash));
+               
+               // Set the hash from the local storage
+               hashUtils.setHashString(hashString);
             }
             else if (hashString !== "" && 
                      this.useLocalStorageHashFallback === true && 
@@ -137,28 +140,19 @@ define(["dojo/_base/declare",
             {
                // Store the initial hash...
                localStorage.setItem(this.useLocalStorageHashFallbackKey, hashUtils.getHashString());
-            }
 
-            var currHash = ioQuery.queryToObject(hashString);
-            if(!this.doHashVarUpdate(currHash))
-            {
-               if (this.currentFilter)
+               var currHash = ioQuery.queryToObject(hashString);
+               if(this.doHashVarUpdate(currHash, this.updateInstanceValues))
+               {
+                  this.loadData();
+               }
+               else if (this.currentFilter)
                {
                   this.alfPublish("ALF_NAVIGATE_TO_PAGE", {
                      url: ioQuery.objectToQuery(this.currentFilter),
                      type: "HASH"
                   }, true);
                }
-               else
-               {
-                  this.loadData();
-               }
-            }
-            else
-            {
-               // When using hashes (e.g. a URL fragment in the browser address bar) then we need to 
-               // actually get the initial filter and use it to generate the first data set...
-               this.initialiseFilter(hashString); // Function provided by the _AlfHashMixin
             }
          }
          else

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -122,29 +122,20 @@ define(["dojo/_base/declare",
             this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onHashChanged));
 
             var hashString = hashUtils.getHashString();
-            if (hashString === "" && 
-                this.useLocalStorageHashFallback === true && 
-                ("localStorage" in window && window.localStorage !== null))
+            if (hashString === "")
             {
-               // No hash has been provided, check local storage for last hash...
-               var locallyStoredHash = localStorage.getItem(this.useLocalStorageHashFallbackKey);
-               hashString = (locallyStoredHash !== null) ? locallyStoredHash : "";
-               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.updateLocallyStoredHash));
-               
-               // Set the hash from the local storage
-               hashUtils.setHashString(hashString);
-            }
-            else if (hashString !== "" && 
-                     this.useLocalStorageHashFallback === true && 
-                     ("localStorage" in window && window.localStorage !== null))
-            {
-               // Store the initial hash...
-               localStorage.setItem(this.useLocalStorageHashFallbackKey, hashUtils.getHashString());
-
-               var currHash = ioQuery.queryToObject(hashString);
-               if(this.doHashVarUpdate(currHash, this.updateInstanceValues))
+               if (this.useLocalStorageHashFallback === true && 
+                   ("localStorage" in window && window.localStorage !== null))
                {
-                  this.loadData();
+                  // No hash has been provided, check local storage for last hash...
+                  var locallyStoredHash = localStorage.getItem(this.useLocalStorageHashFallbackKey);
+                  hashString = (locallyStoredHash !== null) ? locallyStoredHash : "";
+                  this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.updateLocallyStoredHash));
+               }
+
+               if (hashString)
+               {
+                  hashUtils.setHashString(hashString);
                }
                else if (this.currentFilter)
                {
@@ -153,6 +144,24 @@ define(["dojo/_base/declare",
                      type: "HASH"
                   }, true);
                }
+               else
+               {
+                  this.loadData();
+               }
+            }
+            else 
+            {
+               if (this.useLocalStorageHashFallback === true && 
+                   ("localStorage" in window && window.localStorage !== null))
+               {
+                  // Store the initial hash...
+                  localStorage.setItem(this.useLocalStorageHashFallbackKey, hashString);
+               }
+
+               var currHash = ioQuery.queryToObject(hashString);
+               this.doHashVarUpdate(currHash, this.updateInstanceValues);
+               this._updateCoreHashVars(currHash);
+               this.loadData();
             }
          }
          else

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -114,6 +114,17 @@ define(["dojo/_base/declare",
       spellcheck: true,
 
       /**
+       * Overrides the [inherited default]{@link module:alfresco/lists/AlfHashList#updateInstanceValues}
+       * to ensure that instance values should be updated from the hash. This only appliees when
+       * [useHash]{@link module:alfresco/lists/AlfHashList#useHash} is configured to be true.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      updateInstanceValues: true,
+
+      /**
        * The vars and terms showing on the url hash that should be reset for a new search.
        *
        * @instance

--- a/aikau/src/test/resources/alfresco/lists/LocalStorageFallbackTest.js
+++ b/aikau/src/test/resources/alfresco/lists/LocalStorageFallbackTest.js
@@ -1,0 +1,237 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+
+   // The first test page has a list that does not fallback on local storage and has no current filter...
+   registerSuite({
+      name: "List Local Storage (1)",
+      
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/ListLocalStorageFallback", "List Local Storage (1)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "When there is no hash only topic is published": function() {
+         return browser.findById("LIST").end()
+            .getLastPublish("LOAD")
+               .then(function(payload) {
+                  assert.isNotNull(payload, "The list should have requested data");
+               });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // The second test page sets local storage using the current filter...
+   registerSuite({
+      name: "List Local Storage (2)",
+      
+      setup: function() {
+         browser = this.remote;
+         browser.clearLocalStorage(); // NOTE: Need to clear previous local storage...
+         return TestCommon.loadTestWebScript(this.remote, 
+                                             "/ListLocalStorageFallback?listType=CurrentFilterWithLocalStorage", 
+                                             "List Local Storage (2)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Data should have been requested": function() {
+         return browser.findById("LIST").end()
+            .getLastPublish("LOAD")
+               .then(function(payload) {
+                  assert.isNotNull(payload, "The list should have requested data");
+               });
+      },
+
+      "When there is no hash, the current filter is set as the hash": function() {
+         return browser.getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "#key2=value2&key1=value1", "The URL hash was not set to the current filter");
+            });
+      },
+     
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // The third test page has a hash which trumps the current filter and is stored...
+   registerSuite({
+      name: "Local Storage for Lists Tests (3)",
+      
+      setup: function() {
+         // NOTE: Do not clear local storage this time!
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, 
+                                             "/ListLocalStorageFallback?listType=CurrentFilterWithLocalStorage#key3=value3", 
+                                             "Local Storage for Lists Tests (3)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "When there is a hash, the current filter should not be used": function() {
+         return browser.getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "#key3=value3", "The requested URL hash was not retained");
+            });
+      },
+     
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // The fourth test page has no hash, and although there is a current filter the locally stored hash is used...
+   registerSuite({
+      name: "Local Storage for Lists Tests (4)",
+      
+      setup: function() {
+         // NOTE: Do not clear local storage this time!
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, 
+                                             "/ListLocalStorageFallback?listType=CurrentFilterWithLocalStorage", 
+                                             "Local Storage for Lists Tests (4)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "When there is no hash, local storage should trump the current filter": function() {
+         return browser.getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "#key3=value3", "Local storage was NOT used as the hash");
+            });
+      },
+     
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // The fifth test page has no hash, and the list is configured to not use the previously stored
+   // hash to the current filter should be used...
+   registerSuite({
+      name: "Local Storage for Lists Tests (5)",
+      
+      setup: function() {
+         // NOTE: Do not clear local storage this time!
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, 
+                                             "/ListLocalStorageFallback?listType=CurrentFilter", 
+                                             "Local Storage for Lists Tests (5)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "When there is no hash and local storage is available the current filter should still be used": function() {
+         return browser.getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "#key2=value2&key1=value1", "Current filter was not used");
+            });
+      },
+     
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // The sixth test page has a list without a current filter, it should re-use the locally stored hash
+   registerSuite({
+      name: "Local Storage for Lists Tests (6)",
+      
+      setup: function() {
+         // NOTE: Do not clear local storage this time!
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, 
+                                             "/ListLocalStorageFallback?listType=LocalStorage", 
+                                             "Local Storage for Lists Tests (6)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "When there is no hash, local storage should be used": function() {
+         return browser.getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "#key3=value3", "Local storage was NOT used as the hash");
+            });
+      },
+     
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   // The sixth test page has a list but sets a hash which should be used...
+   registerSuite({
+      name: "Local Storage for Lists Tests (7)",
+      
+      setup: function() {
+         // NOTE: Do not clear local storage this time!
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, 
+                                             "/ListLocalStorageFallback?listType=LocalStorage#update=test", 
+                                             "Local Storage for Lists Tests (7)").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "When there is a hash it should be used": function() {
+         return browser.getCurrentUrl()
+            .then(function (url) {
+               assert.include(url, "#update=test", "Local storage should not have been used as the hash");
+            })
+            .getLastPublish("LOAD")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "update", "test", "The data request did not include the hash parameter");
+               });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -143,6 +143,7 @@ define({
       "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
       "src/test/resources/alfresco/lists/FilteredListTest",
       "src/test/resources/alfresco/lists/InfiniteScrollTest",
+      "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
       "src/test/resources/alfresco/lists/views/AlfListViewTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/LocalStorageFallback.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/LocalStorageFallback.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Local Storage fallback for lists</shortname>
+  <description>A test page for verifying the local storage fallback behaviour</description>
+  <family>aikau-unit-tests</family>
+  <url>/ListLocalStorageFallback</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/LocalStorageFallback.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/LocalStorageFallback.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/LocalStorageFallback.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/LocalStorageFallback.get.js
@@ -1,0 +1,123 @@
+var views = [
+   {
+      name: "alfresco/lists/views/AlfListView",
+      config: {
+         widgets: [
+            {
+               name: "alfresco/lists/views/layouts/Row",
+               config: {
+                  widgets: [
+                     {
+                        name: "alfresco/lists/views/layout/Cell",
+                        config: {
+                           widgets: [
+                              {
+                                 name: "alfresco/renderers/Property",
+                                 config: {
+                                    propertyToRender: "name"
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   }
+];
+
+/* global page */
+var type = page.url.args.listType;
+var listWidget;
+switch (type) {
+
+   case "CurrentFilter":
+      listWidget = {
+         id: "LIST",
+         name: "alfresco/lists/AlfHashList",
+         config: {
+            useHash: true,
+            useLocalStorageHashFallback: false,
+            loadDataPublishTopic: "LOAD",
+            currentFilter: {
+               key1: "value1",
+               key2: "value2"
+            },
+            widgets: views
+         }
+      };
+      break;
+
+   case "CurrentFilterWithLocalStorage":
+      listWidget = {
+         id: "LIST",
+         name: "alfresco/lists/AlfHashList",
+         config: {
+            useHash: true,
+            useLocalStorageHashFallback: true,
+            loadDataPublishTopic: "LOAD",
+            currentFilter: {
+               key1: "value1",
+               key2: "value2"
+            },
+            widgets: views
+         }
+      };
+      break;
+
+   case "LocalStorage":
+      listWidget = {
+         id: "LIST",
+         name: "alfresco/lists/AlfHashList",
+         config: {
+            useHash: true,
+            useLocalStorageHashFallback: true,
+            loadDataPublishTopic: "LOAD",
+            updateInstanceValues: true,
+            hashVarsForUpdate: [
+               "update"
+            ],
+            mapHashVarsToPayload: true,
+            widgets: views
+         }
+      };
+      break;
+
+   default: 
+      listWidget = {
+         id: "LIST",
+         name: "alfresco/lists/AlfHashList",
+         config: {
+            useHash: true,
+            useLocalStorageHashFallback: false,
+            loadDataPublishTopic: "LOAD",
+            widgets: views
+         }
+      };
+}
+
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets: [
+      listWidget,
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-476 and re-works the use of local storage in lists as a fallback when a URL hash is not available. I've added tests to ensure the correct behaviour and prevent future regressions. I've also tested that the originally reported problem has been resolved on Share.