### PR TITLE
AKU-290: Support for pagination hiding on list loading

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -101,7 +101,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {number} 
-       * @default null
+       * @default
        */
       currentPage: null,
       
@@ -165,7 +165,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {object}
-       * @default null 
+       * @default
        */
       pageSelector: null,
       
@@ -174,7 +174,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       pageSelectorGroup: null,
       
@@ -185,7 +185,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {array}
-       * @default null
+       * @default
        */
       pageSizes: null,
 
@@ -203,7 +203,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {number} 
-       * @default null
+       * @default
        */
       totalPages: null,
       
@@ -212,7 +212,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {number} 
-       * @default null
+       * @default
        */
       totalRecords: null,
       
@@ -233,7 +233,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {array}
-       * @default null
+       * @default
        */
       widgetsAfter: null,
 
@@ -245,7 +245,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {array}
-       * @default null
+       * @default
        */
       widgetsBefore: null,
 

--- a/aikau/src/test/resources/alfresco/lists/PaginatorVisibilityTest.js
+++ b/aikau/src/test/resources/alfresco/lists/PaginatorVisibilityTest.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Paginator Visibility Tests",
+      
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/PaginatorVisibility", "Paginator Visibility Tests").end();
+      },
+      
+      beforeEach: function() {
+         browser.end();
+      },
+
+      // See AKU-290 for the context behind the following tests...
+      "Paginator should be initially hidden": function() {
+         // When the page loads the list will make a request for data but no service is included to provide
+         // a response, so the paginator should be hidden and remain hidden...
+         return browser.findById("PAGINATOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The paginator should not be visible whilst awaiting data");
+            });
+      },
+
+      "Paginator should be visible when data is provided": function() {
+         // Click a button to publish list data, this should make the paginator be displayed...
+         return browser.findById("PROVIDE_DATA_label")
+            .click()
+         .end()
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+         .end()
+         .findById("PAGINATOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The paginator should visible once data is displayed");
+            });
+      },
+
+      "Paginator should be hidden when new data is requested": function() {
+         // Click a button to publish a request for the list to reload the data, this should
+         // hide the paginator again...
+         return browser.findById("RELOAD_DATA_label")
+            .click()
+         .end()
+         .findById("PAGINATOR")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The paginator should visible once data is displayed");
+            });
+      },
+      
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -146,6 +146,7 @@ define({
       "src/test/resources/alfresco/lists/FilteredListUseCaseTest",
       "src/test/resources/alfresco/lists/InfiniteScrollTest",
       "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
+      "src/test/resources/alfresco/lists/PaginatorVisibilityTest",
       "src/test/resources/alfresco/lists/views/AlfListViewTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/PaginatorVisibility.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/PaginatorVisibility.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Paginator Visibility</shortname>
+  <description>A test page checking that the alfresco/lists/Paginator can be configured to be hidden when data is loading and displayed when data is provided.</description>
+  <family>aikau-unit-tests</family>
+  <url>/PaginatorVisibility</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/PaginatorVisibility.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/PaginatorVisibility.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/PaginatorVisibility.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/PaginatorVisibility.get.js
@@ -1,0 +1,66 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "PROVIDE_DATA",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Provide Data",
+            publishTopic: "GET_DATA_SUCCESS",
+            publishPayload: {
+               items: [
+                  {
+                     name: "Test"
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "RELOAD_DATA",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Request Reload",
+            publishTopic: "RELOAD_DATA"
+         }
+      },
+      {
+         id: "PAGINATOR",
+         name: "alfresco/lists/Paginator",
+         config: {
+            hideWhenLoading: true,
+            loadDataPublishTopic: "GET_DATA"
+         }
+      },
+      {
+         id: "LIST",
+         name: "alfresco/lists/AlfList",
+         config: {
+            loadDataPublishTopic: "GET_DATA",
+            reloadDataTopic: "RELOAD_DATA",
+            widgets: [
+               {
+                  name: "alfresco/lists/views/HtmlListView",
+                  config: {
+                     listStyleType: "square",
+                     propertyToRender: "name"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-290 to add support for the alfresco/lists/Paginator to be configured to hide when lists request data and displayed when data is successfully retrieved. The default behaviour is for this to be off because it preserves existing behaviour and also the data request/response topics are variable/configurable. Unit tests have been added to verify behaviour.