### PR TITLE
AKU-506: Updates to improve layout behaviour

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -23,10 +23,12 @@
  *
  * @module alfresco/core/Page
  * @extends module:alfresco/core/ProcessWidgets
+ * @mixes module:alfresco/core/ResizeMixin
  * @author Dave Draper
  * @author Martin Doyle
  */
 define(["alfresco/core/ProcessWidgets",
+        "alfresco/core/ResizeMixin",
         "alfresco/core/topics",
         "service/constants/Default",
         "dojo/string",
@@ -40,10 +42,10 @@ define(["alfresco/core/ProcessWidgets",
         "jquery", // NOTE: Need to include JQuery at root page to prevent XHR require request for first module that uses it
         "jqueryui", // NOTE: Need to include JQuery UI at root page to prevent XHR require request for first module that uses it
         "alfresco/core/shims"],
-        function(ProcessWidgets, topics, AlfConstants, string, declare, domConstruct, array,
+        function(ProcessWidgets, ResizeMixin, topics, AlfConstants, string, declare, domConstruct, array,
                  lang, domClass, win, PubQueue, jquery, jqueryui, shims) {
 
-   return declare([ProcessWidgets], {
+   return declare([ProcessWidgets, ResizeMixin], {
 
       /**
        * This is the base class for the page
@@ -327,6 +329,12 @@ define(["alfresco/core/ProcessWidgets",
          // created...
          PubQueue.getSingleton().release();
          this.alfPublish(topics.PAGE_WIDGETS_READY, {});
+
+         // Once everything has completed loading we want to publish a resize event to give all of the widgets
+         // a chance to set their dimensions correctly. This is somewhat using a sledgehammer to crack a nut but
+         // is a simple and effective means of ensuring the correct layout on page load. In particular this was
+         // prompted by issues with the AlfTabContainer in Chrome not handling client height correctly (see AKU-506)
+         this.alfPublishResizeEvent(this.domNode);
 
          // Add a class to indicate that the page is ready. This is primarily for testing purposes.
          domClass.add(this.domNode, "allWidgetsProcessed");

--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -303,7 +303,10 @@ define(["dojo/_base/declare",
          var availableHeight = winBox.h - offset - this.footerHeight;
          
          // Get the height of the content...
-         var sidebarContentHeight = this.calculateHeight(this.sidebarNode, 0, this.sidebarNode.children.length - 1);
+         // NOTE: When we get the sizebar height we want to ignore the first child element as this will be the resizer
+         //       bar and will always be the previously set height, if we include this then we skew the results and
+         //       the container height can never shrink (see AKU-506)
+         var sidebarContentHeight = this.calculateHeight(this.sidebarNode, 1, this.sidebarNode.children.length - 1);
          var mainContentHeight = this.calculateHeight(this.mainNode, 0, this.mainNode.children.length);
          
          // Work out the max height for the side bar...

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -336,7 +336,7 @@ define(["dojo/_base/declare",
             }
 
             // Now add tabs for each widget...
-            array.forEach(this.widgets, lang.hitch(this, "addWidget"));
+            array.forEach(this.widgets, lang.hitch(this, this.addWidget));
          }
          this.tabContainerWidget.startup();
 
@@ -422,7 +422,7 @@ define(["dojo/_base/declare",
          {
             this._delayedProcessingWidgets.push(
                {
-                  "domNode": domNode,
+                  "domNode": cp.domNode,
                   "contentPane": cp,
                   "widget": widget
                }

--- a/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
@@ -42,13 +42,10 @@ define(["intern!object",
       },
 
      "Test preferences requested": function () {
-         return browser.findByCssSelector(TestCommon.pubDataCssSelector("ALF_PREFERENCE_GET", "preference", "org.alfresco.share.sideBarWidth"))
-            .then(
-               function() {
-                  // No action - preferences request found
-               },
-               function() {
-                  assert(false, "User preferences were not requested");
+         return browser.findByCssSelector(".resize-handle") // Need to find something before getting logged publish data
+            .getLastPublish("ALF_PREFERENCE_GET")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "preference", "org.alfresco.share.sideBarWidth", "User preferences were not requested");
                });
       },
 
@@ -136,6 +133,46 @@ define(["intern!object",
                assert(width === "350px", "The sidebar wasn't shown via publication");
             })
          .end();
+      },
+
+      "Increase window size and check sidebar height": function() {
+         var bodyHeight;
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar") // Need to find something before clearing logs!
+            .end()
+            .clearLog() // Clear the logs otherwise they'll force the size of the window
+            .setWindowSize(null, 1024, 968)
+            .findByCssSelector("body")
+               .getSize()
+               .then(function(size) {
+                  // We need the body size, not the window size because the window size includes all the OS chrome
+                  bodyHeight = size.height;
+               })
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+               .getSize()
+               .then(function(size) {
+                  // Substracting the padding from the height!
+                  assert.closeTo(size.height, (bodyHeight - 20), 5, "The sidebar height didn't increase with the window size");
+               });
+      },
+
+      "Decrease window size and check sidebar height": function() {
+         var bodyHeight;
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar") // Need to find something before clearing logs!
+            .end()
+            .clearLog() // Clear the logs otherwise they'll force the size of the window
+            .setWindowSize(null, 1024, 568)
+            .findByCssSelector("body")
+               .getSize()
+               .then(function(size) {
+                  // We need the body size, not the window size because the window size includes all the OS chrome
+                  bodyHeight = size.height;
+               })
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+               .getSize()
+               .then(function(size) {
+                  // Substracting the padding from the height!
+                  assert.closeTo(size.height, (bodyHeight - 20), 5, "The sidebar height didn't decrease with the window size");
+               });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -649,7 +649,10 @@ define(["intern!object",
       // it's height should be the body height, minus the offset (approx 36px) and the configured footer (10px)
       "Check inner sidebar height": function() {
          var height;
-         return browser.findByCssSelector("body")
+         return browser.findByCssSelector(".dijitTabInner:nth-child(2) .tabLabel")
+            .click()
+         .end()
+         .findByCssSelector("body")
             .getSize()
             .then(function(size) {
                height = size.height;
@@ -661,6 +664,18 @@ define(["intern!object",
                   var target = height - 46;
                   assert.closeTo(size.height, target, 5, "Sidebar height incorrect");
                });
+      },
+
+      // See AKU-506 - make sure that widgets waiting for page readiness (in this case a list) get informed that
+      // they can do their stuff (in this case, load data)
+      "Check that list data is loaded": function() {
+         return browser.findByCssSelector(".dijitTabInner:nth-child(3) .tabLabel")
+            .click()
+         .end()
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS")
+            .then(function(payload) {
+               assert.isNotNull(payload, "List data was not requested on tab load");
+            });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfSideBarContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfSideBarContainer.get.js
@@ -15,6 +15,7 @@ model.jsonModel = {
       {
          name: "alfresco/layout/AlfSideBarContainer",
          config: {
+            footerHeight: 10,
             widgets: [
                {
                   name: "alfresco/layout/HorizontalWidgets",
@@ -77,12 +78,12 @@ model.jsonModel = {
                         }
                      ]
                   }
+               },
+               {
+                  name: "alfresco/logging/DebugLog"
                }
             ]
          }
-      },
-      {
-         name: "alfresco/logging/SubscriptionLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.js
@@ -23,6 +23,11 @@ model.jsonModel = {
          config: {
             widgets: [
                {
+                  id: "LOGO1",
+                  name: "alfresco/logo/Logo",
+                  title: "Logo"
+               },
+               {
                   id: "SIDEBAR",
                   title: "Sidebar",
                   name: "alfresco/layout/AlfSideBarContainer",
@@ -30,7 +35,7 @@ model.jsonModel = {
                      footerHeight: 10,
                      widgets: [
                         {
-                           id: "LOGO",
+                           id: "LOGO2",
                            name: "alfresco/logo/Logo",
                            align: "sidebar"
                         },
@@ -39,7 +44,8 @@ model.jsonModel = {
                            name: "alfresco/documentlibrary/AlfDocumentList",
                            align: "main",
                            config: {
-                              useHash: true,
+                              useHash: false,
+                              currentPageSize: 10,
                               widgets: [
                                  {
                                     name: "alfresco/lists/views/AlfListView",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-506. It updates the AlfSideBarContainer so that the previous height of the resizer bar is ignored when calculating the container height (this allows the container to reduce in size as the browser window reduces in size). The main Page widget now publishes a resize topic when loading has completed to ensure that all widgets have a final resize opportunity (this is something of a brute force solution to the problem, but is effective). Unit tests have been added to verify the new resizing behaviour and confirm dynamically added tabs work as expected (in this case with lists)