### PR TITLE
AKU-528: Further link updates

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -79,6 +79,17 @@ define([],function() {
        * @type {string}
        * @default
        */
-      PATH_CHANGED: "ALF_DOCUMENTLIST_PATH_CHANGED"
+      PATH_CHANGED: "ALF_DOCUMENTLIST_PATH_CHANGED",
+
+      /**
+       * This topic can be used to publish a request to change the title of a page. It is subscribed to by the
+       * [Title widget]{@link module:alfresco/header/Title} and published by the 
+       * [SetTitle widget]{@link module:alfresco/header/SetTitle}
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      UPDATE_PAGE_TITLE: "ALF_UPDATE_PAGE_TITLE"
    };
 });

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -94,11 +94,16 @@
 // Link colours and decoration
 @link-font-color: @general-font-color;
 @link-emphasized-font-color: @emphasized-font-color;
-@link-visited-font-color: @link-font-color;
 @link-text-decoration: none;
-@link-text-decoration-hover: underline;
 @link-title-text-decoration: @link-text-decoration;
 @link-title-font-color: @link-font-color;
+
+// Hovered link colours and decoration
+@link-font-color-hover: @link-font-color;
+@link-text-decoration-hover: underline;
+@link-title-font-color-hover: @link-title-font-color;
+@link-title-text-decoration-hover: @link-title-text-decoration;
+
 
 // Borders...
 // These have been initially added for form controls...

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -97,6 +97,8 @@
 @link-visited-font-color: @link-font-color;
 @link-text-decoration: none;
 @link-text-decoration-hover: underline;
+@link-title-text-decoration: @link-text-decoration;
+@link-title-font-color: @link-font-color;
 
 // Borders...
 // These have been initially added for form controls...

--- a/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
+++ b/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
@@ -122,6 +122,7 @@
             text-decoration: @link-text-decoration;
          }
          &:hover {
+            colour: @link-font-color-hover;
             text-decoration: @link-text-decoration-hover;
          }
       }

--- a/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
+++ b/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
@@ -67,5 +67,9 @@
    > a {
       color: @link-font-color;
       text-decoration: @link-text-decoration;
+      &:hover {
+         colour: @link-font-color-hover;
+         text-decoration: @link-text-decoration-hover;
+      }
    }
 }

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -26,6 +26,10 @@
 .alfresco-dialog-AlfDialog.dijitDialog a {
    color: @general-font-color;
    text-decoration: @link-text-decoration;
+   &:hover {
+      colour: @link-font-color-hover;
+      text-decoration: @link-text-decoration-hover;
+   }
 }
 
 /*

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfBreadcrumb.css
@@ -17,6 +17,10 @@
    float: left;
    cursor: pointer;
    height: 20px;
+   &:hover {
+      colour: @link-font-color-hover;
+      text-decoration: @link-text-decoration-hover;
+   }
 }
 
 .alfresco-documentlibrary-AlfBreadcrumb a:after { 

--- a/aikau/src/main/resources/alfresco/header/SetTitle.js
+++ b/aikau/src/main/resources/alfresco/header/SetTitle.js
@@ -30,8 +30,9 @@
  */
 define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
-        "alfresco/core/Core"], 
-        function(declare, _WidgetBase, AlfCore) {
+        "alfresco/core/Core",
+        "alfresco/core/topics"], 
+        function(declare, _WidgetBase, AlfCore, topics) {
    
    /**
     * The purpose of this widget is to allow the page title (controlled by "alfresco/header/Title" to be
@@ -56,7 +57,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_header_SetTitle__postCreate() {
-         this.alfPublish("ALF_UPDATE_PAGE_TITLE", {
+         this.alfPublish(topics.UPDATE_PAGE_TITLE, {
             title: this.message(this.title)
          });
       }

--- a/aikau/src/main/resources/alfresco/header/css/SearchBox.css
+++ b/aikau/src/main/resources/alfresco/header/css/SearchBox.css
@@ -14,6 +14,10 @@
    a {
       color: @link-emphasized-font-color;
       text-decoration: @link-text-decoration;
+      &:hover {
+         colour: @link-emphasized-font-color;
+         text-decoration: @link-text-decoration-hover;
+      }
    }
 
    .dijit.dijitReset.dijitInline.dijitDropDownButton {

--- a/aikau/src/main/resources/alfresco/header/css/Title.css
+++ b/aikau/src/main/resources/alfresco/header/css/Title.css
@@ -5,15 +5,24 @@
       font-size: 185%;
       font-weight: normal;
       margin-top: 19px;
-      > .text {
-         color: @link-font-color !important;
+      
+      .alfresco-header-Title__text {
          font-family: @condensed-font;
-         text-decoration: @link-text-decoration;
+         color: @general-font-color !important;
+         text-decoration: none;
          &.has-max-width {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
             display: inline-block;
+         }
+
+         > a {
+            /* PLEASE NOTE: Title link behaviour can be configured independently of the other
+                         links because it is considered a special case. Title are significantly
+                         different to be indicative of being a link */
+            color: @link-title-font-color !important;
+            text-decoration: @link-title-text-decoration;
          }
       }
    }

