### PR TITLE
AKU-510: Accessibility focus updates

### DIFF
--- a/aikau/src/main/resources/alfresco/accessibility/css/AccessibilityMenu.css
+++ b/aikau/src/main/resources/alfresco/accessibility/css/AccessibilityMenu.css
@@ -1,5 +1,4 @@
-.accessibilityMenu
-{
+.alfresco-accessibility-AccessibilityMenu {
    position: absolute;
    left: 0;
    top: 0;
@@ -7,40 +6,41 @@
    width: 100%;
    margin-left: 0;
    text-align: center;
-}
-.accessibilityMenu p
-{
-   position: absolute;
-   left: -99999px;
-}
-.accessibilityMenu ul
-{
-   list-style: outside none;
-}
-.accessibilityMenu li
-{
-   list-style-type: none;
-}
-.accessibilityMenu a
-{
-   position: absolute;
-   left: -99999px;
-   top: 58px;
-}
-.accessibilityMenu a:focus,
-.accessibilityMenu a:active{
-   position: relative;
-   left: 0;
-   z-index: 9999;
-   width: 75%;
-   height: auto;
-   margin: 0 auto;
-   padding: 20px 25px;
-   text-align: center;
-   text-decoration: none;
-   font: bold 30px "Arial", "Freesans", sans-serif;
-   color: #333;
-   background-color: #fff;
-   opacity: 0.80;
-   border: 1px solid #333;
+
+   &__header {
+      position: absolute;
+      left: -99999px;
+   }
+
+   &__access-key-list {
+      list-style: outside none;
+   }
+
+   &__access-key-item {
+      list-style-type: none;
+
+      &__link {
+         position: absolute;
+         left: -99999px;
+         top: 58px;
+
+         &:focus,
+         &:active {
+            position: relative;
+            left: 0;
+            z-index: 9999;
+            width: 75%;
+            height: auto;
+            margin: 0 auto;
+            padding: 20px 25px;
+            text-align: center;
+            text-decoration: none;
+            font: bold 30px "Arial", "Freesans", sans-serif;
+            color: #333;
+            background-color: #fff;
+            opacity: 0.80;
+            border: 1px solid #333;
+         }
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/accessibility/templates/AccessibilityMenu.html
+++ b/aikau/src/main/resources/alfresco/accessibility/templates/AccessibilityMenu.html
@@ -1,1 +1,1 @@
-<div id="accessKeys" class="accessibilityMenu" data-dojo-attach-point="accessKeys"></div>
+<div id="accessKeys" class="alfresco-accessibility-AccessibilityMenu" data-dojo-attach-point="accessKeys"></div>

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -775,6 +775,18 @@ define(["dojo/_base/declare",
       _pubSubOptionsHandle: null,
 
       /**
+       * Delegates focus calls to the wrapped widget.
+       * 
+       * @instance
+       */
+      focus: function alfresco_forms_controls_BaseFormControl__focus() {
+         if (this.wrappedWidget && typeof this.wrappedWidget.focus === "function")
+         {
+            this.wrappedWidget.focus();
+         }
+      },
+
+      /**
        * Sets up a new subscription for options changes and then publishes a request to get those options.
        *
        * @instance

--- a/aikau/src/test/resources/alfresco/accessibility/AccessibilityMenuTest.js
+++ b/aikau/src/test/resources/alfresco/accessibility/AccessibilityMenuTest.js
@@ -21,11 +21,11 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
+        "intern/chai!assert",
         "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, expect, require, TestCommon, keys) {
+        function (registerSuite, assert, require, TestCommon, keys) {
 
    var browser;
    registerSuite({
@@ -40,77 +40,54 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
-      "Find the menu element": function () {
-         // Find the menu element
-         return browser.findById("AccessibilityMenu")
-            .then(function (el) {
-               expect(el).to.be.an("object", "The Accessibility Menu could not be found");
-            });
-      },
-
       "Find the heading text": function() {
          // Find the heading text
-         return browser.findByCssSelector("#AccessibilityMenu > p")
+         return browser.findByCssSelector(".alfresco-accessibility-AccessibilityMenu__header")
             .getVisibleText()
             .then(function(headingText) {
-               expect(headingText).to.equal("Access key links:", "The heading text is wrong");
+               assert.equal(headingText, "Access key links:", "The heading text is wrong");
             });
       },
 
       "Find the menu items": function() {
          // Find the menu items
-         return browser.findAllByCssSelector("#AccessibilityMenu > ul > li")
+         return browser.findAllByCssSelector(".alfresco-accessibility-AccessibilityMenu__access-key-item")
             .then(function (menuitems) {
-               expect(menuitems).to.have.length(8, "The Accessibility Menu does not contain 8 <li> items");
+               assert.lengthOf(menuitems, 11, "The Accessibility Menu does not contain 11 access key items");
             });
       },
 
-      "Find the first target": function() {
-         // Find the first target
-         return browser.findByCssSelector("a#accesskey-skip")
-            .then(function (el) {
-               expect(el).to.be.an("object", "The accesskey-skip target is missing");
-            });
+      "Test tab to skip to textbox (may not work on OS/X)": function() {
+         return browser.pressKeys(keys.TAB)
+            .pressKeys(keys.TAB)
+            .pressKeys(keys.TAB)
+            .pressKeys(keys.ENTER)
+            .pressKeys("H") // NOTE: need to use pressKeys and not type here
+            .getLastPublish("_valueChangeOf_textbox", "Text box was not focused");
       },
 
-      "Find the second target": function() {
-         // Find the second target
-         return browser.findById("accesskey-foot")
-            .then(function (el) {
-               expect(el).to.be.an("object", "The accesskey-foot target is missing");
-            });
-      },
-
-      "Find the first menu link - which links the first target": function() {
-         // Find the first menu link - which links the first target
-         return browser.findByCssSelector("#AccessibilityMenu > ul > li:nth-of-type(1) > a ")
-            .then(function (el) {
-               expect(el).to.be.an("object", "The first link is missing");
-            });
-      },
-
-      "Test access keys": function() {
+      "Test button access key (may not work on OS/X)": function() {
          // Hit the browser with a sequence of different accesskey combinations and the letter 's' for a nav skip
-         return browser.pressKeys([keys.SHIFT, "s"])
-            .pressKeys([keys.SHIFT])
-            .pressKeys([keys.ALT, keys.SHIFT, "s"])
-            .pressKeys([keys.ALT, keys.SHIFT])
-//       Can't do this because of a conflict in FF on Windows that calls up a dialogue
-//         .pressKeys([keys["Control"], keys["Command"], "s"])
-//         .pressKeys([keys["Control"], keys["Command"]])
-            .getCurrentUrl()
-            .then(function (page) {
-               // Only check the test if this isn't a Mac because of key combo conflicts.
-               if(browser.environmentType.platform !== "MAC") {
-                  expect(page).to.contain("#accesskey-skip", "Accesskey target not linked to");
-               }
-               else {
-               }
-            });
+         return browser.pressKeys([keys.ALT, "b"])
+            .pressKeys([keys.ALT]) // Release SHIFT (Chrome)
+            .pressKeys([keys.ALT, keys.SHIFT, "b"])
+            .pressKeys([keys.ALT, keys.SHIFT]) // Release ALT + SHIFT (Firefox)
+
+            // The button should now have focus - hit enter to use it...
+            .pressKeys(keys.ENTER)
+            .getLastPublish("BUTTON_FOCUS_SUCCESS", "Button was not focused");
+      },
+
+      "Test menu access key (may not work on OS/X)": function() {
+         // Hit the browser with a sequence of different accesskey combinations and the letter 's' for a nav skip
+         return browser.pressKeys([keys.ALT, "m"])
+            .pressKeys([keys.ALT]) // Release SHIFT (Chrome)
+            .pressKeys([keys.ALT, keys.SHIFT, "m"])
+            .pressKeys([keys.ALT, keys.SHIFT]) // Release ALT + SHIFT (Firefox)
+
+            // The button should now have focus - hit enter to use it...
+            .pressKeys(keys.ENTER)
+            .getLastPublish("MENU_FOCUS_SUCCESS", "Button was not focused");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/accessibility/AccessibilityMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/accessibility/AccessibilityMenu.get.js
@@ -1,37 +1,80 @@
 model.jsonModel = {
    services: [
-      "alfresco/services/ErrorReporter"
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
    ],
    widgets: [
       {
          name: "aikauTesting/CssOverrides"
       },
       {
+         id: "ACCESSIBILITY_MENU",
          name: "alfresco/accessibility/AccessibilityMenu",
          config: {
-            id: "AccessibilityMenu",
             titleMsgKey: "access.key.links.message",
             menu: [
                {url: "#accesskey-skip", key: "s", msgKey: "skip.to.content.message"},
+               {url: "#BUTTON", key: "b", msgKey: "Skip to button"},
+               {url: "#TEXTBOX", key: "t", msgKey: "Skip to text box"},
+               {url: "#MENU_ITEM", key: "m", msgKey: "Skip to menu"},
                {url: "/share/page/accessibility-help", key: "0", msgKey: "access.keys.message"},
                {url: "/share/page/user/admin/dashboard", key: "1", msgKey: "home.page.message"},
                {url: "/share/page/advsearch", key: "4", msgKey: "search.this.site.message"},
                {url: "/share/page/site-help", key: "6", msgKey: "accessibility.help.message"},
                {url: "/share/page/terms", key: "8", msgKey: "terms.and.conditions.message"},
                {url: "/share", key: "9", msg: "This is just a test message"},
-               {url: "#accesskey-foot", key: "b", msgKey: "skip.to.foot.message"}
+               {url: "#accesskey-foot", key: "f", msgKey: "skip.to.foot.message"}
             ],
             targets: [
-               {domid: "AccessibilityMenu", targetid: "accesskey-skip", after: false},
-               {domid: "AccessibilityMenu", targetid: "accesskey-foot", after: true}
+               {domid: "ACCESSIBILITY_MENU", targetid: "accesskey-skip", after: false},
+               {domid: "ACCESSIBILITY_MENU", targetid: "accesskey-foot", after: true}
             ]
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Demonstrates focus",
+            publishTopic: "BUTTON_FOCUS_SUCCESS"
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         id: "TEXTBOX",
+         name: "alfresco/forms/controls/TextBox",
+         config: {
+            fieldId: "textbox",
+            label: "Test",
+            name: "test"
+         }
+      },
+      {
+         id: "MENU",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "MENU_ITEM",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Menu Item",
+                     publishTopic: "MENU_FOCUS_SUCCESS"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/css/CssOverrides.css
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/css/CssOverrides.css
@@ -1,8 +1,13 @@
 /* Accessibility Menu */
 .hiddenAccessible,
-.accessibilityMenu p,
-.accessibilityMenu a
-{
-   position: static;
-   left: auto;
+.alfresco-accessibility-AccessibilityMenu,
+.alfresco-accessibility-AccessibilityMenu__header {
+   position: inherit;
+   height: auto;
+   left: 0;
+}
+
+.alfresco-accessibility-AccessibilityMenu__access-key-item__link {
+   position: inherit;
+   left: 0;
 }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-510 to update the alfresco/accessibility/AcessibilityMenu so that it conforms to our BEM CSS approach and correctly focuses on the items linked to in the skip links. The unit tests have been updated to verify this behaviour.