### PR TITLE
AKU-490: Updates to form validation

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1905,6 +1905,7 @@ define(["dojo/_base/declare",
       hideValidationFailure: function alfresco_forms_controls_BaseFormControl__hideValidationFailure() {
          domClass.remove(this._validationIndicator, "validation-error");
          domClass.remove(this._validationMessage, "display");
+         this._pendingValidationFailureDisplay = false;
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
@@ -133,6 +133,26 @@ define(["intern!object",
             });
       },
 
+      "Make third text field valid and then remove focus and verify that error indicator is not displayed": function() {
+         return browser.findByCssSelector("#TB5 .dijitInputContainer input")
+            .clearValue()
+            .type("abcde")
+         .end()
+         .findByCssSelector("#TB3 .dijitInputContainer input")
+            .click()
+         .end()
+         .findAllByCssSelector("#TB5 .validation-error")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The error icon should NOT have been displayed (TB5)");
+            })
+         .end()
+         .findByCssSelector("#TB5 .validation-message")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The error message should NOT have been displayed (TB5)");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.js
@@ -64,6 +64,27 @@ model.jsonModel = {
                                  errorMessage: "Value must be a number"
                               }
                            }
+                        },
+                        {
+                           id: "TB5",
+                           name: "alfresco/forms/controls/DojoValidationTextBox",
+                           config: {
+                              fieldId: "FIELD5",
+                              label: "Field 5",
+                              name: "field5",
+                              description: "Needs to be 3 characters or more",
+                              value: "a",
+                              requirementConfig: {
+                                 initialValue: true
+                              },
+                              validationConfig: [
+                                 {
+                                    validation: "minLength",
+                                    length: 3,
+                                    errorMessage: "Too short"
+                                 }
+                              ]
+                           }
                         }
                      ]
                   }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-490 to ensure that pending validation failures are cleared if the form control becomes valid before focus is lost. The unit test has been updated to verify the correct behaviour.