### PR TITLE
AKU-503: Default tag warnings

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Tags.js
+++ b/aikau/src/main/resources/alfresco/renderers/Tags.js
@@ -54,7 +54,27 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Tags.css"}]
        */
       cssRequirements: [{cssFile:"./css/Tags.css"}],
-      
+
+      /**
+       * Override [default configuration]{@link module:alfresco/renderers/Property#warnIfNotAvailable} to 
+       * display a message when no tags have been configured.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      warnIfNotAvailable: true,
+
+      /**
+       * Override [default configuration]{@link module:alfresco/renderers/Property#warnIfNotAvailableMessage} to 
+       * to set a tag specific warning message.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      warnIfNotAvailableMessage: "no.tags.message",
+
       /**
        * Overrides the [inherited function]{@link module:alfresco/renderers/Property#getRenderedProperty} to convert the tags
        * value into visual tokens.


### PR DESCRIPTION
This PR is a minor update to https://issues.alfresco.com/jira/browse/AKU-503 to add default warnings for the Tags renderer when the Node has not been tagged.