### PR TITLE
AKU-528: Updated link decoration to be based off LESS variables

### DIFF
--- a/aikau/src/main/resources/alfresco/accessibility/css/AccessibilityMenu.css
+++ b/aikau/src/main/resources/alfresco/accessibility/css/AccessibilityMenu.css
@@ -34,7 +34,7 @@
             margin: 0 auto;
             padding: 20px 25px;
             text-align: center;
-            text-decoration: none;
+            text-decoration: @link-text-decoration;
             font: bold 30px "Arial", "Freesans", sans-serif;
             color: #333;
             background-color: #fff;

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -94,7 +94,7 @@
 // Link colours and decoration
 @link-font-color: @general-font-color;
 @link-emphasized-font-color: @emphasized-font-color;
-@link-visited-font-color: @general-font-color;
+@link-visited-font-color: @link-font-color;
 @link-text-decoration: none;
 @link-text-decoration-hover: underline;
 

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -42,6 +42,7 @@
 // Font families
 @standard-font: Open Sans,Arial,Helvetica,sans-serif;
 @bold-font: Open Sans Bold, Arial, sans-serif;
+@condensed-font: Open Sans Condensed, Arial, sans-serif;
 
 // Font Mixins
 
@@ -89,6 +90,13 @@
 @emphasized-font-color: #000;
 @de-emphasized-font-color: #999;
 @highlighted-font-color: #fff;
+
+// Link colours and decoration
+@link-font-color: @general-font-color;
+@link-emphasized-font-color: @emphasized-font-color;
+@link-visited-font-color: @general-font-color;
+@link-text-decoration: none;
+@link-text-decoration-hover: underline;
 
 // Borders...
 // These have been initially added for form controls...

