### PR TITLE
AKU-526: Filmstrip view with infinite scroll corrections

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
@@ -86,9 +86,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {boolean} preserveCurrentData
        */
-      renderView: function alfresco_documentlibrary_views_AlfFilmStripView__renderView(preserveCurrentData) {
+      renderView: function alfresco_documentlibrary_views_AlfFilmStripView__renderView(/*jshint unused:false*/ preserveCurrentData) {
          this.inherited(arguments);
-         
          if (this.currentData && this.currentData.items && this.currentData.items.length > 0)
          {
             if (this.contentCarousel)
@@ -163,13 +162,12 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Extends the [inherited function]{@link module:alfresco/lists/views/AlfListView#clearOldView}
+       * Extends the [inherited function]{@link module:alfresco/lists/views/AlfListView#destroyRenderer}
        * to destroy the content carousel.
        *
        * @instance
-       * @override
        */
-      clearOldView: function alfresco_documentlibrary_views_AlfFilmStripView__clearOldView() {
+      destroyRenderer: function alfresco_documentlibrary_views_AlfFilmStripView__destroyRenderer() {
          if (this.contentCarousel)
          {
             this.contentCarousel.destroyRecursive();

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
@@ -166,6 +166,7 @@ define(["dojo/_base/declare",
        * to destroy the content carousel.
        *
        * @instance
+       * @since 1.0.32
        */
       destroyRenderer: function alfresco_documentlibrary_views_AlfFilmStripView__destroyRenderer() {
          if (this.contentCarousel)

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -26,7 +26,6 @@
    right: 0;
    border-right: @standard-border;
    border-left: @standard-border;
-   z-index: 10000;
 }
 
 /* Overrides JQuery default behaviour to hide the handle when disabled, but this would

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -428,6 +428,13 @@ define(["dojo/_base/declare",
          this.clearData();
       },
 
+      /**
+       * This should be called when the renderers need to be removed. 
+       * 
+       * @instance
+       * @extendable
+       * @since 1.0.32
+       */
       destroyRenderer: function alfresco_lists_views_AlfListView__destroyRenderer() {
          if (this.docListRenderer)
          {

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -342,10 +342,7 @@ define(["dojo/_base/declare",
                // then we should destroy the previous renderer...
                if ((preserveCurrentData === false || preserveCurrentData === undefined) && this.docListRenderer)
                {
-                  this.docListRenderer.destroy();
-
-                  // TODO: Concerned about this - it needs further investigation as to why anything is being left behind!
-                  this.docListRenderer = null;
+                  this.destroyRenderer();
                }
 
                // If the renderer is null we need to create one (this typically wouldn't be expected to happen)
@@ -421,13 +418,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       clearOldView: function alfresco_lists_views_AlfListView__clearOldView() {
-         if (this.docListRenderer)
-         {
-            this.docListRenderer.destroy();
-
-            // TODO: Concerned about this - it needs further investigation as to why anything is being left behind!
-            this.docListRenderer = null;
-         }
+         this.destroyRenderer();
          if (this.messageNode)
          {
             domConstruct.destroy(this.messageNode);
@@ -435,6 +426,15 @@ define(["dojo/_base/declare",
          // Remove all table body elements. (preserves headers)
          query("tbody", this.tableNode).forEach(domConstruct.destroy);
          this.clearData();
+      },
+
+      destroyRenderer: function alfresco_lists_views_AlfListView__destroyRenderer() {
+         if (this.docListRenderer)
+         {
+            this.docListRenderer.destroy();
+            // TODO: Concerned about this - it needs further investigation as to why anything is being left behind!
+            this.docListRenderer = null;
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
@@ -156,9 +156,11 @@ define(["dojo/_base/declare",
        */
       resize: function alfresco_lists_views_layouts_Carousel__resize() {
          this.calculateSizes();
-         domStyle.set(this.itemsNode, "width", this.itemsNodeWidth + "px");
-         domStyle.set(this.itemsNode, "height", this.height);
-
+         if (this.itemsNode)
+         {
+            domStyle.set(this.itemsNode, "width", this.itemsNodeWidth + "px");
+            domStyle.set(this.itemsNode, "height", this.height);
+         }
          this.resizeContainer();
 
          // Set the range of displayed items...
@@ -176,7 +178,7 @@ define(["dojo/_base/declare",
        */
       resizeContainer: function alfresco_lists_views_layouts_Carousel__resizeContainer() {
          var itemsCount = lang.getObject("currentData.items.length", false, this);
-         if (itemsCount !== null)
+         if (this.containerNode && itemsCount !== null)
          {
             var totalWidth = (itemsCount * this.itemsNodeWidth) + "px";
             domStyle.set(this.containerNode, "width", totalWidth);
@@ -214,7 +216,7 @@ define(["dojo/_base/declare",
             this.numberOfItemsShown = Math.floor(overallWidth/this.itemWidth);
             this.itemsNodeWidth = this.numberOfItemsShown * this.itemWidth;
 
-            if (this.fixedHeight != null)
+            if (this.fixedHeight)
             {
                // Use the configured height...
                this.height = this.fixedHeight;
@@ -240,7 +242,7 @@ define(["dojo/_base/declare",
        * @param {element} rootNode The DOM element to add them into.
        */
       processWidgets: function alfresco_lists_views_layouts_Carousel__processWidgets(widgets, rootNode) {
-         var nodeToAdd = nodeToAdd = domConstruct.create("li", {}, rootNode);
+         var nodeToAdd = domConstruct.create("li", {}, rootNode);
          this.inherited(arguments, [widgets, nodeToAdd]);
       },
 
@@ -280,7 +282,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onPrevClick: function alfresco_lists_views_layouts_Carousel__onPrevClick(evt) {
+      onPrevClick: function alfresco_lists_views_layouts_Carousel__onPrevClick(/*jshint unused:false*/ evt) {
          if (this.currentLeftPosition > 0)
          {
             this.currentLeftPosition -= this.itemsNodeWidth;
@@ -298,7 +300,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onNextClick: function alfresco_lists_views_layouts_Carousel__onNextClick(evt) {
+      onNextClick: function alfresco_lists_views_layouts_Carousel__onNextClick(/*jshint unused:false*/ evt) {
          this.currentLeftPosition += this.itemsNodeWidth;
 
          // Update the displayed range...
@@ -324,27 +326,27 @@ define(["dojo/_base/declare",
             {
                var widgets = this._renderedItemWidgets[i];
                array.forEach(widgets, lang.hitch(this, this.renderDisplayedItem));
-
             }
          }
 
          // Make sure the frame is aligned correctly...
          this.currentLeftPosition = (this.firstDisplayedIndex / this.numberOfItemsShown) * this.itemsNodeWidth;
          var left = "-" + this.currentLeftPosition + "px";
-         domStyle.set(this.containerNode, "left", left);
+         this.containerNode && domStyle.set(this.containerNode, "left", left);
 
          var itemsCount = lang.getObject("currentData.items.length", false, this);
-         domStyle.set(this.prevNode, "visibility", (this.firstDisplayedIndex == 0) ? "hidden": "visible");
-         domStyle.set(this.nextNode, "visibility", (this.firstDisplayedIndex <= itemsCount-1 && this.lastDisplayedIndex >= itemsCount-1) ? "hidden": "visible");
+         this.prevNode && domStyle.set(this.prevNode, "visibility", (this.firstDisplayedIndex === 0) ? "hidden": "visible");
+         this.nextNode && domStyle.set(this.nextNode, "visibility", (this.firstDisplayedIndex <= itemsCount-1 && this.lastDisplayedIndex >= itemsCount-1) ? "hidden": "visible");
 
          // Can only enter this condition if we're an items carousel in infinite
          // scroll mode (because the preview carousel doesn't get told this)
-         if (this.useInfiniteScroll) {
+         if (this.useInfiniteScroll) 
+         {
             var hasMoreItems = this.currentData.totalRecords > itemsCount,
-               numPages = Math.ceil(itemsCount / this.numberOfItemsShown),
-               lastPageStartIndex = (numPages - 1) * this.numberOfItemsShown,
-               lastPageEndIndex = lastPageStartIndex + (this.numberOfItemsShown - 1),
-               onLastPage = (this.lastDisplayedIndex >= lastPageStartIndex) && (this.lastDisplayedIndex <= lastPageEndIndex);
+                numPages = Math.ceil(itemsCount / this.numberOfItemsShown),
+                lastPageStartIndex = (numPages - 1) * this.numberOfItemsShown,
+                lastPageEndIndex = lastPageStartIndex + (this.numberOfItemsShown - 1),
+                onLastPage = (this.lastDisplayedIndex >= lastPageStartIndex) && (this.lastDisplayedIndex <= lastPageEndIndex);
             if (hasMoreItems && onLastPage) {
                this.alfPublish(this.loadMoreDataTopic);
             }
@@ -358,7 +360,7 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget to render
        * @param {number} index The index of the widget within the array
        */
-      renderDisplayedItem: function alfresco_lists_views_layouts_Carousel__renderDisplayedItem(widget, index) {
+      renderDisplayedItem: function alfresco_lists_views_layouts_Carousel__renderDisplayedItem(widget, /*jshint unused:false*/ index) {
          if (widget && typeof widget.render === "function")
          {
             widget.render();
@@ -372,9 +374,9 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       selectItem: function alfresco_lists_views_layouts_Carousel__item(payload) {
-         if (payload.index != null && !isNaN(parseInt(payload.index)))
+         if ((payload.index || payload.index === 0) && !isNaN(parseInt(payload.index, 10)))
          {
-            var targetIndex = parseInt(payload.index);
+            var targetIndex = parseInt(payload.index, 10);
             if (targetIndex >= this.firstDisplayedIndex && targetIndex <= this.lastDisplayedIndex)
             {
                // The requested item is currently displayed, no action necessary...

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -450,7 +450,6 @@ define(["dojo/_base/declare",
             // in a document library)...
             this.publishPayload = {};
             this.publishTopic = this.generateFileFolderLink(this.publishPayload);
-            this.publishGlobal = true;
          }
          else if (this.publishPayload)
          {

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -120,6 +120,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @since 1.0.32
        */
       totalResultsProperty: "numberFound",
 

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -114,6 +114,16 @@ define(["dojo/_base/declare",
       spellcheck: true,
 
       /**
+       * Overrides the [default value]{@link module:alfresco/lists/AlfList#totalResultsProperty} to use
+       * the property expected when using the search API.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      totalResultsProperty: "numberFound",
+
+      /**
        * Overrides the [inherited default]{@link module:alfresco/lists/AlfHashList#updateInstanceValues}
        * to ensure that instance values should be updated from the hash. This only appliees when
        * [useHash]{@link module:alfresco/lists/AlfHashList#useHash} is configured to be true.
@@ -634,6 +644,7 @@ define(["dojo/_base/declare",
        * @param {object} originalRequestConfig The configuration that was passed to the the [serviceXhr]{@link module:alfresco/core/CoreXhr#serviceXhr} function
        */
       onDataLoadSuccess: function alfresco_search_AlfSearchList__onDataLoadSuccess(payload) {
+         /* jshint maxcomplexity:false */
          this.alfLog("log", "Search Results Loaded", payload, this);
 
          var newData = payload.response;
@@ -647,7 +658,7 @@ define(["dojo/_base/declare",
          if (view !== null)
          {
             this.showRenderingMessage();
-
+            this.processLoadedData(payload.response || this.currentData);
             if (this.useInfiniteScroll)
             {
                view.augmentData(newData);


### PR DESCRIPTION
This PR makes some updates following the initial PRs for https://issues.alfresco.com/jira/browse/AKU-526. After some preliminary testing in Share we hit a few issues that needed to be resolved because the AlfSearchList was not calling the processLoadedData function so wasn't taking advantage of some of the improvements made in the previous PR. This has now been corrected along with some defensive code updates and some other minor corrections