### PR TITLE
FilteredList regressions

### DIFF
--- a/aikau/src/grunt/testing.js
+++ b/aikau/src/grunt/testing.js
@@ -61,7 +61,13 @@ module.exports = function(grunt) {
    });
    grunt.event.on("intern.fail", function(data) {
       notify({
-         title: "Unit Test Failed",
+         title: "Unit test(s) failed",
+         message: data
+      });
+   });
+   grunt.event.on("intern.pass", function(data) {
+      notify({
+         title: "Unit test(s) passed successfully",
          message: data
       });
    });

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -160,19 +160,49 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Update the filter form fields using the filter values in the hash
+       * Update the filter form fields using the filter values in the hash, and update the
+       * [dataFilters property]{@link module:alfresco/lists/AlfList#dataFilters} at the same time.
        *
        * @instance
        */
       _updateFilterFieldsFromHash: function alfresco_lists_AlfFilteredList___updateFilterFieldsFromHash() {
+
+         // Get the hash
          var currHash = hashUtils.getHash();
+
+         // Run through all of the filter widgets
          array.forEach(Object.keys(this._filterWidgets), function(widgetName) {
+
+            // Get the widget and the filter value, normalising non-values to null
             var widget = this._filterWidgets[widgetName],
                filterValue = currHash[widgetName];
             if (typeof filterValue === "undefined") {
                filterValue = null;
             }
+
+            // Update the dataFilters
+            if (filterValue === null) {
+               this.dataFilters = array.filter(this.dataFilters, function(filter) {
+                  return filter.name !== widgetName;
+               });
+            } else {
+               var filterFound = array.some(this.dataFilters, function(filter) {
+                  if (filter.name === widgetName) {
+                     filter.value = filterValue;
+                     return true;
+                  }
+               });
+               if (!filterFound) {
+                  this.dataFilters.push({
+                     name: widgetName,
+                     value: filterValue
+                  });
+               }
+            }
+
+            // Set the widget value
             widget.setValue && widget.setValue(filterValue);
+
          }, this);
       },
 

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -238,7 +238,8 @@ define(["dojo/_base/declare",
       onHashChanged: function alfresco_lists_AlfHashList__onHashChanged(payload) {
          // Process the hash...
          var dataLoaded = false,
-            filtersRemoved = !this.dataFilters.length && this.currentData.filters.length;
+            numCurrentFilters = lang.getObject("currentData.filters.length", false, this),
+            filtersRemoved = !this.dataFilters.length && numCurrentFilters;
          if(this.doHashVarUpdate(payload, this.updateInstanceValues) || filtersRemoved)
          {
             this._updateCoreHashVars(payload);

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -233,17 +233,22 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param {object} payload
+       * @returns {bool} true if data was loaded as a result of the hash-change
        */
       onHashChanged: function alfresco_lists_AlfHashList__onHashChanged(payload) {
          // Process the hash...
-         if(this.doHashVarUpdate(payload, this.updateInstanceValues))
+         var dataLoaded = false,
+            filtersRemoved = !this.dataFilters.length && this.currentData.filters.length;
+         if(this.doHashVarUpdate(payload, this.updateInstanceValues) || filtersRemoved)
          {
             this._updateCoreHashVars(payload);
             if (this._readyToLoad)
             {
                this.loadData();
+               dataLoaded = true;
             }
          }
+         return dataLoaded;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -238,6 +238,15 @@ define(["dojo/_base/declare",
       dataFailureMessage: "alflist.data.failure.message",
 
       /**
+       * The constructor
+       *
+       * @instance
+       */
+      constructor: function alfresco_lists_AlfList__constructor(){
+         this.dataFilters = [];
+      },
+
+      /**
        * This function should be overridden as necessary to change the messages displayed for various states
        * of the list, e.g.
        * <ul><li>When no view is configured</li>
@@ -316,35 +325,22 @@ define(["dojo/_base/declare",
       onFilterRequest: function alfresco_lists_AlfList__onFilterRequest(payload) {
          if (payload && payload.name)
          {
-            if (!this.dataFilters)
-            {
-               // No filters yet, just add this one as the first
-               this.dataFilters = [
-                  {
-                     name: payload.name,
-                     value: payload.value
-                  }
-               ];
-            }
-            else
-            {
-               // Look to see if there is an existing filter that needs to be updated
-               var existingFilter = array.some(this.dataFilters, function(filter) {
-                  var match = filter.name === payload.name;
-                  if (match)
-                  {
-                     filter.value = payload.value;
-                  }
-                  return match;
-               });
-               // If there wasn't an existing filter then add the payload as a new one...
-               if (!existingFilter)
+            // Look to see if there is an existing filter that needs to be updated
+            var existingFilter = array.some(this.dataFilters, function(filter) {
+               var match = filter.name === payload.name;
+               if (match)
                {
-                  this.dataFilters.push({
-                     name: payload.name,
-                     value: payload.value
-                  });
+                  filter.value = payload.value;
                }
+               return match;
+            });
+            // If there wasn't an existing filter then add the payload as a new one...
+            if (!existingFilter)
+            {
+               this.dataFilters.push({
+                  name: payload.name,
+                  value: payload.value
+               });
             }
 
             // Setup a new timeout (clearing the old one, just in case)

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -982,7 +982,7 @@ define(["dojo/_base/declare",
 
             if (foundItems)
             {
-               this.currentData.filters = this._extractFilters(payload.requestConfig);
+               this.currentData.filters = payload.requestConfig && this._extractFilters(payload.requestConfig);
                this.processLoadedData(payload.response || this.currentData);
                this.renderView();
             }

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -79,7 +79,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       viewMap: null,
 
@@ -90,7 +90,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       viewControlsMap: null,
 
@@ -108,7 +108,7 @@ define(["dojo/_base/declare",
        * Is there currently a request in progress?
        *
        * @instance
-       * @default false
+       * @default
        * @type {Boolean}
        */
       requestInProgress: false,
@@ -118,7 +118,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {boolean}
-       * @default true
+       * @default
        */
       useInfiniteScroll: false,
 
@@ -128,7 +128,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+       * @default
        */
       loadDataPublishTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST",
 
@@ -138,7 +138,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       loadDataPublishPayload: null,
 
@@ -275,7 +275,6 @@ define(["dojo/_base/declare",
             array.forEach(this.filteringTopics, function(topic) {
                this.alfSubscribe(topic, lang.hitch(this, this.onFilterRequest));
             }, this);
-            
          }
       },
 
@@ -292,7 +291,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {array}
-       * @default null
+       * @default
        */
       filteringTopics: null,
 
@@ -303,7 +302,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {array}
-       * @default null
+       * @default
        */
       dataFilters: null,
 
@@ -381,7 +380,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {boolean}
-       * @default true
+       * @default
        */
       waitForPageWidgets: true,
 
@@ -394,7 +393,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {boolean}
-       * @default false
+       * @default
        */
       _readyToLoad: false,
 
@@ -427,7 +426,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "org.alfresco.share.documentList.viewRendererName"
+       * @default
        */
       viewPreferenceProperty: "org.alfresco.share.documentList.viewRendererName",
 
@@ -576,7 +575,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "DOCLIB_TOOLBAR"
+       * @default
        */
       additionalControlsTarget: "DOCLIB_TOOLBAR",
 
@@ -586,7 +585,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       additionalViewControlVisibilityConfig: null,
 
@@ -646,7 +645,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default null
+       * @default
        */
       _currentlySelectedView: null,
 
@@ -655,7 +654,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       currentData: null,
 
@@ -892,7 +891,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "items"
+       * @default
        */
       itemsProperty: "items",
 
@@ -903,7 +902,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "metadata"
+       * @default
        */
       metadataProperty: "metadata",
 
@@ -912,7 +911,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "startIndex"
+       * @default
        */
       startIndexProperty: "startIndex",
 
@@ -921,7 +920,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default "startIndex"
+       * @default
        */
       totalResultsProperty: "totalRecords",
 

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -163,7 +163,7 @@ define(["dojo/_base/declare",
        * that when a new filter is set the page is reset to the first page.
        *
        * @instance
-       * @overridea
+       * @override
        */
       onFiltersUpdated: function alfresco_lists_AlfList__onFiltersUpdated() {
          this.onPageChange({

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -159,19 +159,16 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#onFilterRequest} to ensure
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#onFiltersUpdated} to ensure
        * that when a new filter is set the page is reset to the first page.
        *
        * @instance
-       * @param {object} payload The filter payload
+       * @overridea
        */
-      onFilterRequest: function alfresco_lists_AlfSortablePaginatedList__onFilterRequest(/*jshint unused:false*/ payload) {
-         if (payload && payload.name)
-         {
-            this.onPageChange({
-               value: 1
-            });
-         }
+      onFiltersUpdated: function alfresco_lists_AlfList__onFiltersUpdated() {
+         this.onPageChange({
+            value: 1
+         });
          this.inherited(arguments);
       },
 

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -668,6 +668,14 @@ define(["dojo/_base/declare",
          this.pageMarker = registry.byId(this.id + "_PAGE_MARKER");
          this.resultsPerPageGroup = registry.byId(this.id + "_RESULTS_PER_PAGE_SELECTOR");
 
+         // Decorate the paginator elements with appropriate classes
+         var paginatorClass = "alfresco-lists-Paginator";
+         this.pageSelector && domClass.add(this.pageSelector.domNode, paginatorClass + "__page-selector");
+         domClass.add(this.pageBack.domNode, paginatorClass + "__page-back");
+         domClass.add(this.pageForward.domNode, paginatorClass + "__page-forward");
+         domClass.add(this.pageMarker.domNode, paginatorClass + "__page-marker");
+         domClass.add(this.resultsPerPageGroup.domNode, paginatorClass + "__results-per-page");
+
          // Check to see if any document data was provided before widget instantiation completed and
          // if so process it with the now available widgets...
          if (this.__deferredLoadedDocumentData)

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -24,10 +24,11 @@
  * @module alfresco/util/hashUtils
  * @author Martin Doyle
  */
-define(["dojo/_base/lang",
+define(["dojo/_base/array",
+        "dojo/_base/lang",
         "dojo/hash",
         "dojo/io-query"],
-        function(lang, hash, ioQuery) {
+        function(array, lang, hash, ioQuery) {
 
    // The private container for the functionality and properties of the util
    var util = {
@@ -36,6 +37,9 @@ define(["dojo/_base/lang",
       getHash: function alfresco_util_hashUtils__getHash() {
          var hashString = this.getHashString(),
             hashObj = ioQuery.queryToObject(hashString);
+         array.forEach(Object.keys(hashObj), function(hashKey) {
+            hashObj[hashKey] = decodeURIComponent(hashObj[hashKey]);
+         });
          return hashObj;
       },
 
@@ -46,7 +50,11 @@ define(["dojo/_base/lang",
 
       // See API below
       setHash: function alfresco_util_hashUtils__setHash(hashObj, replace) {
-         var hashString = ioQuery.objectToQuery(hashObj);
+         var hashObjToUse = lang.clone(hashObj);
+         array.forEach(Object.keys(hashObjToUse), function(hashKey) {
+            hashObjToUse[hashKey] = encodeURIComponent(hashObjToUse[hashKey]);
+         });
+         var hashString = ioQuery.objectToQuery(hashObjToUse);
          this.setHashString(hashString, replace);
       },
 
@@ -75,7 +83,7 @@ define(["dojo/_base/lang",
                } else {
                   newHashValue = "" + newHashValue;
                   if (newHashValue !== currHashValue) {
-                     newHash[hashName] = encodeURIComponent(newHashValue);
+                     newHash[hashName] = newHashValue;
                      hashChanged = true;
                   }
                }
@@ -95,7 +103,7 @@ define(["dojo/_base/lang",
    return {
 
       /**
-       * Get the current hash value as an object
+       * Get the current hash value as an object. All values will be URI decoded.
        *
        * @instance
        * @returns {Object} The hash value as an object
@@ -103,7 +111,7 @@ define(["dojo/_base/lang",
       getHash: lang.hitch(util, util.getHash),
 
       /**
-       * Get the current hash value as a string
+       * Get the current hash value as a string. All values will be URI decoded.
        *
        * @instance
        * @returns {string} The hash value as a string
@@ -111,7 +119,7 @@ define(["dojo/_base/lang",
       getHashString: lang.hitch(util, util.getHashString),
 
       /**
-       * Set the current hash value from an object
+       * Set the current hash value from an object. All values will be URI encoded.
        *
        * @instance
        * @param {Object} hashObj The new hash object
@@ -121,7 +129,7 @@ define(["dojo/_base/lang",
       setHash: lang.hitch(util, util.setHash),
 
       /**
-       * Set the current hash value from a string
+       * Set the current hash value from a string. All values will be URI encoded.
        *
        * @instance
        * @param {string} hashString The new hash string
@@ -133,7 +141,7 @@ define(["dojo/_base/lang",
       /**
        * Update the current hash (by default, this will not do the update if the
        * values are unchanged). To remove a value from the hash, pass through null
-       * or undefined.
+       * or undefined. All values will be URI encoded.
        *
        * @instance
        * @param {Object} newValues The new hash values with hash names as keys and

--- a/aikau/src/test/resources/alfresco/core/ResponseScopeTest.js
+++ b/aikau/src/test/resources/alfresco/core/ResponseScopeTest.js
@@ -50,7 +50,8 @@ define(["intern!object",
       },
 
       "pubSubScope used as alfResponseScope when responseScope and alfResponseScope aren't set (scoped)": function() {
-         return browser.findById("B2_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B2_label")
             .click()
          .end()
          .getLastPublish("SCOPE_B2")
@@ -60,7 +61,8 @@ define(["intern!object",
       },
 
       "resposeScope used as alfResponseScope when included in payload (global)": function() {
-         return browser.findById("B3_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B3_label")
             .click()
          .end()
          .getLastPublish("B3")
@@ -70,7 +72,8 @@ define(["intern!object",
       },
 
       "resposeScope used as alfResponseScope when included in payload (scoped)": function() {
-         return browser.findById("B4_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B4_label")
             .click()
          .end()
          .getLastPublish("SCOPE_B4")
@@ -80,7 +83,8 @@ define(["intern!object",
       },
 
       "alfResponseScope used as alfResponseScope when included in payload (global)": function() {
-         return browser.findById("B5_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B5_label")
             .click()
          .end()
          .getLastPublish("B5")
@@ -90,7 +94,8 @@ define(["intern!object",
       },
 
       "alfResponseScope used as alfResponseScope when included in payload (scoped)": function() {
-         return browser.findById("B6_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B6_label")
             .click()
          .end()
          .getLastPublish("SCOPE_B6")
@@ -100,7 +105,8 @@ define(["intern!object",
       },
 
       "Dialog with no responseScope uses global scope as alfResponseScope": function() {
-         return browser.findById("B7_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B7_label")
             .click()
          .end()
          .findAllByCssSelector("#B7_DIALOG.dialogDisplayed")
@@ -115,7 +121,8 @@ define(["intern!object",
       },
 
       "Dialog with responseScope used as alfResponseScope": function() {
-         return browser.findById("B8_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B8_label")
             .click()
          .end()
          .findAllByCssSelector("#B8_DIALOG.dialogDisplayed")
@@ -130,7 +137,8 @@ define(["intern!object",
       },
 
       "Dialog with responseScope in used as alfResponseScope": function() {
-         return browser.findById("B9_label")
+         return browser.waitForDeletedByClassName("dialogDisplayed")
+            .findById("B9_label")
             .click()
          .end()
          .findAllByCssSelector("#B9_DIALOG.dialogDisplayed")

--- a/aikau/src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest.js
@@ -61,10 +61,7 @@ define(["alfresco/TestCommon",
             .pressKeys(keys.ARROW_DOWN)
             .end()
 
-         .getLastPublish("BELOW_ALF_EVENTS_SCROLL")
-            .then(function(payload) {
-               assert.isNotNull(payload, "List scroll event not registered");
-            })
+         .getLastPublish("BELOW_ALF_EVENTS_SCROLL", "List scroll event not registered")
             .end()
 
          .findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
@@ -95,10 +92,7 @@ define(["alfresco/TestCommon",
             .pressKeys(keys.ARROW_DOWN)
             .end()
 
-         .getLastPublish("ABOVE_ALF_EVENTS_SCROLL")
-            .then(function(payload) {
-               assert.isNotNull(payload, "List scroll event not registered");
-            })
+         .getLastPublish("ABOVE_ALF_EVENTS_SCROLL", "List scroll event not registered")
             .end()
 
          .findAllByCssSelector("#INFINITE_SCROLL_LIST_2 tr")

--- a/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
+++ b/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
@@ -106,9 +106,9 @@ define(["intern!object",
             .click()
             .end()
 
-         .getLastPublish("LINK_CLICKED")
-            .then(function(payload) {
-               assert.isNull(payload, "Payload published incorrectly when clicking info link");
+         .getAllPublishes("LINK_CLICKED")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0, "Payload published incorrectly when clicking info link");
             });
       },
       

--- a/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
@@ -180,9 +180,8 @@ define(["intern!object",
             .click()
             .end()
 
-         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE", "Navigation publication not found")
             .then(function(payload){
-               assert.isNotNull(payload, "Navigation publication not found");
                assert.propertyVal(payload, "url", "path=/different", "Navigation payload URL incorrect");
             });
       },

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -72,6 +72,7 @@ define(["intern!object",
          .click()
       .end()
       .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+      .end()
       .findAllByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem")
          .then(function(elements) {
             assert.lengthOf(elements, 3, "The data wasn't reloaded");
@@ -88,10 +89,7 @@ define(["intern!object",
          .clearLog()
          .click()
       .end()
-      .getLastPublish(pubSubScope + "ALF_CURRENT_NODEREF_CHANGED")
-         .then(function(payload) {
-            assert.isNotNull(payload, "The current Node data should have been published");
-         })
+      .getLastPublish(pubSubScope + "ALF_CURRENT_NODEREF_CHANGED", "The current Node data should have been published")
       .end()
       .findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
          .getVisibleText()

--- a/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
@@ -52,9 +52,9 @@ define(["intern!object",
          // The initial AlfSearchList doesn't perform an initial search when "useHash" is set to true (which
          // for this test it is).
          // Check that no request to search exists...
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.isNull(payload, "Search request made unexpectedly");
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "Search request made unexpectedly");
          });
       },
       
@@ -63,9 +63,9 @@ define(["intern!object",
          return browser.findByCssSelector("#SET_SEARCH_TERM_1")
             .click()
          .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.isNull(payload, "Search request made unexpectedly");
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "Search request made unexpectedly");
          });
       },
       
@@ -88,9 +88,9 @@ define(["intern!object",
             .clearLog()
             .click()
          .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.isNull(payload, "Another search request made before previous response returned");
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "Another search request made before previous response returned");
          });
       },
 
@@ -164,9 +164,9 @@ define(["intern!object",
          .findByCssSelector("#SET_SCOPE_0")
             .click()
          .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.isNull(payload, "Setting a null scope issued a search request");
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "Setting a null scope issued a search request");
          });
       },
 
@@ -174,9 +174,9 @@ define(["intern!object",
          return browser.findByCssSelector("#SET_SCOPE_1")
             .click()
          .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.isNull(payload, "Setting the same scope issued a search request.");
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "Setting the same scope issued a search request");
          });
       },
 
@@ -264,9 +264,9 @@ define(["intern!object",
          .findByCssSelector("#APPLY_FACET_FILTER_0")
             .click()
          .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.isNull(payload, "Bad facet filter triggered search");
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "Bad facet filter triggered search");
          });
       },
 

--- a/aikau/src/test/resources/alfresco/forms/AutoSaveFormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/AutoSaveFormsTest.js
@@ -68,7 +68,7 @@ define(["intern!object",
          .end()
          .getAllPublishes("AUTOSAVE_FORM2")
             .then(function(payloads) {
-               assert.lengthOf(payload, 0, "There should be no auto save when the page loads");
+               assert.lengthOf(payloads, 0, "There should be no auto save when the page loads");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/forms/AutoSaveFormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/AutoSaveFormsTest.js
@@ -42,10 +42,10 @@ define(["intern!object",
       "Check autosave doesn't occur on page load": function() {
          return browser.findByCssSelector("#AUTOSAVE_FORM")
          .end()
-         .getLastPublish("AUTOSAVE_FORM")
-            .then(function(payload) {
-               assert.isNull(payload, "There should be no auto save when the page loads");
-            });
+         .getAllPublishes("AUTOSAVE_FORM")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "There should be no auto save when the page loads");
+         });
       },
 
       "Check that autosave works on control update": function() {
@@ -66,9 +66,9 @@ define(["intern!object",
          // Wait for dialog to open...
          .findAllByCssSelector("#DIALOG1.dialogDisplayed")
          .end()
-         .getLastPublish("AUTOSAVE_FORM2")
-            .then(function(payload) {
-               assert.isNull(payload, "There should be no auto save when the page loads");
+         .getAllPublishes("AUTOSAVE_FORM2")
+            .then(function(payloads) {
+               assert.lengthOf(payload, 0, "There should be no auto save when the page loads");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -138,9 +138,9 @@ define(["intern!object",
          return browser.findById("CLEAR_AUTOSAVE_1")
             .click()
             .clearLog()
-            .getLastPublish("AUTOSAVE_FORM_1")
-            .then(function(payload) {
-               assert.isNull(payload, "Published form when invalid");
+            .getAllPublishes("AUTOSAVE_FORM_1")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0, "Published form when invalid");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -373,15 +373,12 @@ define([
                .click()
                .end()
 
-            .getLastPublish("FORM_POST")
+            .getLastPublish("FORM_POST", "Could not find form submission")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Could not find form submission");
-                  if (payload) {
-                     assert.deepPropertyVal(payload, "tags[0].name", "tag1", "Failed to submit tag1 name");
-                     assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "Failed to submit tag1 value");
-                     assert.deepPropertyVal(payload, "tags[1].name", "tag2", "Failed to submit tag2 name");
-                     assert.deepPropertyVal(payload, "tags[1].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value");
-                  }
+                  assert.deepPropertyVal(payload, "tags[0].name", "tag1", "Failed to submit tag1 name");
+                  assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "Failed to submit tag1 value");
+                  assert.deepPropertyVal(payload, "tags[1].name", "tag2", "Failed to submit tag2 name");
+                  assert.deepPropertyVal(payload, "tags[1].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value");
                });
          },
 
@@ -664,13 +661,10 @@ define([
                .click()
                .end()
 
-            .getLastPublish("DIALOG_POST")
+            .getLastPublish("DIALOG_POST", "Could not find dialog submission")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Could not find dialog submission");
-                  if (payload) {
-                     assert.deepPropertyVal(payload, "tags[0].name", "tag2", "Failed to submit tag2 name from dialog");
-                     assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value from dialog");
-                  }
+                  assert.deepPropertyVal(payload, "tags[0].name", "tag2", "Failed to submit tag2 name from dialog");
+                  assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value from dialog");
                });
          },
 

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -672,10 +672,7 @@ define(["intern!object",
          return browser.findByCssSelector(".dijitTabInner:nth-child(3) .tabLabel")
             .click()
          .end()
-         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS")
-            .then(function(payload) {
-               assert.isNotNull(payload, "List data was not requested on tab load");
-            });
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS", "List data was not requested on tab load");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -38,10 +38,7 @@ define(["intern!object",
       .execute(function() {
          document.querySelector("#INFINITE_SCROLL_AREA_WITH_DOCLIST .alfresco-layout-FixedHeaderFooter__content").scrollTop += 50;
       })
-      .getLastPublish("DOCUMENT_LIST_ALF_EVENTS_SCROLL")
-         .then(function(payload) {
-            assert.isNotNull(payload, "Document list scroll event not registered");
-         })
+      .getLastPublish("DOCUMENT_LIST_ALF_EVENTS_SCROLL", "Document list scroll event not registered")
       .end()
       .findAllByCssSelector("#DOCUMENT_LIST tr")
          .then(function(elements) {
@@ -54,10 +51,7 @@ define(["intern!object",
       .findByCssSelector(buttonId)
          .click()
       .end()
-      .getLastPublish("DOCUMENT_LIST_ALF_DOCLIST_REQUEST_FINISHED")
-         .then(function(payload) {
-            assert.isNotNull(payload, "More results not loaded");
-         })
+      .getLastPublish("DOCUMENT_LIST_ALF_DOCLIST_REQUEST_FINISHED", "More results not loaded")
       .end()
       .findAllByCssSelector("#DOCUMENT_LIST tr")
          .then(function(elements) {
@@ -141,10 +135,7 @@ define(["intern!object",
          return browser.execute(function() {
                document.querySelector("#INFINITE_SCROLL_AREA .alfresco-layout-FixedHeaderFooter__content").scrollTop += 50;
             })
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_EVENTS_SCROLL")
-            .then(function(payload) {
-               assert.isNotNull(payload, "List scroll event not registered");
-            })
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_EVENTS_SCROLL", "List scroll event not registered")
          .end()
          .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
             .then(function(elements) {
@@ -160,10 +151,7 @@ define(["intern!object",
          .findByCssSelector("#SIMULATE_FILTER_label")
             .click()
          .end()
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
-            .then(function(payload) {
-               assert.isNotNull(payload, "More results not loaded");
-            })
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", 1500, "More results not loaded")
          .end()
          .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
             .then(function(elements) {
@@ -178,10 +166,7 @@ define(["intern!object",
          .findByCssSelector("#SIMULATE_RELOAD_label")
             .click()
          .end()
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED")
-            .then(function(payload) {
-               assert.isNotNull(payload, "More results not loaded");
-            })
+         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", "More results not loaded")
          .end()
          .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
             .then(function(elements) {

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -18,12 +18,15 @@
  */
 
 /**
+ * Test the filtered list widget
+ * 
  * @author Dave Draper
+ * @author Martin Doyle
  */
-define(["alfresco/TestCommon",
-        "intern/chai!assert",
-        "intern/dojo/node!leadfoot/keys",
-        "intern!object"],
+define(["alfresco/TestCommon", 
+        "intern/chai!assert", 
+        "intern/dojo/node!leadfoot/keys", 
+        "intern!object"], 
         function(TestCommon, assert, keys, registerSuite) {
 
    var browser;
@@ -66,7 +69,7 @@ define(["alfresco/TestCommon",
             .end()
 
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
             .end()
 
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
@@ -82,7 +85,7 @@ define(["alfresco/TestCommon",
             .type(keys.BACKSPACE)
             .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
             .end()
 
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
@@ -91,7 +94,7 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Select a filter from drop down": function() {
+      "Select a filter from drop down (useHash=true)": function() {
          return browser.findByCssSelector("#COMPOSITE_DROPDOWN .dijitArrowButtonInner")
             .clearLog()
             .click()
@@ -101,7 +104,7 @@ define(["alfresco/TestCommon",
             .click()
             .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
             .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
@@ -110,14 +113,14 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Apply a 2nd filter": function() {
+      "Apply a 2nd filter (useHash=true)": function() {
          return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
             .clearLog()
             .type("t")
             .end()
 
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
             .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
@@ -126,7 +129,7 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Hash reflects current filter values": function() {
+      "Hash reflects current filter values (useHash=true)": function() {
          return browser.getCurrentUrl()
             .then(function(url) {
                var hash = url.split("#")[1],
@@ -141,7 +144,7 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Changing hash value updates filter": function() {
+      "Changing hash value updates filter (useHash=true)": function() {
          var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#description=woof");
          return browser.findByCssSelector("body")
             .clearLog()
@@ -152,13 +155,13 @@ define(["alfresco/TestCommon",
          .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
             .getVisibleText()
             .then(function(visibleText) {
-               var text = visibleText.split("\n").join(),
-                  expectedText = "five woof,five and a half woof,six woof,six and a half woof";
+               var text = visibleText.split("\n").join("|"),
+                  expectedText = "five woof|five and a half woof|six woof|six and a half woof";
                assert.equal(text, expectedText, "Incorrect results displayed for intended filter");
             });
       },
 
-      "Filter field reflects applied filter": function() {
+      "Filter field reflects applied filter (useHash=true)": function() {
          return browser.findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL + input")
             .getProperty("value")
             .then(function(value) {
@@ -166,16 +169,23 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Deleting filter field value removes filter": function() {
-         return browser.findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL")
+      "Deleting filter field value removes filter (useHash=true)": function() {
+         var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#name=one");
+         return browser.findByCssSelector("body")
             .clearLog()
-            .clearValue()
+            .get(updatedUrl)
             .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
-            .then(function(payload) {
-               assert.isNotNull(payload, "Clearing filter field did not reload list");
-            })
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Didn't reload list after hash change")
+            .end()
+
+         .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
+            .clearLog()
+            .clearValue()
+            .pressKeys(keys.TAB)
+            .end()
+
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500, "Didn't reload list after filter removal")
             .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
@@ -184,16 +194,12 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Going to next page displays second page of results": function() {
+      "Going to next page displays second page of results (useHash=true)": function() {
          return browser.findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-forward")
             .click()
             .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
-            .then(function(payload) {
-               assert.isNotNull(payload, "Going to next page did not reload list");
-            })
-            .end()
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500, "Going to next page did not reload list")
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
@@ -201,14 +207,13 @@ define(["alfresco/TestCommon",
             });
       },
 
-      "Filter values with spaces in should not be URL escaped": function() {
-         return browser
-            .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
+      "Filter values with spaces in should not be URL escaped (useHash=true)": function() {
+         return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
             .clearLog()
             .type("five and")
             .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", false, 1500)
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
             .end()
 
          .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputInner")
@@ -220,18 +225,18 @@ define(["alfresco/TestCommon",
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
-               assert.lengthOf(elements, 1, "One result should be displayed for chosen filter");
+               assert.lengthOf(elements, 1, "One result should be displayed for filter 'five and'");
             })
             .end()
 
          .findByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Cell:nth-child(2) .alfresco-renderers-Property .value")
             .getVisibleText()
             .then(function(visibleText) {
-               assert.equal(visibleText, "five and a half", "Incorrect result displayed for filter");
+               assert.equal(visibleText, "five and a half", "Incorrect result displayed for filter 'five and'");
             });
       },
 
-      "Navigating to another page and then back will re-apply filter": function() {
+      "Navigating to another page and then back will re-apply filter (useHash=true)": function() {
          var anotherPageUrl = TestCommon.testWebScriptURL("/Index"),
             returnUrl = TestCommon.testWebScriptURL("/FilteredList#description=woof");
          return browser.findByCssSelector("body")
@@ -243,9 +248,9 @@ define(["alfresco/TestCommon",
          .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
             .getVisibleText()
             .then(function(visibleText) {
-               var text = visibleText.split("\n").join(),
-                  expectedText = "five woof,five and a half woof,six woof,six and a half woof";
-               assert.equal(text, expectedText, "Incorrect results displayed for intended filter");
+               var text = visibleText.split("\n").join("|"),
+                  expectedText = "five woof|five and a half woof|six woof|six and a half woof";
+               assert.equal(text, expectedText, "Incorrect results displayed for filter 'woof'");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/lists/FilteredListUseCaseTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListUseCaseTest.js
@@ -51,10 +51,10 @@ define(["intern!object",
          .end()
          .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed")
          .end()
-         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS")
-            .then(function(payload) {
-               assert.isNull(payload, "A request to load data should not have been made when the dialog opens");
-            });
+         .getAllPublishes("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "A request to load data should not have been made when the dialog opens");
+         });
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/lists/LocalStorageFallbackTest.js
+++ b/aikau/src/test/resources/alfresco/lists/LocalStorageFallbackTest.js
@@ -43,10 +43,7 @@ define(["intern!object",
 
       "When there is no hash only topic is published": function() {
          return browser.findById("LIST").end()
-            .getLastPublish("LOAD")
-               .then(function(payload) {
-                  assert.isNotNull(payload, "The list should have requested data");
-               });
+            .getLastPublish("LOAD", "The list should have requested data");
       },
 
       "Post Coverage Results": function() {
@@ -72,10 +69,7 @@ define(["intern!object",
 
       "Data should have been requested": function() {
          return browser.findById("LIST").end()
-            .getLastPublish("LOAD")
-               .then(function(payload) {
-                  assert.isNotNull(payload, "The list should have requested data");
-               });
+            .getLastPublish("LOAD", "The list should have requested data");
       },
 
       "When there is no hash, the current filter is set as the hash": function() {

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -78,10 +78,7 @@ define(["intern!object",
          return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
             .click()
          .end()
-         .getLastPublish("ALF_ITEM_SELECTED")
-            .then(function(payload) {
-               assert.isNotNull(payload, "The topic published by clicking on TREE2 nodes is not requested custom topic");
-            });
+         .getLastPublish("ALF_ITEM_SELECTED", "The topic published by clicking on TREE2 nodes is not requested custom topic");
       },
   
       "Test that TREE1 has NOT filtered site containers": function() {

--- a/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
@@ -52,9 +52,8 @@ define(["intern!object",
          "Publishes topic when clicked": function() {
             return browser.findByCssSelector("#GUEST_THUMBNAIL .inner")
                .click()
-               .getLastPublish("ALF_DISPLAY_NOTIFICATION", true)
+               .getLastPublish("ALF_DISPLAY_NOTIFICATION", true, "Did not publish correct topic when clicked")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Did not publish correct topic when clicked");
                   assert.propertyVal(payload, "message", "You clicked on the guest thumbnail", "Did not publish correct payload");
                });
          },

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -171,10 +171,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("TEST_PROPERTY_LINK_CLICK")
-               .then(function(payload) {
-                  assert.isNotNull(payload, "Property link topic not published on click");
-               });
+            .getLastPublish("TEST_PROPERTY_LINK_CLICK", "Property link topic not published on click");
          },
 
          "Clicking on property does not start editing": function() {
@@ -243,9 +240,8 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("ALF_CRUD_UPDATE", true)
+            .getLastPublish("ALF_CRUD_UPDATE", true, "Property update not requested")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Property update not requested");
                   assert.propertyVal(payload, "name", "New", "New value didn't publish correctly");
                   assert.propertyVal(payload, "hiddenData", "hidden_update", "Hidden value didn't get included");
                   assert.propertyVal(payload, "alfResponseScope", "", "Unscoped property link generated alfResponseScope");
@@ -279,9 +275,8 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("ALF_CRUD_UPDATE", true)
+            .getLastPublish("ALF_CRUD_UPDATE", true, "Property update not requested")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Property update not requested");
                   assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "Scoped property link generated incorrect alfResponseScope");
                });
          },
@@ -292,9 +287,8 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("TEST_PROPERTY_LINK_CLICK", true)
+            .getLastPublish("TEST_PROPERTY_LINK_CLICK", true, "'Test item (topic, no scope)' did not publish correct topic")
                .then(function(payload) {
-                  assert.isNotNull(payload, "'Test item (topic, no scope)' did not publish correct topic");
                   assert.propertyVal(payload, "alfResponseScope", "", "'Test item (topic, no scope)' generated incorrect alfResponseScope");
                })
                .end()
@@ -304,9 +298,8 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("SCOPED_TEST_PROPERTY_LINK_CLICK", true)
+            .getLastPublish("SCOPED_TEST_PROPERTY_LINK_CLICK", true, "'Test item (topic, scoped)' did not publish correct topic")
                .then(function(payload) {
-                  assert.isNotNull(payload, "'Test item (topic, scoped)' did not publish correct topic");
                   assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "'Test item (topic, scoped)' generated incorrect alfResponseScope");
                })
                .end()
@@ -316,9 +309,8 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("SCOPED_ALF_NAVIGATE_TO_PAGE", true)
+            .getLastPublish("SCOPED_ALF_NAVIGATE_TO_PAGE", true, "'Test item (no topic, scoped)' did not publish correct topic")
                .then(function(payload) {
-                  assert.isNotNull(payload, "'Test item (no topic, scoped)' did not publish correct topic");
                   assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "'Test item (no topic, scoped)' generated incorrect alfResponseScope");
                });
          },

--- a/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
@@ -211,10 +211,7 @@ define(["intern!object",
             })
          .end()
 
-         .getLastPublish("ALF_APPLY_FACET_FILTER")
-            .then(function(payload) {
-               assert.isNotNull(payload, "The facet did not publish on 'ALF_APPLY_FACET_FILTER'");
-            });
+         .getLastPublish("ALF_APPLY_FACET_FILTER");
       },
 
       "Facet menu item should de-select when clicked again": function() {
@@ -229,10 +226,7 @@ define(["intern!object",
             })
          .end()
 
-         .getLastPublish("ALF_REMOVE_FACET_FILTER")
-            .then(function(payload) {
-               assert.isNotNull(payload, "The facet did not publish on 'ALF_REMOVE_FACET_FILTER'");
-            });
+         .getLastPublish("ALF_REMOVE_FACET_FILTER");
       },
 
       "Post Coverage Results": function() {
@@ -320,10 +314,7 @@ define(["intern!object",
             })
          .end()
 
-         .getLastPublish("ALF_APPLY_FACET_FILTER")
-            .then(function(payload) {
-               assert.isNotNull(payload, "The facet did not publish on 'ALF_APPLY_FACET_FILTER'");
-            });
+         .getLastPublish("ALF_APPLY_FACET_FILTER");
       },
       
       "Facet menu item should de-select when clicked again using the keyboard": function() {
@@ -338,10 +329,7 @@ define(["intern!object",
             })
          .end()
 
-         .getLastPublish("ALF_REMOVE_FACET_FILTER")
-            .then(function(payload) {
-               assert.isNotNull(payload, "The facet did not publish on 'ALF_REMOVE_FACET_FILTER'");
-            });
+         .getLastPublish("ALF_REMOVE_FACET_FILTER");
       },
       
       "Post Coverage Results": function() {
@@ -458,10 +446,7 @@ define(["intern!object",
             .clearLog()
             .click()
          .end()
-         .getLastPublish("ALF_INCLUDE_FACET")
-         .then(function(payload) {
-            assert.isNotNull(payload, "There was no include facets publication");
-         });
+         .getLastPublish("ALF_INCLUDE_FACET");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
@@ -47,13 +47,10 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("ALF_SELECTED_FILES_CHANGED")
+            .getLastPublish("ALF_SELECTED_FILES_CHANGED", "Selected files change not published")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Selected files change not published");
-                  if (payload) {
-                     assert.lengthOf(payload.selectedFiles, 1, "Should have one node selected");
-                     assert.deepPropertyVal(payload, "selectedFiles[0].node.nodeRef", "workspace://SpacesStore/b0037179-f105-4858-9d8f-44bfb0f67d8a", "Incorrect node selected");
-                  }
+                  assert.lengthOf(payload.selectedFiles, 1, "Should have one node selected");
+                  assert.deepPropertyVal(payload, "selectedFiles[0].node.nodeRef", "workspace://SpacesStore/b0037179-f105-4858-9d8f-44bfb0f67d8a", "Incorrect node selected");
                });
          },
 
@@ -62,12 +59,9 @@ define(["intern!object",
                .click()
                .end()
 
-            .getLastPublish("ALF_SELECTED_FILES_CHANGED")
+            .getLastPublish("ALF_SELECTED_FILES_CHANGED", "Selected files change not published")
                .then(function(payload) {
-                  assert.isNotNull(payload, "Selected files change not published");
-                  if (payload) {
-                     assert.lengthOf(payload.selectedFiles, 0, "Should not have a current selected node");
-                  }
+                  assert.lengthOf(payload.selectedFiles, 0, "Should not have a current selected node");
                });
          },
 

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -170,10 +170,7 @@ define(["intern!object",
          .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogDisplayed") // Wait for dialog
             .end()
 
-         .getLastPublish("ALF_BASIC_METADATA_SUCCESS")
-            .then(function(payload) {
-               assert.isNotNull(payload, "Did not publish basic metadata success");
-            });
+         .getLastPublish("ALF_BASIC_METADATA_SUCCESS", "Did not publish basic metadata success");
       },
 
       "Check retrieved node data": function() {
@@ -210,10 +207,7 @@ define(["intern!object",
             .click()
             .end()
 
-         .getLastPublish("ALF_UPLOAD_REQUEST")
-            .then(function(payload) {
-               assert.isNotNull(payload, "Did not publish upload request");
-            });
+         .getLastPublish("ALF_UPLOAD_REQUEST", "Did not publish upload request");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -265,19 +265,21 @@ define(["intern!object",
          return browser.findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
             .clearValue()
             .type("another")
-         .end()
+            .end()
 
          .findById("CUSTOM_REPEAT_BUTTON_ID")
             .click()
-         .end()
+            .end()
 
-         .getLastPublish("POST_FORM_DIALOG")
+         .waitForDeletedByClassName(".dialogDisplayed")
+            .getLastPublish("POST_FORM_DIALOG")
             .then(function(payload) {
-               assert.propertyVal(payload, "text","another", "Textbox value was not posted");
+               assert.propertyVal(payload, "text", "another", "Textbox value was not posted");
             })
 
          .findAllByCssSelector("#CUSTOM_DIALOG.dialogDisplayed")
-         .end()
+            .end()
+
          .findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
             .getProperty("value")
             .then(function(resultText) {
@@ -295,6 +297,7 @@ define(["intern!object",
             .click()
          .end()
 
+         .waitForDeletedByClassName(".dialogDisplayed")
          .getLastPublish("POST_FORM_DIALOG")
             .then(function(payload) {
                assert.propertyVal(payload, "text","encore", "Textbox value was not posted");
@@ -320,19 +323,21 @@ define(["intern!object",
          return browser.findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
             .clearValue()
             .type("more")
-         .end()
+            .end()
 
          .findById("ERROR_REPEATING_OK_AND_REPEAT")
             .click()
-         .end()
-            
-         .getLastPublish("POST_FORM_DIALOG")
+            .end()
+
+         .waitForDeletedByClassName(".dialogDisplayed")
+            .getLastPublish("POST_FORM_DIALOG")
             .then(function(payload) {
                assert.propertyVal(payload, "text", "more", "Textbox value was not posted");
             })
 
          .findAllByCssSelector("#ERROR_REPEATING.dialogDisplayed")
-         .end()
+            .end()
+            
          .findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
             .getProperty("value")
             .then(function(resultText) {

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -75,10 +75,7 @@ define(["intern!object",
       "Test publication on dialog show": function() {
          return browser.findByCssSelector(".alfresco-dialog-AlfDialog")
          .end()
-         .getLastPublish("DISPLAYED_FD1").findAllByCssSelector(TestCommon.topicSelector("DISPLAYED_FD1", "publish", "any"))
-            .then(function(payload) {
-               assert.isNotNull(payload, "Could not find topic published when displayed dialog");
-            });
+         .getLastPublish("DISPLAYED_FD1", "Could not find topic published when displayed dialog");
       },
 
       "Test recreating dialog with no ID": function() {
@@ -410,11 +407,7 @@ define(["intern!object",
                   .click()
                   .end()
 
-               .getLastPublish("DISPLAYED_INNER_DIALOG")
-                  .then(function(payload) {
-                     assert.isNotNull(payload, "Inner dialog not displayed");
-                  })
-                  .end()
+               .getLastPublish("DISPLAYED_INNER_DIALOG", "Inner dialog not displayed")
 
                .findByCssSelector("#INNER_DIALOG .dijitDialogCloseIcon")
                   .click()
@@ -440,9 +433,8 @@ define(["intern!object",
             .click()
             .end()
 
-         .getLastPublish("CUSTOM_FORM_SCOPE_CUSTOM_FORM_TOPIC", true)
+         .getLastPublish("CUSTOM_FORM_SCOPE_CUSTOM_FORM_TOPIC", true, "Did not publish correctly scoped topic")
             .then(function(payload){
-               assert.isNotNull(payload, "Did not publish correctly scoped topic");
                assert.propertyVal(payload, "text", "This is some sample text", "Did not publish correct form value to scoped topic");
             });
       },

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -59,10 +59,7 @@ define(["intern!object",
          return browser.setFindTimeout(5000)
             .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message")
 
-         .getLastPublish("ALF_NOTIFICATION_DESTROYED")
-            .then(function(payload) {
-               assert.isNotNull(payload, "Post-notification topic not published");
-            });
+         .getLastPublish("ALF_NOTIFICATION_DESTROYED", "Post-notification topic not published");
       },
 
       "Can close notification early": function() {

--- a/aikau/src/test/resources/alfresco/services/UserServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/UserServiceTest.js
@@ -152,22 +152,13 @@ define(["intern!object",
          return browser.findByCssSelector("#HEADER_USER_SET_HOME_PAGE_label")
             .click()
          .end()
-         .getLastPublish("ALF_SET_USER_HOME_PAGE")
+         .getLastPublish("ALF_SET_USER_HOME_PAGE", "Set user home page not published")
+         .getLastPublish("ALF_PREFERENCE_SET", "Set user home page preference not published")
             .then(function(payload) {
-               assert.isNotNull(payload, "Set user home page not published");
+               assert.propertyVal(payload, "preference", "org.alfresco.share.user.homePage", "The user home page preference key was incorrect");
+               assert.propertyVal(payload, "value", "NewHomePage", "The user home page value was incorrect");
             })
-         .getLastPublish("ALF_PREFERENCE_SET")
-            .then(function(payload) {
-               assert.isNotNull(payload, "Set user home page preference not published");
-               if (payload) {
-                  assert.propertyVal(payload, "preference", "org.alfresco.share.user.homePage", "The user home page preference key was incorrect");
-                  assert.propertyVal(payload, "value", "NewHomePage", "The user home page value was incorrect");
-               }
-            })
-         .getLastPublish("ALF_SET_USER_HOME_PAGE_SUCCESS")
-            .then(function(payload) {
-               assert.isNotNull(payload, "Set user home page success not published");
-            });
+         .getLastPublish("ALF_SET_USER_HOME_PAGE_SUCCESS", "Set user home page success not published");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/actions/NodeLocationTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/NodeLocationTest.js
@@ -45,10 +45,7 @@ define(["intern!object",
          .end()
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
-            assert.isNotNull(payload, "Navigation publication not found");
-            if (payload) {
-               assert.equal(payload.url, "/aikau/page/site/site1/documentlibrary#path=%2Fsome%2Frandom%2Fpath", "Unexpected location");
-            }
+            assert.equal(payload.url, "/aikau/page/site/site1/documentlibrary#path=%2Fsome%2Frandom%2Fpath", "Unexpected location");
          });
       },
 
@@ -58,10 +55,7 @@ define(["intern!object",
          .end()
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
-            assert.isNotNull(payload, "Navigation publication not found");
-            if (payload) {
-               assert.equal(payload.url, "/aikau/page/repository#path=%2Fanother%2Frandom%2Fpath", "Unexpected location");
-            }
+            assert.equal(payload.url, "/aikau/page/repository#path=%2Fanother%2Frandom%2Fpath", "Unexpected location");
          });
       },
 
@@ -71,10 +65,7 @@ define(["intern!object",
          .end()
          .getLastPublish("CUSTOM_ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
-            assert.isNotNull(payload, "Navigation publication not found");
-            if (payload) {
-               assert.equal(payload.url, "/aikau/page/site/site1/dp/ws/document-libarary#path=%2Fsome%2Frandom%2Fpath", "Unexpected location");
-            }
+            assert.equal(payload.url, "/aikau/page/site/site1/dp/ws/document-libarary#path=%2Fsome%2Frandom%2Fpath", "Unexpected location");
          });
       },
 
@@ -84,10 +75,7 @@ define(["intern!object",
          .end()
          .getLastPublish("CUSTOM_ALF_NAVIGATE_TO_PAGE")
          .then(function(payload) {
-            assert.isNotNull(payload, "Navigation publication not found");
-            if (payload) {
-               assert.equal(payload.url, "/aikau/page/dp/ws/repo#path=%2Fanother%2Frandom%2Fpath", "Unexpected location");
-            }
+            assert.equal(payload.url, "/aikau/page/dp/ws/repo#path=%2Fanother%2Frandom%2Fpath", "Unexpected location");
          });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/DateTextBoxTest"
+      "src/test/resources/alfresco/lists/FilteredListTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
@@ -9,6 +9,7 @@ model.jsonModel = {
             }
          }
       },
+      "alfresco/services/NavigationService",
       "aikauTesting/mockservices/FilteredListMockService"
    ],
    widgets: [
@@ -126,6 +127,13 @@ model.jsonModel = {
                                           labelAttribute: "label",
                                           valueAttribute: "value"
                                        }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/Paginator",
+                                    config: {
+                                       documentsPerPage: 5,
+                                       pageSizes: [5, 10, 15]
                                     }
                                  }
                               ],

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
@@ -192,6 +192,9 @@ model.jsonModel = {
          }
       },
       {
+         name: "aikauTesting/mockservices/FilteredListMockXhr"
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FilteredListMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FilteredListMockXhr.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Sets up a mock server for FilteredList testing
+ * 
+ * @module aikauTesting/mockservices/FilteredListMockXhr
+ * @author Martin Doyle
+ */
+define([
+      "aikauTesting/MockXhr",
+      "dojo/_base/declare",
+      "dojo/_base/lang",
+      "dojo/io-query"
+   ],
+   function(MockXhr, declare, lang, ioQuery) {
+
+      return declare([MockXhr], {
+
+         /**
+          * Setup the data
+          *
+          * @instance
+          * @type {Object}
+          */
+         data: [{
+            name: "one",
+            description: "moo"
+         }, {
+            name: "two",
+            description: "moo"
+         }, {
+            name: "three",
+            description: "moo"
+         }, {
+            name: "four",
+            description: "moo"
+         }, {
+            name: "five",
+            description: "woof"
+         }, {
+            name: "five and a half",
+            description: "woof"
+         }, {
+            name: "six",
+            description: "woof"
+         }, {
+            name: "six and a half",
+            description: "woof"
+         }],
+
+         /**
+          * This sets up the fake server with all the responses it should provide.
+          *
+          * @instance
+          */
+         setupServer: function alfresco_testing_mockservices_FilteredListMockXhr__setupServer() {
+            try {
+               this.server.respondWith(/.+filteredlist\?(.+)/, lang.hitch(this, this.respond));
+               this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+            } catch (e) {
+               this.alfLog("error", "The following error occurred setting up the mock server", e);
+            }
+         },
+
+         /**
+          * Respond to the supplied request
+          *
+          * @instance
+          * @param {Object} request The request object
+          * @param {string} queryString The query string from the request URL
+          */
+         respond: function alfresco_testing_mockservices_FilteredListMockXhr__respond(request, queryString) {
+
+            // Analyse the query
+            var queryObj = ioQuery.queryToObject(queryString),
+               filters = queryObj.filters.split(",").map(function(filter) {
+                  var parts = filter.split("|");
+                  return {
+                     name: parts[0],
+                     value: parts[1]
+                  };
+               });
+
+            // Apply the filters
+            var filteredData = this.data.filter(function(item) {
+               return Object.keys(item).every(function(propName) {
+                  var propValue = item[propName];
+                  return filters.every(function(filter) {
+                     return filter.name !== propName || propValue.indexOf(filter.value) !== -1;
+                  });
+               });
+            });
+
+            // Apply pagination
+            var pageSize = queryObj.pageSize ? parseInt(queryObj.pageSize, 10) : 0,
+               startIndex = queryObj.startIndex ? parseInt(queryObj.startIndex, 10) : 0,
+               endIndex = startIndex + pageSize,
+               responseData = filteredData.slice();
+            if (endIndex) {
+               responseData = responseData.slice(startIndex, Math.min(endIndex, responseData.length));
+            }
+
+            // Construct the response
+            var response = {
+               totalRecords: filteredData.length,
+               startIndex: startIndex,
+               items: responseData
+            };
+
+            // Send the response
+            request.respond(200, {
+               "Content-Type": "application/json;charset=UTF-8"
+            }, JSON.stringify(response));
+         }
+      });
+   });


### PR DESCRIPTION
This pull request addresses issues [AKU-507](https://issues.alfresco.com/jira/browse/AKU-507) and [AKU-505](https://issues.alfresco.com/jira/browse/AKU-505), which cover various regressions or bugs with `AlfFilteredList` behaviour. Additionally, the `TestCommon` methods of `screenie()`, `getLastPublish()` and `getLogEntries()` have been updated and new one added of `getAllPublishes()`. The `FilteredListTest` has been updated and the test pages and mock services similarly upgraded to cope. Additionally all other tests affected by the `TestCommon` changes have been updated and a full test suite has been successfully run.