### PR TITLE
AKU-494: Update PathTree to track path changes

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -67,6 +67,18 @@ define([],function() {
        * @type {string}
        * @default
        */
-      PAGE_WIDGETS_READY: "ALF_WIDGETS_READY"
+      PAGE_WIDGETS_READY: "ALF_WIDGETS_READY",
+
+      /**
+       * This topic is published when a path changed. It is typically used in Document Libraries
+       * to communicate navigation through a folder hierarchy to both request data and to keep
+       * navigation widgets synchronized (e.g. [Document Lists]{@link module:alfresco/documentlibrary/AlfDocumentList}
+       * and [Path Trees]{@link module:alfresco/navigation/PathTree}).
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      PATH_CHANGED: "ALF_DOCUMENTLIST_PATH_CHANGED"
    };
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -26,11 +26,12 @@
 define(["dojo/_base/declare",
         "alfresco/lists/AlfSortablePaginatedList",
         "alfresco/core/JsNode",
+        "alfresco/core/topics",
         "dojo/_base/array",
         "dojo/_base/lang",
         "alfresco/util/hashUtils",
         "dojo/io-query"],
-        function(declare, AlfSortablePaginatedList, JsNode, array, lang, hashUtils, ioQuery) {
+        function(declare, AlfSortablePaginatedList, JsNode, topics, array, lang, hashUtils, ioQuery) {
 
    return declare([AlfSortablePaginatedList], {
 
@@ -147,7 +148,7 @@ define(["dojo/_base/declare",
        */
       setupSubscriptions: function alfrescdo_documentlibrary_AlfDocumentList__setupSubscriptions() {
          this.inherited(arguments);
-         this.alfSubscribe("ALF_DOCUMENTLIST_PATH_CHANGED", lang.hitch(this, this.onPathChanged));
+         this.alfSubscribe(topics.PATH_CHANGED, lang.hitch(this, this.onPathChanged));
          this.alfSubscribe("ALF_DOCUMENTLIST_CATEGORY_CHANGED", lang.hitch(this, this.onCategoryChanged));
          this.alfSubscribe("ALF_DOCUMENTLIST_TAG_CHANGED", lang.hitch(this, this.onTagChanged));
          this.alfSubscribe(this.filterSelectionTopic, lang.hitch(this, this.onFilterChanged));

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -25,8 +25,9 @@
  * @module alfresco/documentlibrary/_AlfDocumentListTopicMixin
  * @author Dave Draper
  */
-define(["dojo/_base/declare"], 
-        function(declare) {
+define(["dojo/_base/declare",
+        "alfresco/core/topics"], 
+        function(declare, topics) {
    
    return declare(null, {
 
@@ -333,8 +334,8 @@ define(["dojo/_base/declare"],
        * 
        * @instance
        * @type {string}
-       * @default "ALF_DOCUMENTLIST_PATH_CHANGED"
+       * @default [topics.PATH_CHANGED]{@link module:alfresco/core/topics#PATH_CHANGED}
        */
-      pathChangeTopic: "ALF_DOCUMENTLIST_PATH_CHANGED"
+      pathChangeTopic: topics.PATH_CHANGED
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/VerticalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/VerticalWidgets.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -94,16 +94,17 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       allWidgetsProcessed: function alfresco_layout_VerticalWidgets__allWidgetsProcessed(widgets) {
-         if (this.widgetMarginTop != null || this.widgetMarginBottom != null)
+         if (this.widgetMarginTop || this.widgetMarginTop === 0 || 
+             this.widgetMarginBottom || this.widgetMarginBottom === 0)
          {
-            array.forEach(widgets, function(widget, i) {
-               if(this.widgetMarginTop != null)
+            array.forEach(widgets, function(widget) {
+               if(this.widgetMarginTop || this.widgetMarginTop === 0)
                {
                   domStyle.set(widget.domNode, {
                      "marginTop": this.widgetMarginTop + "px"
                   });
                }
-               if(this.widgetMarginBottom != null)
+               if(this.widgetMarginBottom || this.widgetMarginBottom === 0)
                {
                   domStyle.set(widget.domNode, {
                      "marginBottom": this.widgetMarginBottom + "px"

--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -36,6 +36,19 @@ define(["dojo/_base/declare",
    return declare([Tree, _AlfDocumentListTopicMixin], {
       
       /**
+       * This determines whether or not to subcribe to the 
+       * [hash change topic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#hashChangeTopic}
+       * or the [path change topic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#pathChangeTopic}.
+       * Although the path tree doesn't make changes to the browser URL hash, it can be driven from them to that
+       * it expands tree nodes to reflect the path attribute set as a hash parameter.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      useHash: true,
+
+      /**
        * Extends the inherited function to subscribe to the [hashChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#hashChangeTopic}
        * topic passing the [onFilterChange function]{@link module:alfresco/navigation/PathTree#onFilterChange} as the callback handler.
        * 
@@ -43,7 +56,14 @@ define(["dojo/_base/declare",
        */
       postMixInProperties: function alfresco_navigation_PathTree__postMixInProperties() {
          this.inherited(arguments);
-         this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, "onFilterChange"));
+         if (this.useHash === true)
+         {
+            this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onFilterChange));
+         }
+         else
+         {
+            this.alfSubscribe(this.pathChangeTopic, lang.hitch(this, this.onFilterChange));
+         }
       },
       
       /**
@@ -97,7 +117,9 @@ define(["dojo/_base/declare",
             var childNodes = node.getChildren(),
                 pathElement = pathElements.shift(),
                 filteredNodes = array.filter(childNodes, function(item) {
-               return item.item.name === pathElement;
+               // NOTE: Compare the value, not the name as the name can be switched (e.g. documentLibrary 
+               //       becomes Document Library, see "updateChild" function in TreeStore).
+               return item.item.value === pathElement;
             });
             if (filteredNodes.length === 1)
             {

--- a/aikau/src/main/resources/alfresco/navigation/Tree.js
+++ b/aikau/src/main/resources/alfresco/navigation/Tree.js
@@ -33,6 +33,7 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Tree.html",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/core/Core",
+        "alfresco/core/topics",
         "service/constants/Default",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/services/_NavigationServiceTopicMixin",
@@ -42,7 +43,7 @@ define(["dojo/_base/declare",
         "alfresco/navigation/TreeStore",
         "dijit/tree/ObjectStoreModel",
         "dijit/Tree"], 
-        function(declare, _Widget, _Templated, template, _PublishPayloadMixin, AlfCore, AlfConstants, _AlfDocumentListTopicMixin, 
+        function(declare, _Widget, _Templated, template, _PublishPayloadMixin, AlfCore, topics, AlfConstants, _AlfDocumentListTopicMixin, 
                  _NavigationServiceTopicMixin, domConstruct, lang, array, TreeStore, ObjectStoreModel, Tree) {
    
    return declare([_Widget, _Templated, _PublishPayloadMixin, AlfCore, _AlfDocumentListTopicMixin, _NavigationServiceTopicMixin], {
@@ -244,13 +245,13 @@ define(["dojo/_base/declare",
       /**
        * This is the topic that is published when a node on the tree is clicked. The data applied
        * to the filter is the the value of the node clicked. By default it is expected that the
-       * tree represents a location so the default id is "ALF_DOCUMENTLIST_PATH_CHANGED". 
+       * tree represents a path so is set to the [path changed topic]{@link module:alfresco/core/topics#PATH_CHANGED}.
        * 
        * @instance
        * @type {string}
-       * @default "ALF_DOCUMENTLIST_PATH_CHANGED"
+       * @default [topics.PATH_CHANGED]{@link module:alfresco/core/topics#PATH_CHANGED}
        */
-      publishTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
+      publishTopic: topics.PATH_CHANGED,
 
       /**
        * By default the payload type will the the current item. This will automatically be set

--- a/aikau/src/main/resources/alfresco/navigation/TreeStore.js
+++ b/aikau/src/main/resources/alfresco/navigation/TreeStore.js
@@ -55,7 +55,7 @@ define(["dojo/_base/declare",
        * @param {object} object The parent to retrieve the children for
        * @param {object} options The options for the query (these are currently ignored)
        */
-      getChildren: function alfresco_navigation_TreeStore__getChildren(object, options) {
+      getChildren: function alfresco_navigation_TreeStore__getChildren(object, /*jshint unused:false*/ options) {
          var deferred = new Deferred();
          var config = {
             url: this.target + object.path,
@@ -106,7 +106,7 @@ define(["dojo/_base/declare",
        * @param {number} index The index of the item in the original array
        * @returns {boolean} true if the item should be kept
        */
-      filterChildren: function alfresco_navigation_TreeStore__filterChildren(item, index) {
+      filterChildren: function alfresco_navigation_TreeStore__filterChildren(item, /*jshint unused:false*/ index) {
          var include = array.some(this.filterPaths, function(filter) {
             var matches = true;
             try
@@ -134,7 +134,7 @@ define(["dojo/_base/declare",
        * @param {object} child The child object to update
        * @param {number} index The index of the child
        */
-      updateChild: function alfresco_navigation_TreeStore__updateChild(parent, child, index) {
+      updateChild: function alfresco_navigation_TreeStore__updateChild(parent, child, /*jshint unused:false*/ index) {
          child.id = child.nodeRef;
          child.value = child.name;
          child.path = parent.path + child.name + "/";

--- a/aikau/src/main/resources/alfresco/renderers/_ItemLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ItemLinkMixin.js
@@ -27,9 +27,10 @@
 define(["dojo/_base/declare",
         "service/constants/Default",
         "alfresco/core/UrlUtilsMixin",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/_base/event"], 
-        function(declare, AlfConstants, UrlUtilsMixin, lang, event) {
+        function(declare, AlfConstants, UrlUtilsMixin, topics, lang, event) {
    
    return declare([UrlUtilsMixin], {
 
@@ -93,7 +94,7 @@ define(["dojo/_base/declare",
                   if (item.node.isContainer)
                   {
                      this.updateFolderLinkPublication(publishPayload);
-                     topic = "ALF_DOCUMENTLIST_PATH_CHANGED";
+                     topic = topics.PATH_CHANGED;
                   }
                   else
                   {
@@ -106,7 +107,7 @@ define(["dojo/_base/declare",
                   if (item.node.isContainer)
                   {
                      this.updateFolderLinkPublication(publishPayload);
-                     topic = "ALF_DOCUMENTLIST_PATH_CHANGED";
+                     topic = topics.PATH_CHANGED;
                   }
                   else
                   {

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -64,30 +64,23 @@ define(["intern!object",
             });
       },
      
-      "Test that clicking on TREE1 publishes default topic": function() {
+      "Test that clicking on TREE1 publishes path": function() {
          return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
             .click()
          .end()
-         .findByCssSelector(TestCommon.topicSelector("ALF_DOCUMENTLIST_PATH_CHANGED", "publish", "last"))
-            .then(null, function() {
-               assert(false, "The topic published by clicking on TREE1 nodes is not the default publishTopic");
+         .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "path", "/", "Clicking on the root of TREE1 did not publish the expected path");
             });
       },
    
-      "Test that clicking on TREE1 publishes path": function() {
-         return browser.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "path", "/"))
-            .then(null, function() {
-               assert(false, "Clicking on the root of TREE1 did not publish the expected path");
-            });
-      },
-  
       "Test that clicking on TREE2 publishes custom topic": function() {
          return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
             .click()
          .end()
-         .findByCssSelector(TestCommon.topicSelector("ALF_ITEM_SELECTED", "publish", "last"))
-            .then(null, function() {
-               assert(false, "The topic published by clicking on TREE1 nodes is not requested custom topic");
+         .getLastPublish("ALF_ITEM_SELECTED")
+            .then(function(payload) {
+               assert.isNotNull(payload, "The topic published by clicking on TREE2 nodes is not requested custom topic");
             });
       },
   
@@ -134,9 +127,34 @@ define(["intern!object",
          return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > div:first-child div.dijitTreeRow .dijitTreeLabel")
             .click()
          .end()
-         .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "path", "/documentLibrary/Agency Files/"))
-            .then(null, function() {
-               assert(false, "Clicking on a child node of TREE2 did not publish the expected path");
+         .getLastPublish("ALF_ITEM_SELECTED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "path", "/documentLibrary/Agency Files/", "Clicking on a child node of TREE2 did not publish the expected path");
+            });
+      },
+
+      "Publish hash change": function() {
+         return browser.findById("SET_HASH_label")
+            .click()
+         .end()
+         .findAllByCssSelector("#TREE1 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Setting the hash did not expand the first tree");
+            })
+         .end()
+         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "Setting the hash should not have expanded the second tree");
+            });
+      },
+
+      "Publish path change": function() {
+         return browser.findById("SET_PATH_label")
+            .click()
+         .end()
+         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Setting the path did not expand the second tree");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
@@ -25,6 +25,37 @@ model.jsonModel = {
                      widgetMarginRight: 10,
                      widgets: [
                         {
+                           name: "alfresco/layout/VerticalWidgets",
+                           widthPx: "100",
+                           config: {
+                              widgetMarginBottom: 10,
+                              widgets: [
+                                 {
+                                    id: "SET_HASH",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Set hash",
+                                       publishTopic: "ALF_HASH_CHANGED",
+                                       publishPayload: {
+                                          path: "/documentLibrary/Budget Files/Invoices/"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "SET_PATH",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Set path",
+                                       publishTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
+                                       publishPayload: {
+                                          path: "/documentLibrary/Budget Files/Invoices/"
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
                            name: "alfresco/layout/ClassicWindow",
                            config: {
                               title: "Showing Root",
@@ -50,6 +81,7 @@ model.jsonModel = {
                                     name: "alfresco/navigation/PathTree",
                                     config: {
                                        showRoot: false,
+                                       useHash: false,
                                        filterPaths: ["^/documentLibrary/(.*)$"],
                                        rootNode: "workspace://SpacesStore/b4cff62a-664d-4d45-9302-98723eac1319",
                                        publishTopic: "ALF_ITEM_SELECTED",
@@ -71,10 +103,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/PathTreeMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-494 to ensure that the alfresco/navigation/PathTree can be configured to track path change publication as well as hash changes. I've also moved the relevant topics into the constants file and updated the unit test appropriately. One final change also ensures that tree nodes are expanded based on value and not name as the TreeStore can swap the names with descriptions in certain circumstances.