--- a/aikau/src/main/resources/alfresco/header/templates/Title.html
+++ b/aikau/src/main/resources/alfresco/header/templates/Title.html
@@ -1,3 +1,3 @@
 <h1 class="alfresco-header-Title">
-   <a href="#" class="text" data-dojo-attach-point="textNode"></a>
+   <span class="alfresco-header-Title__text" data-dojo-attach-point="textNode" data-dojo-attach-event="ondijitclick:onClick"></span>
 </h1>

--- a/aikau/src/main/resources/alfresco/layout/css/Twister.css
+++ b/aikau/src/main/resources/alfresco/layout/css/Twister.css
@@ -18,6 +18,10 @@
    padding: 0.5em;
    color: @link-font-color;
    text-decoration: @link-text-decoration;
+   &:hover {
+      colour: @link-font-color-hover;
+      text-decoration: @link-text-decoration-hover;
+   }
 }
 
 .alfresco-layout-Twister--open {

--- a/aikau/src/main/resources/alfresco/navigation/css/Link.css
+++ b/aikau/src/main/resources/alfresco/navigation/css/Link.css
@@ -2,8 +2,8 @@
    color: @link-font-color;
    text-decoration: @link-text-decoration;
    cursor: pointer;
-}
-
-.alfresco-share .alfresco-navigation-Link:hover {
-   text-decoration: @link-text-decoration-hover;
+   &:hover {
+      colour: @link-font-color-hover;
+      text-decoration: @link-text-decoration-hover;
+   }
 }

--- a/aikau/src/main/resources/alfresco/navigation/css/_HtmlAnchorMixin.css
+++ b/aikau/src/main/resources/alfresco/navigation/css/_HtmlAnchorMixin.css
@@ -1,4 +1,7 @@
 .alfresco-share a.alfresco-navigation-_HtmlAnchorMixin {
    color: inherit;
    text-decoration: @link-text-decoration;
+   &:hover {
+      text-decoration: @link-text-decoration-hover;
+   }
 }

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/css/Outline.css
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/css/Outline.css
@@ -22,4 +22,8 @@
 .alfresco-preview-PdfJs-Outline .outlineItem>a {
    text-decoration: @link-text-decoration;
    color: @link-font-color;
+   &:hover {
+      colour: @link-font-color-hover;
+      text-decoration: @link-text-decoration-hover;
+   }
 }

--- a/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
@@ -22,7 +22,7 @@
  * 
  * @module alfresco/renderers/PropertyLink
  * @extends alfresco/renderers/Property
- * @mixes external:dojo/_OnDijitClickMixin
+ * @mixes external:dijit/_OnDijitClickMixin
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  * @author Richard Smith

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditPropertyLink.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditPropertyLink.css
@@ -3,5 +3,9 @@
       cursor: pointer;
       color: @link-font-color;
       text-decoration: @link-text-decoration;
+      &:hover {
+         colour: @link-font-color-hover;
+         text-decoration: @link-text-decoration-hover;
+      }
    }
 }

--- a/aikau/src/main/resources/alfresco/renderers/css/Property.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Property.css
@@ -43,6 +43,10 @@
       color: @link-font-color;
       cursor: pointer;
       text-decoration: @link-text-decoration;
+      &:hover {
+         colour: @link-font-color-hover;
+         text-decoration: @link-text-decoration-hover;
+      }
    }
 }
 

--- a/aikau/src/main/resources/alfresco/renderers/css/PropertyLink.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/PropertyLink.css
@@ -2,4 +2,8 @@
    cursor: pointer;
    text-decoration: @link-text-decoration;
    color: @link-font-color;
