### PR TITLE
AKU-452: Update Aikau buttons to match new Share improvements

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -2,10 +2,14 @@
    background: @standard-button-background;
    border: @standard-button-border;
    border-radius: @standard-button-border-radius;
+   box-sizing: border-box;
    font-size: @standard-button-font-size;
    font-weight: @standard-button-font-weight;
    margin: @standard-button-margin;
    padding: @standard-button-padding;
+   * {
+      box-sizing: inherit;
+   }
    .alf-white-search-icon {
       background-image: url("./images/20x20-search-icon-white.png");
       background-repeat: no-repeat;
@@ -54,7 +58,14 @@
    &.call-to-action {
       background: @call-to-action-button-background;
       border: @call-to-action-button-border;
+      border-radius: @call-to-action-button-border-radius;
+      font-size: @call-to-action-button-font-size;
+      font-weight: @call-to-action-button-font-weight;
+      margin: @call-to-action-button-margin;
       padding: @call-to-action-button-padding;
+      .dijitButtonContents, .dijitButtonText {
+         line-height: @call-to-action-button-line-height;
+      }
       .dijitReset.dijitInline.dijitButtonNode {
          color: @call-to-action-button-font-color;
       }

--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -3,8 +3,7 @@
    border: @standard-button-border;
    border-radius: @standard-button-border-radius;
    box-sizing: border-box;
-   font-size: @standard-button-font-size;
-   font-weight: @standard-button-font-weight;
+   font-size: 0;
    margin: @standard-button-margin;
    padding: @standard-button-padding;
    * {
@@ -21,6 +20,8 @@
       line-height: @standard-button-line-height;
    }
    .dijitButtonText {
+      font-size: @standard-button-font-size;
+      font-weight: @standard-button-font-weight;
       padding: 0;
    }
    .dijitReset.dijitInline.dijitButtonNode {
@@ -59,12 +60,15 @@
       background: @call-to-action-button-background;
       border: @call-to-action-button-border;
       border-radius: @call-to-action-button-border-radius;
-      font-size: @call-to-action-button-font-size;
-      font-weight: @call-to-action-button-font-weight;
       margin: @call-to-action-button-margin;
       padding: @call-to-action-button-padding;
       .dijitButtonContents, .dijitButtonText {
          line-height: @call-to-action-button-line-height;
+      }
+      .dijitButtonText {
+         font-size: @call-to-action-button-font-size;
+         font-weight: @call-to-action-button-font-weight;
+         padding: 0;
       }
       .dijitReset.dijitInline.dijitButtonNode {
          color: @call-to-action-button-font-color;

--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -1,20 +1,23 @@
 .alfresco-buttons-AlfButton {
-   background-color: @standard-button-background-color;
-   background-image: none;
+   background: @standard-button-background;
    border: @standard-button-border;
-   border-radius: 0;
+   border-radius: @standard-button-border-radius;
    font-size: @standard-button-font-size;
-   margin: 0;
-   margin-right: @standard-column-width;
-   span {
-      line-height: @standard-button-font-size + 2;
-      &.dijitIcon.alf-white-search-icon {
-         background-image: url("./images/20x20-search-icon-white.png");
-         background-repeat: no-repeat;
-         height: 20px;
-         text-align: center;
-         width: 24px;
-      }
+   font-weight: @standard-button-font-weight;
+   margin: @standard-button-margin;
+   padding: @standard-button-padding;
+   .alf-white-search-icon {
+      background-image: url("./images/20x20-search-icon-white.png");
+      background-repeat: no-repeat;
+      height: 20px;
+      text-align: center;
+      width: 24px;
+   }
+   .dijitButtonContents, .dijitButtonText {
+      line-height: @standard-button-line-height;
+   }
+   .dijitButtonText {
+      padding: 0;
    }
    .dijitReset.dijitInline.dijitButtonNode {
       background: none repeat scroll 0 0;
@@ -22,30 +25,59 @@
       border-radius: 0;
       box-shadow: none;
       color: @standard-button-font-color;
-      padding: 3px 10px;
+      padding: 0;
    }
    &.dijitButtonFocused, &.dijitButtonHover {
-      border: @standard-button-focus-border;
+      background: @standard-button-background-focus;
+      border: @standard-button-border-focus;
+      .dijitReset.dijitInline.dijitButtonNode {
+         color: @standard-button-font-color-focus;
+      }
+   }
+   &.dijitButtonActive {
+      background: @standard-button-background-active;
+      border: @standard-button-border-active;
+      .dijitReset.dijitInline.dijitButtonNode {
+         color: @standard-button-font-color-active;
+      }
+   }
+   &.dijitButtonDisabled {
+      background: @standard-button-background-disabled;
+      border: @standard-button-border-disabled;
+      .dijitReset.dijitInline.dijitButtonNode {
+         color: @standard-button-font-color-disabled;
+      }
+      .alf-white-search-icon {
+         opacity: .5;
+      }
    }
    &.call-to-action {
-      background-color: @call-to-action-button-background-color;
+      background: @call-to-action-button-background;
       border: @call-to-action-button-border;
+      padding: @call-to-action-button-padding;
       .dijitReset.dijitInline.dijitButtonNode {
          color: @call-to-action-button-font-color;
       }
       &.dijitButtonFocused, &.dijitButtonHover {
-         border: @call-to-action-button-focus-border;
+         background: @call-to-action-button-background-focus;
+         border: @call-to-action-button-border-focus;
+         .dijitReset.dijitInline.dijitButtonNode {
+            color: @call-to-action-button-font-color-focus;
+         }
       }
-   }
-   &.dijitButtonDisabled {
-      .dijitReset.dijitInline.dijitButtonNode {
-         color: rgba(red(@standard-button-font-color), green(@standard-button-font-color), blue(@standard-button-font-color), .4);
+      &.dijitButtonActive {
+         background: @call-to-action-button-background-active;
+         border: @call-to-action-button-border-active;
+         .dijitReset.dijitInline.dijitButtonNode {
+            color: @call-to-action-button-font-color-active;
+         }
       }
-      &.call-to-action .dijitReset.dijitInline.dijitButtonNode {
-         color: rgba(red(@call-to-action-button-font-color), green(@call-to-action-button-font-color), blue(@call-to-action-button-font-color), .4);
-      }
-      span.dijitIcon.alf-white-search-icon {
-         opacity: .4;
+      &.dijitButtonDisabled {
+         background: @call-to-action-button-background-disabled;
+         border: @call-to-action-button-border-disabled;
+         .dijitReset.dijitInline.dijitButtonNode {
+            color: @call-to-action-button-font-color-disabled;
+         }
       }
    }
 }

--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -1,64 +1,51 @@
 .alfresco-buttons-AlfButton {
+   background-color: @standard-button-background-color;
    background-image: none;
-   background-color: @standard-button-background-color; 
    border: @standard-button-border;
-   margin: 0;
-   margin-right: @standard-column-width;
    border-radius: 0;
    font-size: @standard-button-font-size;
-}
-
-/* Set tge line-height of all spans in the button to be 2px greater than the standard font size */
-.alfresco-buttons-AlfButton span {
-   line-height: @standard-button-font-size + 2;
-}
-
-/* Convert the HEX color to RGBA so that an opacity can be set on the font color */
-.alfresco-buttons-AlfButton.dijitButtonDisabled .dijitReset.dijitInline.dijitButtonNode{
-   color: rgba(red(@standard-button-font-color), green(@standard-button-font-color), blue(@standard-button-font-color), 0.4);
-}
-
-.alfresco-buttons-AlfButton.dijitButtonFocused,
-.alfresco-buttons-AlfButton.dijitButtonHover {
-   border: @standard-button-focus-border;
-}
-
-.alfresco-buttons-AlfButton.call-to-action {
-   background-color: @call-to-action-button-background-color; 
-   border: @call-to-action-button-border;
-   /*font-size: @call-to-action-button-font-size;*/
-}
-
-.alfresco-buttons-AlfButton.call-to-action.dijitButtonFocused,
-.alfresco-buttons-AlfButton.call-to-action.dijitButtonHover {
-   border: @call-to-action-button-focus-border;
-}
-
-.alfresco-buttons-AlfButton .dijitReset.dijitInline.dijitButtonNode {
-   background: none repeat scroll 0 0;
-   border: none;
-   border-radius: 0;
-   box-shadow: none;
-   padding: 3px 10px;
-   color: @standard-button-font-color;
-}
-
-.alfresco-buttons-AlfButton.call-to-action .dijitReset.dijitInline.dijitButtonNode {
-   color: @call-to-action-button-font-color;
-}
-
-.alfresco-buttons-AlfButton.call-to-action.dijitButtonDisabled .dijitReset.dijitInline.dijitButtonNode{
-   color: rgba(red(@call-to-action-button-font-color), green(@call-to-action-button-font-color), blue(@call-to-action-button-font-color), 0.4);
-}
-
-.alfresco-buttons-AlfButton span.dijitIcon.alf-white-search-icon {
-   background-image: url("./images/20x20-search-icon-white.png");
-   background-repeat: no-repeat;
-   height: 20px;
-   text-align: center;
-   width: 24px;
-}
-
-.alfresco-buttons-AlfButton.dijitButtonDisabled span.dijitIcon.alf-white-search-icon {
-   opacity: 0.4;
+   margin: 0;
+   margin-right: @standard-column-width;
+   span {
+      line-height: @standard-button-font-size + 2;
+      &.dijitIcon.alf-white-search-icon {
+         background-image: url("./images/20x20-search-icon-white.png");
+         background-repeat: no-repeat;
+         height: 20px;
+         text-align: center;
+         width: 24px;
+      }
+   }
+   .dijitReset.dijitInline.dijitButtonNode {
+      background: none repeat scroll 0 0;
+      border: none;
+      border-radius: 0;
+      box-shadow: none;
+      color: @standard-button-font-color;
+      padding: 3px 10px;
+   }
+   &.dijitButtonFocused, &.dijitButtonHover {
+      border: @standard-button-focus-border;
+   }
+   &.call-to-action {
+      background-color: @call-to-action-button-background-color;
+      border: @call-to-action-button-border;
+      .dijitReset.dijitInline.dijitButtonNode {
+         color: @call-to-action-button-font-color;
+      }
+      &.dijitButtonFocused, &.dijitButtonHover {
+         border: @call-to-action-button-focus-border;
+      }
+   }
+   &.dijitButtonDisabled {
+      .dijitReset.dijitInline.dijitButtonNode {
+         color: rgba(red(@standard-button-font-color), green(@standard-button-font-color), blue(@standard-button-font-color), .4);
+      }
+      &.call-to-action .dijitReset.dijitInline.dijitButtonNode {
+         color: rgba(red(@call-to-action-button-font-color), green(@call-to-action-button-font-color), blue(@call-to-action-button-font-color), .4);
+      }
+      span.dijitIcon.alf-white-search-icon {
+         opacity: .4;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -22,6 +22,7 @@
       line-height: @standard-button-line-height;
    }
    .dijitButtonText {
+      font-family: @standard-button-font-family;
       font-size: @standard-button-font-size;
       font-weight: @standard-button-font-weight;
       padding: 0;
@@ -68,6 +69,7 @@
          line-height: @call-to-action-button-line-height;
       }
       .dijitButtonText {
+         font-family: @call-to-action-button-font-family;
          font-size: @call-to-action-button-font-size;
          font-weight: @call-to-action-button-font-weight;
          padding: 0;

--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -6,6 +6,8 @@
    font-size: 0;
    margin: @standard-button-margin;
    padding: @standard-button-padding;
+
+   .buttonMixin(@use-legacy-buttons);
    * {
       box-sizing: inherit;
    }

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -31,94 +31,6 @@
 @primary-title-color: #fff;
 @primary-theme-color: #eee;
 
-// Layout settings...
-// This is used to control the overall layout of the page. Line-heights will be a multiple of
-// this value based on the font-size
-@standard-line-height: 10px;
-@standard-column-width: 15px;
-// This is used when the columns need some breathing space.
-@standard-column-spacing: 5px;
-// Used for e.g. the facets on the search page.
-@sidebar-component-width: 320px;
-// Used for dialog label width area
-@dialog-label-section: 160px;
-@dialog-control-section: 530px;
-
-// Font Colours
-@general-font-color: #333;
-@emphasized-font-color: #000;
-@de-emphasized-font-color: #999;
-@highlighted-font-color: #fff;
-
-// Borders...
-// These have been initially added for form controls...
-@standard-border-width: 1px;
-@standard-border-style: solid;
-@standard-border-color: #d3d3d3;
-@standard-border: @standard-border-width @standard-border-style @standard-border-color;
-@standard-border-radius: 6px;
-@hover-border-color: #d3d3d3;
-@focused-border-color: #8dc63f;
-
-// Buttons
-// The standard button is what is normally seen...
-@standard-button-border-color: #ccc;
-@standard-button-background-color: #fff;
-@standard-button-border: 1px solid @standard-button-border-color;
-@standard-button-focus-border: 1px solid @standard-button-border-color;
-@standard-button-font-color: @general-font-color;
-@standard-button-font-size: @normal-font-size;
-
-// "Call-to-action" buttons should be darker with larger text to capture the users attention
-@call-to-action-button-background-color: #8dc63f;
-@call-to-action-button-border: 1px solid #8dc63f;
-@call-to-action-button-focus-border: 1px solid #5eae41;
-@call-to-action-button-font-color: #fff;
-@call-to-action-button-font-size: @large-font-size;
-
-// Shadows
-@standard-box-shadow: .33px 2px 8px rgba(0, 0, 0, .3);
-@inset-box-shadow: 1px 1px 3px @standard-button-border-color inset;
-
-// Dashlets
-@dashlet-background: @primary-background-color;
-@dashlet-border: @standard-border;
-@dashlet-border-radius: @standard-border-radius @standard-border-radius 0 0; // This gives rounding at the top of the dashlet only
-@dashlet-title-background: @alternate-background-color;
-@dashlet-title-border-bottom: @standard-border;
-@dashlet-title-border-radius: @standard-border-radius @standard-border-radius 0 0; // This gives rounding at the top of the dashlet only
-@dashlet-title-color: @alternate-font-color;
-@dashlet-toolbar-background: transparent;
-@dashlet-toolbar-border-bottom: @standard-border;
-@dashlet-body-background: @primary-background-color;
-@dashlet-body-border-radius: 0; // This gives rounding at the top of the dashlet only
-
-// Notifications
-@notification-background: #666;
-@notification-foreground: @highlighted-font-color;
-@notification-foreground-dimmed: @de-emphasized-font-color;
-@notification-width: 400px;
-@notification-border-radius: 0 0 5px 5px;
-
-// Lists
-@list-header-border-color: #e5e5e5;
-@list-header-background-color: #f5f5f5;
-@list-background-color: #fff;
-@list-hover-color: #eee;
-@list-focus-color: #ddd;
-@list-zebra-color-odd: #fff;
-@list-zebra-color-even: #f8f8f8;
-@list-border-color: #e5e5e5;
-@list-dnd-hover-outline: 2px solid #0082ca;
-
-// Tabs
-@tab-border: @standard-button-border;
-@tab-color: #d8d8d8;
-@tab-background: @tab-color none;
-@tab-color-active: #fff;
-@tab-border-radius: 2px 2px 0 0;
-@tab-opacity-disabled: .5;
-
 // Font Sizes
 @page-title-font-size: 26px;
 @title-font-size: 20px;
@@ -158,6 +70,129 @@
    color: @de-emphasized-font-color;
    font-family: @standard-font;
 }
+
+// Layout settings...
+// This is used to control the overall layout of the page. Line-heights will be a multiple of
+// this value based on the font-size
+@standard-line-height: 10px;
+@standard-column-width: 15px;
+// This is used when the columns need some breathing space.
+@standard-column-spacing: 5px;
+// Used for e.g. the facets on the search page.
+@sidebar-component-width: 320px;
+// Used for dialog label width area
+@dialog-label-section: 160px;
+@dialog-control-section: 530px;
+
+// Font Colours
+@general-font-color: #333;
+@emphasized-font-color: #000;
+@de-emphasized-font-color: #999;
+@highlighted-font-color: #fff;
+
+// Borders...
+// These have been initially added for form controls...
+@standard-border-width: 1px;
+@standard-border-style: solid;
+@standard-border-color: #d3d3d3;
+@standard-border: @standard-border-width @standard-border-style @standard-border-color;
+@standard-border-radius: 6px;
+@hover-border-color: #d3d3d3;
+@focused-border-color: #8dc63f;
+
+// Button (colours)
+@button-color-background: #fff;
+@button-color-default: #0082c8;
+@button-color-hover: #006ca6;
+@button-color-active: #005684;
+@button-color-disabled: #b8b8b8;
+
+// The standard button is what is normally seen
+@standard-button-background: @button-color-background;
+@standard-button-background-focus: @button-color-background;
+@standard-button-background-active: @button-color-background;
+@standard-button-background-disabled: @button-color-background;
+@standard-button-border-width: 1px;
+@standard-button-border-style: solid;
+@standard-button-border: @standard-button-border-width @standard-button-border-style @button-color-default;
+@standard-button-border-focus: @standard-button-border-width @standard-button-border-style @button-color-hover;
+@standard-button-border-active: @standard-button-border-width @standard-button-border-style @button-color-active;
+@standard-button-border-disabled: @standard-button-border-width @standard-button-border-style @button-color-disabled;
+@standard-button-border-radius: 2px;
+@standard-button-font-color: @button-color-default;
+@standard-button-font-color-focus: @button-color-hover;
+@standard-button-font-color-active: @button-color-active;
+@standard-button-font-color-disabled: @button-color-disabled;
+@standard-button-font-size: @normal-font-size;
+@standard-button-font-weight: bold;
+@standard-button-line-height: @standard-button-font-size * 1.5;
+// 30px used here, as it's the visible height of a search field in Chrome
+@standard-button-padding-vertical: (30px - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
+@standard-button-padding-horizontal: @standard-button-font-size;
+@standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
+@standard-button-margin: 0 @standard-column-width 0 0;
+
+// "Call-to-action" buttons capture the users attention
+@call-to-action-button-background: @button-color-default;
+@call-to-action-button-background-focus: @button-color-hover;
+@call-to-action-button-background-active: @button-color-active;
+@call-to-action-button-background-disabled: @button-color-disabled;
+@call-to-action-button-border-width: 0;
+@call-to-action-button-border-style: solid;
+@call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-default;
+@call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
+@call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
+@call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
+@call-to-action-button-font-color: @button-color-background;
+@call-to-action-button-font-color-focus: @button-color-background;
+@call-to-action-button-font-color-active: @button-color-background;
+@call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
+@call-to-action-button-padding-vertical: (30px - (@call-to-action-button-border-width * 2) - @standard-button-line-height) / 2;
+@call-to-action-button-padding-horizontal: @standard-button-font-size;
+@call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
+
+// Shadows
+@standard-box-shadow: .33px 2px 8px rgba(0, 0, 0, .3);
+@inset-box-shadow: 1px 1px 3px #ccc inset;
+
+// Dashlets
+@dashlet-background: @primary-background-color;
+@dashlet-border: @standard-border;
+@dashlet-border-radius: @standard-border-radius @standard-border-radius 0 0; // This gives rounding at the top of the dashlet only
+@dashlet-title-background: @alternate-background-color;
+@dashlet-title-border-bottom: @standard-border;
+@dashlet-title-border-radius: @standard-border-radius @standard-border-radius 0 0; // This gives rounding at the top of the dashlet only
+@dashlet-title-color: @alternate-font-color;
+@dashlet-toolbar-background: transparent;
+@dashlet-toolbar-border-bottom: @standard-border;
+@dashlet-body-background: @primary-background-color;
+@dashlet-body-border-radius: 0; // This gives rounding at the top of the dashlet only
+
+// Notifications
+@notification-background: #666;
+@notification-foreground: @highlighted-font-color;
+@notification-foreground-dimmed: @de-emphasized-font-color;
+@notification-width: 400px;
+@notification-border-radius: 0 0 5px 5px;
+
+// Lists
+@list-header-border-color: #e5e5e5;
+@list-header-background-color: #f5f5f5;
+@list-background-color: #fff;
+@list-hover-color: #eee;
+@list-focus-color: #ddd;
+@list-zebra-color-odd: #fff;
+@list-zebra-color-even: #f8f8f8;
+@list-border-color: #e5e5e5;
+@list-dnd-hover-outline: 2px solid #0082ca;
+
+// Tabs
+@tab-border: @standard-button-border;
+@tab-color: #d8d8d8;
+@tab-background: @tab-color none;
+@tab-color-active: #fff;
+@tab-border-radius: 2px 2px 0 0;
+@tab-opacity-disabled: .5;
 
 // Breadcrumbs
 @breadcrumb-font-color: @general-font-color;

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -108,48 +108,52 @@
 @button-color-disabled: #b8b8b8;
 
 // The standard button is what is normally seen
-@standard-button-background: @button-color-background;
-@standard-button-background-focus: @button-color-background;
-@standard-button-background-active: @button-color-background;
-@standard-button-background-disabled: @button-color-background;
+@standard-button-background: #fff;
+@standard-button-background-focus: #fff;
+@standard-button-background-active: #fff;
+@standard-button-background-disabled: #fff;
 @standard-button-border-width: 1px;
 @standard-button-border-style: solid;
-@standard-button-border: @standard-button-border-width @standard-button-border-style @button-color-default;
-@standard-button-border-focus: @standard-button-border-width @standard-button-border-style @button-color-hover;
-@standard-button-border-active: @standard-button-border-width @standard-button-border-style @button-color-active;
-@standard-button-border-disabled: @standard-button-border-width @standard-button-border-style @button-color-disabled;
-@standard-button-border-radius: 2px;
-@standard-button-font-color: @button-color-default;
-@standard-button-font-color-focus: @button-color-hover;
-@standard-button-font-color-active: @button-color-active;
-@standard-button-font-color-disabled: @button-color-disabled;
+@standard-button-border: @standard-button-border-width @standard-button-border-style #ccc;
+@standard-button-border-focus: @standard-button-border-width @standard-button-border-style #ccc;
+@standard-button-border-active: @standard-button-border-width @standard-button-border-style #ccc;
+@standard-button-border-disabled: @standard-button-border-width @standard-button-border-style #ccc;
+@standard-button-border-radius: 0;
+@standard-button-font-color: @general-font-color;
+@standard-button-font-color-focus: @general-font-color;
+@standard-button-font-color-active: @general-font-color;
+@standard-button-font-color-disabled: fade(@general-font-color, 40%);
 @standard-button-font-size: @normal-font-size;
-@standard-button-font-weight: bold;
+@standard-button-font-weight: normal;
 @standard-button-line-height: @standard-button-font-size * 1.5;
-// 30px used here, as it's the visible height of a search field in Chrome
-@standard-button-padding-vertical: (30px - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
+@standard-button-padding-vertical: 0;
 @standard-button-padding-horizontal: @standard-button-font-size;
 @standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
 @standard-button-margin: 0 @standard-column-width 0 0;
 
 // "Call-to-action" buttons capture the users attention
-@call-to-action-button-background: @button-color-default;
-@call-to-action-button-background-focus: @button-color-hover;
-@call-to-action-button-background-active: @button-color-active;
-@call-to-action-button-background-disabled: @button-color-disabled;
-@call-to-action-button-border-width: 0;
+@call-to-action-button-background: #8dc63f;
+@call-to-action-button-background-focus: #8dc63f;
+@call-to-action-button-background-active: #8dc63f;
+@call-to-action-button-background-disabled: #8dc63f;
+@call-to-action-button-border-width: 1px;
 @call-to-action-button-border-style: solid;
-@call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-default;
-@call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
-@call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
-@call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
-@call-to-action-button-font-color: @button-color-background;
-@call-to-action-button-font-color-focus: @button-color-background;
-@call-to-action-button-font-color-active: @button-color-background;
-@call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
+@call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style #8dc63f;
+@call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style #5eae41;
+@call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style #5eae41;
+@call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style #8dc63f;
+@call-to-action-button-border-radius: 0;
+@call-to-action-button-font-color: #fff;
+@call-to-action-button-font-color-focus: #fff;
+@call-to-action-button-font-color-active: #fff;
+@call-to-action-button-font-color-disabled: fade(#fff, 40%);
+@call-to-action-button-font-size: @large-font-size;
+@call-to-action-button-font-weight: normal;
+@call-to-action-button-line-height: @call-to-action-button-font-size * 1.5;
 @call-to-action-button-padding-vertical: (30px - (@call-to-action-button-border-width * 2) - @standard-button-line-height) / 2;
 @call-to-action-button-padding-horizontal: @standard-button-font-size;
 @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
+@call-to-action-button-margin: 0 @standard-column-width 0 0;
 
 // Shadows
 @standard-box-shadow: .33px 2px 8px rgba(0, 0, 0, .3);

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -107,7 +107,7 @@
 @button-color-active: #005684;
 @button-color-disabled: #b8b8b8;
 @legacy-button-color: #ccc;
-@legacy-button-color-text: #000;
+@legacy-button-color-text: @general-font-color;
 @legacy-action-button-color: #8dc63f;
 
 // The standard button is what is normally seen
@@ -126,6 +126,7 @@
 @standard-button-font-color-focus: @button-color-hover;
 @standard-button-font-color-active: @button-color-active;
 @standard-button-font-color-disabled: @button-color-disabled;
+@standard-button-font-family: @bold-font;
 @standard-button-font-size: @normal-font-size;
 @standard-button-font-weight: bold;
 @standard-button-height: 28px;
@@ -151,6 +152,7 @@
 @call-to-action-button-font-color-focus: @button-color-background;
 @call-to-action-button-font-color-active: @button-color-background;
 @call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
+@call-to-action-button-font-family: @standard-button-font-family;
 @call-to-action-button-font-size: @standard-button-font-size;
 @call-to-action-button-font-weight: @standard-button-font-weight;
 @call-to-action-button-height: @standard-button-height;
@@ -171,6 +173,8 @@
    @standard-button-font-color-focus: @legacy-button-color-text;
    @standard-button-font-color-active: @legacy-button-color-text;
    @standard-button-font-color-disabled: fade(@legacy-button-color-text, 40%);
+   @standard-button-font-family: @standard-font;
+   @standard-button-font-weight: normal;
    @call-to-action-button-background: @legacy-action-button-color;
    @call-to-action-button-background-focus: @legacy-action-button-color;
    @call-to-action-button-background-active: @legacy-action-button-color;

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -106,26 +106,29 @@
 @button-color-hover: #006ca6;
 @button-color-active: #005684;
 @button-color-disabled: #b8b8b8;
+@legacy-button-color: #ccc;
+@legacy-button-color-text: #000;
+@legacy-action-button-color: #8dc63f;
 
 // The standard button is what is normally seen
-@standard-button-background: #fff;
-@standard-button-background-focus: #fff;
-@standard-button-background-active: #fff;
-@standard-button-background-disabled: #fff;
+@standard-button-background: @button-color-background;
+@standard-button-background-focus: @button-color-background;
+@standard-button-background-active: @button-color-background;
+@standard-button-background-disabled: @button-color-background;
 @standard-button-border-width: 1px;
 @standard-button-border-style: solid;
-@standard-button-border: @standard-button-border-width @standard-button-border-style #ccc;
-@standard-button-border-focus: @standard-button-border-width @standard-button-border-style #ccc;
-@standard-button-border-active: @standard-button-border-width @standard-button-border-style #ccc;
-@standard-button-border-disabled: @standard-button-border-width @standard-button-border-style #ccc;
-@standard-button-border-radius: 0;
-@standard-button-font-color: @general-font-color;
-@standard-button-font-color-focus: @general-font-color;
-@standard-button-font-color-active: @general-font-color;
-@standard-button-font-color-disabled: fade(@general-font-color, 40%);
+@standard-button-border: @standard-button-border-width @standard-button-border-style @button-color-default;
+@standard-button-border-focus: @standard-button-border-width @standard-button-border-style @button-color-hover;
+@standard-button-border-active: @standard-button-border-width @standard-button-border-style @button-color-active;
+@standard-button-border-disabled: @standard-button-border-width @standard-button-border-style @button-color-disabled;
+@standard-button-border-radius: 2px;
+@standard-button-font-color: @button-color-default;
+@standard-button-font-color-focus: @button-color-hover;
+@standard-button-font-color-active: @button-color-active;
+@standard-button-font-color-disabled: @button-color-disabled;
 @standard-button-font-size: @normal-font-size;
-@standard-button-font-weight: normal;
-@standard-button-height: 26px;
+@standard-button-font-weight: bold;
+@standard-button-height: 28px;
 @standard-button-line-height: @standard-button-font-size * 1.2;
 @standard-button-padding-vertical: (@standard-button-height - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
 @standard-button-padding-horizontal: @standard-button-font-size;
@@ -133,29 +136,46 @@
 @standard-button-margin: 0 @standard-column-width 0 0;
 
 // "Call-to-action" buttons capture the users attention
-@call-to-action-button-background: #8dc63f;
-@call-to-action-button-background-focus: @call-to-action-button-background;
-@call-to-action-button-background-active: @call-to-action-button-background;
-@call-to-action-button-background-disabled: @call-to-action-button-background;
-@call-to-action-button-border-width: @standard-button-border-width;
-@call-to-action-button-border-style: @standard-button-border-style;
-@call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style #8dc63f;
-@call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style #5eae41;
-@call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style #5eae41;
-@call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style #8dc63f;
+@call-to-action-button-background: @button-color-default;
+@call-to-action-button-background-focus: @button-color-hover;
+@call-to-action-button-background-active: @button-color-active;
+@call-to-action-button-background-disabled: @button-color-disabled;
+@call-to-action-button-border-width: 0;
+@call-to-action-button-border-style: solid;
+@call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-default;
+@call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
+@call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
+@call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
 @call-to-action-button-border-radius: @standard-button-border-radius;
-@call-to-action-button-font-color: #fff;
-@call-to-action-button-font-color-focus: @call-to-action-button-font-color;
-@call-to-action-button-font-color-active: @call-to-action-button-font-color;
-@call-to-action-button-font-color-disabled: fade(@call-to-action-button-font-color, 40%);
-@call-to-action-button-font-size: @normal-font-size;
+@call-to-action-button-font-color: @button-color-background;
+@call-to-action-button-font-color-focus: @button-color-background;
+@call-to-action-button-font-color-active: @button-color-background;
+@call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
+@call-to-action-button-font-size: @standard-button-font-size;
 @call-to-action-button-font-weight: @standard-button-font-weight;
 @call-to-action-button-height: @standard-button-height;
 @call-to-action-button-line-height: @standard-button-line-height;
-@call-to-action-button-padding-vertical: @standard-button-padding-vertical;
+@call-to-action-button-padding-vertical: (@call-to-action-button-height - (@call-to-action-button-border-width * 2) - @call-to-action-button-line-height) / 2;
 @call-to-action-button-padding-horizontal: @standard-button-padding-horizontal;
 @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
 @call-to-action-button-margin: @standard-button-margin;
+
+// Update the variables for legacy buttons
+@use-legacy-buttons: true;
+.buttonMixin(@use-legacy-buttons) when (@use-legacy-buttons = true) {
+   @standard-button-border: @standard-button-border-width @standard-button-border-style @legacy-button-color;
+   @standard-button-border-focus: @standard-button-border-width @standard-button-border-style @legacy-button-color;
+   @standard-button-border-active: @standard-button-border-width @standard-button-border-style @legacy-button-color;
+   @standard-button-border-disabled: @standard-button-border-width @standard-button-border-style @legacy-button-color;
+   @standard-button-font-color: @legacy-button-color-text;
+   @standard-button-font-color-focus: @legacy-button-color-text;
+   @standard-button-font-color-active: @legacy-button-color-text;
+   @standard-button-font-color-disabled: fade(@legacy-button-color-text, 40%);
+   @call-to-action-button-background: @legacy-action-button-color;
+   @call-to-action-button-background-focus: @legacy-action-button-color;
+   @call-to-action-button-background-active: @legacy-action-button-color;
+   @call-to-action-button-background-disabled: @legacy-action-button-color;
+}
 
 // Shadows
 @standard-box-shadow: .33px 2px 8px rgba(0, 0, 0, .3);

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -125,35 +125,37 @@
 @standard-button-font-color-disabled: fade(@general-font-color, 40%);
 @standard-button-font-size: @normal-font-size;
 @standard-button-font-weight: normal;
-@standard-button-line-height: @standard-button-font-size * 1.5;
-@standard-button-padding-vertical: 0;
+@standard-button-height: 26px;
+@standard-button-line-height: @standard-button-font-size * 1.2;
+@standard-button-padding-vertical: (@standard-button-height - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
 @standard-button-padding-horizontal: @standard-button-font-size;
 @standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
 @standard-button-margin: 0 @standard-column-width 0 0;
 
 // "Call-to-action" buttons capture the users attention
 @call-to-action-button-background: #8dc63f;
-@call-to-action-button-background-focus: #8dc63f;
-@call-to-action-button-background-active: #8dc63f;
-@call-to-action-button-background-disabled: #8dc63f;
-@call-to-action-button-border-width: 1px;
-@call-to-action-button-border-style: solid;
+@call-to-action-button-background-focus: @call-to-action-button-background;
+@call-to-action-button-background-active: @call-to-action-button-background;
+@call-to-action-button-background-disabled: @call-to-action-button-background;
+@call-to-action-button-border-width: @standard-button-border-width;
+@call-to-action-button-border-style: @standard-button-border-style;
 @call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style #8dc63f;
 @call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style #5eae41;
 @call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style #5eae41;
 @call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style #8dc63f;
-@call-to-action-button-border-radius: 0;
+@call-to-action-button-border-radius: @standard-button-border-radius;
 @call-to-action-button-font-color: #fff;
-@call-to-action-button-font-color-focus: #fff;
-@call-to-action-button-font-color-active: #fff;
-@call-to-action-button-font-color-disabled: fade(#fff, 40%);
-@call-to-action-button-font-size: @large-font-size;
-@call-to-action-button-font-weight: normal;
-@call-to-action-button-line-height: @call-to-action-button-font-size * 1.5;
-@call-to-action-button-padding-vertical: (30px - (@call-to-action-button-border-width * 2) - @standard-button-line-height) / 2;
-@call-to-action-button-padding-horizontal: @standard-button-font-size;
+@call-to-action-button-font-color-focus: @call-to-action-button-font-color;
+@call-to-action-button-font-color-active: @call-to-action-button-font-color;
+@call-to-action-button-font-color-disabled: fade(@call-to-action-button-font-color, 40%);
+@call-to-action-button-font-size: @normal-font-size;
+@call-to-action-button-font-weight: @standard-button-font-weight;
+@call-to-action-button-height: @standard-button-height;
+@call-to-action-button-line-height: @standard-button-line-height;
+@call-to-action-button-padding-vertical: @standard-button-padding-vertical;
+@call-to-action-button-padding-horizontal: @standard-button-padding-horizontal;
 @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
-@call-to-action-button-margin: 0 @standard-column-width 0 0;
+@call-to-action-button-margin: @standard-button-margin;
 
 // Shadows
 @standard-box-shadow: .33px 2px 8px rgba(0, 0, 0, .3);

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Buttons test page</shortname>
+  <description>Test page that demonstrates the different styles of buttons</description>
+  <family>aikau-unit-tests</family>
+  <url>/Buttons</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
@@ -12,14 +12,123 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         id: "BUTTON",
-         name: "alfresco/buttons/AlfButton",
+         name: "alfresco/layout/VerticalWidgets",
          config: {
-            label: "This is a button",
-            publishTopic: "BUTTON_TOPIC",
-            publishPayload: {
-               foo: "bar"
-            }
+            widgetMarginBottom: 30,
+            widgets: [
+               {
+                  name: "alfresco/layout/HorizontalWidgets",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Default",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "dijitButtonHover",
+                              label: "Hover",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "dijitButtonActive",
+                              label: "Pressed",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Disabled",
+                              disabled: true,
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/HorizontalWidgets",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "call-to-action",
+                              label: "Default",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "call-to-action dijitButtonHover",
+                              label: "Hover",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "call-to-action dijitButtonActive",
+                              label: "Pressed",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "call-to-action",
+                              label: "Disabled",
+                              disabled: true,
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/SingleTextFieldForm",
+                  config: {
+                     okButtonLabel: "Search",
+                     okButtonIconClass: "alf-white-search-icon",
+                     okButtonClass: "call-to-action",
+                     textFieldName: "search",
+                     textBoxIconClass: "alf-search-icon"
+                  }
+               }
+            ]
          }
       },
       {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
@@ -1,0 +1,29 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "This is a button",
+            publishTopic: "BUTTON_TOPIC",
+            publishPayload: {
+               foo: "bar"
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -13,17 +13,10 @@
          @header-menubar-font-color: pink;
          @header-dropdown-menu-font-color: purple;
 
-         @button-color-background: #fff;
-         @button-color-default: #0082c8;
-         @button-color-hover: #006ca6;
-         @button-color-active: #005684;
-         @button-color-disabled: #b8b8b8;
          @standard-button-background: @button-color-background;
          @standard-button-background-focus: @button-color-background;
          @standard-button-background-active: @button-color-background;
          @standard-button-background-disabled: @button-color-background;
-         @standard-button-border-width: 1px;
-         @standard-button-border-style: solid;
          @standard-button-border: @standard-button-border-width @standard-button-border-style @button-color-default;
          @standard-button-border-focus: @standard-button-border-width @standard-button-border-style @button-color-hover;
          @standard-button-border-active: @standard-button-border-width @standard-button-border-style @button-color-active;
@@ -33,14 +26,10 @@
          @standard-button-font-color-focus: @button-color-hover;
          @standard-button-font-color-active: @button-color-active;
          @standard-button-font-color-disabled: @button-color-disabled;
-         @standard-button-font-size: @normal-font-size;
          @standard-button-font-weight: bold;
          @standard-button-height: 28px;
-         @standard-button-line-height: @standard-button-font-size * 1.2;
          @standard-button-padding-vertical: (@standard-button-height - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
-         @standard-button-padding-horizontal: @standard-button-font-size;
          @standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
-         @standard-button-margin: 0 @standard-column-width 0 0;
          @call-to-action-button-background: @button-color-default;
          @call-to-action-button-background-focus: @button-color-hover;
          @call-to-action-button-background-active: @button-color-active;
@@ -56,14 +45,11 @@
          @call-to-action-button-font-color-focus: @button-color-background;
          @call-to-action-button-font-color-active: @button-color-background;
          @call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
-         @call-to-action-button-font-size: @standard-button-font-size;
          @call-to-action-button-font-weight: @standard-button-font-weight;
          @call-to-action-button-height: @standard-button-height;
-         @call-to-action-button-line-height: @standard-button-line-height;
          @call-to-action-button-padding-vertical: (@call-to-action-button-height - (@call-to-action-button-border-width * 2) - @call-to-action-button-line-height) / 2;
          @call-to-action-button-padding-horizontal: @standard-button-padding-horizontal;
          @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
-         @call-to-action-button-margin: @standard-button-margin;
       </less-variables>
    </css-tokens>
 </theme>

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -35,8 +35,9 @@
          @standard-button-font-color-disabled: @button-color-disabled;
          @standard-button-font-size: @normal-font-size;
          @standard-button-font-weight: bold;
-         @standard-button-line-height: @standard-button-font-size * 1.5;
-         @standard-button-padding-vertical: (30px - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
+         @standard-button-height: 28px;
+         @standard-button-line-height: @standard-button-font-size * 1.2;
+         @standard-button-padding-vertical: (@standard-button-height - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
          @standard-button-padding-horizontal: @standard-button-font-size;
          @standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
          @standard-button-margin: 0 @standard-column-width 0 0;
@@ -50,18 +51,19 @@
          @call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
          @call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
          @call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
-         @call-to-action-button-border-radius: 2px;
+         @call-to-action-button-border-radius: @standard-button-border-radius;
          @call-to-action-button-font-color: @button-color-background;
          @call-to-action-button-font-color-focus: @button-color-background;
          @call-to-action-button-font-color-active: @button-color-background;
          @call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
-         @call-to-action-button-font-size: @normal-font-size;
-         @call-to-action-button-font-weight: bold;
-         @call-to-action-button-line-height: @call-to-action-button-font-size * 1.5;
-         @call-to-action-button-padding-vertical: (30px - (@call-to-action-button-border-width * 2) - @standard-button-line-height) / 2;
-         @call-to-action-button-padding-horizontal: @standard-button-font-size;
+         @call-to-action-button-font-size: @standard-button-font-size;
+         @call-to-action-button-font-weight: @standard-button-font-weight;
+         @call-to-action-button-height: @standard-button-height;
+         @call-to-action-button-line-height: @standard-button-line-height;
+         @call-to-action-button-padding-vertical: (@call-to-action-button-height - (@call-to-action-button-border-width * 2) - @call-to-action-button-line-height) / 2;
+         @call-to-action-button-padding-horizontal: @standard-button-padding-horizontal;
          @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
-         @call-to-action-button-margin: 0 @standard-column-width 0 0;
+         @call-to-action-button-margin: @standard-button-margin;
       </less-variables>
    </css-tokens>
 </theme>

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -50,13 +50,18 @@
          @call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
          @call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
          @call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
+         @call-to-action-button-border-radius: 2px;
          @call-to-action-button-font-color: @button-color-background;
          @call-to-action-button-font-color-focus: @button-color-background;
          @call-to-action-button-font-color-active: @button-color-background;
          @call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
+         @call-to-action-button-font-size: @normal-font-size;
+         @call-to-action-button-font-weight: bold;
+         @call-to-action-button-line-height: @call-to-action-button-font-size * 1.5;
          @call-to-action-button-padding-vertical: (30px - (@call-to-action-button-border-width * 2) - @standard-button-line-height) / 2;
          @call-to-action-button-padding-horizontal: @standard-button-font-size;
          @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
+         @call-to-action-button-margin: 0 @standard-column-width 0 0;
       </less-variables>
    </css-tokens>
 </theme>

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -12,6 +12,51 @@
          @header-focus-font-color: red;
          @header-menubar-font-color: pink;
          @header-dropdown-menu-font-color: purple;
+
+         @button-color-background: #fff;
+         @button-color-default: #0082c8;
+         @button-color-hover: #006ca6;
+         @button-color-active: #005684;
+         @button-color-disabled: #b8b8b8;
+         @standard-button-background: @button-color-background;
+         @standard-button-background-focus: @button-color-background;
+         @standard-button-background-active: @button-color-background;
+         @standard-button-background-disabled: @button-color-background;
+         @standard-button-border-width: 1px;
+         @standard-button-border-style: solid;
+         @standard-button-border: @standard-button-border-width @standard-button-border-style @button-color-default;
+         @standard-button-border-focus: @standard-button-border-width @standard-button-border-style @button-color-hover;
+         @standard-button-border-active: @standard-button-border-width @standard-button-border-style @button-color-active;
+         @standard-button-border-disabled: @standard-button-border-width @standard-button-border-style @button-color-disabled;
+         @standard-button-border-radius: 2px;
+         @standard-button-font-color: @button-color-default;
+         @standard-button-font-color-focus: @button-color-hover;
+         @standard-button-font-color-active: @button-color-active;
+         @standard-button-font-color-disabled: @button-color-disabled;
+         @standard-button-font-size: @normal-font-size;
+         @standard-button-font-weight: bold;
+         @standard-button-line-height: @standard-button-font-size * 1.5;
+         @standard-button-padding-vertical: (30px - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
+         @standard-button-padding-horizontal: @standard-button-font-size;
+         @standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
+         @standard-button-margin: 0 @standard-column-width 0 0;
+         @call-to-action-button-background: @button-color-default;
+         @call-to-action-button-background-focus: @button-color-hover;
+         @call-to-action-button-background-active: @button-color-active;
+         @call-to-action-button-background-disabled: @button-color-disabled;
+         @call-to-action-button-border-width: 0;
+         @call-to-action-button-border-style: solid;
+         @call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-default;
+         @call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
+         @call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
+         @call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
+         @call-to-action-button-font-color: @button-color-background;
+         @call-to-action-button-font-color-focus: @button-color-background;
+         @call-to-action-button-font-color-active: @button-color-background;
+         @call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
+         @call-to-action-button-padding-vertical: (30px - (@call-to-action-button-border-width * 2) - @standard-button-line-height) / 2;
+         @call-to-action-button-padding-horizontal: @standard-button-font-size;
+         @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
       </less-variables>
    </css-tokens>
 </theme>

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -13,43 +13,7 @@
          @header-menubar-font-color: pink;
          @header-dropdown-menu-font-color: purple;
 
-         @standard-button-background: @button-color-background;
-         @standard-button-background-focus: @button-color-background;
-         @standard-button-background-active: @button-color-background;
-         @standard-button-background-disabled: @button-color-background;
-         @standard-button-border: @standard-button-border-width @standard-button-border-style @button-color-default;
-         @standard-button-border-focus: @standard-button-border-width @standard-button-border-style @button-color-hover;
-         @standard-button-border-active: @standard-button-border-width @standard-button-border-style @button-color-active;
-         @standard-button-border-disabled: @standard-button-border-width @standard-button-border-style @button-color-disabled;
-         @standard-button-border-radius: 2px;
-         @standard-button-font-color: @button-color-default;
-         @standard-button-font-color-focus: @button-color-hover;
-         @standard-button-font-color-active: @button-color-active;
-         @standard-button-font-color-disabled: @button-color-disabled;
-         @standard-button-font-weight: bold;
-         @standard-button-height: 28px;
-         @standard-button-padding-vertical: (@standard-button-height - (@standard-button-border-width * 2) - @standard-button-line-height) / 2;
-         @standard-button-padding: @standard-button-padding-vertical @standard-button-padding-horizontal;
-         @call-to-action-button-background: @button-color-default;
-         @call-to-action-button-background-focus: @button-color-hover;
-         @call-to-action-button-background-active: @button-color-active;
-         @call-to-action-button-background-disabled: @button-color-disabled;
-         @call-to-action-button-border-width: 0;
-         @call-to-action-button-border-style: solid;
-         @call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-default;
-         @call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-hover;
-         @call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-active;
-         @call-to-action-button-border-disabled: @call-to-action-button-border-width @call-to-action-button-border-style @button-color-disabled;
-         @call-to-action-button-border-radius: @standard-button-border-radius;
-         @call-to-action-button-font-color: @button-color-background;
-         @call-to-action-button-font-color-focus: @button-color-background;
-         @call-to-action-button-font-color-active: @button-color-background;
-         @call-to-action-button-font-color-disabled: fade(@button-color-background, 50%);
-         @call-to-action-button-font-weight: @standard-button-font-weight;
-         @call-to-action-button-height: @standard-button-height;
-         @call-to-action-button-padding-vertical: (@call-to-action-button-height - (@call-to-action-button-border-width * 2) - @call-to-action-button-line-height) / 2;
-         @call-to-action-button-padding-horizontal: @standard-button-padding-horizontal;
-         @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
+         @use-legacy-buttons: false;
       </less-variables>
    </css-tokens>
 </theme>


### PR DESCRIPTION
This addresses issue [AKU-452](https://issues.alfresco.com/jira/browse/AKU-452), which is about making updates to the Aikau buttons to match the new Share improvements.

The final effect should be invisible to end-users of Share, however the "Aikau Test Theme"—as applied to our test application—will make the new changes visible on all unit-test pages.

NOTE: If at all possible, please double-check the aesthetics for me (both old and new) to ensure I've not broken the old and that it matches the new.