### PR TITLE
AKU-460: Update hidden search term handling in SearchBox

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -760,6 +760,25 @@ define(["dojo/_base/declare",
       defaultSearchScope: "repo",
 
       /**
+       * This function is used to construct the search terms that are passed to a search service. The
+       * terms provided by the user (e.g. the text that the user has typed) is parenthesized and concatonated
+       * with any [hiddenSearchTerms]{@link module:alfresco/header/SearchBox#hiddenSearchTerms} so that the scope
+       * of the user search request is not lost.
+       * 
+       * @instance
+       * @since 1.0.31
+       * @overrideable
+       */
+      generateSearchTerm: function alfresco_header_SearchBox__generateSearchTerm(terms) {
+         var searchTerm = terms;
+         if (this.hiddenSearchTerms)
+         {
+            searchTerm = encodeURIComponent("(" + terms + ") " + this.hiddenSearchTerms);
+         }
+         return searchTerm;
+      },
+
+      /**
        * This function is called from the [onSearchBoxKeyUp function]{@link module:alfresco/header/SearchBox#onSearchBoxKeyUp}
        * when the enter key is pressed and will generate a link to either the faceted search page or the old search page
        * based on the value of [linkToFacetedSearch]{@link module:alfresco/header/SearchBox#linkToFacetedSearch}. This function
@@ -775,17 +794,17 @@ define(["dojo/_base/declare",
          if (this.searchResultsPage)
          {
             // Generate custom search page link...
-            url = this.searchResultsPage + "#searchTerm=" + encodeURIComponent(terms + this.hiddenSearchTerms) + "&scope=" + scope + "&sortField=Relevance";
+            url = this.searchResultsPage + "#searchTerm=" + this.generateSearchTerm(terms) + "&scope=" + scope + "&sortField=Relevance";
          }
          else if (this.linkToFacetedSearch === true)
          {
             // Generate faceted search page link...
-            url = "dp/ws/faceted-search#searchTerm=" + encodeURIComponent(terms + this.hiddenSearchTerms) + "&scope=" + scope + "&sortField=Relevance";
+            url = "dp/ws/faceted-search#searchTerm=" + this.generateSearchTerm(terms) + "&scope=" + scope + "&sortField=Relevance";
          }
          else
          {
             // Generate old search page link...
-            url = "search?t=" + encodeURIComponent(terms + this.hiddenSearchTerms) + (this.allsites ? "&a=true&r=false" : "&a=false&r=true");
+            url = "search?t=" + this.generateSearchTerm(terms) + (this.allsites ? "&a=true&r=false" : "&a=false&r=true");
          }
          if (this.site)
          {
@@ -974,7 +993,7 @@ define(["dojo/_base/declare",
       liveSearchDocuments: function alfresco_header_SearchBox__liveSearchDocuments(terms, startIndex) {
          this._requests.push(
             this.serviceXhr({
-               url: AlfConstants.PROXY_URI + "slingshot/live-search-docs?t=" + encodeURIComponent(terms + this.hiddenSearchTerms) + "&maxResults=" + this._resultPageSize + "&startIndex=" + startIndex,
+               url: AlfConstants.PROXY_URI + "slingshot/live-search-docs?t=" + this.generateSearchTerm(terms) + "&maxResults=" + this._resultPageSize + "&startIndex=" + startIndex,
                method: "GET",
                successCallback: function(response) {
                   if (startIndex === 0)
@@ -1068,7 +1087,7 @@ define(["dojo/_base/declare",
       liveSearchSites: function alfresco_header_SearchBox__liveSearchSites(terms, /*jshint unused:false*/ startIndex) {
          this._requests.push(
             this.serviceXhr({
-               url: AlfConstants.PROXY_URI + "slingshot/live-search-sites?t=" + encodeURIComponent(terms + this.hiddenSearchTerms) + "&maxResults=" + this._resultPageSize,
+               url: AlfConstants.PROXY_URI + "slingshot/live-search-sites?t=" + this.generateSearchTerm(terms) + "&maxResults=" + this._resultPageSize,
                method: "GET",
                successCallback: function(response) {
                   this._LiveSearch.containerNodeSites.innerHTML = "";
@@ -1115,7 +1134,7 @@ define(["dojo/_base/declare",
       liveSearchPeople: function alfresco_header_SearchBox__liveSearchPeople(terms, /*jshint unused:false*/ startIndex) {
          this._requests.push(
             this.serviceXhr({
-               url: AlfConstants.PROXY_URI + "slingshot/live-search-people?t=" + encodeURIComponent(terms + this.hiddenSearchTerms) + "&maxResults=" + this._resultPageSize,
+               url: AlfConstants.PROXY_URI + "slingshot/live-search-people?t=" + this.generateSearchTerm(terms) + "&maxResults=" + this._resultPageSize,
                method: "GET",
                successCallback: function(response) {
                   this._LiveSearch.containerNodePeople.innerHTML = "";

--- a/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
+++ b/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
@@ -95,9 +95,9 @@ define(["intern!object",
          return browser.findByCssSelector(".alf-livesearch-item a")
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "/aikau/page/site/swsdp/document-details?nodeRef=workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Did not find expected navigation publication request");
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", "/aikau/page/site/swsdp/document-details?nodeRef=workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e");
             });
       },
 
@@ -105,10 +105,9 @@ define(["intern!object",
          return browser.findByCssSelector(".alf-livesearch-item > span > a:nth-child(1)")
             .click()
          .end()
-         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "url"))
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, Config.urls.unitTestAppBaseUrl + "/aikau/page/site/swsdp/documentlibrary", "Wrong URL");
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", Config.urls.unitTestAppBaseUrl + "/aikau/page/site/swsdp/documentlibrary", "Wrong URL");
             });
       },
 
@@ -116,10 +115,9 @@ define(["intern!object",
          return browser.findByCssSelector(".alf-livesearch-item > span > a:nth-child(2)")
             .click()
          .end()
-         .findByCssSelector(TestCommon.pubSubDataValueCssSelector("last", "url"))
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, Config.urls.unitTestAppBaseUrl + "/aikau/page/user/admin/profile", "Wrong URL");
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", Config.urls.unitTestAppBaseUrl + "/aikau/page/user/admin/profile", "Wrong URL");
             });
       },
 
@@ -128,9 +126,9 @@ define(["intern!object",
             .click()
             .pressKeys(keys.RETURN)
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "dp/ws/faceted-search#searchTerm=pdf&scope=repo&sortField=Relevance"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Did not find expected navigation publication request (check the search scope!)");
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", "dp/ws/faceted-search#searchTerm=pdf&scope=repo&sortField=Relevance", "Did not find expected navigation publication request (check the search scope!)");
             });
       },
 
@@ -191,9 +189,9 @@ define(["intern!object",
             .click()
             .pressKeys(keys.RETURN)
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "site/site1/dp/ws/faceted-search#searchTerm=site&scope=site1&sortField=Relevance"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Did not find expected navigation publication request (check the search scope contains site!)");
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", "site/site1/dp/ws/faceted-search#searchTerm=site&scope=site1&sortField=Relevance");
             });
       },
 
@@ -246,14 +244,14 @@ define(["intern!object",
 
       "Check search results redirect can be suppressed": function() {
          return browser.findByCssSelector("#SB2 input.alfresco-header-SearchBox-text")
+            .clearLog()
             .type("site")
             .pressKeys(keys.RETURN)
          .end()
-         .sleep(500)
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_WIDGET_PROCESSING_COMPLETE", "publish", "last"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "The search request was not suppressed");
-            });
+         .getAllPublishes("ALF_NAVIGATE_TO_PAGE")
+         .then(function(payloads) {
+            assert.lengthOf(payloads, 0, "The search request was not suppressed");
+         });
       },
 
       "Check that document titles can be overridden": function() {
@@ -326,9 +324,9 @@ define(["intern!object",
                .type("data")
                .pressKeys(keys.RETURN)
             .end()
-            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_NAVIGATE_TO_PAGE", "url", "dp/ws/faceted-search#searchTerm=data%20secret%20squirrels&scope=repo&sortField=Relevance"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Did not find expected navigation publication request (check the search scope contains site!)");
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "url", "dp/ws/faceted-search#searchTerm=(data)%20secret%20squirrels&scope=repo&sortField=Relevance");
                });
       },
 
@@ -358,9 +356,9 @@ define(["intern!object",
          .findByCssSelector(".alf-livesearch-item a")
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("CUSTOM_TOPIC", "name", "WebSiteReview.mp4"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Custom publication not made for result click");
+         .getLastPublish("CUSTOM_TOPIC")
+            .then(function(payload) {
+               assert.propertyVal(payload, "name", "WebSiteReview.mp4", "Custom publication not made for result click");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
@@ -91,7 +91,7 @@ model.jsonModel = {
             alignment: "left",
             placeholder: "Has hidden search terms",
             showPeopleResults: false,
-            hiddenSearchTerms: " secret squirrels",
+            hiddenSearchTerms: "secret squirrels",
             advancedSearch: false
          }
       },
@@ -99,7 +99,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/SearchBoxMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-460 to wrap user search terms in brackets when hidden search terms are configured for an alfresco/header/SearchBox. The unit test has been updated to reflect this change and converted to use DebugLog.