### PR TITLE
AKU-494: Update doclib.lib.js to use useHash option on PathTree config

### DIFF
--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -577,7 +577,8 @@ function getDocLibTree(options) {
                   siteId: options.siteId,
                   containerId: options.containerId,
                   rootNode: options.rootNode,
-                  rootLabel: options.rootLabel || "documentlibrary.root.label"
+                  rootLabel: options.rootLabel || "documentlibrary.root.label",
+                  useHash: (options.useHash !== false)
                }
             }
          ]


### PR DESCRIPTION
Update to doclib.lib.js to pass on useHash from options to PathTree (see https://issues.alfresco.com/jira/browse/AKU-494)