--- a/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
+++ b/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
@@ -117,11 +117,12 @@
       position: relative;
       a {
          cursor: pointer;
+         color: @link-font-color;
          &:link, &:visited, &:active {
-            text-decoration: none;
+            text-decoration: @link-text-decoration;
          }
          &:hover {
-            text-decoration: underline;
+            text-decoration: @link-text-decoration-hover;
          }
       }
       h3 {

--- a/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
+++ b/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
@@ -65,7 +65,7 @@
       margin-right: 10px;
    }
    > a {
-      color: @general-font-color;
-      text-decoration: none;
+      color: @link-font-color;
+      text-decoration: @link-text-decoration;
    }
 }

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -25,7 +25,7 @@
  */
 .alfresco-dialog-AlfDialog.dijitDialog a {
    color: @general-font-color;
-   text-decoration: none;
+   text-decoration: @link-text-decoration;
 }
 
 /*

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
@@ -8,7 +8,8 @@
    background: @breadcrumb-border-color;
 }
 .alfresco-documentlibrary-AlfBreadcrumb a {
-   text-decoration: none; 
+   color: @link-font-color;
+   text-decoration: @link-text-decoration; 
    padding: 5px 15px 5px 30px;
    background: @breadcrumb-background-color;
    position: relative; 

--- a/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
@@ -121,7 +121,8 @@
          &__highlighted-label {
             font-family: @bold-font;
             font-weight: 700;
-            text-decoration: underline;
+            color: @link-font-color
+            text-decoration: @link-text-decoration;
          }
          &:first-child {
             border-top-color: @standard-border-color;

--- a/aikau/src/main/resources/alfresco/header/css/SearchBox.css
+++ b/aikau/src/main/resources/alfresco/header/css/SearchBox.css
@@ -12,8 +12,8 @@
    height: 23px;
 
    a {
-      color: @emphasized-font-color;
-      text-decoration: none;
+      color: @link-emphasized-font-color;
+      text-decoration: @link-text-decoration;
    }
 
    .dijit.dijitReset.dijitInline.dijitDropDownButton {

--- a/aikau/src/main/resources/alfresco/header/css/Title.css
+++ b/aikau/src/main/resources/alfresco/header/css/Title.css
@@ -6,9 +6,9 @@
       font-weight: normal;
       margin-top: 19px;
       > .text {
-         color: @general-font-color !important;
-         font-family: Open Sans Condensed, Arial, sans-serif;
-         text-decoration: none;
+         color: @link-font-color !important;
+         font-family: @condensed-font;
+         text-decoration: @link-text-decoration;
          &.has-max-width {
             overflow: hidden;
             text-overflow: ellipsis;

--- a/aikau/src/main/resources/alfresco/layout/css/Twister.css
+++ b/aikau/src/main/resources/alfresco/layout/css/Twister.css
@@ -16,7 +16,8 @@
    background-position: 0 center;
    background-repeat: no-repeat;
    padding: 0.5em;
-   text-decoration: none;
+   color: @link-font-color;
+   text-decoration: @link-text-decoration;
 }
 
 .alfresco-layout-Twister--open {

--- a/aikau/src/main/resources/alfresco/navigation/css/Link.css
+++ b/aikau/src/main/resources/alfresco/navigation/css/Link.css
@@ -1,8 +1,9 @@
 .alfresco-share .alfresco-navigation-Link {
-   text-decoration: none;
+   color: @link-font-color;
+   text-decoration: @link-text-decoration;
    cursor: pointer;
 }
 
 .alfresco-share .alfresco-navigation-Link:hover {
-   text-decoration: underline;
+   text-decoration: @link-text-decoration-hover;
 }

--- a/aikau/src/main/resources/alfresco/navigation/css/_HtmlAnchorMixin.css
+++ b/aikau/src/main/resources/alfresco/navigation/css/_HtmlAnchorMixin.css
@@ -1,4 +1,4 @@
 .alfresco-share a.alfresco-navigation-_HtmlAnchorMixin {
    color: inherit;
-   text-decoration: inherit;
+   text-decoration: @link-text-decoration;
 }

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/css/Outline.css
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/css/Outline.css
@@ -20,6 +20,6 @@
 }
 
 .alfresco-preview-PdfJs-Outline .outlineItem>a {
-   text-decoration: none;
-   color: black;
+   text-decoration: @link-text-decoration;
+   color: @link-font-color;
 }

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditPropertyLink.js
@@ -31,10 +31,20 @@ define(["dojo/_base/declare",
         "dijit/a11yclick",
         "dojo/_base/lang",
         "dojo/on",
-        "dojo/_base/event"],
-        function(declare, InlineEditProperty, _ItemLinkMixin, a11yclick, lang, on, event) {
+        "dojo/_base/event",
+        "dojo/dom-class"],
+        function(declare, InlineEditProperty, _ItemLinkMixin, a11yclick, lang, on, event, domClass) {
 
    return declare([InlineEditProperty, _ItemLinkMixin], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/InlineEditPropertyLink.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/InlineEditPropertyLink.css"}],
       
       /**
        * Whether the widget should be put into edit mode when rendered value is clicked.
@@ -52,6 +62,7 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_renderers_InlineEditPropertyLink__postCreate() {
          this.inherited(arguments);
+         domClass.add(this.domNode, "alfresco-renderers-InlineEditPropertyLink");
          this.own(on(this.renderedValueNode, a11yclick, lang.hitch(this, this.onLinkClick)));
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -8,7 +8,6 @@
       }
    }
    .inlineEditValue {
-      cursor: pointer;
       line-height: 20px;
       &.hidden ~ .editIcon {
          display: none;

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditPropertyLink.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditPropertyLink.css
@@ -1,0 +1,7 @@
+.alfresco-renderers-InlineEditPropertyLink {
+   .inlineEditValue {
+      cursor: pointer;
+      color: @link-font-color;
+      text-decoration: @link-text-decoration;
+   }
+}

--- a/aikau/src/main/resources/alfresco/renderers/css/Property.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Property.css
@@ -40,9 +40,9 @@
       display: none;
    }
    span.value > a {
-      color: @general-font-color;
+      color: @link-font-color;
       cursor: pointer;
-      text-decoration: none;
+      text-decoration: @link-text-decoration;
    }
 }
 

--- a/aikau/src/main/resources/alfresco/renderers/css/PropertyLink.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/PropertyLink.css
@@ -1,3 +1,5 @@
 .alfresco-renderers-PropertyLink > span.inner {
    cursor: pointer;
+   text-decoration: @link-text-decoration;
+   color: @link-font-color;
 }

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -15,8 +15,8 @@
 
          @use-legacy-buttons: false;
 
-         @link-font-color: blue;
-         @link-emphasized-font-color: blue;
+         @link-font-color: @button-color-default;
+         @link-emphasized-font-color: @button-color-default;
          @link-text-decoration: underline;
       </less-variables>
    </css-tokens>

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -14,6 +14,10 @@
          @header-dropdown-menu-font-color: purple;
 
          @use-legacy-buttons: false;
+
+         @link-font-color: blue;
+         @link-emphasized-font-color: blue;
+         @link-text-decoration: underline;
       </less-variables>
    </css-tokens>
 </theme>


### PR DESCRIPTION
This is an initial commit for https://issues.alfresco.com/jira/browse/AKU-528 (I expect that there will potentially be subsequent commits to update the defaults.less file). 

I've been through all the existing widget modules and updated them to use new LESS variables for styling links. Currently the defaults remain as they were previously (e.g. no link specific colour and no underline). However, I'd like to get this reviewed and merged as an initial starting point. If nothing else this will allow themes to be created that change the links colour and decoration.