### PR TITLE
AKU-508: Ensure only once page widgets subscription is created in lists

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -464,7 +464,16 @@ define(["dojo/_base/declare",
          {
             // Create a subscription to listen out for all widgets on the page being reported
             // as ready (then we can start loading data)...
-            this.pageWidgetsReadySubcription = this.alfSubscribe(topics.PAGE_WIDGETS_READY, lang.hitch(this, this.onPageWidgetsReady), true);
+            if (this.pageWidgetsReadySubcription)
+            {
+               // A subscription already exists, this can occur when an inheriting list module
+               // calls processWidgets more than once (which will result in allWidgetsProcessed
+               // being called more than once). We want to avoid multiple subscriptions - see AKU-508
+            }
+            else
+            {
+               this.pageWidgetsReadySubcription = this.alfSubscribe(topics.PAGE_WIDGETS_READY, lang.hitch(this, this.onPageWidgetsReady), true);
+            }
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/lists/FilteredListUseCaseTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListUseCaseTest.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "FilteredList Tests (Use Case 1)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/FilteredListUseCase1", "FilteredList Tests (Use Case 1").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      // See AKU-508 for the context, but we want to make sure that opening a dialog will not trigger the filtered list
+      // to request data...
+      "Check displaying dialog does not reload list": function() {
+         return browser.findByCssSelector("#PDM_ITEM_1_SELECT_CONTROL span")
+            .clearLog()
+            .click()
+         .end()
+         .findByCssSelector("#PDM_ITEM_1_SELECT_CONTROL_menu tr[data-value='MODERATED']")
+            .click()
+         .end()
+         .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed")
+         .end()
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS")
+            .then(function(payload) {
+               assert.isNull(payload, "A request to load data should not have been made when the dialog opens");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -143,6 +143,7 @@ define({
       "src/test/resources/alfresco/lists/AlfHashListTest",
       "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
       "src/test/resources/alfresco/lists/FilteredListTest",
+      "src/test/resources/alfresco/lists/FilteredListUseCaseTest",
       "src/test/resources/alfresco/lists/InfiniteScrollTest",
       "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
       "src/test/resources/alfresco/lists/views/AlfListViewTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredListUseCase1.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredListUseCase1.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfFilteredList (use case 1)</shortname>
+  <description>This test page implements an AlfFilteredList to address a specific use case with PublishingDropDown menus that create dialogs</description>
+  <family>aikau-unit-tests</family>
+  <url>/FilteredListUseCase1</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredListUseCase1.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredListUseCase1.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredListUseCase1.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredListUseCase1.get.js
@@ -1,0 +1,123 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "aikauTesting/mockservices/PublishingDropDownMenuMockService",
+      "alfresco/services/DialogService",
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/TitleDescriptionAndContent",
+         config: {
+            title: "Filtered List (Use Case 1)",
+            description: "In this example the displayed filter will not perform any action, the purpose of this test page " +
+                         "is to verify that displaying a dialog will not cause the list to reload",
+            widgets: [
+               {
+                  name: "alfresco/lists/AlfFilteredList",
+                  config: {
+                     noDataMessage: "No data",
+                     filteringTopics: ["_valueChangeof_FILTER"],
+                     useHash: true,
+                     sortField: "cm:userName",
+                     widgetsForFilters: [{
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "TEXTBOX_FILTER",
+                              name: "nameFilter",
+                              placeHolder: "Enter filter...",
+                              label: "Filter"
+                           }
+                        }
+                     ],
+                     currentPageSize: 1,
+                     widgets: [
+                        {
+                           id: "LIST_VIEW",
+                           name: "alfresco/lists/views/AlfListView",
+                           config: {
+                              widgets:[
+                                 {
+                                    name: "alfresco/lists/views/layouts/Row",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      id: "PDM",
+                                                      name: "alfresco/renderers/PublishingDropDownMenu",
+                                                      config: {
+                                                         additionalCssClasses: "custom-css",
+                                                         publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                                                         publishPayload: {
+                                                            dialogTitle: "Title",
+                                                            handleOverflow: false,
+                                                            textContent: "Test",
+                                                            widgetsButtons: [
+                                                               {
+                                                                  name: "alfresco/buttons/AlfButton",
+                                                                  id: "OK",
+                                                                  config: {
+                                                                     label: "OK",
+                                                                     publishTopic: "CONFIRMATION",
+                                                                     publishPayload: {}
+                                                                  }
+                                                               },
+                                                               {
+                                                                  name: "alfresco/buttons/AlfButton",
+                                                                  id: "CANCEL",
+                                                                  config: {
+                                                                     label: "Cancel",
+                                                                     publishTopic: "CANCEL"
+                                                                  }
+                                                               }
+                                                            ]
+                                                         },
+                                                         propertyToRender: "index",
+                                                         optionsConfig: {
+                                                            fixed: [
+                                                               {label: "Public", value: "PUBLIC"},
+                                                               {label: "Moderated", value: "MODERATED"},
+                                                               {label: "Private", value: "PRIVATE"}
+                                                            ]
+                                                         },
+                                                         cancellationPublishTopic: "CANCEL_UPDATE",
+                                                         cancellationPublishPayloadType: "CURRENT_ITEM"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-508 to ensure that lists only make subscriptions to the page ready topic once. This was impacting the AlfFilteredList widget because it was calling processWidgets twice. A check has been added to ensure only one subscription is created and a unit test has been created to prevent future regressions.