### PR TITLE
AKU-503: InlineEditProperty updates

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
@@ -146,16 +146,19 @@ define(["alfresco/lists/views/layouts/Row",
             }
          }, {
             _attachPoint: "title",
-            _render: function(item) {
-               return item.node.properties["cm:title"];
-            },
+            // _render: function(item) {
+            //    return item.node.properties["cm:title"];
+            // },
             id: "DETAILED_VIEW_TITLE",
             name: "alfresco/renderers/InlineEditProperty",
             config: {
                propertyToRender: "node.properties.cm:title",
                postParam: "prop_cm_title",
+               renderSize: "small",
                renderedValuePrefix: "(",
-               renderedValueSuffix: ")"
+               renderedValueSuffix: ")",
+               warnIfNotAvailable: true,
+               warnIfNotAvailableMessage: "no.title.message"
             }
          }, {
             _attachPoint: "version",
@@ -186,7 +189,7 @@ define(["alfresco/lists/views/layouts/Row",
                propertyToRender: "node.properties.cm:description",
                postParam: "prop_cm_description",
                warnIfNotAvailable: true,
-               warnIfNoteAvailableMessage: "no.description.message"
+               warnIfNotAvailableMessage: "no.description.message"
             }
          }, {
             _attachPoint: "tags",
@@ -199,7 +202,7 @@ define(["alfresco/lists/views/layouts/Row",
                propertyToRender: "node.properties.cm:taggable",
                postParam: "prop_cm_taggable",
                warnIfNotAvailable: true,
-               warnIfNoteAvailableMessage: "no.tags.message"
+               warnIfNotAvailableMessage: "no.tags.message"
             }
          }, {
             _attachPoint: "category",

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
@@ -146,9 +146,6 @@ define(["alfresco/lists/views/layouts/Row",
             }
          }, {
             _attachPoint: "title",
-            // _render: function(item) {
-            //    return item.node.properties["cm:title"];
-            // },
             id: "DETAILED_VIEW_TITLE",
             name: "alfresco/renderers/InlineEditProperty",
             config: {

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfSimpleView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfSimpleView.js
@@ -128,15 +128,11 @@ define(["dojo/_base/declare",
                                                 config: {
                                                    propertyToRender: "node.properties.cm:title",
                                                    postParam: "prop_cm_title",
+                                                   renderSize: "small",
                                                    renderedValuePrefix: "(",
                                                    renderedValueSuffix: ")",
-                                                   renderFilter: [
-                                                      {
-                                                         property: "node.properties.cm:title",
-                                                         values: [""],
-                                                         negate: true
-                                                      }
-                                                   ]
+                                                   warnIfNotAvailable: true,
+                                                   warnIfNotAvailableMessage: "no.title.message"
                                                 }
                                              }
                                           ]

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
@@ -190,7 +190,9 @@ define(["dojo/_base/declare",
                               name: "alfresco/renderers/InlineEditProperty",
                               config: {
                                  propertyToRender: "node.properties.cm:title",
-                                 postParam: "prop_cm_title"
+                                 postParam: "prop_cm_title",
+                                 warnIfNotAvailable: true,
+                                 warnIfNotAvailableMessage: "no.title.message"
                               }
                            }
                         ]
@@ -205,7 +207,9 @@ define(["dojo/_base/declare",
                               name: "alfresco/renderers/InlineEditProperty",
                               config: {
                                  propertyToRender: "node.properties.cm:description",
-                                 postParam: "prop_cm_description"
+                                 postParam: "prop_cm_description",
+                                 warnIfNotAvailable: true,
+                                 warnIfNotAvailableMessage: "no.description.message"
                               }
                            }
                         ]

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -46,7 +46,6 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/on",
         "dojo/dom-class",
-        "dojo/dom-style",
         "dojo/html",
         "dojo/dom-attr",
         "dojo/keys",
@@ -57,7 +56,7 @@ define(["dojo/_base/declare",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
         function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin,
-                 template, lang, array, on, domClass, domStyle, html, domAttr, keys, event, query) {
+                 template, lang, array, on, domClass, html, domAttr, keys, event, query) {
 
    return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin], {
       
@@ -274,7 +273,7 @@ define(["dojo/_base/declare",
             var hasEditPermission = lang.getObject(this.permissionProperty, false, this.currentItem);
             if (!hasEditPermission)
             {
-               domStyle.set(this.editIconNode, "display", "none");
+               domClass.add(this.editIconNode, "disabled");
                this._disableEdit = true;
             }
          }

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -46,6 +46,7 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/on",
         "dojo/dom-class",
+        "dojo/dom-style",
         "dojo/html",
         "dojo/dom-attr",
         "dojo/keys",
@@ -56,7 +57,7 @@ define(["dojo/_base/declare",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
         function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin,
-                 template, lang, array, on, domClass, html, domAttr, keys, event, query) {
+                 template, lang, array, on, domClass, domStyle, html, domAttr, keys, event, query) {
 
    return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin], {
       
@@ -86,23 +87,6 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
-       * The is the name of the parameter that will be used to persist changes to the property
-       * @instance
-       * @type {string}
-       * @default null
-       */
-      postParam: null,
-      
-       /**
-       * This is the message or message key that will be used for save link text.
-       *
-       * @instance
-       * @type {string}
-       * @default "inline-edit.save.label"
-       */
-      saveLabel: "inline-edit.save.label",
-
-       /**
        * This is the message or message key that will be used for the cancel link text.
        *
        * @instance
@@ -137,6 +121,75 @@ define(["dojo/_base/declare",
       editOnClickRenderedValue: true,
 
       /**
+       * References the widget used for editing. Created by calling the 
+       * [getFormWidget]{@link module:alfresco/renderers/InlineEditProperty#getFormWidget}
+       * for the first time.
+       * 
+       * @instance
+       * @type {object}
+       * @default null
+       */
+      formWidget: null,
+
+      /**
+       * <p>In certain circimstances it may be necessary to submit additional data along with that
+       * provided by the main edit control. This configuration property should take the form:</p>
+       * <p><pre>hiddenDataRules: [
+       *   {
+       *     name: "customProperties",
+       *     rulePassValue: "hiddenData",
+       *     ruleFailValue: "",
+       *     is: ["includeHiddenData"]
+       *   }
+       * ]</pre></p>
+       *
+       * @instance
+       * @type {array}
+       * @default null
+       */
+      hiddenDataRules: null,
+
+      /**
+       * The is the name of the parameter that will be used to persist changes to the property
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      postParam: null,
+      
+      /**
+       * The value configured will be used to look up a property for the item being rendered to 
+       * determine whether or not to render the edit controls. The default value maps to the
+       * write permissions typically found in the data returned for a Node in the Alfresco
+       * repository. If this is configured to be null then the edit controls will always
+       * be rendered.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      permissionProperty: "node.permissions.user.Write",
+
+      /**
+       * Indicates whether or not the currentItem should be updated following a successful
+       * save event.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      refreshCurrentItem: false,
+
+      /**
+       * This is the message or message key that will be used for save link text.
+       *
+       * @instance
+       * @type {string}
+       * @default "inline-edit.save.label"
+       */
+      saveLabel: "inline-edit.save.label",
+
+       /**
        * The topic to publish when a property edit should be persisted. For convenience it is assumed that document
        * or folder properties are being edited so this function is called whenever a 'publishTopic' attribute
        * has not been set. The defaults are to publish on the "ALF_CRUD_CREATE" topic which will publish a payload
@@ -207,33 +260,25 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * References the widget used for editing. Created by calling the 
-       * [getFormWidget]{@link module:alfresco/renderers/InlineEditProperty#getFormWidget}
-       * for the first time.
-       * 
-       * @instance
-       * @type {object}
-       * @default null
-       */
-      formWidget: null,
-
-      /**
-       * <p>In certain circimstances it may be necessary to submit additional data along with that
-       * provided by the main edit control. This configuration property should take the form:</p>
-       * <p><pre>hiddenDataRules: [
-       *   {
-       *     name: "customProperties",
-       *     rulePassValue: "hiddenData",
-       *     ruleFailValue: "",
-       *     is: ["includeHiddenData"]
-       *   }
-       * ]</pre></p>
+       * Extends the [inherited function]{@link module:alfresco/renderers/Property#postCreate} to
+       * check the [permissionProperty]{@link module:alfresco/renderers/InlineEditProperty#permissionProperty}
+       * to determine whether or not the current user actually has permission to edit the current item. If
+       * the user does not have permission then then edit controls will be hidden (and keyboard shortcuts suppressed).
        *
        * @instance
-       * @type {array}
-       * @default null
        */
-      hiddenDataRules: null,
+      postCreate: function alfresco_renderers_InlineEditProperty__postCreate() {
+         this.inherited(arguments);
+         if (this.permissionProperty)
+         {
+            var hasEditPermission = lang.getObject(this.permissionProperty, false, this.currentItem);
+            if (!hasEditPermission)
+            {
+               domStyle.set(this.editIconNode, "display", "none");
+               this._disableEdit = true;
+            }
+         }
+      },
 
       /**
        * Gets the form widget that will be rendered as the edit field. By default this will 
@@ -374,15 +419,18 @@ define(["dojo/_base/declare",
        * @instance
        */
       onEditClick: function alfresco_renderers_InlineEditProperty__onEditClick(evt) {
-         this.suppressContainerKeyboardNavigation(true);
-         var formWidget = this.getFormWidget();
-         var o = {};
-         lang.setObject(this.postParam, this.originalRenderedValue, o);
-         formWidget.setValue(o);
-         domClass.toggle(this.renderedValueNode, "hidden");
-         domClass.toggle(this.editNode, "hidden");
-         formWidget.focus(); // Focus on the input node so typing can occur straight away
-         evt && event.stop(evt);
+         if (!this._disableEdit)
+         {
+            this.suppressContainerKeyboardNavigation(true);
+            var formWidget = this.getFormWidget();
+            var o = {};
+            lang.setObject(this.postParam, this.originalRenderedValue, o);
+            formWidget.setValue(o);
+            domClass.toggle(this.renderedValueNode, "hidden");
+            domClass.toggle(this.editNode, "hidden");
+            formWidget.focus(); // Focus on the input node so typing can occur straight away
+            evt && event.stop(evt);
+         }
       },
       
       /**
@@ -412,16 +460,6 @@ define(["dojo/_base/declare",
       updateSaveData: function alfresco_renderers_InlineEditProperty__getSaveData(payload) {
          lang.mixin(payload, this.getFormWidget().getValue());
       },
-
-      /**
-       * Indicates whether or not the currentItem should be updated following a successful
-       * save event.
-       *
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      refreshCurrentItem: false,
 
       /**
        * Called following successful save attempts. This will update the read-only display using the requested save

--- a/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
+++ b/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
@@ -333,10 +333,6 @@ define(["dojo/_base/declare",
                                              noRefresh: false,
                                              successMessage: "moreInfo.inlineEdit.update.success"
                                           },
-                                          renderFilter: [{
-                                             property: "node.permissions.user.Write",
-                                             values: [true]
-                                          }],
                                           requirementConfig: {
                                              initialValue: true
                                           },
@@ -352,37 +348,15 @@ define(["dojo/_base/declare",
                                        }
                                     },
                                     {
-                                       name: "alfresco/renderers/Property",
-                                       config: {
-                                          propertyToRender: "node.properties.cm:name",
-                                          renderFilter: [{
-                                             property: "node.permissions.user.Write",
-                                             values: [false]
-                                          }]
-                                       }
-                                    },
-                                    {
                                        name: "alfresco/renderers/InlineEditProperty",
                                        config: {
                                           propertyToRender: "node.properties.cm:title",
                                           postParam: "prop_cm_title",
                                           renderSize: "small",
                                           warnIfNotAvailable: true,
-                                          warnIfNoteAvailableMessage: "no.title.message",
+                                          warnIfNotAvailableMessage: "no.title.message",
                                           renderedValuePrefix: "(",
                                           renderedValueSuffix: ")",
-                                          renderFilterMethod: "ALL",
-                                          renderFilter: [
-                                             {
-                                                property: "node.properties.cm:title",
-                                                values: [""],
-                                                negate: true
-                                             },
-                                             {
-                                                property: "node.permissions.user.Write",
-                                                values: [true]
-                                             }
-                                          ],
                                           publishTopic: "ALF_CRUD_CREATE",
                                           publishPayloadType: "PROCESS",
                                           publishPayloadModifiers: ["processCurrentItemTokens"],
@@ -392,27 +366,6 @@ define(["dojo/_base/declare",
                                              noRefresh: false,
                                              successMessage: "moreInfo.inlineEdit.update.success"
                                           }
-                                       }
-                                    },
-                                    {
-                                       name: "alfresco/renderers/Property",
-                                       config: {
-                                          propertyToRender: "node.properties.cm:title",
-                                          renderSize: "small",
-                                          warnIfNotAvailable: true,
-                                          warnIfNoteAvailableMessage: "no.title.message",
-                                          renderFilterMethod: "ALL",
-                                          renderFilter: [
-                                             {
-                                                property: "node.properties.cm:title",
-                                                values: [""],
-                                                negate: true
-                                             },
-                                             {
-                                                property: "node.permissions.user.Write",
-                                                values: [false]
-                                             }
-                                          ]
                                        }
                                     },
                                     {
@@ -481,7 +434,7 @@ define(["dojo/_base/declare",
                                           renderSize: "small",
                                           postParam: "prop_cm_description",
                                           warnIfNotAvailable: true,
-                                          warnIfNoteAvailableMessage: "no.description.message",
+                                          warnIfNotAvailableMessage: "no.description.message",
                                           publishTopic: "ALF_CRUD_CREATE",
                                           publishPayloadType: "PROCESS",
                                           publishPayloadModifiers: ["processCurrentItemTokens"],
@@ -489,38 +442,7 @@ define(["dojo/_base/declare",
                                           publishPayload: {
                                              url: "api/node/{jsNode.nodeRef.uri}/formprocessor",
                                              noRefresh: false
-                                          },
-                                          renderFilter: [
-                                             {
-                                                property: "node.properties.cm:description",
-                                                values: [""],
-                                                negate: true
-                                             },
-                                             {
-                                                property: "node.permissions.user.Write",
-                                                values: [true]
-                                             }
-                                          ]
-                                       }
-                                    },
-                                    {
-                                       name: "alfresco/renderers/Property",
-                                       config: {
-                                          propertyToRender: "node.properties.cm:description",
-                                          renderSize: "small",
-                                          warnIfNotAvailable: true,
-                                          warnIfNoteAvailableMessage: "no.description.message",
-                                          renderFilter: [
-                                             {
-                                                property: "node.properties.cm:description",
-                                                values: [""],
-                                                negate: true
-                                             },
-                                             {
-                                                property: "node.permissions.user.Write",
-                                                values: [false]
-                                             }
-                                          ]
+                                          }
                                        }
                                     }
                                  ]

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -91,6 +91,44 @@ define(["dojo/_base/declare",
       currentItem: null,
 
       /**
+       * Indicates whether or not the property should be de-emphasized. This will result in a lighter colour
+       * being used.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      deemphasized: false,
+
+      /**
+       * The label for the property. Won't be shown if left as null.
+       *
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      label: null,
+
+      /**
+       * Specifies a maximum width for the content of the renderer, and will overflow with an ellipsis if necessary
+       *
+       * @instance
+       * @type {string}
+       * @default null
+       */
+      maxWidth: null,
+
+      /**
+       * Indicates that this should only be displayed when the item (note: NOT the renderer) is
+       * hovered over.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      onlyShowOnHover: false,
+
+      /**
        * This should be set to the name of the property to render (e.g. "cm:name"). The property is expected
        * to be in the properties map for the item being rendered.
        *
@@ -114,96 +152,81 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "alfresco-renderers-Property"
+       * @default
        */
       renderedValueClass: "alfresco-renderers-Property",
 
       /**
        * A label to go before the rendered value
+       * 
        * @instance
        * @type {string}
-       * @default ""
+       * @default
        */
       renderedValuePrefix: "",
 
       /**
        * A label to go after the rendered value
+       * 
        * @instance
        * @type {string}
-       * @default ""
+       * @default
        */
       renderedValueSuffix: "",
-
-      /**
-       * Indicates whether or not to hide the property if is not available or not set
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      warnIfNotAvailable: false,
-
-      /**
-       * This can be either small, medium or large.
-       * @instance
-       * @type {string}
-       * @default "medium"
-       */
-      renderSize: "medium",
-
-      /**
-       * This indicates whether or not the requestes property can be found for the current item
-       *
-       * @instance
-       * @type {boolean}
-       * @default true
-       */
-      renderPropertyNotFound: true,
-
-      /**
-       * Indicates that this should only be displayed when the item (note: NOT the renderer) is
-       * hovered over.
-       *
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      onlyShowOnHover: false,
-
-      /**
-       * The label for the property. Won't be shown if left as null.
-       *
-       * @instance
-       * @type {string}
-       * @default null
-       */
-      label: null,
 
       /**
        * Indicates whether or not the property will be rendered on a new line.
        *
        * @instance
        * @type {boolean}
-       * @default false
+       * @default
        */
       renderOnNewLine: false,
 
       /**
-       * Indicates whether or not the property should be de-emphasized. This will result in a lighter colour
-       * being used.
+       * This indicates whether or not the requestes property can be found for the current item
        *
        * @instance
        * @type {boolean}
-       * @default false
+       * @default
        */
-      deemphasized: false,
+      renderPropertyNotFound: true,
 
       /**
-       * Specifies a maximum width for the content of the renderer, and will overflow with an ellipsis if necessary
+       * This can be either small, medium or large.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      renderSize: "medium",
+
+      /**
+       * Indicates whether or not a message should be displayed in place of the 
+       * [propertyToRender]{@link module:alfresco/renderers/Property#propertyToRender} when it is not available.
+       * This defaults to false but if configured to be true then the 
+       * [warnIfNotAvailableMessage]{@link module:alfresco/renderers/Property#warnIfNotAvailableMessage}
+       * will be displayed.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      warnIfNotAvailable: false,
+
+      /**
+       * This is the message that will be displayed in place of the property value if that value does not
+       * exist. The message will only be displayed if 
+       * [warnIfNotAvailable]{@link module:alfresco/renderers/Property#warnIfNotAvailable} is not configured
+       * to be true. If this is left as the default value then an attempt will be made to set an appropriate
+       * message but will ultimately fallback to referencing the configured 
+       * [propertyToRender]{@link module:alfresco/renderers/Property#propertyToRender} value.
        *
        * @instance
        * @type {string}
+       * @default null
        */
-      maxWidth: null,
+      warnIfNotAvailableMessage: null,
 
       /**
        * The positions where a tooltip can appear over a truncated value
@@ -244,7 +267,7 @@ define(["dojo/_base/declare",
             if (this.warnIfNotAvailable) {
                // Get appropriate message
                // Check message based on propertyToRender otherwise default to sensible alternative
-               var warningKey = this.warnIfNoteAvailableMessage,
+               var warningKey = this.warnIfNotAvailableMessage,
                   warningMessage = "";
                if (!warningKey) {
                   warningKey = "no." + this.propertyToRender + ".message";

--- a/aikau/src/main/resources/alfresco/renderers/Tags.js
+++ b/aikau/src/main/resources/alfresco/renderers/Tags.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -101,8 +101,8 @@ define(["dojo/_base/declare",
        * @param {object} tagData The tag data to render
        * @param {number} index The index of the tag in the overall array
        */
-      createReadOnlyTag: function alfresco_renderers_Tags__createReadOnlyTag(nameAttribute, valueAttribute, tagData, index) {
-         if (tagData == null || tagData[nameAttribute] == null)
+      createReadOnlyTag: function alfresco_renderers_Tags__createReadOnlyTag(nameAttribute, valueAttribute, tagData, /*jshint unused:false*/ index) {
+         if (!tagData || !tagData[nameAttribute])
          {
             this.alfLog("warn", "No '" + nameAttribute + "' attribute for tag", this, tagData);
          }
@@ -147,7 +147,7 @@ define(["dojo/_base/declare",
        * @param {object} tagWidget The tag widget to place.
        * @param {number} index The index of the tag
        */
-      placeReadOnlyTag: function alfresco_renderers_Tags__placeReadOnlyTag(tagWidget, index) {
+      placeReadOnlyTag: function alfresco_renderers_Tags__placeReadOnlyTag(tagWidget, /*jshint unused:false*/ index) {
          tagWidget.placeAt(this.renderedValueNode);
       },
       
@@ -185,7 +185,7 @@ define(["dojo/_base/declare",
        */
       onEditClick: function alfresco_renderers_Tags__onEditClick() {
          this.inherited(arguments);
-         if (this.editTagsNode != null)
+         if (this.editTagsNode)
          {
             var oldEditTags = registry.findWidgets(this.editTagsNode);
             array.forEach(oldEditTags, lang.hitch(this, this.destroyTag));
@@ -206,7 +206,7 @@ define(["dojo/_base/declare",
        * @param {object} tagData The read-only tag widget to create a corresponding edit tag for.
        * @param {number} index The index of the tag in the overall array
        */
-      createEditTag: function alfresco_renderers_Tags__createEditTag(nameAttribute, valueAttribute, tagData, index) {
+      createEditTag: function alfresco_renderers_Tags__createEditTag(nameAttribute, valueAttribute, tagData, /*jshint unused:false*/ index) {
          var tagWidget = new EditTag({
             tagName: tagData[nameAttribute],
             tagValue: tagData[valueAttribute]
@@ -223,12 +223,12 @@ define(["dojo/_base/declare",
        */
       onRemoveEditTag: function alfresco_renderers_Tags__onRemoveEditTag(evt) {
          var tagWidget = registry.byNode(evt.target);
-         if (tagWidget != null)
+         if (tagWidget)
          {
             // Filter out the deleted tag from the list of current tags, this is done to ensure
             // that we persist the correct tags on save and redraw the correct tags on readonly mode...
             var tagName = tagWidget.tagName;
-            this.currentTags = array.filter(this.currentTags, function(currTag, index) {
+            this.currentTags = array.filter(this.currentTags, function(currTag) {
                return currTag.tagName !== tagName;
             });
             tagWidget.destroy();
@@ -244,12 +244,12 @@ define(["dojo/_base/declare",
        * @param {object} e The key press event
        */
       onValueEntryKeyPress: function alfresco_renderers_Tags__onValueEntryKeyPress(e) {
-         if(e.charOrCode == keys.ESCAPE)
+         if(e.charOrCode === keys.ESCAPE)
          {
             event.stop(e);
             this.onCancel();
          }
-         else if(e.charOrCode == keys.ENTER)
+         else if(e.charOrCode === keys.ENTER)
          {
             event.stop(e);
             var formValue = this.getFormWidget().getValue();
@@ -288,7 +288,7 @@ define(["dojo/_base/declare",
        * @param {boolean} saveTagsAfterCreate Indicates whether or not to save all tags on successful creation.
        * @return {object} The created tag details
        */
-      createTag: function alfresco_renderers_Tags__createTag(tagName, saveTagsAfterCreate) {
+      createTag: function alfresco_renderers_Tags__createTag(tagName, /*jshint unused:false*/ saveTagsAfterCreate) {
 
          var tagUsed = array.some(this.currentTags, function(currentTag, index) {
             return currentTag.tagName === tagName;
@@ -376,7 +376,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The success payload
        */
-      onSaveSuccess: function alfresco_renderers_Tags__onSaveSuccess(payload) {
+      onSaveSuccess: function alfresco_renderers_Tags__onSaveSuccess(/*jshint unused:false*/ payload) {
          this.alfUnsubscribeSaveHandles([this._saveSuccessHandle, this._saveFailureHandle]);
 
          this.alfLog("log", "Property '" + this.propertyToRender + "' successfully updated for node: ", this.currentItem);

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -31,6 +31,9 @@
       opacity: 0;
       transition: opacity .2s ease-out;
       width: 16px;
+      &.disabled {
+         display: none;
+      }
    }
    .action {
       color: @general-font-color;

--- a/aikau/src/main/resources/alfresco/renderers/i18n/Property.properties
+++ b/aikau/src/main/resources/alfresco/renderers/i18n/Property.properties
@@ -2,3 +2,4 @@ no.property.message=No property for: "{0}"
 no.description.message=No description
 no.title.message=No title
 no.tags.message=No tags
+

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
@@ -92,13 +92,7 @@ define(["intern!object",
       "Title appears when specified": function() {
          return browser.findAllByCssSelector(".detail-item__title")
             .then(function(elements) {
-               assert.lengthOf(elements, 2, "Incorrect number of title widgets created");
-            })
-            .end()
-
-         .findAllByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(1) .detail-item__title, .alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(4) .detail-item__title")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "Title widgets were not created for correct items");
+               assert.lengthOf(elements, 4, "Incorrect number of title widgets created");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -297,6 +297,28 @@ define(["intern!object",
             });
       },
 
+      "Check edit disabled when user has no write permissions": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_1 .inlineEditValue")
+            .moveMouseTo()
+         .end()
+         .findByCssSelector("#INLINE_EDIT_ITEM_1 .editIcon")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The edit icon should not be displayed for items without write permission");
+            });
+      },
+
+      "Check keyboard shortcut edit disabled when user has no write permissions": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_ITEM_1 .inlineEditValue")
+            .click()
+            .pressKeys([keys.CONTROL, "e"])
+            .pressKeys(keys.NULL)
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Keyboard shortcut should not have worked for item without write permission");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -24,10 +24,9 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "intern/chai!expect",
         "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, expect, require, TestCommon) {
+        function (registerSuite, assert, require, TestCommon) {
 
    var browser;
    registerSuite({
@@ -45,21 +44,21 @@ define(["intern!object",
      "Check there are the expected number of tag controls successfully rendered": function () {
          return browser.findAllByCssSelector("span.alfresco-renderers-InlineEditProperty.alfresco-renderers-Property")
             .then(function (tagcontrols){
-               expect(tagcontrols).to.have.length(4, "Test #1a - There should be 4 tag controls successfully rendered");
+               assert.lengthOf(tagcontrols, 4, "There should be 4 tag controls successfully rendered");
             });
       },
 
       "Check there are the expected number of readonlytags successfully rendered": function() {
          return browser.findAllByCssSelector("#TAGS_4 span.alfresco-renderers-ReadOnlyTag")
             .then(function (readonlytags){
-               expect(readonlytags).to.have.length(3, "Test #1b - There should be 3 readonlytags successfully rendered");
+               assert.lengthOf(readonlytags, 3, "There should be 3 readonlytags successfully rendered");
             });
       },
 
       "Check there are no edittags shown": function() {
          return browser.findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
             .then(function (edittags){
-               expect(edittags).to.have.length(0, "Test #1c - There should be 0 edittags shown");
+               assert.lengthOf(edittags, 0, "There should be 0 edittags shown");
             });
       },
 
@@ -67,26 +66,11 @@ define(["intern!object",
          return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-ReadOnlyTag:first-of-type a")
             .click()
          .end()
-         .then(
-            function(){},
-            function(){assert(false, "Test #1d - The link did not publish on 'ALF_NAVIGATE_TO_PAGE' after mouse clicks");}
-         );
-      },
-
-      "Check the link click published the payload as expected (HASH)": function() {
-         return browser.findByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "type", "HASH"))
-            .then(
-               function(){},
-               function(){assert(false, "Test #1e - The link did not publish the payload with 'type' as 'HASH'");}
-            );
-      },
-
-      "Check the link click published the payload as expected (URL)": function() {
-         return browser.findByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "tag=Test1"))
-            .then(
-               function(){},
-               function(){assert(false, "Test #1f - The link did not publish the payload with 'url' as 'tag=Test1'");}
-            );
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "type", "HASH", "The link did not publish the payload with 'type' as 'HASH'");
+               assert.propertyVal(payload, "url", "tag=Test1", "The link did not publish the payload with 'url' as 'tag=Test1'");
+            });
       },
 
       "Check there are 3 edit tags now shown": function() {
@@ -96,7 +80,7 @@ define(["intern!object",
 
          .findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
             .then(function (edittags){
-               expect(edittags).to.have.length(3, "Test #1g - There should be 3 edittags now shown");
+               assert.lengthOf(edittags, 3, "There should be 3 edittags now shown");
             });
       },
 
@@ -104,7 +88,7 @@ define(["intern!object",
          return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type")
             .getVisibleText()
             .then(function (edittagtext){
-               expect(edittagtext).to.contain("Test1", "Test #1h - Edit tag 1 should read 'Test1'");
+               assert.include(edittagtext, "Test1", "Edit tag 1 should read 'Test1'");
             });
       },
 
@@ -115,7 +99,7 @@ define(["intern!object",
 
          .findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
             .then(function (edittags){
-               expect(edittags).to.have.length(2, "Test #1i - There should be 2 edittags now shown");
+               assert.lengthOf(edittags, 2, "There should be 2 edittags now shown");
             });
       },
 
@@ -123,7 +107,7 @@ define(["intern!object",
          return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type")
             .getVisibleText()
             .then(function (edittagtext){
-               expect(edittagtext).to.contain("Test2", "Test #1j - Edit tag 1 should now read 'Test2'");
+               assert.include(edittagtext, "Test2", "Edit tag 1 should now read 'Test2'");
             })
          .end()
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
@@ -21,7 +21,27 @@ model.jsonModel = {
                items: [
                   {
                      name: "Test",
-                     option: "1"
+                     option: "1",
+                     node: {
+                        nodeRef: "dummy://node/1",
+                        permissions: {
+                           user: {
+                              Write: true
+                           }
+                        }
+                     }
+                  },
+                  {
+                     name: "Test 2",
+                     option: "2",
+                     node: {
+                        nodeRef: "dummy://node/2",
+                        permissions: {
+                           user: {
+                              Write: false
+                           }
+                        }
+                     }
                   }
                ]
             },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
@@ -11,6 +11,7 @@ var propertyLinkWidgets = [
                            id: "INLINE_EDIT",
                            name: "alfresco/renderers/InlineEditPropertyLink",
                            config: {
+                              permissionProperty: null,
                               propertyToRender: "name",
                               linkPublishTopic: "TEST_PROPERTY_LINK_CLICK",
                               linkPublishPayload: {},
@@ -51,6 +52,7 @@ var propertyLinkWidgets = [
                            id: "INLINE_EDIT",
                            name: "alfresco/renderers/InlineEditPropertyLink",
                            config: {
+                              permissionProperty: null,
                               propertyToRender: "name",
                               publishTopic: "ALF_CRUD_UPDATE",
                               publishPayloadType: "PROCESS",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Tags.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Tags.get.js
@@ -16,13 +16,17 @@ model.jsonModel = {
    widgets:[
       {
          id: "TAGS_1",
-         name: "alfresco/renderers/Tags"
+         name: "alfresco/renderers/Tags",
+         config: {
+            permissionProperty: null
+         }
       },
       {
          id: "TAGS_2",
          name: "alfresco/renderers/Tags",
          config: {
-            propertyToRender: "node.properties.cm:taggable"
+            propertyToRender: "node.properties.cm:taggable",
+            permissionProperty: null
          }
       },
       {
@@ -36,6 +40,11 @@ model.jsonModel = {
                   name: "TAGS_3",
                   properties: {
                      "cm:taggable": {}
+                  },
+                  permissions: {
+                     user: {
+                        Write: true
+                     }
                   }
                }
             }
@@ -65,6 +74,11 @@ model.jsonModel = {
                            name: "Test3"
                         }
                      ]
+                  },
+                  permissions: {
+                     user: {
+                        Write: true
+                     }
                   }
                }
             }
@@ -74,10 +88,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/ComboBoxMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-503 and has made updates to both the alfresco/renderers/InlineEditProperty widget and how it is used within the various views. It also updates in particular how the cm:title is displayed in views. There is a new check within the InlineEditProperty widget on whether or not the current user has edit permissions (this is a configurable property) and editing will automatically be disabled if they do not. After discussion with UX it was agreed to always display the title and display a warning if the property is not actually set, but we will further review this in the future. Unit tests have been updated.