### PR TITLE
AKU-489: AlfTabContainer and AlfSideBarContainer heights

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -251,7 +251,7 @@ define(["dojo/_base/declare",
          }
          
          // Keep track of the overall browser window changing in size...
-         on(window, "resize", lang.hitch(this, this.resizeHandler));
+         this.alfSetupResizeSubscriptions(this.resizeHandler, this);
          
          // Perform the initial rendering...
          this.lastSidebarWidth = this.initialSidebarWidth;
@@ -295,9 +295,12 @@ define(["dojo/_base/declare",
          }
          
          // Get the position of the DOM node and the available view port height...
-         var box = domGeom.getMarginBox(this.containerNode);
          var winBox = win.getBox();
-         var availableHeight = winBox.h - box.t - this.footerHeight;
+
+         // We're using JQuery here to get the offset as it has proved more reliable than either the Dojo margin box
+         // or native browser offsetTop options...
+         var offset = $(this.domNode).offset().top;
+         var availableHeight = winBox.h - offset - this.footerHeight;
          
          // Get the height of the content...
          var sidebarContentHeight = this.calculateHeight(this.sidebarNode, 0, this.sidebarNode.children.length - 1);

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -9,6 +9,7 @@
    display: inline-block;
    vertical-align: top;
    background: none;
+   border: none;
 }
 
 .alfresco-layout-AlfSideBarContainer > .container > ui-widget-content {
@@ -22,7 +23,7 @@
 .alfresco-layout-AlfSideBarContainer .resize-handle {
    background-color: #ffffff;
    width: 9px;
-   right: -1px;
+   right: 0;
    border-right: @standard-border;
    border-left: @standard-border;
 }

--- a/aikau/src/main/resources/alfresco/layout/css/AlfTabContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfTabContainer.css
@@ -25,3 +25,7 @@
 .alfresco-layout-AlfTabContainer .dijitTabContainerTop-container {
    border: none;
 }
+
+.alfresco-layout-AlfTabContainer .alfresco-layout-AlfTabContainer__OuterTab {
+  padding: 0;
+}

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -632,4 +632,39 @@ define(["intern!object",
          TestCommon.alfPostCoverageResults(this, browser);
       }
    });
+
+   registerSuite({
+      name: "Tab Container Tests (height calculations)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/MixedLayoutHeights", "Tab Container Tests (height calculations)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      // See AKU-489 - we want to check that a sidebar inside a tab is not bigger than the window. In fact
+      // it's height should be the body height, minus the offset (approx 36px) and the configured footer (10px)
+      "Check inner sidebar height": function() {
+         var height;
+         return browser.findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               height = size.height;
+            })
+         .end()
+         .findById("SIDEBAR")
+            .getSize()
+               .then(function(size) {
+                  var target = height - 46;
+                  assert(size.height > (target - 5) && size.height < (target + 5), "The sidebar height (" + size.height + ") was not within a margin of error of the expected height (" + target + ")");
+               });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
 });

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -659,7 +659,7 @@ define(["intern!object",
             .getSize()
                .then(function(size) {
                   var target = height - 46;
-                  assert(size.height > (target - 5) && size.height < (target + 5), "The sidebar height (" + size.height + ") was not within a margin of error of the expected height (" + target + ")");
+                  assert.closeTo(size.height, target, 5, "Sidebar height incorrect");
                });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Mixed layout widgets</shortname>
+  <description>Shows a compination of nested layout widgets. Used for testing initial heights are correctly set.</description>
+  <family>aikau-unit-tests</family>
+  <url>/MixedLayoutHeights</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.js
@@ -1,0 +1,86 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "TABS",
+         name: "alfresco/layout/AlfTabContainer",
+         config: {
+            widgets: [
+               {
+                  id: "SIDEBAR",
+                  title: "Sidebar",
+                  name: "alfresco/layout/AlfSideBarContainer",
+                  config: {
+                     footerHeight: 10,
+                     widgets: [
+                        {
+                           id: "LOGO",
+                           name: "alfresco/logo/Logo",
+                           align: "sidebar"
+                        },
+                        {
+                           id: "LIST",
+                           name: "alfresco/documentlibrary/AlfDocumentList",
+                           align: "main",
+                           config: {
+                              useHash: true,
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/AlfListView",
+                                    config: {
+                                       itemKey: "index",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Row",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      config: {
+                                                         widgets: [
+                                                            {
+                                                               name: "alfresco/renderers/Property",
+                                                               config: {
+                                                                  propertyToRender: "index"
+                                                               }
+                                                            }
+                                                         ]
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/logging/DebugLog",
+                  title: "Debug Log"
+               }
+            ]
+         }
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-489 and updates the AlfTabContainer so that it creates its tabs in the DOM model before creating widgets in them (this allows the widgets in the tabs to have access to actual dimensions to work from). The AlfSideBarContainer is also updated to make better use of the _ResizeMixin capabilities. The styling of the tabs has been tidied up (to remove the default padding) which has allowed the sidebar borders to be tidied up as well. A unit test has been added to verify that the heights are now calculated sensibly. 