### PR TITLE
AKU-493: MultiSelect values displayed twice

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -478,6 +478,9 @@ define([
                newValuesArray = (newValueParam && [newValueParam]) || [];
             }
 
+            // Clear existing values
+            array.forEach(this._choices, this._removeChoice, this);
+
             // Create an items array
             var chosenItems = array.map(newValuesArray, function(nextNewValue) {
 
@@ -938,33 +941,9 @@ define([
           * @param    {object} evt Dojo-normalised event object
           */
          _onChoiceCloseClick: function alfresco_forms_controls_MultiSelect___onChoiceCloseClick(choiceToRemove, evt) {
-
-            // Update the choices collection
-            this._choices = array.filter(this._choices, function(nextChoice) {
-               return nextChoice.value !== choiceToRemove.value;
-            });
-            if (this._selectedChoice === choiceToRemove) {
-               this._selectedChoice = null;
-            }
-
-            // Synchronise the control's value with the choices collection
-            var updatedValue = array.map(this._choices, function(nextChoice) {
-               return nextChoice.item;
-            }, this);
-            this._changeAttrValue("value", updatedValue);
-
-            // Remove the node and its listeners
-            domConstruct.destroy(choiceToRemove.domNode);
-            choiceToRemove.selectListener.remove();
-            choiceToRemove.closeListener.remove();
-
-            // Stop the click doing anything else
+            this._removeChoice(choiceToRemove);
             evt.preventDefault();
             evt.stopPropagation();
-
-            // Update the results (i.e. adjust the items' chosen states)
-            this._updateResultsDropdown();
-            this._hideResultsDropdown();
          },
 
          /**
@@ -1176,6 +1155,39 @@ define([
                   this.own(on(nextParent, "scroll", lang.hitch(this, this._hideResultsDropdown)));
                }
             }
+         },
+
+         /**
+          * Remove a specific choice value
+          *
+          * @instance
+          * @param    {object} choiceToRemove The choice object to remove
+          * @param    {object} evt Dojo-normalised event object
+          */
+         _removeChoice: function alfresco_forms_controls_MultiSelect___removeChoice(choiceToRemove) {
+
+            // Update the choices collection
+            this._choices = array.filter(this._choices, function(nextChoice) {
+               return nextChoice.value !== choiceToRemove.value;
+            });
+            if (this._selectedChoice === choiceToRemove) {
+               this._selectedChoice = null;
+            }
+
+            // Synchronise the control's value with the choices collection
+            var updatedValue = array.map(this._choices, function(nextChoice) {
+               return nextChoice.item;
+            }, this);
+            this._changeAttrValue("value", updatedValue);
+
+            // Remove the node and its listeners
+            domConstruct.destroy(choiceToRemove.domNode);
+            choiceToRemove.selectListener.remove();
+            choiceToRemove.closeListener.remove();
+
+            // Update the results (i.e. adjust the items' chosen states)
+            this._updateResultsDropdown();
+            this._hideResultsDropdown();
          },
 
          /**

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -695,6 +695,74 @@ define([
 
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
+         },
+
+         // STATE AFTER THIS TEST
+         // 
+         // Control 1
+         //    *choices: "tag1", "tag11"
+         //    searchbox: ""
+         //    results dropdown: hidden
+         //    
+         // Control 2
+         //    choices: "Those that belong to the emperor"
+         //    searchbox: ""
+         //    results dropdown: hidden
+         //    
+         // Misc
+         //    *focused element: Set tags value button
+         //    
+         "Setting a value replaces not appends": function() {
+            return browser.findById("SET_TAGS_VALUE_BUTTON")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Did not render two values for control");
+               })
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "tag1", "Did not display first tag label correctly");
+               })
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "tag11", "Did not display second tag label correctly");
+               })
+               .end()
+
+            .findById("SET_TAGS_VALUE_BUTTON")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Does not still render two values for control");
+               })
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "tag1", "Did not display first tag label correctly");
+               })
+               .end()
+
+            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "tag11", "Did not display second tag label correctly");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
          }
       });
    }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -1,5 +1,6 @@
-var hrStyle = "border: 1px solid #eee; width: 300px; margin: 25px 15px;";
-
+var hrStyle = "border: 1px solid #eee; width: 300px; margin: 25px 15px;",
+   tagsValue = ["workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478e"];
+   
 model.jsonModel = {
    services: [
       {
@@ -54,6 +55,17 @@ model.jsonModel = {
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "SET_TAGS_VALUE_BUTTON",
+         config: {
+            label: "Set tags value",
+            publishTopic: "SET_FORM1_VALUE",
+            publishPayload: {
+               tags: tagsValue
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
          id: "FOCUS_HELPER_BUTTON",
          config: {
             label: "Focus helper"
@@ -75,9 +87,10 @@ model.jsonModel = {
                   config: {
                      okButtonPublishTopic: "FORM_POST",
                      pubSubScope: "FORM1_",
+                     setValueTopic: "SET_FORM1_VALUE",
                      scopeFormControls: false,
                      value: {
-                        tags: ["workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478e"]
+                        tags: tagsValue
                      },
                      widgets: [
                         {
@@ -147,7 +160,7 @@ model.jsonModel = {
                      pubSubScope: "FORM1_",
                      scopeFormControls: false,
                      value: {
-                        tags: ["workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "workspace://SpacesStore/d37d7dfa-8410-46be-af6a-5d5880ca478e"]
+                        tags: tagsValue
                      },
                      widgets: [
                         {


### PR DESCRIPTION
This addresses [AKU-493](https://issues.alfresco.com/jira/browse/AKU-493) which notes that a MultiSelect control can have duplicated values displayed inside it. It has been fixed, such that multiple attempts to set the value will always replace the current value, not append to it.