### PR TITLE
AKU-534: Single select drop drop should filter anywhere

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -48,7 +48,7 @@
  *             result: "${label}",
  *             full: "${value} - ${label}"
  *          },
- *          searchStartsWith: false // Whether the query attribute should start with the search string (defaults to true)
+ *          searchStartsWith: true // Whether the query attribute should start with the search string (defaults to false)
  *       }
  *    }
  * }

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
@@ -76,9 +76,9 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {string}
-       * @default true
+       * @default
        */
-      searchStartsWith: true,
+      searchStartsWith: false,
 
       /**
        * If this is configured to be an array of fixed options then the query will be run against

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/UseServiceStoreMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/UseServiceStoreMixin.js
@@ -47,7 +47,7 @@ define(["dojo/_base/declare",
          var labelAttribute = lang.getObject("optionsConfig.labelAttribute", false, this);
          var valueAttribute = lang.getObject("optionsConfig.valueAttribute", false, this);
          var fixedOptions = lang.getObject("optionsConfig.fixed", false, this);
-         var searchStartsWith = lang.getObject("optionsConfig.searchStartsWith", true, this);
+         var searchStartsWith = lang.getObject("optionsConfig.searchStartsWith", false, this);
          var serviceStore = new ServiceStore({
             idProperty: (valueAttribute != null) ? valueAttribute : "value",
             queryAttribute: (queryAttribute != null) ? queryAttribute : "name",
@@ -56,7 +56,7 @@ define(["dojo/_base/declare",
             publishTopic: publishTopic,
             publishPayload: publishPayload,
             fixed: fixedOptions,
-            searchStartsWith: searchStartsWith
+            searchStartsWith: !!searchStartsWith // Normalises to boolean; also means that default is false as per AKU-534
          });
          return serviceStore;
       },

--- a/aikau/src/test/resources/alfresco/forms/controls/ComboBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ComboBoxTest.js
@@ -18,15 +18,16 @@
  */
 
 /**
- * 
+ * Test the ComboBox control
+ *
  * @author Dave Draper
+ * @author Martin Doyle
  */
-define(["intern!object",
+define(["alfresco/TestCommon",
+        "intern!object",
         "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        "intern/dojo/node!leadfoot/keys"],
+        function(TestCommon, registerSuite, assert, keys) {
 
    var browser;
    registerSuite({
@@ -41,56 +42,57 @@ define(["intern!object",
          browser.end();
       },
 
-      "Checking the number of tag options...": function () {
+      "Checking the number of tag options...": function() {
          return browser.findByCssSelector("#TAGS .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
 
          .findAllByCssSelector("#TAGS_CONTROL_popup .dijitMenuItem[item]")
             .then(function(elements) {
-               assert(elements.length === 4, "Test 1a - Four tag options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 4, "Didn't display full list of tags");
             });
       },
 
       "Checking the number of properties options": function() {
          return browser.findByCssSelector("#TAGS label.label")
             .click()
-         .end()
+            .end()
 
-         // Open the properties combo and count the available options...
          .findByCssSelector("#PROPERTIES .dijitArrowButtonInner")
             .click()
-         .end()
+            .end()
 
          .findAllByCssSelector("#PROPERTIES_CONTROL_popup .dijitMenuItem[item]")
             .then(function(elements) {
-               assert(elements.length === 5, "Test 1b - Five property options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 5, "Didn't display full list of properties");
             });
       },
 
       "Checking tag options are reduced": function() {
          return browser.findByCssSelector("#TAGS_CONTROL")
-            .click()
+            .clearLog()
             .type("t")
-            .sleep(1000)
-         .end()
+            .end()
+
+         .getLastPublish("_SUCCESS")
 
          .findAllByCssSelector("#TAGS_CONTROL_popup .dijitMenuItem[item]")
             .then(function(elements) {
-               assert(elements.length === 3, "Three tag options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 4, "Did not expect 't' to reduce elements list");
             });
       },
 
       "Checking tag options are further reduced": function() {
          return browser.findByCssSelector("#TAGS_CONTROL")
-            .click()
+            .clearLog()
             .type("ag1")
-            .sleep(1000)
-         .end()
+            .end()
+
+         .getLastPublish("_SUCCESS")
 
          .findAllByCssSelector("#TAGS_CONTROL_popup .dijitMenuItem[item]")
             .then(function(elements) {
-               assert(elements.length === 2, "Two tag options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 2, "List was not filtered correctly for search 'tag1'");
             });
       },
 
@@ -98,15 +100,15 @@ define(["intern!object",
          return browser.findByCssSelector("#TAGS_CONTROL")
             .click()
             .pressKeys(keys.RETURN)
-         .end()
+            .end()
 
          .findByCssSelector(".confirmationButton > span")
             .click()
-         .end()
+            .end()
 
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("POST_FORM", "tag", "tag1"))
-            .then(function(elements) {
-               assert(elements.length === 1, "The tag value was not auto-completed and posted");
+         .getLastPublish("POST_FORM")
+            .then(function(payload) {
+               assert.propertyVal(payload, "tag", "tag1", "Tag value was not auto-completed and posted");
             });
       },
 
@@ -127,17 +129,17 @@ define(["intern!object",
          browser.end();
       },
 
-      "Down arrow test": function () {
+      "Down arrow test": function() {
          // Slightly convoluted way to leave a result stem in the #TAGS_CONTROL
          return browser.pressKeys(keys.TAB)
-            .pressKeys("ta")
+            .pressKeys("g1")
             .sleep(500)
             .pressKeys(keys.TAB)
             .sleep(500)
             .pressKeys([keys.SHIFT, keys.TAB])
             .pressKeys(keys.ARROW_DOWN)
             .sleep(500)
-         .end()
+            .end()
 
          // Release SHIFT and TAB before assertion...
          .pressKeys([keys.SHIFT, keys.TAB])
@@ -145,7 +147,7 @@ define(["intern!object",
          // Test that clicking the down arrow gives results based on the stem left above
          .findAllByCssSelector("#TAGS_CONTROL_popup .dijitMenuItem[item]")
             .then(function(elements) {
-               assert(elements.length === 3, "Three tag options were expected, found: " + elements.length);
+               assert.lengthOf(elements, 2, "Wrong number of results for search string 'g1'");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ComboBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ComboBox.get.js
@@ -61,10 +61,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/ComboBoxMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -107,8 +107,7 @@ model.jsonModel = {
                                  publishTopic: "ALF_RETRIEVE_CURRENT_TAGS",
                                  publishPayload: {
                                     resultsProperty: "response.data.items"
-                                 },
-                                 searchStartsWith: false
+                                 }
                               },
                               requirementConfig: {
                                  initialValue: true
@@ -144,8 +143,7 @@ model.jsonModel = {
                                     choice: "{label}",
                                     result: "{value}: {label}",
                                     full: "ID={value}, Name={label}"
-                                 },
-                                 searchStartsWith: false
+                                 }
                               }
                            }
                         }
@@ -177,8 +175,7 @@ model.jsonModel = {
                                  publishTopic: "ALF_RETRIEVE_CURRENT_TAGS",
                                  publishPayload: {
                                     resultsProperty: "response.data.items"
-                                 },
-                                 searchStartsWith: false
+                                 }
                               },
                               disablementConfig: {
                                  initialValue: true


### PR DESCRIPTION
This addresses issue [AKU-534](https://issues.alfresco.com/jira/browse/AKU-534) by changing the default value of `searchStartsWith` to be `false`. This change affects the FilteringSelect, MultiSelect and ComboBox controls. More details are in the linked JIRA ticket.