### PR TITLE
AKU-516: MultiSelectInput widget makes several calls to the server

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -287,6 +287,18 @@ define(["dojo/_base/declare",
       noPostWhenValueIs: null,
 
       /**
+       * Whether - when a publishTopic is available in the supplied optionsConfig - to immediately
+       * publish to that topic in order to retrieve any default pubSubOptions for this control. If
+       * set to false, then it will not do that initial publish.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.33
+       */
+      getPubSubOptionsImmediately: true,
+
+      /**
        * The default visibility status is always true (this can be overridden by extending controls).
        *
        * @instance
@@ -580,7 +592,7 @@ define(["dojo/_base/declare",
             var pubSub = lang.getObject("publishTopic", false, config),
                 callback = lang.getObject("callback", false, config),
                 fixed = lang.getObject("fixed", false, config);
-            if (pubSub)
+            if (pubSub && this.getPubSubOptionsImmediately)
             {
                this.getPubSubOptions(config);
             }

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -480,6 +480,23 @@ define([
                newValuesArray = (newValueParam && [newValueParam]) || [];
             }
 
+            // Normalise attrNames 
+            if (!nameAttrName && !labelAttrName && !valueAttrName) {
+               throw new Error("No attribute names available!");
+            } else if (nameAttrName && !labelAttrName && !valueAttrName) {
+               labelAttrName = valueAttrName = nameAttrName;
+            } else if (!nameAttrName && labelAttrName && !valueAttrName) {
+               nameAttrName = valueAttrName = labelAttrName;
+            } else if (!nameAttrName && !labelAttrName && valueAttrName) {
+               nameAttrName = labelAttrName = valueAttrName;
+            } else if (!nameAttrName) {
+               nameAttrName = labelAttrName;
+            } else if (!labelAttrName) {
+               labelAttrName = nameAttrName;
+            } else if (!valueAttrName) {
+               valueAttrName = nameAttrName;
+            }
+
             // Clear existing values
             array.forEach(this._choices, this._removeChoice, this);
 
@@ -1097,7 +1114,7 @@ define([
           * @instance
           * @param {object} evt Dojo-normalised event object
           */
-         _onSearchKeyup: function alfresco_forms_controls_MultiSelect___onSearchKeyup(/*jshint unused:false*/ evt) {
+         _onSearchKeyup: function alfresco_forms_controls_MultiSelect___onSearchKeyup( /*jshint unused:false*/ evt) {
             if (this._suppressKeyUp) {
                this._suppressKeyUp = false;
             } else {
@@ -1274,7 +1291,8 @@ define([
           * @instance
           */
          _setupDisabling: function alfresco_forms_controls_MultiSelect___setupDisabling() {
-            var methodsToDisable = ["_onChoiceClick",
+            var methodsToDisable = [
+               "_onChoiceClick",
                "_onChoiceCloseClick",
                "_onControlClick",
                "_onFocus",
@@ -1283,12 +1301,13 @@ define([
                "_onSearchChange",
                "_onSearchKeypress",
                "_onSearchKeyup",
-               "_onSearchUpdate"];
-            array.forEach(methodsToDisable, function(methodName){
+               "_onSearchUpdate"
+            ];
+            array.forEach(methodsToDisable, function(methodName) {
                var oldMethodName = "_OLD" + methodName;
                this[oldMethodName] = this[methodName];
                this[methodName] = lang.hitch(this, function() {
-                  if(this._disabled) {
+                  if (this._disabled) {
                      return;
                   } else {
                      return this[oldMethodName].apply(this, arguments);

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
@@ -60,7 +60,6 @@ define([
                id: this.id + "_CONTROL",
                name: this.name,
                width: this.width,
-               value: this.value,
                choiceCanWrap: this.optionsConfig.choiceCanWrap,
                choiceMaxWidth: this.optionsConfig.choiceMaxWidth,
                labelFormat: this.optionsConfig.labelFormat

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
@@ -38,6 +38,18 @@ define([
       return declare([BaseFormControl, CoreWidgetProcessing, UseServiceStoreMixin, IconMixin], {
 
          /**
+          * Override the [inherited value]{@link module:alfresco/forms/controls/BaseFormControl#getPubSubOptionsImmediately}
+          * to suppress the initial retrieval of pubSubOptions for this control.
+          *
+          * @instance
+          * @override
+          * @type {boolean}
+          * @default
+          * @since 1.0.33
+          */
+         getPubSubOptionsImmediately: false,
+
+         /**
           * @override
           * @instance
           */

--- a/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
@@ -199,6 +199,15 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
+      _clearLog: function alfresco_testing_MockXhr___clearLog() {
+         domConstruct.empty(this.logNode);
+      },
+
+      /**
+       * Toggle the body visibility for the log
+       *
+       * @instance
+       */
       _toggleBody: function alfresco_testing_MockXhr___toggleBody() {
          domClass.toggle(this.domNode, "alfresco-testing-MockXhr--hide-body");
       }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
@@ -32,6 +32,27 @@
       font-weight: 700;
       text-align: left;
    }
+   &__toggle-body, &__clear-log {
+      background: @standard-button-background;
+      border: @standard-button-border;
+      border-radius: @standard-button-border-radius;
+      color: @standard-button-font-color;
+      cursor: pointer;
+      font-size: 10px;
+      line-height: 15px;
+      margin-left: 10px;
+      padding: 0 5px;
+      position: relative;
+      &:hover, &:focus {
+         color: @standard-button-font-color-focus;
+         outline: 0;
+      }
+      &:active {
+         color: @standard-button-font-color-active;
+         left: 1px;
+         top: 1px;
+      }
+   }
    .mx-response {
       position: relative;
       &__info {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
@@ -27,7 +27,6 @@
    caption {
       background: #ccc;
       border-bottom: none;
-      cursor: pointer;
       font-size: 1.1em;
       font-weight: 700;
       text-align: left;
@@ -39,7 +38,7 @@
       color: @standard-button-font-color;
       cursor: pointer;
       font-size: 10px;
-      line-height: 15px;
+      line-height: 19px;
       margin-left: 10px;
       padding: 0 5px;
       position: relative;

--- a/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
@@ -1,6 +1,10 @@
 <div class="alfresco-testing-MockXhr" data-dojo-attach-point="containerNode">
    <table class="log">
-      <caption data-dojo-attach-event="onclick:_toggleBody">MockXhr Log (toggle visibility)</caption>
+      <caption>
+         MockXhr Log
+         <button data-dojo-attach-event="onclick:_toggleBody" class="alfresco-testing-MockXhr__toggle-body">toggle body</button>
+         <button data-dojo-attach-event="onclick:_clearLog" class="alfresco-testing-MockXhr__clear-log">clear log</button>
+      </caption>
       <thead class="mx-thead">
          <tr>
             <th class="mx-method">Method</th>

--- a/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
@@ -2,8 +2,8 @@
    <table class="log">
       <caption>
          MockXhr Log
-         <button data-dojo-attach-event="onclick:_toggleBody" class="alfresco-testing-MockXhr__toggle-body">toggle body</button>
-         <button data-dojo-attach-event="onclick:_clearLog" class="alfresco-testing-MockXhr__clear-log">clear log</button>
+         <button id="mockXhr_toggleBody" data-dojo-attach-event="onclick:_toggleBody" class="alfresco-testing-MockXhr__toggle-body">toggle body</button>
+         <button id="mockXhr_clearLog" data-dojo-attach-event="onclick:_clearLog" class="alfresco-testing-MockXhr__clear-log">clear log</button>
       </caption>
       <thead class="mx-thead">
          <tr>


### PR DESCRIPTION
This addresses issue [AKU-516](https://issues.alfresco.com/jira/browse/AKU-516) which is about multiple XHR requests being made. In making minor changes to BaseFormControl and MultiSelect, we have removed two of the three calls, meaning that there should now only be one call made. Also did some minor refactoring of the MockXHR log.