+   &:hover {
+      colour: @link-font-color-hover;
+      text-decoration: @link-text-decoration-hover;
+   }
 }

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -50,7 +50,7 @@ define(["intern!object",
       },
 
       "Test title text is correct": function() {
-         return browser.findByCssSelector(".alfresco-header-Title > .text")
+         return browser.findByCssSelector(".alfresco-header-Title__text")
             .getVisibleText()
             .then(function(resultText) {
                assert.equal(resultText, "Test Title", "The title was not set correctly");
@@ -214,7 +214,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SET_TITLE_BUTTON")
             .click()
             .end()
-            .findByCssSelector(".alfresco-header-Title > .text")
+            .findByCssSelector(".alfresco-header-Title__text")
             .getVisibleText()
             .then(function(resultText) {
                assert.equal(resultText, "Updated Title", "The title was not updated");
@@ -328,7 +328,7 @@ define(["intern!object",
 
       "Long title is truncated": function() {
          return browser.execute(function() {
-               var title = document.querySelector(".alfresco-header-Title:nth-child(3) .text");
+               var title = document.querySelector("#LONG .alfresco-header-Title__text");
                return title.clientWidth < title.scrollWidth;
             })
             .then(function(truncated) {
@@ -336,7 +336,7 @@ define(["intern!object",
             })
             .end()
 
-         .findByCssSelector(".alfresco-header-Title:nth-child(3) .text")
+         .findByCssSelector("#LONG .alfresco-header-Title__text")
             .then(function(elem) {
                return elem.getSize();
             })
@@ -346,6 +346,17 @@ define(["intern!object",
             .end()
 
          .screenie(); // For visual verification of ellipsis if required
+      },
+
+      "Test link title": function() {
+         return browser.findByCssSelector("#LINK .alfresco-header-Title__text a")
+            .click()
+         .end()
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", "dp/ws/some-other-page");
+               assert.propertyVal(payload, "type", "PAGE_RELATIVE");
+            });
       },
 
       "Post Coverage Results": function() {
@@ -366,7 +377,7 @@ define(["intern!object",
       },
 
       "Test title gets set": function() {
-         return browser.findByCssSelector(".alfresco-header-Title > .text")
+         return browser.findByCssSelector(".alfresco-header-Title__text")
             .getVisibleText()
             .then(function(resultText) {
                assert.equal(resultText, "Updated Title", "The title was not updated");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
-  <shortname>Set Title Test</shortname>
+  <shortname>Set Title</shortname>
+  <description>This shows an example of the alfresco/header/SetTitle widget that can be used to set an alfresco/header/Title widget that might be rendered by a different Surf component</description>
   <family>aikau-unit-tests</family>
   <url>/SetTitle</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.js
@@ -32,10 +32,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
-  <shortname>Title Test</shortname>
+  <shortname>Title</shortname>
+  <description>This shows various configurations of the alfresco/header/Title widget</description>
   <family>aikau-unit-tests</family>
   <url>/Title</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/Title.get.js
@@ -16,26 +16,33 @@ model.jsonModel = {
          config: {
             widgets: [
                {
+                  id: "BASIC",
                   name: "alfresco/header/Title",
                   config: {
                      label: "This is a title"
                   }
                },
                {
+                  id: "LONG",
                   name: "alfresco/header/Title",
                   config: {
                      label: "ThisIsAReallyLongTitleWithoutAnySpacesInIt",
                      maxWidth: "300px"
+                  }
+               },
+               {
+                  id: "LINK",
+                  name: "alfresco/header/Title",
+                  config: {
+                     label: "Link Title",
+                     targetUrl: "dp/ws/some-other-page"
                   }
                }
             ]
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -17,7 +17,9 @@
 
          @link-font-color: @button-color-default;
          @link-emphasized-font-color: @button-color-default;
-         @link-text-decoration: underline;
+         @link-text-decoration-hover: underline;
+         @link-title-font-color-hover: @button-color-default;
+         @link-title-text-decoration-hover: underline;
       </less-variables>
    </css-tokens>
 </theme>


### PR DESCRIPTION
This PR makes further updates to https://issues.alfresco.com/jira/browse/AKU-528. Primarily the purpose was to add in additional LESS configuration for link hover states to allow themes to be customized so that different decoration and colour can be applied based on whether or not the mouse is hovering over the link or not. 

I've also made further updates around the alfresco/header/Title to improve accessibility by ensuring that title are only links when they have a targetUrl set and defining dedicated LESS variables for title links (because I think they should be special cased).

Default Aikau LESS variable remain consistent with Share 5.0.x (e.g no text decoration or colours for links).