### PR TITLE
AKU-502: Updated alt text for inline edit property with no value

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -193,9 +193,17 @@ define(["dojo/_base/declare",
          // Localize the labels and alt-text...
          this.saveLabel = this.message(this.saveLabel);
          this.cancelLabel = this.message(this.cancelLabel);
-         this.editAltText = this.message(this.editAltText, {
-            0: this.renderedValue
-         });
+
+         if (this.renderedValue)
+         {
+            this.editAltText = this.message(this.editAltText, {
+               0: this.renderedValue
+            });
+         }
+         else
+         {
+            this.editAltText = this.message("inline-edit.edit.altTextNoValue");
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/i18n/InlineEditProperty.properties
+++ b/aikau/src/main/resources/alfresco/renderers/i18n/InlineEditProperty.properties
@@ -1,4 +1,5 @@
 inline-edit.edit.altText=Click to edit '{0}'
+inline-edit.edit.altTextNoValue=Click to edit
 inline-edit.edit.label=Click to edit
 inline-edit.save.label=Save
 inline-edit.cancel.label=Cancel

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -60,7 +60,7 @@ define(["intern!object",
       },
 
       "Edit icon initially invisible": function() {
-         return browser.findByCssSelector(".alfresco-testing-SubscriptionLog")
+         return browser.findByCssSelector(".alfresco_logging_DebugLog__header")
             .moveMouseTo()
          .end()
          .sleep(250) // Make sure the mouse isn't over the row!
@@ -227,27 +227,16 @@ define(["intern!object",
          return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .dijitInputContainer input")
             .clearValue()
             .type("New")
-            .end()
+         .end()
 
          .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
             .click()
-            .end()
+         .end()
 
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATE", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Property update not requested");
-            })
-            .end()
-
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "name", "New"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "New value didn't publish correctly");
-            })
-            .end()
-
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "hiddenData", "hidden_update"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Hidden value didn't get included");
+         .getLastPublish("ALF_CRUD_UPDATE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "name", "New", "New value didn't publish correctly");
+               assert.propertyVal(payload, "hiddenData", "hidden_update", "Hidden value didn't get included");
             });
       },
 
@@ -300,9 +289,16 @@ define(["intern!object",
             });
       },
 
+      "Check rendered alt text when no value available": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_ITEM_0 .editIcon")
+            .getAttribute("alt")
+            .then(function(alt) {
+               assert.equal(alt, "Click to edit", "Alt text for missing value incorrect");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
-
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
@@ -78,6 +78,29 @@ model.jsonModel = {
                                           ]
                                        }
                                     }
+                                 },
+                                 {
+                                    id: "INLINE_EDIT_NO_VALUE",
+                                    name: "alfresco/renderers/InlineEditProperty",
+                                    config: {
+                                       propertyToRender: "title",
+                                       publishTopic: "ALF_CRUD_UPDATE",
+                                       publishPayloadType: "PROCESS",
+                                       publishPayloadModifiers: ["processCurrentItemTokens"],
+                                       publishPayloadItemMixin: true,
+                                       publishPayload: {
+                                          url: "api/solr/facet-config/{name}"
+                                       },
+                                       hiddenDataRules: [
+                                          {
+                                             name: "hiddenData",
+                                             rulePassValue: "hidden_update",
+                                             ruleFailValue: "",
+                                             is: ["New"]
+                                          }
+                                       ],
+                                       renderOnNewLine: true
+                                    }
                                  }
                               ]
                            }
@@ -90,10 +113,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-502. This isn't a brilliant change accessibility wise, but is something of an edge case and we can make further improvements when we go through an accessibility review. However, this does satisfy the test case in the raised issue.