### PR TITLE
AKU-526: Filmstrip view for search previews and links

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument.js
@@ -38,7 +38,7 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dojo/query", 
         "dojo/NodeList-dom"], 
-        function(declare, AlfDocument, ResizeMixin, lang, array, registry, domConstruct, domGeom, domStyle, query, nodeListDom) {
+        function(declare, AlfDocument, ResizeMixin, lang, array, registry, domConstruct, domGeom, domStyle, query, /*jshint unused:false*/ nodeListDom) {
    
    return declare([AlfDocument, ResizeMixin], {
       

--- a/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
+++ b/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
@@ -59,23 +59,26 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_layout_LeftAndRight__postCreate() {
-         domClass.add(this.domNode, (this.additionalCssClasses != null ? this.additionalCssClasses : ""));
+         domClass.add(this.domNode, this.additionalCssClasses || "");
          if (this.widgets)
          {
             this._processedWidgets = [];
             
             // Iterate over all the widgets in the configuration object and add them...
             array.forEach(this.widgets, function(entry, i) {
-               var domNode = null;
-               if (entry.align == "right")
+               if (this.filterWidget(entry, i))
                {
-                  domNode = this.createWidgetDomNode(entry, this.rightWidgets, entry.className);
+                  var domNode = null;
+                  if (entry.align === "right")
+                  {
+                     domNode = this.createWidgetDomNode(entry, this.rightWidgets, entry.className);
+                  }
+                  else
+                  {
+                     domNode = this.createWidgetDomNode(entry, this.leftWidgets, entry.className);
+                  }
+                  this.createWidget(entry, domNode, this._registerProcessedWidget, this, i);
                }
-               else
-               {
-                  domNode = this.createWidgetDomNode(entry, this.leftWidgets, entry.className);
-               }
-               this.createWidget(entry, domNode, this._registerProcessedWidget, this, i);
             }, this);
          }
 

--- a/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
@@ -75,14 +75,14 @@ define(["dojo/_base/declare",
       onLinkClick: function alfresco_renderers_PropertyLink__onLinkClick(evt) {
          event.stop(evt);
          var publishTopic = this.getPublishTopic();
-         if (publishTopic == null || lang.trim(publishTopic) == "")
+         if (!publishTopic || lang.trim(publishTopic) === "")
          {
             this.alfLog("warn", "No publishTopic provided for PropertyLink", this);
          }
          else
          {
-            var publishGlobal = (this.publishGlobal != null) ? this.publishGlobal : false;
-            var publishToParent = (this.publishToParent != null) ? this.publishToParent : false;
+            var publishGlobal = this.publishGlobal || false;
+            var publishToParent = this.publishToParent || false;
             this.alfPublish(publishTopic, this.getPublishPayload(), publishGlobal, publishToParent);
          }
       },
@@ -108,7 +108,7 @@ define(["dojo/_base/declare",
        * @returns {string} The currentItem being renderered.
        */ 
       getPublishPayload: function alfresco_renderers_PropertyLink__getPublishPayload() {
-         if (this.useCurrentItemAsPayload == true)
+         if (this.useCurrentItemAsPayload === true)
          {
             return this.currentItem;
          }

--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -127,9 +127,28 @@ define(["alfresco/core/TemporalUtils",
                   payload.url = "document-details?nodeRef=" + nodeRef;
                }
          }
-
          return payload;
-      }
+      },
 
+      /**
+       * Override to ensure that search result link payloads aren't re-generated.
+       * 
+       * @instance
+       * @since 1.0.32
+       */
+      onNonPreviewAction: function alfresco_renderers__SearchResultLinkMixin__onNonPreviewAction() {
+         var publishGlobal = this.publishGlobal || false;
+         var publishToParent = this.publishToParent || false;
+         if (!this.publishTopic)
+         {
+            this.alfPublish("ALF_NAVIGATE_TO_PAGE", this.publishPayload, publishGlobal, publishToParent);
+         }
+         else if (this.publishPayload)
+         {
+            // If a payload has been provided then use it...
+            this.publishPayload = this.getGeneratedPayload(false, null);
+            this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
+         }
+      }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -128,27 +128,6 @@ define(["alfresco/core/TemporalUtils",
                }
          }
          return payload;
-      },
-
-      /**
-       * Override to ensure that search result link payloads aren't re-generated.
-       * 
-       * @instance
-       * @since 1.0.32
-       */
-      onNonPreviewAction: function alfresco_renderers__SearchResultLinkMixin__onNonPreviewAction() {
-         var publishGlobal = this.publishGlobal || false;
-         var publishToParent = this.publishToParent || false;
-         if (!this.publishTopic)
-         {
-            this.alfPublish("ALF_NAVIGATE_TO_PAGE", this.publishPayload, publishGlobal, publishToParent);
-         }
-         else if (this.publishPayload)
-         {
-            // If a payload has been provided then use it...
-            this.publishPayload = this.getGeneratedPayload(false, null);
-            this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
-         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -448,8 +448,7 @@ define(["dojo/_base/declare",
          new SearchThumbnail({
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
-            showDocumentPreview: true,
-            publishTopic: "ALF_NAVIGATE_TO_PAGE"
+            showDocumentPreview: true
          }, this.thumbnailNode);
       },
 

--- a/aikau/src/main/resources/alfresco/search/FilmStripViewSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/FilmStripViewSearchResult.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This extends the standard [AlfFilmStripViewDocument]{@link module:alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument}
+ * to provide dedicated rendering and link handling for search results. This has been created to be used within the
+ * [SearchFilmStripView]{@link module:alfresco/search/SearchFilmStripView}.
+ * 
+ * @module alfresco/search/FilmStripViewSearchResult
+ * @extends module:alfresco/documentlibrary/AlfDocument
+ * @mixes module:alfresco/core/ResizeMixin
+ * @author Dave Draper
+ * @since 1.0.32
+ */
+define(["dojo/_base/declare",
+        "alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument",
+        "dojo/_base/lang",
+        "dojo/dom-class"], 
+        function(declare, AlfFilmStripViewDocument, lang, domClass) {
+   
+   return declare([AlfFilmStripViewDocument], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance cssRequirements {Array}
+       * @type {object[]}
+       * @default [{cssFile:"./css/FilmStripViewSearchResult.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/FilmStripViewSearchResult.css"}],
+      
+      /**
+       * Sets up a NodeRef specific subscription if the current item is a document (such that the document data is only
+       * requested if asked for by the [Film Strip View]{@link module:alfresco/documentlibrary/views/AlfFilmStripView})
+       * and if the current item is a container then the standard thumbnail is rendered
+       *
+       * @instance
+       */
+      postCreate: function alfresco_search_FilmStripViewSearchResult__postCreate() {
+         domClass.add(this.domNode, "alfresco-search-FilmStripViewSearchResult");
+         this.nodeRef = lang.getObject("currentItem.nodeRef", false, this);
+         this.type = lang.getObject("currentItem.type", false, this);
+         if (this.type === "document")
+         {
+            // This is a document so we can subscribe to the expected request to display content
+            this.widgets = [{
+               name: "alfresco/preview/AlfDocumentPreview"
+            }];
+            this.alfSubscribe("ALF_FILMSTRIP_DOCUMENT_REQUEST__" + this.nodeRef, lang.hitch(this, this.requestDocument, this.nodeRef));
+         }
+         else
+         {
+            this.processWidgets(lang.clone(this.widgetsForSearchResults), this.containerNode);
+            this.alfSetupResizeSubscriptions(this.resizeThumbnails, this);
+         }
+      },
+
+      /**
+       * This function is provided so that explicit requests can be made to generate the preview
+       *
+       * @instance
+       */
+      render: function alfresco_search_FilmStripViewSearchResult__render() {
+         if (this.type === "document" && this.nodeRef)
+         {
+            this.requestDocument(this.nodeRef);
+         }
+      },
+      
+      /**
+       * Defines the widgets to use for non-folder, non-document search results.
+       *
+       * @instance
+       * @type {array}
+       */
+      widgetsForSearchResults: [
+         {
+            name: "alfresco/search/SearchThumbnail",
+            config: {
+               folderImage: "folder-256.png"
+            }
+         }
+      ]
+   });
+});

--- a/aikau/src/main/resources/alfresco/search/FilmStripViewSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/FilmStripViewSearchResult.js
@@ -39,7 +39,7 @@ define(["dojo/_base/declare",
       /**
        * An array of the CSS files to use with this widget.
        * 
-       * @instance cssRequirements {Array}
+       * @instance
        * @type {object[]}
        * @default [{cssFile:"./css/FilmStripViewSearchResult.css"}]
        */
@@ -87,7 +87,7 @@ define(["dojo/_base/declare",
        * Defines the widgets to use for non-folder, non-document search results.
        *
        * @instance
-       * @type {array}
+       * @type {object[]}
        */
       widgetsForSearchResults: [
          {

--- a/aikau/src/main/resources/alfresco/search/SearchFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/search/SearchFilmStripView.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This extends the standard [Film Strip View]{@link module:alfresco/documentlibrary/views/AlfFilmStripView}
+ * to provide a model dedicated to rendering search results. The main difference is in using the
+ * [FilmStripViewSearchResult]{@link module:alfresco/search/FilmStripViewSearchResult} that has special handling
+ * for types of nodes that are not found in Document Libraries. This view is only intended for use in the
+ * [AlfSearchList]{@link module:alfresco/search/AlfSearchList} widget.
+ *
+ * @module alfresco/search/SearchFilmStripView
+ * @extends module:alfresco/documentlibrary/views/AlfFilmStripView
+ * @author Dave Draper
+ * @since 1.0.32
+ */
+define(["dojo/_base/declare",
+        "alfresco/documentlibrary/views/AlfFilmStripView"], 
+        function(declare, AlfFilmStripView) {
+   
+   return declare([AlfFilmStripView], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance cssRequirements {Array}
+       * @type {object[]}
+       * @default [{cssFile:"./css/SearchFilmStripView.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/SearchFilmStripView.css"}],
+      
+      /**
+       * The definition of how a single item is represented the preview.
+       * 
+       * @instance
+       * @type {object[]}
+       */
+      widgetsForContent: [
+         {
+            name: "alfresco/layout/LeftAndRight",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/renderers/Property",
+                     align: "left",
+                     config: {
+                        propertyToRender: "displayName"
+                     }
+                  },
+                  {
+                     name: "alfresco/renderers/MoreInfo",
+                     align: "right",
+                     config: {
+                        filterActions: true,
+                        xhrRequired: true,
+                        renderFilter: [
+                           {
+                              property: "type",
+                              values: ["document","folder"]
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         },
+         {
+            name: "alfresco/search/FilmStripViewSearchResult"
+         }
+      ],
+
+      /**
+       * The definition of how a single item is represented in the view. 
+       * 
+       * @instance
+       * @type {object[]}
+       */
+      widgets: [
+         {
+            name: "alfresco/search/SearchGalleryThumbnail",
+            config: {
+               additionalCssClasses: "alfresco-search-SearchFilmStripView__thumbnail",
+               publishTopic: "ALF_FILMSTRIP_SELECT_ITEM",
+               publishPayloadType: "PROCESS",
+               publishPayload: {
+                  index: "{index}",
+                  nodeRef: "{nodeRef}"
+               },
+               publishPayloadModifiers: ["processCurrentItemTokens"],
+               widgetsForSelectBar: null
+            }
+         }
+      ]
+   });
+});

--- a/aikau/src/main/resources/alfresco/search/SearchFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/search/SearchFilmStripView.js
@@ -38,7 +38,7 @@ define(["dojo/_base/declare",
       /**
        * An array of the CSS files to use with this widget.
        * 
-       * @instance cssRequirements {Array}
+       * @instance
        * @type {object[]}
        * @default [{cssFile:"./css/SearchFilmStripView.css"}]
        */

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
@@ -55,12 +55,21 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_renderers_SearchThumbnailMixin__postCreate() {
          this.inherited(arguments);
-         if (!this.publishPayload)
+         if (!this.publishTopic)
          {
-            this.publishPayload = {};
+            // If specific publishTopic has been set then we can assume that the intention is to
+            // provide the standard link result that this mixin provides, however we do want to
+            // allow topic and payload overrides. This if clause has been added in particular for
+            // enabling the SearchGalleryThumbnail (into which this model has been mixed) to be
+            // used within the SearchFilmStripView and allow the click topic/payload to not be
+            // a standard search link
+            if (!this.publishPayload)
+            {
+               this.publishPayload = {};
+            }
+            this.publishPayload = this.generateSearchLinkPayload(this.publishPayload, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
+            this.makeAnchor(this.publishPayload.url, this.publishPayload.type);
          }
-         this.publishPayload = this.generateSearchLinkPayload(this.publishPayload, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
-         this.makeAnchor(this.publishPayload.url, this.publishPayload.type);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
@@ -55,9 +55,9 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_renderers_SearchThumbnailMixin__postCreate() {
          this.inherited(arguments);
-         if (!this.publishTopic)
+         if (!this.publishTopic || this.publishTopic === "ALF_NAVIGATE_TO_PAGE")
          {
-            // If specific publishTopic has been set then we can assume that the intention is to
+            // If no specific publishTopic has been set then we can assume that the intention is to
             // provide the standard link result that this mixin provides, however we do want to
             // allow topic and payload overrides. This if clause has been added in particular for
             // enabling the SearchGalleryThumbnail (into which this model has been mixed) to be
@@ -126,6 +126,31 @@ define(["dojo/_base/declare",
        */
       getAnchorTargetSelectors: function alfresco_renderers_SearchThumbnailMixin__getAnchorTargetSelectors() {
          return ["span.inner"];
+      },
+
+      /**
+       * Override to ensure that search result link payloads aren't re-generated.
+       * 
+       * @instance
+       * @since 1.0.32
+       */
+      onNonPreviewAction: function alfresco_renderers_SearchThumbnailMixin__onNonPreviewAction() {
+         var publishGlobal = this.publishGlobal || false;
+         var publishToParent = this.publishToParent || false;
+         if (!this.publishTopic || this.publishTopic === "ALF_NAVIGATE_TO_PAGE")
+         {
+            // If no specific publishTopic has been configured then we can assume that the standard search
+            // result linking publication is required. The publishPayload should have already been provided
+            // by the postCreate function...
+            this.alfPublish("ALF_NAVIGATE_TO_PAGE", this.publishPayload, publishGlobal, publishToParent);
+         }
+         else
+         {
+            // If a publishTopic HAS been provided then we can assume this is a custom publication replacing
+            // the standard search result linking behaviour...
+            this.publishPayload = this.getGeneratedPayload(false, null);
+            this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/search/css/FilmStripViewSearchResult.css
+++ b/aikau/src/main/resources/alfresco/search/css/FilmStripViewSearchResult.css
@@ -1,0 +1,5 @@
+.alfresco-search-FilmStripViewSearchResult .alfresco-search-SearchThumbnail img {
+   display: inline-block;
+   float: none;
+   height: 256px;
+}

--- a/aikau/src/main/resources/alfresco/search/css/SearchFilmStripView.css
+++ b/aikau/src/main/resources/alfresco/search/css/SearchFilmStripView.css
@@ -1,0 +1,10 @@
+.alfresco-search-SearchFilmStripView__thumbnail.alfresco-renderers-Thumbnail.gallery img {
+   height: 100px;
+   width: auto;
+}
+
+.alfresco-search-SearchFilmStripView__thumbnail.alfresco-renderers-Thumbnail.gallery span.inner {
+   width: 100%;
+   text-align: center;
+   display: inline-block;
+}


### PR DESCRIPTION
This PR has been created in relation to the work done for https://issues.alfresco.com/jira/browse/AKU-526 (although it is not the primary task associated with that issue). AKU-526 is about making the alfresco/documentlibrary/views/AlfFilmStripView work with infinite scrolling lists, but this PR is specifically to extending the AlfFilmStripView to provide a new view that is dedicated exclusively to working with the alfresco/search/AlfSearchList (which does not need to be infinitely scrolled).

This new view provides the bare minimum implementation for getting a film strip style view into Alfresco Share faceted search and addresses the issues of inconsistent API and additional node types (i.e. nodes that are neither documents nor folders).

No unit tests have yet been added for this as we expect to iterate on this view once we've reviewed the current design. This is simply a first step on the road to a fully product quality film strip view.