### PR TITLE
AKU-529: FixedHeaderFooter resize handling update

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -271,9 +271,9 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       onResize: function alfresco_layout_FixedHeaderFooter__onResize() {
-         if (this.height === "auto" && this.recalculateAutoHeightOnResize === true)
+         if ((!this.height || this.height === "auto") && this.recalculateAutoHeightOnResize === true)
          {
-            this.height = this.setHeight();
+            this.setHeight();
          }
 
          var widgetHeight = this.domNode.offsetHeight,

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -27,6 +27,7 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function(registerSuite, assert, TestCommon) {
 
+   /* global document*/
    var browser;
    registerSuite({
       name: "FixedHeaderFooter tests",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AutoHeightFixedHeaderFooter.get.js
@@ -21,6 +21,7 @@ model.jsonModel = {
          name: "alfresco/layout/FixedHeaderFooter",
          id: "HEADER_FOOTER",
          config: {
+            height: "auto",
             autoHeightPaddingAllowance: 10,
             recalculateAutoHeightOnResize: true,
             widgetsForHeader: [


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-529 to ensure that when an alfresco/layout/FixedHeaderFooter widget is explicitly configured with "auto" height (as opposed to not setting any value which also defaults to auto height calculation) that resizing occurs but does NOT update the height setting. This ensures that repeating resize events are correctly processed. The unit test was testing the behaviour but the test model was not addressing the explicit height setting.