### PR TITLE
AKU-492: Improvements in JS logic to support DocLib options

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/Tree.js
+++ b/aikau/src/main/resources/alfresco/navigation/Tree.js
@@ -157,11 +157,11 @@ define(["dojo/_base/declare",
        */
       getTargetUrl: function alfresco_navigation_Tree__getTargetUrl() {
          var url = null;
-         if (this.siteId !== null && this.containerId !== null)
+         if (this.siteId && this.containerId)
          {
             url = AlfConstants.PROXY_URI + "slingshot/doclib/treenode/site/" + this.siteId + "/documentlibrary";
          }
-         else if (this.rootNode !== null)
+         else if (this.rootNode)
          {
             url = AlfConstants.PROXY_URI + "slingshot/doclib/treenode/node/alfresco/company/home";
          }
@@ -187,11 +187,11 @@ define(["dojo/_base/declare",
             children: "false",
             max: "-1"
          };
-         if (this.siteId !== null && this.containerId !== null)
+         if (this.siteId && this.containerId)
          {
             // No changes to the default query
          }
-         else if (this.rootNode !== null)
+         else if (this.rootNode)
          {
             query.max = "500";
             query.libraryRoot = this.rootNode;

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -141,51 +141,54 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload defining the document to retrieve the details for.
        */
       onSearchRequest: function alfresco_services_SearchService__onSearchRequest(payload) {
-         if (payload == null || payload.term == null)
+         // jshint maxlen:300, maxcomplexity:false
+         if (!payload || !payload.term)
          {
             this.alfLog("warn", "A request was made to perform a search but no 'term' attribute was provided", payload, this);
          }
          else
          {
             // Check to see whether or not a success topic has been provided...
-            var alfTopic = (payload.alfResponseTopic != null) ? payload.alfResponseTopic : "ALF_SEARCH_REQUEST";
+            var alfTopic = (payload.alfResponseTopic) ? payload.alfResponseTopic : "ALF_SEARCH_REQUEST";
             var url = AlfConstants.PROXY_URI + "slingshot/search/";
 
             // Use any unexpected attributes as a query attribute...
             var query = this.query;
-            if (payload.query == null)
+            if (!payload.query)
             {
                var queryAttributes = {};
                for (var key in payload)
                {
-                  switch(key) {
-                     case "alfTopic":
-                     case "alfResponseScope":
-                     case "alfResponseTopic":
-                     case "alfPublishScope":
-                     case "alfCallerName":
-                     case "term":
-                     case "tag":
-                     case "startIndex":
-                     case "sort":
-                     case "site":
-                     case "rootNode":
-                     case "repo":
-                     case "pageSize":
-                     case "maxResults":
-                     case "facetFields":
-                     case "filters":
-                     case "sortAscending":
-                     case "sortField":
-                     case "requestId":
-                     case "spellcheck":
-                        break;
-                     default:
-                        queryAttributes[key] = payload[key];
+                  if (payload.hasOwnProperty(key)) {
+                     switch(key) {
+                        case "alfTopic":
+                        case "alfResponseScope":
+                        case "alfResponseTopic":
+                        case "alfPublishScope":
+                        case "alfCallerName":
+                        case "term":
+                        case "tag":
+                        case "startIndex":
+                        case "sort":
+                        case "site":
+                        case "rootNode":
+                        case "repo":
+                        case "pageSize":
+                        case "maxResults":
+                        case "facetFields":
+                        case "filters":
+                        case "sortAscending":
+                        case "sortField":
+                        case "requestId":
+                        case "spellcheck":
+                           break;
+                        default:
+                           queryAttributes[key] = payload[key];
+                     }
                   }
                }
                query = dojoJson.stringify(queryAttributes);
-               if (query == "{}")
+               if (query === "{}")
                {
                   query = "";
                }
@@ -196,7 +199,7 @@ define(["dojo/_base/declare",
             }
 
             var sort = "";
-            if (payload.sortField != null && (payload.sortField === "null" || payload.sortField === ""))
+            if (payload.sortField && payload.sortField === "null")
             {
                // No action required - leave as the empty string which is relevance - no direction can be applied
             }
@@ -206,25 +209,26 @@ define(["dojo/_base/declare",
             }
             else
             {
-               sort = ((payload.sortField != null) ? payload.sortField : this.sort) + "|" + 
-                      ((payload.sortAscending != null) ? payload.sortAscending : this.sortAscending);
+               sort = ((payload.sortField) ? payload.sortField : this.sort) + "|" + 
+                      ((payload.sortAscending) ? payload.sortAscending : this.sortAscending);
             }
 
+            var defaultFacetFields = "{http://www.alfresco.org/model/content/1.0}content.mimetype,{http://www.alfresco.org/model/content/1.0}modifier.__,{http://www.alfresco.org/model/content/1.0}creator.__,{http://www.alfresco.org/model/content/1.0}description.__";
             var data = {
-               facetFields: (payload.facetFields != null) ? payload.facetFields : "{http://www.alfresco.org/model/content/1.0}content.mimetype,{http://www.alfresco.org/model/content/1.0}modifier.__,{http://www.alfresco.org/model/content/1.0}creator.__,{http://www.alfresco.org/model/content/1.0}description.__",
-               filters: (payload.filters != null) ? payload.filters : "",
+               facetFields: payload.facetFields || defaultFacetFields,
+               filters: payload.filters || "",
                term: payload.term,
-               tag: (payload.tag != null) ? payload.tag : this.tag,
-               startIndex: (payload.startIndex != null) ? payload.startIndex : this.startIndex,
+               tag: payload.tag || this.tag,
+               startIndex: (payload.startIndex || payload.startIndex === 0) ? payload.startIndex : this.startIndex,
                sort: sort,
-               site: (payload.site != null) ? payload.site : this.site,
-               rootNode: (payload.rootNode != null) ? payload.rootNode : this.rootNode,
-               repo: (payload.repo != null) ? payload.repo : this.repo,
+               site: payload.site || this.site,
+               rootNode: payload.rootNode || this.rootNode,
+               repo: payload.repo || this.repo,
                query: query,
-               pageSize: (payload.pageSize != null) ? payload.pageSize : this.pageSize,
-               maxResults: (payload.maxResults != null) ? payload.maxResults : 0,
+               pageSize: payload.pageSize || this.pageSize, // It makes no sense for page size to ever be 0
+               maxResults: payload.maxResults || 0,
                noCache: new Date().getTime(),
-               spellcheck: (payload.spellcheck != null) ? payload.spellcheck: false
+               spellcheck: payload.spellcheck || false
             };
             var config = {
                requestId: payload.requestId,
@@ -250,7 +254,7 @@ define(["dojo/_base/declare",
          var options = {
             t: ""
          };
-         if (payload.query != null)
+         if (payload.query)
          {
             options.t = payload.query;
          }

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -199,18 +199,13 @@ define(["dojo/_base/declare",
             }
 
             var sort = "";
-            if (payload.sortField && payload.sortField === "null")
+            if (payload.sortField === "null" || payload.sortField === "Relevance" || payload.sortField === "")
             {
                // No action required - leave as the empty string which is relevance - no direction can be applied
             }
-            else if (payload.sortField === "Relevance")
-            {
-               sort = "";
-            }
             else
             {
-               sort = ((payload.sortField) ? payload.sortField : this.sort) + "|" + 
-                      ((payload.sortAscending) ? payload.sortAscending : this.sortAscending);
+               sort = (payload.sortField || this.sort) + "|" + (payload.sortAscending || this.sortAscending);
             }
 
             var defaultFacetFields = "{http://www.alfresco.org/model/content/1.0}content.mimetype,{http://www.alfresco.org/model/content/1.0}modifier.__,{http://www.alfresco.org/model/content/1.0}creator.__,{http://www.alfresco.org/model/content/1.0}description.__";

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -577,7 +577,7 @@ function getDocLibTree(options) {
                   siteId: options.siteId,
                   containerId: options.containerId,
                   rootNode: options.rootNode,
-                  rootLabel: options.rootLabel
+                  rootLabel: options.rootLabel || "documentlibrary.root.label"
                }
             }
          ]
@@ -1198,7 +1198,7 @@ function getDocLib(options) {
                         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
                         config: {
                            hide: options.docLibPrefrences.hideBreadcrumbTrail,
-                           rootLabel: options.rootLabel,
+                           rootLabel: options.rootLabel || "root.label",
                            lastBreadcrumbIsCurrentNode: true,
                            useHash: (options.useHash !== false),
                            pathChangeTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -80,7 +80,7 @@ define(["intern!object",
          return browser.findByCssSelector("td.mx-url")
             .getVisibleText()
             .then(function(text) {
-               assert(decodeURIComponent(text).indexOf("&query={") === -1, "unexpected query found")
+               assert(decodeURIComponent(text).indexOf("&query={") === -1, "unexpected query found");
             });
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-492 to improve the logic handling relating to siteId, containerId and rootNode values that might be set via calls to the functions provided in the doclib.lib.js. Previously any undefined values were being interpreted as actual data because explicit checks for null were being made.