### PR TITLE
AKU-499: Incorrect search icon placement

### DIFF
--- a/aikau/src/main/resources/alfresco/header/css/SearchBox.css
+++ b/aikau/src/main/resources/alfresco/header/css/SearchBox.css
@@ -155,6 +155,6 @@
 .alfresco-share .alfresco-header-SearchBox-menu .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
     height: 16px;
     margin-top: 0;
-    margin-left: -2px;
+    margin-left: 1px;
     padding-right: 2px;
 }


### PR DESCRIPTION
Addresses issue [AKU-499](https://issues.alfresco.com/jira/browse/AKU-499) to fix the incorrect search icon placement by moving the icon 3px to right as discussed with Kev. Has been tested in local Share and looks fine without side-effects. Looks like it might have been introduced back in March, as part of a search customisation story.