### PR TITLE
AKU-509: AvatarThumbnail encoding

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/AvatarThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/AvatarThumbnail.js
@@ -108,6 +108,8 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_renderers_AvatarThumbnail__postMixInProperties() {
          if (!this.thumbnailUrlTemplate)
          {
+            // See AKU-509 - make sure that the user name is encoded to ensure that the image can be loaded...
+            this.currentItem[this.userNameProperty] = encodeURIComponent(this.currentItem[this.userNameProperty]);
             this.thumbnailUrlTemplate = "slingshot/profile/avatar/{" + this.userNameProperty + "}/thumbnail/avatar";
          }
          this.inherited(arguments);

--- a/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
@@ -50,9 +50,8 @@ define(["intern!object",
       "Publishes topic when clicked": function() {
          return browser.findByCssSelector("#GUEST_THUMBNAIL .inner")
             .click()
-            .getLastPublish("ALF_DISPLAY_NOTIFICATION", true)
+            .getLastPublish("ALF_DISPLAY_NOTIFICATION", "Did not publish correct topic when clicked")
             .then(function(payload) {
-               assert.isNotNull(payload, "Did not publish correct topic when clicked");
                assert.propertyVal(payload, "message", "You clicked on the guest thumbnail", "Did not publish correct payload");
             });
       },

--- a/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
@@ -50,7 +50,7 @@ define(["intern!object",
       "Publishes topic when clicked": function() {
          return browser.findByCssSelector("#GUEST_THUMBNAIL .inner")
             .click()
-            .getLastPublish("ALF_DISPLAY_NOTIFICATION", "Did not publish correct topic when clicked")
+            .getLastPublish("ALF_DISPLAY_NOTIFICATION", true, "Did not publish correct topic when clicked")
             .then(function(payload) {
                assert.propertyVal(payload, "message", "You clicked on the guest thumbnail", "Did not publish correct payload");
             });

--- a/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
@@ -21,45 +21,44 @@
  * @author Dave Draper
  */
 define(["intern!object",
-      "intern/chai!assert",
-      "require",
-      "alfresco/TestCommon",
-      "intern/dojo/node!leadfoot/keys"
-   ],
-   function(registerSuite, assert, require, TestCommon, keys) {
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, require, TestCommon) {
 
-      var browser;
-      registerSuite({
-         name: "Avatar Thumbnail Tests",
+   var browser;
+   registerSuite({
+      name: "Avatar Thumbnail Tests",
 
-         setup: function() {
-            browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/AvatarThumbnail", "Avatar Thumbnail Tests").end();
-         },
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AvatarThumbnail", "Avatar Thumbnail Tests").end();
+      },
 
-         beforeEach: function() {
-            browser.end();
-         },
+      beforeEach: function() {
+         browser.end();
+      },
 
-         "Image src is correct": function() {
-            return browser.findByCssSelector("#ADMIN_THUMBNAIL .inner img")
-               .getAttribute("src")
-               .then(function(src) {
-                  assert.match(src, /\/aikau\/proxy\/alfresco\/slingshot\/profile\/avatar\/admin\/thumbnail\/avatar/, "Avatar thumbnail src incorrect");
-               });
-         },
+      "Image src is correct": function() {
+         return browser.findByCssSelector("#ADMIN_THUMBNAIL .inner img")
+            .getAttribute("src")
+            .then(function(src) {
+               assert.match(src, /\/aikau\/proxy\/alfresco\/slingshot\/profile\/avatar\/silly%25userid\/thumbnail\/avatar/, "Avatar thumbnail src incorrect");
+            });
+      },
 
-         "Publishes topic when clicked": function() {
-            return browser.findByCssSelector("#GUEST_THUMBNAIL .inner")
-               .click()
-               .getLastPublish("ALF_DISPLAY_NOTIFICATION", true, "Did not publish correct topic when clicked")
-               .then(function(payload) {
-                  assert.propertyVal(payload, "message", "You clicked on the guest thumbnail", "Did not publish correct payload");
-               });
-         },
+      "Publishes topic when clicked": function() {
+         return browser.findByCssSelector("#GUEST_THUMBNAIL .inner")
+            .click()
+            .getLastPublish("ALF_DISPLAY_NOTIFICATION", true)
+            .then(function(payload) {
+               assert.isNotNull(payload, "Did not publish correct topic when clicked");
+               assert.propertyVal(payload, "message", "You clicked on the guest thumbnail", "Did not publish correct payload");
+            });
+      },
 
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         }
-      });
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
    });
+});

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/AvatarThumbnail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/AvatarThumbnail.get.js
@@ -17,7 +17,7 @@ model.jsonModel = {
          id: "ADMIN_THUMBNAIL",
          config: {
             currentItem: {
-               userName: "admin"
+               userName: "silly%userid"
             }
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-509 to ensure that user names containing the % symbol are encoded before being used in the avatar image URL