### PR TITLE
AKU-515: Correct invalid falsy logic for global/parent publish

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -465,8 +465,8 @@ define(["dojo/_base/declare",
          }
          else
          {
-            var publishGlobal = this.publishGlobal !== false;
-            var publishToParent = this.publishToParent !== false;
+            var publishGlobal = this.publishGlobal || false;
+            var publishToParent = this.publishToParent || false;
             this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
          }
       },

--- a/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
@@ -58,9 +58,9 @@ define(["intern!object",
          return browser.findByCssSelector("#DOCLIB_RENDITIONS tr:nth-child(1) .alfresco-renderers-Thumbnail .inner img")
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DOCUMENTLIST_PATH_CHANGED", "path", "/Budget Files/Invoices/Folder"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Could not find standard container link publication");
+         .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "path", "/Budget Files/Invoices/Folder", "Could not find standard container link publication");
             });
       },
 
@@ -68,9 +68,10 @@ define(["intern!object",
          return browser.findByCssSelector("#IMGPREVIEW_RENDITIONS tr:nth-child(2) .alfresco-renderers-Thumbnail .inner img")
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("CUSTOM_CLICK_TOPIC", "nodeRef", "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Could not find custom link click publication");
+
+         .getLastPublish("CUSTOM_SCOPE_CUSTOM_CLICK_TOPIC", "Topic was not published at the correct scope")
+            .then(function(payload) {
+               assert.propertyVal(payload, "nodeRef", "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8", "Could not find custom link click publication");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Thumbnail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Thumbnail.get.js
@@ -88,12 +88,12 @@ model.jsonModel = {
                                                    {
                                                       name: "alfresco/renderers/Thumbnail",
                                                       config: {
+                                                         pubSubScope: "CUSTOM_SCOPE_",
                                                          renditionName: "imgpreview",
                                                          width: "200px",
                                                          publishTopic: "CUSTOM_CLICK_TOPIC",
                                                          publishPayloadType: "CURRENT_ITEM",
-                                                         publishPayload: {},
-                                                         publishGlobal: true
+                                                         publishPayload: {}
                                                       }
                                                    }
                                                 ]
@@ -277,7 +277,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/ThumbnailsMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-515 to ensure that pubSubScope is respected in the alfresco/renderers/Thumbnail widget. The unit test has been updated to verify scoping.