### PR TITLE
AKU-500: Update response scope behaviour to handle empty string falsy logic

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -455,13 +455,20 @@ define(["dojo/_base/declare",
             // Calculate the scope to be used and thus the scoped topic
             var publishScope = "",
                scopedTopic;
-            if (global === true) {
+            if (global === true) 
+            {
                // No action required
-            } else if (parentScope === true) {
+            } 
+            else if (parentScope === true) 
+            {
                publishScope = this.parentPubSubScope;
-            } else if (typeof customScope !== "undefined") {
+            } 
+            else if (typeof customScope !== "undefined") 
+            {
                publishScope = customScope;
-            } else {
+            } 
+            else 
+            {
                publishScope = this.pubSubScope;
             }
             scopedTopic = publishScope + topic;
@@ -469,7 +476,20 @@ define(["dojo/_base/declare",
             // Update the payload
             payload.alfPublishScope = publishScope;
             payload.alfTopic = scopedTopic;
-            payload.alfResponseScope = payload.responseScope || payload.alfResponseScope || this.pubSubScope;
+
+            // Note that we need to take special attention to falsy behaviour of the global scope
+            // as the empty string is a valid scope. If defined as either the reponseScope or the
+            // alfResponseScope then it should be used...
+            var alfResponseScope  = this.pubSubScope;
+            if (payload.responseScope || payload.responseScope === "")
+            {
+               alfResponseScope = payload.responseScope;
+            }
+            else if (payload.alfResponseScope || payload.alfResponseScope === "")
+            {
+               alfResponseScope = payload.alfResponseScope;
+            }
+            payload.alfResponseScope = alfResponseScope;
 
             // Publish...
             PubQueue.getSingleton().publish(scopedTopic, payload, this);

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateContentMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCreateContentMenuBarPopup.js
@@ -33,9 +33,8 @@ define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarPopup",
         "alfresco/documentlibrary/_AlfCreateContentPermissionsMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "dojo/_base/lang",
-        "dojo/dom-class"], 
-        function(declare, AlfMenuBarPopup, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, lang, domClass) {
+        "dojo/_base/lang"], 
+        function(declare, AlfMenuBarPopup, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin, lang) {
    
    return declare([AlfMenuBarPopup, _AlfCreateContentPermissionsMixin, _AlfDocumentListTopicMixin], {
       

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -77,7 +77,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The details of the content to create
        */
-      onCreateContent: function alfresco_services_ContentService__onCreateFolder(payload) {
+      onCreateContent: function alfresco_services_ContentService__onCreateContent(payload) {
          var parentNodeRef = lang.getObject("currentNode.parent.nodeRef", false, payload);
          if (!parentNodeRef)
          {

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -743,22 +743,11 @@ define(["dojo/_base/declare",
             }
 
             // Mixin in any additional payload information...
-            // Use the alfResponseScope from the current payload if a responseScope isn't available,
-            // but values in the formSubmissionPayloadMixin should trump both...
-            // i.e. We might set an initial responseScope form the current payload, but if one has been
-            //      defined in the formSubmissionPayloadMixin then that's the one to use...
-            if (payload.responseScope || payload.responseScope === "")
-            {
-               lang.mixin(data, {
-                  responseScope: payload.responseScope
-               });
-            }
-            else if (payload.alfResponseScope || payload.alfResponseScope === "")
-            {
-               lang.mixin(data, {
-                  responseScope: payload.alfResponseScope
-               });
-            }
+            // An alfResponseScope should always have been set on a payload so it can be set as the
+            // responseScope, but a responseScope in the formSubmissionPayloadMixin will override it
+            lang.mixin(data, {
+               responseScope: payload.alfResponseScope
+            });
             payload.formSubmissionPayloadMixin && lang.mixin(data, payload.formSubmissionPayloadMixin);
 
             // Using JQuery here in order to support deep merging of dot-notation properties...

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -523,7 +523,6 @@ define(["dojo/_base/declare",
                // Construct the form widgets and then construct the dialog using that configuration...
                var formValue = config.formValue ? config.formValue: {};
                var formConfig = this.createFormConfig(config.widgets, formValue);
-               var showValidationErrorsImmediately = true;
                if (config.showValidationErrorsImmediately === false)
                {
                   formConfig.config.showValidationErrorsImmediately = false;
@@ -744,19 +743,37 @@ define(["dojo/_base/declare",
             }
 
             // Mixin in any additional payload information...
+            // Use the alfResponseScope from the current payload if a responseScope isn't available,
+            // but values in the formSubmissionPayloadMixin should trump both...
+            // i.e. We might set an initial responseScope form the current payload, but if one has been
+            //      defined in the formSubmissionPayloadMixin then that's the one to use...
+            if (payload.responseScope || payload.responseScope === "")
+            {
+               lang.mixin(data, {
+                  responseScope: payload.responseScope
+               });
+            }
+            else if (payload.alfResponseScope || payload.alfResponseScope === "")
+            {
+               lang.mixin(data, {
+                  responseScope: payload.alfResponseScope
+               });
+            }
             payload.formSubmissionPayloadMixin && lang.mixin(data, payload.formSubmissionPayloadMixin);
-            payload.alfResponseScope && lang.mixin(data, {
-               responseScope: payload.alfResponseScope
-            });
 
             // Using JQuery here in order to support deep merging of dot-notation properties...
             $.extend(true, data, formData);
 
             // Publish the topic requested for complete...
+            var customScope;
+            if (payload.formSubmissionScope || payload.formSubmissionScope === "") 
+            {
+               customScope = payload.formSubmissionScope;
+            }
+            
             var topic = payload.formSubmissionTopic,
                globalScope = payload.hasOwnProperty("formSubmissionGlobal") ? !!payload.formSubmissionGlobal : true,
-               toParent = false,
-               customScope = payload.formSubmissionScope || undefined;
+               toParent = false;
             this.alfPublish(topic, data, globalScope, toParent, customScope);
          }
          else

--- a/aikau/src/test/resources/alfresco/core/ResponseScopeTest.js
+++ b/aikau/src/test/resources/alfresco/core/ResponseScopeTest.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Response Scope Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/ResponseScope", "Response Scope Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "pubSubScope used as alfResponseScope when responseScope and alfResponseScope aren't set (global)": function() {
+         return browser.findById("B1_label")
+            .click()
+         .end()
+         .getLastPublish("B1")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "", "Wrong response scope");
+            });
+      },
+
+      "pubSubScope used as alfResponseScope when responseScope and alfResponseScope aren't set (scoped)": function() {
+         return browser.findById("B2_label")
+            .click()
+         .end()
+         .getLastPublish("SCOPE_B2")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "resposeScope used as alfResponseScope when included in payload (global)": function() {
+         return browser.findById("B3_label")
+            .click()
+         .end()
+         .getLastPublish("B3")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "OTHER_SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "resposeScope used as alfResponseScope when included in payload (scoped)": function() {
+         return browser.findById("B4_label")
+            .click()
+         .end()
+         .getLastPublish("SCOPE_B4")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "OTHER_SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "alfResponseScope used as alfResponseScope when included in payload (global)": function() {
+         return browser.findById("B5_label")
+            .click()
+         .end()
+         .getLastPublish("B5")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "THIRD_SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "alfResponseScope used as alfResponseScope when included in payload (scoped)": function() {
+         return browser.findById("B6_label")
+            .click()
+         .end()
+         .getLastPublish("SCOPE_B6")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "THIRD_SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "Dialog with no responseScope uses global scope as alfResponseScope": function() {
+         return browser.findById("B7_label")
+            .click()
+         .end()
+         .findAllByCssSelector("#B7_DIALOG.dialogDisplayed")
+         .end()
+         .findById("B7_DIALOG_OK_label")
+            .click()
+         .end()
+         .getLastPublish("B7_DIALOG")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "", "Wrong response scope");
+            });
+      },
+
+      "Dialog with responseScope used as alfResponseScope": function() {
+         return browser.findById("B8_label")
+            .click()
+         .end()
+         .findAllByCssSelector("#B8_DIALOG.dialogDisplayed")
+         .end()
+         .findById("B8_DIALOG_OK_label")
+            .click()
+         .end()
+         .getLastPublish("B8_DIALOG")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "FOURTH_SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "Dialog with responseScope in used as alfResponseScope": function() {
+         return browser.findById("B9_label")
+            .click()
+         .end()
+         .findAllByCssSelector("#B9_DIALOG.dialogDisplayed")
+         .end()
+         .findById("B9_DIALOG_OK_label")
+            .click()
+         .end()
+         .getLastPublish("B9_DIALOG")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "FIFTH_SCOPE_", "Wrong response scope");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -54,6 +54,7 @@ define({
       "src/test/resources/alfresco/core/NotificationUtilsTest",
       "src/test/resources/alfresco/core/PublishPayloadMixinTest",
       "src/test/resources/alfresco/core/RenderFilterTest",
+      "src/test/resources/alfresco/core/ResponseScopeTest",
       "src/test/resources/alfresco/core/TemporalUtilsTest",
       "src/test/resources/alfresco/core/VisibilityConfigTest",
       "src/test/resources/alfresco/core/WidgetCreationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ResponseScope.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ResponseScope.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Response Scope Test Page</shortname>
+  <description>Used for verifying that response scopes are correctly processed in payloads.</description>
+  <family>aikau-unit-tests</family>
+  <url>/ResponseScope</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ResponseScope.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ResponseScope.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ResponseScope.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ResponseScope.get.js
@@ -1,0 +1,171 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         id: "B1",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Global with pubSubScope",
+            pubSubScope: "",
+            publishTopic: "B1",
+            publishPayload: {
+            }
+         }
+      },
+      {
+         id: "B2",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Scoped with pubSubScope",
+            pubSubScope: "SCOPE_",
+            publishTopic: "B2",
+            publishPayload: {
+            }
+         }
+      },
+      {
+         id: "B3",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Global with alfResponseScope",
+            pubSubScope: "",
+            publishTopic: "B3",
+            publishPayload: {
+               alfResponseScope: "OTHER_SCOPE_"
+            }
+         }
+      },
+      {
+         id: "B4",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Scoped with alfResponseScope",
+            pubSubScope: "SCOPE_",
+            publishTopic: "B4",
+            publishPayload: {
+               alfResponseScope: "OTHER_SCOPE_"
+            }
+         }
+      },
+      {
+         id: "B5",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Global with responseScope",
+            pubSubScope: "",
+            publishTopic: "B5",
+            publishPayload: {
+               alfResponseScope: "OTHER_SCOPE_",
+               responseScope: "THIRD_SCOPE_"
+            }
+         }
+      },
+      {
+         id: "B6",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Scoped with responseScope",
+            pubSubScope: "SCOPE_",
+            publishTopic: "B6",
+            publishPayload: {
+               alfResponseScope: "OTHER_SCOPE_",
+               responseScope: "THIRD_SCOPE_"
+            }
+         }
+      },
+      {
+         id: "B7",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Dialog (no responseScope)",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "B7_DIALOG",
+               dialogTitle: "Dialog",
+               formSubmissionTopic: "B7_DIALOG",
+               formSubmissionPayloadMixin: {
+               },
+               widgets: [
+                  {
+                     id: "B7_TB",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "B8",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Dialog (responseScope)",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "B8_DIALOG",
+               dialogTitle: "Dialog",
+               formSubmissionTopic: "B8_DIALOG",
+               formSubmissionPayloadMixin: {
+               },
+               widgets: [
+                  {
+                     id: "B8_TB",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text"
+                     }
+                  }
+               ],
+               responseScope: "FOURTH_SCOPE_"
+            }
+         }
+      },
+      {
+         id: "B9",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Dialog (formSubmissionPayloadMixin)",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "B9_DIALOG",
+               dialogTitle: "Dialog",
+               formSubmissionTopic: "B9_DIALOG",
+               formSubmissionPayloadMixin: {
+                  responseScope: "FIFTH_SCOPE_"
+               },
+               widgets: [
+                  {
+                     id: "B9_TB",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text"
+                     }
+                  }
+               ],
+               responseScope: "FOURTH_SCOPE_"
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-500 and re-works the logic for figuring out the correct alfResponseScope to apply to a payload to ensure that global scope (or empty string) is accepted as a valid scope. I've added some specific unit tests to verify the expected behaviour and checked that the issue no longer occurs on Share with the Document Library.