### PR TITLE
AKU-506: Make FixedHeaderFooter resize consistently with other layout widgets

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -425,7 +425,7 @@ define(["dojo/_base/declare",
          //       totalRecords, startIndex and currentPageSize values...
          if(this.useInfiniteScroll && 
             ((this.totalRecords > (this.startIndex + this.currentPageSize)) ||
-            (this.currentData.totalRecords < this.currentData.numberFound)))
+            (this.currentData && (this.currentData.totalRecords < this.currentData.numberFound))))
          {
             this.currentPage++;
             this.loadData();

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -120,7 +120,6 @@ define(["intern!object",
       "Check auto resizing": function() {
          var windowHeight;
          return browser.setWindowSize(null, 1024, 300)
-            .sleep(100) // Wait for resize debounce
             .findByCssSelector("body")
             .getSize()
             .then(function(size) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/MixedLayoutWidgets.get.js
@@ -40,30 +40,46 @@ model.jsonModel = {
                            align: "sidebar"
                         },
                         {
-                           id: "LIST",
-                           name: "alfresco/documentlibrary/AlfDocumentList",
-                           align: "main",
+                           id: "FIXED_HEADER_FOOTER",
+                           name: "alfresco/layout/FixedHeaderFooter",
                            config: {
-                              useHash: false,
-                              currentPageSize: 10,
+                              height: "auto",
+                              recalculateAutoHeightOnResize: true,
+                              widgetsForFooter: [
+                                 {
+                                    id: "LOGO3",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ],
                               widgets: [
                                  {
-                                    name: "alfresco/lists/views/AlfListView",
+                                    id: "LIST",
+                                    name: "alfresco/documentlibrary/AlfDocumentList",
+                                    align: "main",
                                     config: {
-                                       itemKey: "index",
+                                       useHash: false,
+                                       currentPageSize: 10,
                                        widgets: [
                                           {
-                                             name: "alfresco/lists/views/layouts/Row",
+                                             name: "alfresco/lists/views/AlfListView",
                                              config: {
+                                                itemKey: "index",
                                                 widgets: [
                                                    {
-                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      name: "alfresco/lists/views/layouts/Row",
                                                       config: {
                                                          widgets: [
                                                             {
-                                                               name: "alfresco/renderers/Property",
+                                                               name: "alfresco/lists/views/layouts/Cell",
                                                                config: {
-                                                                  propertyToRender: "index"
+                                                                  widgets: [
+                                                                     {
+                                                                        name: "alfresco/renderers/Property",
+                                                                        config: {
+                                                                           propertyToRender: "index"
+                                                                        }
+                                                                     }
+                                                                  ]
                                                                }
                                                             }
                                                          ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
@@ -157,7 +157,7 @@ model.jsonModel = {
                         {
                            name: "alfresco/layout/FixedHeaderFooter",
                            config: {
-                              height: "200px",
+                              height: 200,
                               widgetsForHeader: [
                                  {
                                     id: "SIMULATE_PATH_CHANGE",


### PR DESCRIPTION
This is a follow on to the previous fix for https://issues.alfresco.com/jira/browse/AKU-506 to address some inconsistencies between resizing behaviour of the alfresco/layout/FixedHeaderFooter widget and the other layout widgets. I've tried to make the behaviour more consistent and more expected - one of the main differences here is to switch the default of the "recalculateAutoHeightOnResize" attribute as that was causing confusion when not set with the default "auto" sizing.

This also addresses https://issues.alfresco.com/jira/browse/AKU-483 which wasn't included in the current sprint but made sense to implement whilst I was working on the module and assumes that all numerical heights provided are intended to be pixels (as this also previously caught people out).

I've updated the unit test pages to ensure that these scenarios are covered, the existing tests sufficiently ensure correct rendering.