### PR TITLE
AKU-521: DateTextBox updates for keyboard entry rule processing

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1128,7 +1128,7 @@ define(["dojo/_base/declare",
 
          // If both values aren't null then compare the .toString() output, if one of them is null
          // then it doesn't really matter whether or not we get the string output for the value or not
-         if (currentValue && targetValue.value)
+         if (currentValue && targetValue && targetValue.value)
          {
             return currentValue.toString() === targetValue.value.toString();
          }

--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -33,6 +33,7 @@
  * 
  * @module alfresco/forms/controls/DateTextBox
  * @extends module:alfresco/forms/controls/BaseFormControl
+ * @mixes module:alfresco/forms/controls/utilities/TextBoxValueChangeMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",

--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -35,14 +35,16 @@
  * @extends module:alfresco/forms/controls/BaseFormControl
  * @author Dave Draper
  */
-define(["alfresco/forms/controls/BaseFormControl",
-        "dojo/_base/declare",
+define(["dojo/_base/declare",
+        "alfresco/forms/controls/BaseFormControl",
+        "alfresco/forms/controls/utilities/TextBoxValueChangeMixin",
         "dojo/_base/lang",
         "dojo/date/stamp",
         "dijit/form/DateTextBox",
-        "dojo/dom-class"],
-        function(BaseFormControl, declare, lang, stamp, DateTextBox, domClass) {
-   return declare([BaseFormControl], {
+        "dojo/dom-class",
+        "alfresco/core/ObjectTypeUtils"],
+        function(declare, BaseFormControl, TextBoxValueChangeMixin, lang, stamp, DateTextBox, domClass, ObjectTypeUtils) {
+   return declare([BaseFormControl, TextBoxValueChangeMixin], {
 
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -25,8 +25,9 @@
 define(["intern!object",
         "intern/chai!assert", 
         "require", 
-        "alfresco/TestCommon"], 
-        function(registerSuite, assert, require, TestCommon) {
+        "alfresco/TestCommon", 
+        "intern/dojo/node!leadfoot/keys"], 
+        function(registerSuite, assert, require, TestCommon, keys) {
 
    var browser;
    registerSuite({
@@ -117,6 +118,39 @@ define(["intern!object",
             .getVisibleText()
             .then(function(visibleText) {
                assert.equal(visibleText, "Enter a valid date", "Did not display correct error text");
+            });
+      },
+
+      "Check that rule declaring textbox is not required initially": function() {
+         return browser.findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The requirement indicator should not have been initially displayed");
+            });
+      },
+
+      "Type a date to verify rules processing occurs on keyboard entry": function() {
+         return browser.findById("RULES_CHECKER_CONTROL")
+            .click()
+            .type("05/05/1946")
+         .end()
+         .findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The requirement indicator should be displayed on date entry via keyboard");
+            });
+      },
+
+      "Clear the date to check that the textbox stops being required": function() {
+         return browser.findById("RULES_CHECKER_CONTROL")
+            .clearValue() // Clear the value, makes it less to delete via backspace...
+            .type("1")    // ...add a single character to be deleted with backspace...
+            .pressKeys(keys.BACKSPACE) // ...and delete
+         .end()
+         .findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The requirement indicator should be hidden when the date field is cleared");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
   <shortname>DateTextBox Test</shortname>
+  <description>This shows various configured instances of the alfresco/forms/controls/DateTextBox.</description>
   <family>aikau-unit-tests</family>
   <url>/DateTextBox</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -44,6 +44,37 @@ model.jsonModel = {
                                  initialValue: true
                               }
                            }
+                        },
+                        {
+                           id: "RULES_CHECKER",
+                           name: "alfresco/forms/controls/DateTextBox",
+                           config: {
+                              fieldId: "RULES_CHECKER",
+                              name: "date3",
+                              value: null,
+                              label: "Any Date",
+                              description: "Enter a data via the keyboard to ensure that the TextBox below becomes required."
+                           }
+                        },
+                        {
+                           id: "RULES_SUBSCRIBER",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "RULES_SUBSCRIBER",
+                              label: "Test",
+                              name: "test",
+                              description: "This should become required when a date is entered into the previous DataTextBox",
+                              value: "",
+                              requirementConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       targetId: "RULES_CHECKER",
+                                       isNot: ["",null]
+                                    }
+                                 ]
+                              }
+                           }
                         }
                      ]
                   }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-521 to update the alfresco/forms/controls/DateTextBox to mixin in the alfresco/forms/controls/utilities/TextBoxValueChangeMixin module to setup up the keyboard entry change events. The unit test has been updated with additional widgets based on the model provide in the JIRA issue.