### PR TITLE
AKU-514: Sidebar improvements.

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -314,7 +314,7 @@ define(["dojo/_base/declare",
          var h = (c > availableHeight) ? c : availableHeight;
 
          domStyle.set(this.sidebarNode, "height", h + "px");
-         domStyle.set(this.mainNode, "width", (size - w - 6) + "px");
+         domStyle.set(this.mainNode, "width", (size - w - 16) + "px");
          
          // Fire a custom event to let contained objects know that the node has been resized.
          this.alfPublishResizeEvent(this.mainNode);
@@ -406,6 +406,10 @@ define(["dojo/_base/declare",
             $(this.sidebarNode).resizable("enable"); // Unlock the resizer when the sidebar is not shown...
             var width = (this.hiddenSidebarWidth) ? this.hiddenSidebarWidth : this.initialSidebarWidth;
             domStyle.set(this.sidebarNode, "width", width + "px");
+
+            // Add some right padding so that the resize bar doesn't appear over the content, this is
+            // particular important with regards to scrollbars that might be present (see AKU-514)
+            domStyle.set(this.sidebarNode, "padding-right", "10px");
             this.lastSidebarWidth = width;
             this.resizeHandler();
             if (this.resizeHandlerButtonNode)
@@ -418,6 +422,10 @@ define(["dojo/_base/declare",
          {
             // Hide the sidebar...
             domStyle.set(this.sidebarNode, "width", "9px");
+
+            // Remove the right-padding to ensure that the resize bar snaps cleanly to the outer edge of
+            // the container
+            domStyle.set(this.sidebarNode, "padding-right", "0");
             this.lastSidebarWidth = 9;
             this.resizeHandler();
             $(this.sidebarNode).resizable("disable"); // Lock the resizer when the sidebar is not shown...

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -26,6 +26,7 @@
    right: 0;
    border-right: @standard-border;
    border-left: @standard-border;
+   z-index: 10000;
 }
 
 /* Overrides JQuery default behaviour to hide the handle when disabled, but this would

--- a/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
@@ -84,9 +84,10 @@ define(["intern!object",
 
       "Test Initial Widths": function () {
          return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert(width === "350px", "The sidebar width wasn't initialised correctly");
+            .getSize()
+            .then(function(size) {
+               // NOTE: The width has to take the 10px right padding into account
+               assert.equal(size.width, 360, "The sidebar width wasn't initialised correctly");
             });
       },
 
@@ -95,9 +96,9 @@ define(["intern!object",
             .click()
          .end()
          .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert(width === "9px", "The sidebar wasn't hidden via the bar control");
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.width, 9, "The sidebar wasn't hidden via the bar control");
             });
       },
 
@@ -106,9 +107,10 @@ define(["intern!object",
             .click()
          .end()
          .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert(width === "350px", "The sidebar wasn't shown via the bar control");
+            .getSize()
+            .then(function(size) {
+               // NOTE: The width has to take the 10px right padding into account
+               assert.equal(size.width, 360, "The sidebar wasn't shown via the bar control");
             });
       },
 
@@ -117,9 +119,9 @@ define(["intern!object",
             .click()
          .end()
          .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert(width === "9px", "The sidebar wasn't hidden via publication");
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.width, 9, "The sidebar wasn't hidden via publication");
             });
       },
 
@@ -128,9 +130,10 @@ define(["intern!object",
             .click()
          .end()
          .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert(width === "350px", "The sidebar wasn't shown via publication");
+            .getSize()
+            .then(function(size) {
+               // NOTE: The width has to take the 10px right padding into account
+               assert.equal(size.width, 360, "The sidebar wasn't shown via publication");
             })
          .end();
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-514 to make some improvements on the layout of the alfresco/layout/AlfSideBarContainer. The key update is that the resize bar is not outside the main sidebar node so that it doesn't overlap any of the sidebar content (this is particularly important when the sidebar contains a scrollbar as it hides the scrollbar). It also ensures that the resize bar is always accessible via the mouse (although a z-index has now been set to ensure this is possible).