### PR TITLE
AKU-522: Add configuration to stop lists from loading immediately

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -184,6 +184,7 @@ define(["dojo/_base/declare",
             else
             {
                // No action required, wait for either a reload request or data to be published
+               this.alfLog("log", "This list configured to not load data immediately", this);
             }
          }
       },

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -58,16 +58,6 @@ define(["dojo/_base/declare",
       hashVarsForUpdate: [],
 
       /**
-       * Indicates whether or not changing URL hash parameters should be set as instance variables
-       * on the list.
-       *
-       * @instance
-       * @type {boolean}
-       * @default false
-       */
-      updateInstanceValues: false,
-
-      /**
        * Indicates whether or not the [hashVarsForUpdate]{@link module:alfresco/lists/AlfHashList#hashVarsForUpdate}
        * that are present in the current hash should be mapped directly into the 
        * [loadDataPublishPayload]{@link module:alfresco/lists/AlfList#loadDataPublishPayload}.
@@ -77,6 +67,16 @@ define(["dojo/_base/declare",
        * @default false
        */
       mapHashVarsToPayload: false,
+
+      /**
+       * Indicates whether or not changing URL hash parameters should be set as instance variables
+       * on the list.
+       *
+       * @instance
+       * @type {boolean}
+       * @default false
+       */
+      updateInstanceValues: false,
 
       /**
        * Determines whether or not a locally stored hash value should be maintained and re-used in the event of 
@@ -177,9 +177,13 @@ define(["dojo/_base/declare",
                this.processLoadedData(this.currentData);
                this.renderView();
             }
-            else
+            else if (this.loadDataImmediately)
             {
                this.loadData();
+            }
+            else
+            {
+               // No action required, wait for either a reload request or data to be published
             }
          }
       },

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -144,6 +144,17 @@ define(["dojo/_base/declare",
       loadDataPublishPayload: null,
 
       /**
+       * Indicates whether or not a request for data should be loaded as soon as the widget is created.
+       * This will have no effect when [currentData]{@link module:alfresco/listsl/AlfList#currentData}
+       * is configured.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      loadDataImmediately: true,
+
+      /**
        * Subscribe the document list topics.
        *
        * @instance
@@ -411,9 +422,13 @@ define(["dojo/_base/declare",
             this.processLoadedData(this.currentData);
             this.renderView();
          }
-         else
+         else if (this.loadDataImmediately)
          {
             this.loadData();
+         }
+         else
+         {
+            // No action required, wait for either a reload request or data to be published
          }
       },
 

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -429,6 +429,7 @@ define(["dojo/_base/declare",
          else
          {
             // No action required, wait for either a reload request or data to be published
+            this.alfLog("log", "This list configured to not load data immediately", this);
          }
       },
 

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -634,6 +634,42 @@ define(["intern!object",
    });
 
    registerSuite({
+      name: "Tab Container Tests (example use case 2)",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AlfTabContainerUseCase2", "Tab Container Tests (example use case 2)").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Select second tab and check search is not in progress": function() {
+         return browser.findByCssSelector(".dijitTabInner:nth-child(2) .tabLabel")
+            .click()
+         .end()
+         .findById("SEARCH_LIST")
+         .end()
+         .getAllPublishes("ALF_SEARCH_REQUEST")
+            .then(function(payloads){
+               assert.lengthOf(payloads, 0, "Search request should not have been made");
+            });
+      },
+
+      "Click a button to trigger a reload and check reload request occurs": function() {
+         return browser.findById("RELOAD_BUTTON_label")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST", "Search request did not occur");
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+
+   registerSuite({
       name: "Tab Container Tests (height calculations)",
 
       setup: function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Search in secondary tab</shortname>
+  <description>This page shows the alfresco/layout/AlfTabContainer where an alfresco/search/AlfSearchList is included on a tab that is not immediately visible.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfTabContainerUseCase2</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.js
@@ -1,0 +1,59 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[ 
+      {
+         name: "alfresco/layout/AlfTabContainer",
+         config: {
+            widgets: [
+               {
+                  id: "DEBUG_TAB",
+                  name: "alfresco/logging/DebugLog",
+                  title: "Debug Log"
+               },
+               {
+                  id: "SEARCH_LIST",
+                  title: "Search",
+                  name: "alfresco/layout/FixedHeaderFooter",
+                  config: {
+                     height: "auto",
+                     widgets: [
+                        {
+                           id: "RELOAD_BUTTON",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Reload",
+                              publishTopic: "RELOAD"
+                           }
+                        },
+                        {
+                           // name: "alfresco/lists/AlfList",
+                           name: "alfresco/search/AlfSearchList",
+                           config: {
+                              useHash: false,
+                              loadDataImmediately: false,
+                              reloadDataTopic: "RELOAD",
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/HtmlListView"
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-522 to provide a configurable way in which to stop lists from publishing requests to load data as soon as the list is created.