### PR TITLE
AKU-523: Warnings in forms support

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -215,6 +215,12 @@
 @notification-width: 400px;
 @notification-border-radius: 0 0 5px 5px;
 
+// Warnings
+@warning-border: @standard-border;
+@warning-background: #f4f4f4;
+@warning-font-color: @emphasized-font-color;
+@warning-font-size: @normal-font-size;
+
 // Lists
 @list-header-border-color: #e5e5e5;
 @list-header-background-color: #f5f5f5;

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -87,6 +87,7 @@
  * @mixes external:dojo/_FocusMixin
  * @mixes module:alfresco/forms/controls/FormControlValidationMixin
  * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/forms/controls/utilities/RulesEngineMixin
  * @extendSafe
  * @author Dave Draper
  * @author Richard Smith
@@ -97,6 +98,7 @@ define(["dojo/_base/declare",
         "dijit/_FocusMixin",
         "alfresco/core/Core",
         "alfresco/forms/controls/FormControlValidationMixin",
+        "alfresco/forms/controls/utilities/RulesEngineMixin",
         "dojo/text!./templates/BaseFormControl.html",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/core/ArrayUtils",
@@ -110,10 +112,10 @@ define(["dojo/_base/declare",
         "dojo/dom-construct",
         "dojo/Deferred",
         "jquery"],
-        function(declare, _Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, template, ObjectTypeUtils,
+        function(declare, _Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, RulesEngineMixin, template, ObjectTypeUtils,
                  arrayUtils, lang, array, domStyle, domClass, Tooltip, domAttr, query, domConstruct, Deferred, $) {
 
-   return declare([_Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin], {
+   return declare([_Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, RulesEngineMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -912,273 +914,6 @@ define(["dojo/_base/declare",
       addOption: function alfresco_forms_controls_BaseFormControl__addOption(option, index) {
          this.processOptionLabel(option, index);
          this.wrappedWidget.addOption(option);
-      },
-
-      /**
-       * <p>This function is reused to process the configuration for the visibility, disablement and requirement attributes of the form
-       * control. The format for the rules is as follows:</p>
-       * <p><pre>"visibilityConfig": {
-       *    "initialValue": true,
-       *    "rules": [
-       *       {
-       *          "targetId": "fieldId1",
-       *          "is": ["a", "b", "c"],
-       *          "isNot": ["d", "e", "f"]
-       *       }
-       *    ],
-       *    "callbacks": {
-       *          "id": "functionA"
-       *    }
-       * }</pre></p>
-       * <p>This structure applied to the following attributes:<ul>
-       * <li>[visibilityConfig]{@link module:alfresco/forms/controls/BaseFormControl#visibilityConfig}</li>
-       * <li>[requirementConfig]{@link module:alfresco/forms/controls/BaseFormControl#requirementConfig}</li>
-       * <li>[disablementConfig]{@link module:alfresco/forms/controls/BaseFormControl#disablementConfig}</li></ul></p>
-       *
-       * @mmethod processConfig
-       * @param {string} attribute
-       * @param {object} config
-       */
-      processConfig: function alfresco_forms_controls_BaseFormControl__processConfig(attribute, config) {
-         if (config)
-         {
-            // Set the initial value...
-            if (typeof config.initialValue !== "undefined")
-            {
-               this[attribute](config.initialValue);
-            }
-
-            // Process the rule subscriptions...
-            if (typeof config.rules !== "undefined")
-            {
-               this.processRulesConfig(attribute, config.rules);
-            }
-            else
-            {
-               // Debug output when instantiation data is incorrect. Only log when some data is defined but isn't an object.
-               // There's no point in logging messages for unsupplied data - just incorrectly supplied data.
-               this.alfLog("log", "The rules configuration for attribute '" + attribute + "' for property '" + this.fieldId + "' was not an Object");
-            }
-
-            // Process the callback subscriptions...
-            if (typeof config.callbacks === "object")
-            {
-               this._processCallbacksConfig(attribute, config.callbacks);
-            }
-            else if (typeof config.callbacks !== "undefined")
-            {
-               // Debug output when instantiation data is incorrect. Only log when some data is defined but isn't an object.
-               // There's no point in logging messages for unsupplied data - just incorrectly supplied data.
-               this.alfLog("log", "The callback configuration for attribute '" + attribute + "' for property '" + this.fieldId + "' was not an Object");
-            }
-         }
-      },
-
-      /**
-       * This holds all the data about rules that need to be processed for the various attributes of the widget. By default this
-       * will handle rules for visibility, requirement and disability.
-       *
-       * @instance
-       * @type {object}
-       * @default null
-       */
-      _rulesEngineData: null,
-
-      /**
-       * This function sets up the subscriptions for processing rules relating to attributes.
-       *
-       * @instance
-       * @param {string} attribute E.g. visibility, editability, requirement
-       * @param {object} rules
-       */
-      processRulesConfig: function alfresco_forms_controls_BaseFormControl__processRulesConfig(attribute, rules) {
-         // TODO: Implement rules for handling changes in validity (each type could have rule type of "isValid"
-         //       and should subscribe to changes in validity. The reason for this would be to allow changes
-         //       on validity. Validity may change asynchronously from value as it could be performed via a
-         //       remote request.
-
-         // Set up the data structure that will be required for processing the rules for the target property changes...
-         if (!this._rulesEngineData)
-         {
-            // Ensure that the rulesEngineData object has been created
-            this._rulesEngineData = {};
-         }
-         if (typeof this._rulesEngineData[attribute] === "undefined")
-         {
-            // Ensure that the rulesEngineData object has specific information about the form control attribute...
-            this._rulesEngineData[attribute] = {};
-         }
-         array.forEach(rules, lang.hitch(this, this.processRule, attribute));
-      },
-
-      /**
-       * This function processes an individual attribute rule (e.g. to change the visibility, disablement or
-       * requirement status).
-       *
-       * @instance
-       * @param {string} attribute The attribute that the rule effects (e.g. visibility)
-       * @param {object} rule The rule to process.
-       * @param {number} index The index of the rule.
-       */
-      processRule: function alfresco_forms_controls_BaseFormControl__processRule(attribute, rule, /*jshint unused:false*/ index) {
-         if (rule.targetId)
-         {
-            if (typeof this._rulesEngineData[attribute][rule.targetId] === "undefined")
-            {
-               this._rulesEngineData[attribute][rule.targetId] = {};
-            }
-
-            // Set the rules to be processed for the current rule...
-            // NOTE: Previous rules can be potentically overridden here...
-            this._rulesEngineData[attribute][rule.targetId].rules = rule;
-
-            // Subscribe to changes in the relevant property...
-            this.alfSubscribe("_valueChangeOf_" + rule.targetId, lang.hitch(this, this.evaluateRules, attribute));
-         }
-         else
-         {
-            this.alfLog("warn", "The following rule is missing a 'name' attribute", rule, this);
-         }
-      },
-
-      /**
-       * This function evaluates all the rules configured for a particular attribute (e.g. "visibility") for the
-       * current form control. It is triggered whenever one of the other fields configured as part of a rule changes,
-       * but ALL the rules are evaluated for that attribute.
-       *
-       * @instance
-       * @param {string} attribute
-       * @param {object} payload The publication posted on the topic that triggered the rule
-       */
-      evaluateRules: function alfresco_forms_controls_BaseFormControl__evaluateRules(attribute, payload) {
-         this.alfLog("log", "RULES EVALUATION('" + attribute + "'): Field '" + this.fieldId + "'");
-
-         // Set the current value that triggered the evaluation of rules...
-         this._rulesEngineData[attribute][payload.fieldId].currentValue = payload.value;
-
-         // Make the assumption that the current status is true (i.e. the rule is PASSED). This is done so that
-         // we can AND the value against the result of each iteration (we can also stop processing the rules once
-         // the rule is negated...
-         var status = true;
-
-         // The exception to the above comment is when NO rules are configured - in that case we leave the status
-         // as false by default
-         var hasProps = false;
-
-         // jshint forin:false
-         for (var key in this._rulesEngineData[attribute])
-         {
-            // Need this assignment to "prove" there are properties (this approach is used for compatibility with older
-            // browsers)...
-            hasProps = true;
-
-            // Keep processing rules until the rule status is negated...
-            if (status)
-            {
-               var currentValue = this._rulesEngineData[attribute][key].currentValue;
-               var validValues = this._rulesEngineData[attribute][key].rules.is;
-               var invalidValues = this._rulesEngineData[attribute][key].rules.isNot;
-
-               // Assume that its NOT valid value (we'll only do the actual test if its not set to an INVALID value)...
-               // UNLESS there are no valid values specified (in which case any value is valid apart form those in the invalid list)
-               var isValidValue = typeof validValues === "undefined" || validValues.length === 0;
-
-               // Initialise the invalid value to be false if no invalid values have been declared (and only check values if defined)...
-               var isInvalidValue = typeof invalidValues !== "undefined" && invalidValues.length > 0;
-               if (isInvalidValue)
-               {
-                  // Check to see if the current value is set to an invalid value (i.e. a value that negates the rule)
-                  isInvalidValue = array.some(invalidValues, lang.hitch(this, this.ruleValueComparator, currentValue));
-               }
-
-               // Check to see if the current value is set to a valid value...
-               if (!isInvalidValue && typeof validValues !== "undefined" && validValues.length > 0)
-               {
-                  isValidValue = array.some(validValues, lang.hitch(this, this.ruleValueComparator, currentValue));
-               }
-
-               // The overall status is true (i.e. the rule is still passing) if the current status is true and the
-               // current value IS set to a valid value and NOT set to an invalid value
-               status = status && isValidValue && !isInvalidValue;
-            }
-         }
-
-         // This last AND ensures that we negate the rule if there were no rules to process...
-         status = status && hasProps;
-         this[attribute](status);
-         return status;
-      },
-
-      /**
-       * The default comparator function used for comparing a rule value against the actual value of a field.
-       * Note that the target value is expected to be an object from the arrays (assigned to the  "is" or "isNot"
-       * attribute) and by default the "value" attribute of those objects are compared with the current value
-       * of the field. It is possible to override this comparator to allow a more complex comparison operation.
-       *
-       * It's important to note that values are compared as strings. This is done to ensure that booleans can
-       * be compared. This is important as it should be possible to construct rules dynamically and values
-       * should be entered as text.
-       *
-       * @instance
-       * @param {object} currentValue The value currently
-       * @param {object} targetValue The value to compare against
-       */
-      ruleValueComparator: function alfresco_forms_controls_BaseFormControl(currentValue, targetValue) {
-         this.alfLog("log", "Comparing", currentValue, targetValue);
-
-         // If both values aren't null then compare the .toString() output, if one of them is null
-         // then it doesn't really matter whether or not we get the string output for the value or not
-         if (currentValue && targetValue && targetValue.value)
-         {
-            return currentValue.toString() === targetValue.value.toString();
-         }
-         else
-         {
-            // return currentValue == targetValue.value; // Commented out because I think this is wrong (shouldn't have .value)
-            return currentValue === targetValue;
-         }
-      },
-
-      /**
-       * The payload of property value changing publications should have the following attributes...
-       *    1) The name of the property that has changed ("name")
-       *    2) The old value of the property that has changed ("oldValue")
-       *    3) The new value of the property that has changed ("value")
-       *  Callbacks should take the following arguments (nameOfChangedProperty, oldValue, newValue, callingObject, attribute)
-       *
-       *  @instance
-       *  @param {string} attribute
-       *  @param {object} callbacks
-       */
-      _processCallbacksConfig: function alfresco_forms_controls_BaseFormControl___processCallbacksConfig(attribute, callbacks) {
-         /*jshint loopfunc:true*/
-         // TODO Should refactor this to both avoid the loop functions and also reduce duplication
-         var _this = this;
-         for (var key in callbacks) {
-            if (typeof callbacks[key] === "function")
-            {
-               // Subscribe using the supplied function (this will only be possible when form controls are created
-               // dynamically from widgets (rather than in configuration)...
-               _this.alfSubscribe("_valueChangeOf_" + key, function(payload) {
-                  var status = callbacks[payload.name](payload.name, payload.oldValue, payload.value, _this, attribute);
-                  _this[attribute](status);
-               });
-            }
-            else if (typeof callbacks[key] === "string" &&
-                     typeof _this[callbacks[key]] === "function")
-            {
-               // Subscribe using a String reference to a function defined in this widget...
-               _this.alfSubscribe(_this.pubSubScope + "_valueChangeOf_" + key, function(payload) {
-                  var status = _this[callbacks[payload.name]](payload.name, payload.oldValue, payload.value, _this, attribute);
-                  _this[attribute](status);
-               });
-            }
-            else
-            {
-               // Log a message if the callback supplied isn't actually a function...
-               this.alfLog("log", "The callback for property '" + _this.name + "' for handling changes to property '" + key + "' was not a function or was not a String that references a local function");
-            }
-         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/RulesEngineMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/RulesEngineMixin.js
@@ -41,7 +41,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {object}
-       * @default null
+       * @default
        */
       _rulesEngineData: null,
 

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/RulesEngineMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/RulesEngineMixin.js
@@ -1,0 +1,305 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This mixin provides the ability to evaluate form control rules that define whether or not a given attribute
+ * is in a positive or negative state based on the changing values of other fields within the same form. The contents
+ * of this module were originally part of the [BaseFormControl]{@link module:alfresco/forms/controls/BaseFormControl}
+ * (into which this module is now mixed in) but was abstracted in order for the rules engine to be easily applied to
+ * other form modules (in particular the ability to support banner display with [Forms]{@link module:alfresco/forms/Form}).
+ * 
+ * @module alfresco/forms/controls/utilities/RulesEngineMixin
+ * @since 1.0.32
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/_base/array"], 
+        function(declare, lang, array) {
+
+   return declare([], {
+
+      /**
+       * This holds all the data about rules that need to be processed for the various attributes of the widget. By default this
+       * will handle rules for visibility, requirement and disability.
+       *
+       * @instance
+       * @type {object}
+       * @default null
+       */
+      _rulesEngineData: null,
+
+      /**
+       * <p>This function is reused to process the configuration for the visibility, disablement and requirement attributes of the form
+       * control. The format for the rules is as follows:</p>
+       * <p><pre>"visibilityConfig": {
+       *    "initialValue": true,
+       *    "rules": [
+       *       {
+       *          "targetId": "fieldId1",
+       *          "is": ["a", "b", "c"],
+       *          "isNot": ["d", "e", "f"]
+       *       }
+       *    ],
+       *    "callbacks": {
+       *          "id": "functionA"
+       *    }
+       * }</pre></p>
+       * <p>This structure applied to the following attributes:<ul>
+       * <li>[visibilityConfig]{@link module:alfresco/forms/controls/BaseFormControl#visibilityConfig}</li>
+       * <li>[requirementConfig]{@link module:alfresco/forms/controls/BaseFormControl#requirementConfig}</li>
+       * <li>[disablementConfig]{@link module:alfresco/forms/controls/BaseFormControl#disablementConfig}</li></ul></p>
+       *
+       * @mmethod processConfig
+       * @param {string} attribute
+       * @param {object} config
+       */
+      processConfig: function alfresco_forms_controls_BaseFormControl__processConfig(attribute, config) {
+         if (config)
+         {
+            // Set the initial value...
+            if (typeof config.initialValue !== "undefined")
+            {
+               this[attribute](config.initialValue);
+            }
+
+            // Process the rule subscriptions...
+            if (typeof config.rules !== "undefined")
+            {
+               this.processRulesConfig(attribute, config.rules);
+            }
+            else
+            {
+               // Debug output when instantiation data is incorrect. Only log when some data is defined but isn't an object.
+               // There's no point in logging messages for unsupplied data - just incorrectly supplied data.
+               this.alfLog("log", "The rules configuration for attribute '" + attribute + "' for property '" + this.fieldId + "' was not an Object");
+            }
+
+            // Process the callback subscriptions...
+            if (typeof config.callbacks === "object")
+            {
+               this._processCallbacksConfig(attribute, config.callbacks);
+            }
+            else if (typeof config.callbacks !== "undefined")
+            {
+               // Debug output when instantiation data is incorrect. Only log when some data is defined but isn't an object.
+               // There's no point in logging messages for unsupplied data - just incorrectly supplied data.
+               this.alfLog("log", "The callback configuration for attribute '" + attribute + "' for property '" + this.fieldId + "' was not an Object");
+            }
+         }
+      },
+
+      /**
+       * This function sets up the subscriptions for processing rules relating to attributes.
+       *
+       * @instance
+       * @param {string} attribute E.g. visibility, editability, requirement
+       * @param {object} rules
+       */
+      processRulesConfig: function alfresco_forms_controls_utilities_RulesEngineMixin__processRulesConfig(attribute, rules) {
+         // TODO: Implement rules for handling changes in validity (each type could have rule type of "isValid"
+         //       and should subscribe to changes in validity. The reason for this would be to allow changes
+         //       on validity. Validity may change asynchronously from value as it could be performed via a
+         //       remote request.
+
+         // Set up the data structure that will be required for processing the rules for the target property changes...
+         if (!this._rulesEngineData)
+         {
+            // Ensure that the rulesEngineData object has been created
+            this._rulesEngineData = {};
+         }
+         if (typeof this._rulesEngineData[attribute] === "undefined")
+         {
+            // Ensure that the rulesEngineData object has specific information about the form control attribute...
+            this._rulesEngineData[attribute] = {};
+         }
+         array.forEach(rules, lang.hitch(this, this.processRule, attribute));
+      },
+
+      /**
+       * This function processes an individual attribute rule (e.g. to change the visibility, disablement or
+       * requirement status).
+       *
+       * @instance
+       * @param {string} attribute The attribute that the rule effects (e.g. visibility)
+       * @param {object} rule The rule to process.
+       * @param {number} index The index of the rule.
+       */
+      processRule: function alfresco_forms_controls_utilities_RulesEngineMixin__processRule(attribute, rule, /*jshint unused:false*/ index) {
+         if (rule.targetId)
+         {
+            if (typeof this._rulesEngineData[attribute][rule.targetId] === "undefined")
+            {
+               this._rulesEngineData[attribute][rule.targetId] = {};
+            }
+
+            // Set the rules to be processed for the current rule...
+            // NOTE: Previous rules can be potentically overridden here...
+            this._rulesEngineData[attribute][rule.targetId].rules = rule;
+
+            // Subscribe to changes in the relevant property...
+            this.alfSubscribe("_valueChangeOf_" + rule.targetId, lang.hitch(this, this.evaluateRules, attribute));
+         }
+         else
+         {
+            this.alfLog("warn", "The following rule is missing a 'name' attribute", rule, this);
+         }
+      },
+
+      /**
+       * This function evaluates all the rules configured for a particular attribute (e.g. "visibility") for the
+       * current form control. It is triggered whenever one of the other fields configured as part of a rule changes,
+       * but ALL the rules are evaluated for that attribute.
+       *
+       * @instance
+       * @param {string} attribute
+       * @param {object} payload The publication posted on the topic that triggered the rule
+       */
+      evaluateRules: function alfresco_forms_controls_utilities_RulesEngineMixin__evaluateRules(attribute, payload) {
+         this.alfLog("log", "RULES EVALUATION('" + attribute + "'): Field '" + this.fieldId + "'");
+
+         // Set the current value that triggered the evaluation of rules...
+         this._rulesEngineData[attribute][payload.fieldId].currentValue = payload.value;
+
+         // Make the assumption that the current status is true (i.e. the rule is PASSED). This is done so that
+         // we can AND the value against the result of each iteration (we can also stop processing the rules once
+         // the rule is negated...
+         var status = true;
+
+         // The exception to the above comment is when NO rules are configured - in that case we leave the status
+         // as false by default
+         var hasProps = false;
+
+         // jshint forin:false
+         for (var key in this._rulesEngineData[attribute])
+         {
+            // Need this assignment to "prove" there are properties (this approach is used for compatibility with older
+            // browsers)...
+            hasProps = true;
+
+            // Keep processing rules until the rule status is negated...
+            if (status)
+            {
+               var currentValue = this._rulesEngineData[attribute][key].currentValue;
+               var validValues = this._rulesEngineData[attribute][key].rules.is;
+               var invalidValues = this._rulesEngineData[attribute][key].rules.isNot;
+
+               // Assume that its NOT valid value (we'll only do the actual test if its not set to an INVALID value)...
+               // UNLESS there are no valid values specified (in which case any value is valid apart form those in the invalid list)
+               var isValidValue = typeof validValues === "undefined" || validValues.length === 0;
+
+               // Initialise the invalid value to be false if no invalid values have been declared (and only check values if defined)...
+               var isInvalidValue = typeof invalidValues !== "undefined" && invalidValues.length > 0;
+               if (isInvalidValue)
+               {
+                  // Check to see if the current value is set to an invalid value (i.e. a value that negates the rule)
+                  isInvalidValue = array.some(invalidValues, lang.hitch(this, this.ruleValueComparator, currentValue));
+               }
+
+               // Check to see if the current value is set to a valid value...
+               if (!isInvalidValue && typeof validValues !== "undefined" && validValues.length > 0)
+               {
+                  isValidValue = array.some(validValues, lang.hitch(this, this.ruleValueComparator, currentValue));
+               }
+
+               // The overall status is true (i.e. the rule is still passing) if the current status is true and the
+               // current value IS set to a valid value and NOT set to an invalid value
+               status = status && isValidValue && !isInvalidValue;
+            }
+         }
+
+         // This last AND ensures that we negate the rule if there were no rules to process...
+         status = status && hasProps;
+         this[attribute](status);
+         return status;
+      },
+
+      /**
+       * The default comparator function used for comparing a rule value against the actual value of a field.
+       * Note that the target value is expected to be an object from the arrays (assigned to the  "is" or "isNot"
+       * attribute) and by default the "value" attribute of those objects are compared with the current value
+       * of the field. It is possible to override this comparator to allow a more complex comparison operation.
+       *
+       * It's important to note that values are compared as strings. This is done to ensure that booleans can
+       * be compared. This is important as it should be possible to construct rules dynamically and values
+       * should be entered as text.
+       *
+       * @instance
+       * @param {object} currentValue The value currently
+       * @param {object} targetValue The value to compare against
+       */
+      ruleValueComparator: function alfresco_forms_controls_utilities_RulesEngineMixin__ruleValueComparator(currentValue, targetValue) {
+         this.alfLog("log", "Comparing", currentValue, targetValue);
+
+         // If both values aren't null then compare the .toString() output, if one of them is null
+         // then it doesn't really matter whether or not we get the string output for the value or not
+         if (currentValue && targetValue && targetValue.value)
+         {
+            return currentValue.toString() === targetValue.value.toString();
+         }
+         else
+         {
+            // return currentValue == targetValue.value; // Commented out because I think this is wrong (shouldn't have .value)
+            return currentValue === targetValue;
+         }
+      },
+
+      /**
+       * The payload of property value changing publications should have the following attributes...
+       *    1) The name of the property that has changed ("name")
+       *    2) The old value of the property that has changed ("oldValue")
+       *    3) The new value of the property that has changed ("value")
+       *  Callbacks should take the following arguments (nameOfChangedProperty, oldValue, newValue, callingObject, attribute)
+       *
+       *  @instance
+       *  @param {string} attribute
+       *  @param {object} callbacks
+       */
+      _processCallbacksConfig: function alfresco_forms_controls_utilities_RulesEngineMixin___processCallbacksConfig(attribute, callbacks) {
+         /*jshint loopfunc:true*/
+         // TODO Should refactor this to both avoid the loop functions and also reduce duplication
+         var _this = this;
+         for (var key in callbacks) {
+            if (typeof callbacks[key] === "function")
+            {
+               // Subscribe using the supplied function (this will only be possible when form controls are created
+               // dynamically from widgets (rather than in configuration)...
+               _this.alfSubscribe("_valueChangeOf_" + key, function(payload) {
+                  var status = callbacks[payload.name](payload.name, payload.oldValue, payload.value, _this, attribute);
+                  _this[attribute](status);
+               });
+            }
+            else if (typeof callbacks[key] === "string" &&
+                     typeof _this[callbacks[key]] === "function")
+            {
+               // Subscribe using a String reference to a function defined in this widget...
+               _this.alfSubscribe(_this.pubSubScope + "_valueChangeOf_" + key, function(payload) {
+                  var status = _this[callbacks[payload.name]](payload.name, payload.oldValue, payload.value, _this, attribute);
+                  _this[attribute](status);
+               });
+            }
+            else
+            {
+               // Log a message if the callback supplied isn't actually a function...
+               this.alfLog("log", "The callback for property '" + _this.name + "' for handling changes to property '" + key + "' was not a function or was not a String that references a local function");
+            }
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/forms/css/Form.css
+++ b/aikau/src/main/resources/alfresco/forms/css/Form.css
@@ -1,0 +1,5 @@
+.alfresco-forms-Form {
+   .alfresco-header-Warning {
+      margin-bottom: @standard-line-height;
+   }
+}

--- a/aikau/src/main/resources/alfresco/forms/templates/Form.html
+++ b/aikau/src/main/resources/alfresco/forms/templates/Form.html
@@ -1,5 +1,7 @@
 <div class="alfresco-forms-Form">
+   <div class="alfresco-forms-Form__warnings-top" data-dojo-attach-point="warningsTopNode"></div>
    <div class="form" data-dojo-attach-point="formNode"></div>
+   <div class="alfresco-forms-Form__warnings-bottom" data-dojo-attach-point="warningsBottomNode"></div>
    <div class="buttons" data-dojo-attach-point="buttonsNode">
       <div data-dojo-attach-point="okButtonNode"></div>
       <div data-dojo-attach-point="cancelButtonNode"></div>

--- a/aikau/src/main/resources/alfresco/header/LicenseWarning.js
+++ b/aikau/src/main/resources/alfresco/header/LicenseWarning.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -27,11 +27,10 @@
  */
 define(["dojo/_base/declare",
         "alfresco/header/Warning", 
-        "dojo/dom-style",
+        "dojo/dom-class",
         "dojo/_base/array",
-        "dojo/_base/lang",
-        "dojo/dom-construct"], 
-        function(declare, Warning, domStyle, array, lang, domConstruct) {
+        "dojo/_base/lang"], 
+        function(declare, Warning, domClass, array, lang) {
    
    return declare([Warning], {
       /**
@@ -62,36 +61,37 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_header_LicenseWarning__postCreate() {
-         if (this.usage == null)
+         domClass.add(this.domNode, "alfresco-header-Warning--hidden");
+         if (!this.usage)
          {
             // If there are no usage instructions then no action is required...
          }
          else
          {
             // Always show a warning if Alfresco is in read only mode...
-            if (this.usage.readOnly == true)
+            if (this.usage.readOnly === true)
             {
                // Always show an error when the system is in readonly mode...
                this.addError(this.message("readonly.warning"));
-               domStyle.set(this.domNode, "display", "block");
+               domClass.remove(this.domNode, "alfresco-header-Warning--hidden");
             }
 
-            if (((this.usage.warnings && this.usage.warnings.length != 0) || 
-                 (this.usage.errors && this.usage.errors.length != 0)) && 
-                (this.userIsAdmin == true || this.usage.level >= 2))
+            if (((this.usage.warnings && this.usage.warnings.length !== 0) || 
+                 (this.usage.errors && this.usage.errors.length !== 0)) && 
+                (this.userIsAdmin === true || this.usage.level >= 2))
             {
                // If warnings or errors are present, display them to the Admin or user
                // Admin sees messages if WARN_ADMIN, WARN_ALL, LOCKED_DOWN
                // Users see messages if WARN_ALL, LOCKED_DOWN
-               if (this.usage.warnings != null)
+               if (this.usage.warnings)
                {
-                  array.forEach(this.usage.warnings, lang.hitch(this, "addWarning"));
+                  array.forEach(this.usage.warnings, lang.hitch(this, this.addWarning));
                }
-               if (this.usage.warnings != null)
+               if (this.usage.warnings)
                {
-                  array.forEach(this.usage.errors, lang.hitch(this, "addError"));
+                  array.forEach(this.usage.errors, lang.hitch(this, this.addError));
                }
-               domStyle.set(this.domNode, "display", "block");
+               domClass.remove(this.domNode, "alfresco-header-Warning--hidden");
             }
          }
       }

--- a/aikau/src/main/resources/alfresco/header/css/Warning.css
+++ b/aikau/src/main/resources/alfresco/header/css/Warning.css
@@ -1,44 +1,51 @@
-.alfresco-header-Warning .warnings
-{
-   margin: 0 -10px;
-   padding: 0.5em 0;
-   color: black;
-   text-align: center;
-   background-color: #F4F4F4;
-   font-size: 108%;
-   border-top: 1px solid lightgrey;
-   border-bottom: 1px solid lightgrey;
-}
+.alfresco-header-Warning {
 
-.alfresco-header-Warning .info
-{
-   padding-top: 2px;
-}
+   display: block;
 
-.alfresco-header-Warning .level0
-{
-   background: url("./images/warning-16.png") no-repeat scroll 0 0 transparent;
-   display: inline;
-   padding-left: 20px;
-}
+   &--hidden {
+      display: none;
+   }
 
-.alfresco-header-Warning .level1
-{
-   background: url("./images/warning-16.png") no-repeat scroll 0 0 transparent;
-   display: inline;
-   padding-left: 20px;
-}
+   .alfresco-header-Warning__warnings {
+      margin: 0 -10px;
+      padding: 0.5em 0;
+      color: @warning-font-color;
+      text-align: center;
+      background-color: @warning-background;
+      font-size: @warning-font-size;
+      border-top: @warning-border;
+      border-bottom: @warning-border;
+   }
 
-.alfresco-header-Warning .level2
-{
-   background: url("./images/warning-16.png") no-repeat scroll 0 0 transparent;
-   display: inline;
-   padding-left: 20px;
-}
+   .alfresco-header-Warning__info
+   {
+      padding-top: 2px;
 
-.alfresco-header-Warning .level3
-{
-   background: url("./images/error-16.png") no-repeat scroll 0 0 transparent;
-   display: inline;
-   padding-left: 20px;
+      &--hidden {
+         display: none;
+      }
+
+      .alfresco-header-Warning__image {
+         display: inline;
+         padding-left: 20px;
+      }
+
+      .alfresco-header-Warning {
+         &__level0 {
+            background: url("./images/warning-16.png") no-repeat scroll 0 0 transparent;
+         }
+
+         &__level1 {
+            background: url("./images/warning-16.png") no-repeat scroll 0 0 transparent;
+         }
+
+         &__level2 {
+            background: url("./images/warning-16.png") no-repeat scroll 0 0 transparent;
+         }
+
+         &__level3 {
+            background: url("./images/error-16.png") no-repeat scroll 0 0 transparent;
+         }
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/header/templates/Warning.html
+++ b/aikau/src/main/resources/alfresco/header/templates/Warning.html
@@ -1,4 +1,3 @@
-<div class="alfresco-header-Warning" data-dojo-attach-point="containerNode" style="display:none;">
-   <div class="warnings" data-dojo-attach-point="warningsNode">
-   </div>
+<div class="alfresco-header-Warning" data-dojo-attach-point="containerNode">
+   <div class="alfresco-header-Warning__warnings" data-dojo-attach-point="warningsNode"></div>
 </div>

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -522,7 +522,7 @@ define(["dojo/_base/declare",
 
                // Construct the form widgets and then construct the dialog using that configuration...
                var formValue = config.formValue ? config.formValue: {};
-               var formConfig = this.createFormConfig(config.widgets, formValue);
+               var formConfig = this.createFormConfig(config, formValue);
                if (config.showValidationErrorsImmediately === false)
                {
                   formConfig.config.showValidationErrorsImmediately = false;
@@ -706,14 +706,16 @@ define(["dojo/_base/declare",
        * @param {object} formValue The initial value to set in the form.
        * @returns {object} The configuration for the form to add to the dialog
        */
-      createFormConfig: function alfresco_services_DialogService__createFormConfig(widgets, formValue) {
+      createFormConfig: function alfresco_services_DialogService__createFormConfig(config, formValue) {
          var formConfig = {
             name: "alfresco/forms/Form",
             config: {
                additionalCssClasses: "root-dialog-form",
                displayButtons: false,
-               widgets: widgets,
-               value: formValue
+               widgets: config.widgets,
+               value: formValue,
+               warnings: config.warnings,
+               warningsPosition: config.warningsPosition
             }
          };
          return formConfig;

--- a/aikau/src/test/resources/alfresco/forms/FormWarningsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormWarningsTest.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"], 
+        function (registerSuite, assert, require, TestCommon, keys) {
+
+   var browser;
+
+   registerSuite({
+      name: "Form Warnings Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/FormWarnings", "Form Warnings Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Test initial warning visibility": function() {
+         return browser.findAllByCssSelector(".alfresco-forms-Form__warnings-top .alfresco-header-Warning")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The form warnings were not displayed at the top of the form");
+            })
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(1)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The first warning should have been displayed on page load");
+            })
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(2)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The second warning should NOT have been displayed on page load");
+            })
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(3)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The second warning should NOT have been displayed on page load");
+            });
+      },
+
+      "Clear the text in field one and check that the first warning gets hidden": function() {
+         return browser.findByCssSelector("#FIELD1 .dijitInputContainer input")
+            .clearValue()
+            .type("a")
+            .pressKeys(keys.BACKSPACE)
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(1)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The first warning should have been hidden when field 1 was cleared");
+            });
+      },
+
+      "Add some text to field two and check that a second warning is displayed": function() {
+         return browser.findByCssSelector("#FIELD2 .dijitInputContainer input")
+            .type("warn")
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(2)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The second warning should have been displayed when field 2 was set to 'warn'");
+            });
+      },
+
+      "Set field three to be 'blank' and check that third warning is NOT displayed": function() {
+         return browser.findByCssSelector("#FIELD3 .dijitInputContainer input")
+            .type("blank")
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(3)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The third warning should NOT have been displayed when field 3 was set to 'blank'");
+            });
+      },
+
+      "Add some text to field three and check that the third warning is NOW displayed": function() {
+         return browser.findByCssSelector("#FIELD4 .dijitInputContainer input")
+            .type("test")
+         .end()
+         .findByCssSelector("#BANNER_FORM_WARNINGS .alfresco-header-Warning__info:nth-child(3)")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The third warning should have NOW been displayed when field 4 was set to a value");
+            });
+      },
+
+      "Create a form dialog with warnings": function() {
+         return browser.findById("CREATE_FORM_DIALOG_label")
+            .click()
+         .end()
+         .findAllByCssSelector("#FORM_WARNING_DIALOG .dialogDisplayed")
+         .end()
+         .findAllByCssSelector("#FORM_WARNING_DIALOG .alfresco-forms-Form__warnings-bottom .alfresco-header-Warning")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "The form dialog warnings were not displayed at the bottom of the form");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/header/WarningTest.js
+++ b/aikau/src/test/resources/alfresco/header/WarningTest.js
@@ -21,11 +21,10 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
         "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, require, TestCommon) {
 
    var browser;
    registerSuite({
@@ -40,52 +39,70 @@ define(["intern!object",
          browser.end();
       },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
-     "Check warning": function () {
-         return browser.findByCssSelector("#WARNINGS1 > div.warnings > div.info > span:last-child")
+      "Check warning": function () {
+         return browser.findByCssSelector("#WARNINGS1 .alfresco-header-Warning__info > span:last-child")
             .getVisibleText()
             .then(function (result1) {
-               expect(result1).to.equal("WARNING", "Warning not displayed");
+               assert.equal(result1, "WARNING", "Warning not displayed");
             });
       },
 
       "Check error": function() {
-         return browser.findByCssSelector("#WARNINGS2 > div.warnings > div.info > span:last-child")
+         return browser.findByCssSelector("#WARNINGS2 .alfresco-header-Warning__info > span:last-child")
             .getVisibleText()
             .then(function (result1) {
-               expect(result1).to.equal("ERROR", "Error not displayed");
+               assert.equal(result1, "ERROR", "Error not displayed");
             });
       },
 
       "Check readonly message": function() {
-         return browser.findByCssSelector("#LICENSEWARNING_READONLY > div.warnings > div.info > span:last-child")
+         return browser.findByCssSelector("#LICENSEWARNING_READONLY .alfresco-header-Warning__info > span:last-child")
             .getVisibleText()
             .then(function (result1) {
-               expect(result1).to.equal("Alfresco is running in READ ONLY mode. Please consult your System Administrator to resolve this.", "Test 1c - Readonly error not displayed");
+               assert.equal(result1, "Alfresco is running in READ ONLY mode. Please consult your System Administrator to resolve this.", "Test 1c - Readonly error not displayed");
             });
       },
 
       "Test that admins see low severity warnings": function() {
-         return browser.findAllByCssSelector("#LICENSEWARNING_DISPLAY_TO_ADMIN > div.warnings > div.info")
+         return browser.findAllByCssSelector("#LICENSEWARNING_DISPLAY_TO_ADMIN .alfresco-header-Warning__info")
             .then(function (adminWarnings) {
-               expect(adminWarnings).to.have.length(3, "Admins should see low severity warnings");
+               assert.lengthOf(adminWarnings, 3, "Admins should see low severity warnings");
             });
       },
 
       "Test that non-admin users don't see low severity warnings": function() {
-         return browser.findAllByCssSelector("#LICENSEWARNING_HIDE_FROM_USER > div.warnings > div.info")
+         return browser.findAllByCssSelector("#LICENSEWARNING_HIDE_FROM_USER .alfresco-header-Warning__info")
             .then(function (nonAdminWarnings) {
-               expect(nonAdminWarnings).to.have.length(0, "Low severity warnings should be hidden from non-admins");
+               assert.lengthOf(nonAdminWarnings, 0, "Low severity warnings should be hidden from non-admins");
             });
       },
 
       "Test that non-admin users see high severity warnings": function() {
-         return browser.findAllByCssSelector("#LICENSEWARNING_DISPLAY_TO_USER > div.warnings > div.info")
+         return browser.findAllByCssSelector("#LICENSEWARNING_DISPLAY_TO_USER .alfresco-header-Warning__info")
             .then(function (nonAdminWarnings) {
-               expect(nonAdminWarnings).to.have.length(3, "High severity warnings should be displayed to non-admins");
+                assert.lengthOf(nonAdminWarnings, 3, "High severity warnings should be displayed to non-admins");
+            });
+      },
+
+      "Hide warning": function() {
+         return browser.findById("HIDE_WARNING_label")
+            .click()
+         .end()
+         .findById("WARNINGS1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The warning should have been hidden");
+            });
+      },
+
+      "Show warning": function() {
+         return browser.findById("SHOW_WARNING_label")
+            .click()
+         .end()
+         .findById("WARNINGS1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The warning should have been revealed");
             });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -96,6 +96,7 @@ define({
       "src/test/resources/alfresco/forms/ControlRowTest",
       "src/test/resources/alfresco/forms/CrudFormTest",
       "src/test/resources/alfresco/forms/DynamicFormTest",
+      "src/test/resources/alfresco/forms/FormWarningsTest",
       "src/test/resources/alfresco/forms/FormsTest",
       "src/test/resources/alfresco/forms/FormValidationTest",
       "src/test/resources/alfresco/forms/HashFormTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormWarnings.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormWarnings.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Form Banners</shortname>
+  <description>This page demonstrates how forms can display banners based on the values of fields in the form.</description>
+  <family>aikau-unit-tests</family>
+  <url>/FormWarnings</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormWarnings.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormWarnings.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormWarnings.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormWarnings.get.js
@@ -1,0 +1,151 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/forms/Form",
+         id: "BANNER_FORM",
+         config: {
+            pubSubScope: "FORM1_",
+            warnings: [
+               {
+                  message: "Warning 1: Field 1 is not blank",
+                  initialValue: true,
+                  rules: [
+                     {
+                        targetId: "FIELD1",
+                        isNot: [""]
+                     }
+                  ]
+               },
+               {
+                  message: "Warning 2: Field 2 is set to 'warn'",
+                  initialValue: false,
+                  rules: [
+                     {
+                        targetId: "FIELD2",
+                        is: ["warn"]
+                     }
+                  ]
+               },
+               {
+                  message: "Warning 3: Field 4 must NOT have a value when Field 3 is 'blank'",
+                  initialValue: false,
+                  rules: [
+                     {
+                        targetId: "FIELD3",
+                        is: ["blank"]
+                     },
+                     {
+                        targetId: "FIELD4",
+                        isNot: [""]
+                     }
+                  ]
+               }
+            ],
+            widgets: [
+               {
+                  id: "FIELD1",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "FIELD1",
+                     name: "field1",
+                     label: "Field 1",
+                     description: "Remove the default value to hide Warning 1",
+                     value: "test"
+                  }
+               },
+               {
+                  id: "FIELD2",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "FIELD2",
+                     name: "field2",
+                     label: "Field 2",
+                     description: "Enter a value of 'warn' to see another warning",
+                     value: ""
+                  }
+               },
+               {
+                  id: "FIELD3",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "FIELD3",
+                     name: "field3",
+                     label: "Field 3",
+                     description: "If either this field is set to 'blank' then Field 4 must NOT have a value otherwise a warning will be displayed",
+                     value: ""
+                  }
+               },
+               {
+                  id: "FIELD4",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "FIELD4",
+                     name: "field4",
+                     label: "Field 4",
+                     description: "If Field 3 is set to 'blank' then this must NOT have a value to avoid a warning being displayed",
+                     value: ""
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "CREATE_FORM_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create form dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "FORM_WARNING_DIALOG",
+               dialogTitle: "Dialog",
+               formSubmissionTopic: "DIALOG_PUBLISH",
+               formSubmissionPayloadMixin: {
+               },
+               warningsPosition: "bottom",
+               warnings: [
+                  {
+                     message: "Warning in a form",
+                     initialValue: true,
+                     rules: [
+                        {
+                           targetId: "FIELD1",
+                           is: [""]
+                        }
+                     ]
+                  }
+               ],
+               widgets: [
+                  {
+                     id: "DIALOG_FIELD1",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        fieldId: "FIELD1",
+                        name: "field1",
+                        label: "Field 1",
+                        value: ""
+                     }
+                  }
+               ],
+               responseScope: "FOURTH_SCOPE_"
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Warning.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Warning.get.js
@@ -19,7 +19,8 @@ model.jsonModel = {
             warnings: [
                {
                   message: "WARNING",
-                  level: 1
+                  level: 1,
+                  subscriptionTopic: "WARNING_VISIBILITY"
                }
             ]
          }
@@ -85,10 +86,29 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "HIDE_WARNING",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide first warning",
+            publishTopic: "WARNING_VISIBILITY",
+            publishPayload: {
+               value: false
+            }
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         id: "SHOW_WARNING",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show first warning",
+            publishTopic: "WARNING_VISIBILITY",
+            publishPayload: {
+               value: true
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-523 to add support for configurable warnings in forms. The warnings are processed using the same rules engine that was originally in the BaseFormControl (the code has now been abstracted to a RulesEngineMixin module so that it can be shared with the Form widget). I've made updates to alfresco/header/Warning to add support for dynamic visibility over pub/sub and have applied BEM to it. 

The unit tests added ensure that the warnings work for both regular forms and forms in dialogs. The warning can also be styled via LESS variables.