### PR TITLE
AKU-478: Horizontal Widget Resizing

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -67,10 +67,8 @@ define(["alfresco/core/ProcessWidgets",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-style",
-        "dojo/dom-geometry",
-        "dojo/on",
-        "alfresco/core/ObjectTypeUtils"], 
-        function(ProcessWidgets, declare, template, ResizeMixin, lang, array, domConstruct, domStyle, domGeom, on, ObjectTypeUtils) {
+        "dojo/dom-geometry"], 
+        function(ProcessWidgets, declare, template, ResizeMixin, lang, array, domConstruct, domStyle, domGeom) {
    
    return declare([ProcessWidgets, ResizeMixin], {
       
@@ -100,6 +98,18 @@ define(["alfresco/core/ProcessWidgets",
       baseClass: "horizontal-widgets",
       
       /**
+       * This array is setup when the [getVisibilityRuleTopics]{@link module:alfresco/layout/HorizontalWidgets#getVisibilityRuleTopics}
+       * is called and each topic is then subscribed to in order to trigger resize events when widgets are
+       * displayed or hidden.
+       *
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.33
+       */
+      visibilityRuleTopics: null,
+
+      /**
        * This will be set to a percentage value such that each widget displayed has an equal share
        * of page width. 
        * 
@@ -128,6 +138,70 @@ define(["alfresco/core/ProcessWidgets",
       widgetMarginRight: null,
 
       /**
+       * Extends the [inherited function]{@link module:alfresco/core/CoreWidgetProcessing#allWidgetsProcessed}
+       * to set up subscriptions for the [visibilityRuleTopics]{@link module:alfresco/layout/HorizontalWidgets#visibilityRuleTopics}
+       * that are returned by calling [getVisibilityRuleTopics]{@link module:alfresco/layout/HorizontalWidgets#getVisibilityRuleTopics}
+       * on the first pass through the [doWidthProcessing]{@link module:alfresco/layout/HorizontalWidgets#doWidthProcessing}
+       * function. The subscriptions need to be created after the widgets have been created in order that their visibility 
+       * is adjusted before the [onResize]{@link module:alfresco/layout/HorizontalWidgets#onResize} function that is bound 
+       * to is called.
+       *
+       * @instance
+       * @param {object[]} widgets The widgets that have been created
+       * @since 1.0.33
+       */
+      allWidgetsProcessed: function alfresco_layout_HorizontalWidgets__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
+         this.inherited(arguments);
+         if (this.visibilityRuleTopics)
+         {
+            array.forEach(this.visibilityRuleTopics, function(topic) {
+               this.alfSubscribe(topic, lang.hitch(this, this.onResize));
+            }, this);
+         }
+      },
+
+      /**
+       * This function is called on the first pass through the 
+       * [doWidthProcessing]{@link module:alfresco/layout/HorizontalWidgets#doWidthProcessing} function and checks all
+       * the supplied widgets for dynamic visibility configuration so that subscriptions can be created
+       * on the same rules to trigger resizing as widgets are displayed or hidden.
+       * 
+       * @instance
+       * @param {object[]} widgets The widgets to check for visibility/invisibility configuration
+       * @return {string[]} An array of the topics that are using in dynamic visibility/invisibility configuration
+       * @since 1.0.33
+       */
+      getVisibilityRuleTopics: function alfresco_layout_HorizontalWidgets__getVisibilityRuleTopics(widgets) {
+         var topics = [];
+         var ruleTopicsObject = {};
+         array.forEach(widgets, function(widget) {
+            var visibilityRules = lang.getObject("config.visibilityConfig.rules", false, widget);
+            array.forEach(visibilityRules, function(rule) {
+               if (rule.topic && !ruleTopicsObject[rule.topic])
+               {
+                  ruleTopicsObject[rule.topic] = true;
+               }
+            });
+            var invisibilityRules = lang.getObject("config.invisibilityConfig.rules", false, widget);
+            array.forEach(invisibilityRules, function(rule) {
+               if (rule.topic && !ruleTopicsObject[rule.topic])
+               {
+                  ruleTopicsObject[rule.topic] = true;
+               }
+            });
+         });
+
+         for (var key in ruleTopicsObject) 
+         {
+            if (ruleTopicsObject.hasOwnProperty(key))
+            {
+               topics.push(key);
+            }
+         }
+         return topics;
+      },
+
+      /**
        * Sets up the default width to be allocated to each child widget to be added.
        * 
        * @instance
@@ -135,7 +209,8 @@ define(["alfresco/core/ProcessWidgets",
       postCreate: function alfresco_layout_HorizontalWidgets__postCreate() {
          // Split the full width between all widgets... 
          // We should update this to allow for specific widget width requests...
-         this.doWidthProcessing(this.widgets);
+         this.visibilityRuleTopics = this.getVisibilityRuleTopics(this.widgets);
+         this.doWidthProcessing(this.widgets, true);
          this.inherited(arguments);
 
          // Update the grid as the window changes...
@@ -150,9 +225,12 @@ define(["alfresco/core/ProcessWidgets",
        *
        * @instance
        * @param {array} widgets The widgets or widget configurations to process the widths for
+       * @param {boolean} firstPass Indicates whether this is the first pass (this determines whether to look at visibility
+       * rule configuration or DOM node visibility).
        */
-      doWidthProcessing: function alfresco_layout_HorizontalWidgets__doWidthProcessing(widgets) {
-         if (widgets != null && this.domNode != null)
+      doWidthProcessing: function alfresco_layout_HorizontalWidgets__doWidthProcessing(widgets, firstPass) {
+         // jshint maxstatements:false
+         if (widgets && this.domNode)
          {
             // Get the dimensions of the current DOM node...
             var computedStyle = domStyle.getComputedStyle(this.domNode);
@@ -166,17 +244,38 @@ define(["alfresco/core/ProcessWidgets",
             // Subtract the margins from the overall width
             var leftMarginsSize = 0,
                 rightMarginsSize = 0;
-            if (this.widgetMarginLeft != null && !isNaN(this.widgetMarginLeft))
+
+            // Filter out any widgets that are configured to be initially invisible (on first pass processing)
+            // or that have a DOM node that is not displayed (on resizing)...
+            if (firstPass)
             {
-               leftMarginsSize = widgets.length * parseInt(this.widgetMarginLeft);
+               widgets = array.filter(widgets, function(widget) {
+                  var visibleInitialValue = lang.getObject("config.visibilityConfig.initialValue", false, widget);
+                  var invisibleInitialValue = lang.getObject("config.visibilityConfig.initialValue", false, widget);
+                  return visibleInitialValue === false || invisibleInitialValue === true;
+               });
+            }
+            else
+            {
+               widgets = array.filter(widgets, function(widget) {
+                  return widget.domNode && domStyle.get(widget.domNode, "display") !== "none";
+               });
+            }
+            
+            // NOTE: In the "if" statements below we're not worried about widgetMarginLeft 
+            //       or widgetMarginRight being 0 and thus the statement failing to evaluate
+            //       to true since the calculated size would remain 0 anyway
+            if (this.widgetMarginLeft && !isNaN(this.widgetMarginLeft))
+            {
+               leftMarginsSize = widgets.length * parseInt(this.widgetMarginLeft, 10);
             }
             else
             {
                this.widgetMarginLeft = 0;
             }
-            if (this.widgetMarginRight != null && !isNaN(this.widgetMarginRight))
+            if (this.widgetMarginRight && !isNaN(this.widgetMarginRight))
             {
-               rightMarginsSize = widgets.length * parseInt(this.widgetMarginRight);
+               rightMarginsSize = widgets.length * parseInt(this.widgetMarginRight, 10);
             }
             else
             {
@@ -187,13 +286,13 @@ define(["alfresco/core/ProcessWidgets",
             // Work out how many pixels widgets have requested and subtract that from the remainder...
             var widgetRequestedWidth = 0;
             var widgetsWithNoWidthReq = 0;
-            array.forEach(widgets, function(widget, index) {
-               if (widget.widthPx != null && !isNaN(widget.widthPx))
+            array.forEach(widgets, function(widget) {
+               if ((widget.widthPx || widget.widthPx === 0) && !isNaN(widget.widthPx))
                {
-                  widgetRequestedWidth += parseInt(widget.widthPx);
+                  widgetRequestedWidth += parseInt(widget.widthPx, 10);
                   widget.widthCalc = widget.widthPx;
                }
-               else if (widget.widthPc != null && !isNaN(widget.widthPc))
+               else if ((widget.widthPc || widget.widthPc === 0) && !isNaN(widget.widthPc))
                {
                   // No action, just avoiding adding to the count of widgets that don't request
                   // a width as either a pixel or percentage size.
@@ -217,10 +316,10 @@ define(["alfresco/core/ProcessWidgets",
 
             // Update the widgets that have requested a percentage of space with a value that is calculated from the remaining space
             var totalWidthAsRequestedPercentage = 0;
-            array.forEach(widgets, function(widget, index) {
-               if (widget.widthPc != null && !isNaN(widget.widthPc))
+            array.forEach(widgets, function(widget) {
+               if ((widget.widthPc || widget.widthPc === 0) && !isNaN(widget.widthPc))
                {
-                  var pc = parseInt(widget.widthPc);
+                  var pc = parseInt(widget.widthPc, 10);
                   totalWidthAsRequestedPercentage += pc;
 
                   if (pc > 100)
@@ -245,11 +344,11 @@ define(["alfresco/core/ProcessWidgets",
             }
 
             // Divide up the remaining horizontal space between the remaining widgets...
-            var remainingPercentage = remainingPercentage / widgetsWithNoWidthReq,
-                standardWidgetWidth = remainingWidth * (remainingPercentage/100);
-            array.forEach(widgets, function(widget, index) {
-               if ((widget.widthPc != null && !isNaN(widget.widthPc)) ||
-                   (widget.widthPx != null && !isNaN(widget.widthPx)))
+            remainingPercentage = remainingPercentage / widgetsWithNoWidthReq;
+            var standardWidgetWidth = remainingWidth * (remainingPercentage/100);
+            array.forEach(widgets, function(widget) {
+               if (((widget.widthPc || widget.widthPc === 0) && !isNaN(widget.widthPc)) ||
+                   ((widget.widthPx || widget.widthPx === 0) && !isNaN(widget.widthPx)))
                {
                   // No action required. 
                }
@@ -268,9 +367,9 @@ define(["alfresco/core/ProcessWidgets",
        * @param {object} evt The resize event.
        */
       onResize: function alfresco_layout_HorizontalWidget__onResize() {
-         this.doWidthProcessing(this._processedWidgets);
-         array.forEach(this._processedWidgets, function(widget, index) {
-            if (widget != null && widget.domNode != null && widget.widthCalc != null && widget.widthCalc != 0)
+         this.doWidthProcessing(this._processedWidgets, false);
+         array.forEach(this._processedWidgets, function(widget) {
+            if (widget && widget.domNode && widget.widthCalc)
             {
                domStyle.set(widget.domNode.parentNode, "width", widget.widthCalc + "px");
             }
@@ -289,15 +388,15 @@ define(["alfresco/core/ProcessWidgets",
        * @param {string} rootClassName A string containing one or more space separated CSS classes to set on the DOM node
        * @returns {element} A new DOM node for the widget to be attached to
        */
-      createWidgetDomNode: function alfresco_layout_HorizontalWidgets__createWidgetDomNode(widget, rootNode, rootClassName) {
+      createWidgetDomNode: function alfresco_layout_HorizontalWidgets__createWidgetDomNode(widget, /*jshint unused:false*/ rootNode, rootClassName) {
          var outerDiv = domConstruct.create("div", { className: "horizontal-widget"}, this.containerNode);
          
          // Set the width of each widget according to how many there are...
          var style = {
             "marginLeft": this.widgetMarginLeft + "px",
             "marginRight": this.widgetMarginRight + "px"
-         }
-         if (widget.widthCalc != 0)
+         };
+         if (widget.widthCalc)
          {
             style.width =  widget.widthCalc + "px";
          }
@@ -317,15 +416,15 @@ define(["alfresco/core/ProcessWidgets",
        * @param {number} index The index of the widget to create (this will effect it's location in the 
        * [_processedWidgets]{@link module:alfresco/core/Core#_processedWidgets} array)
        */
-      createWidget: function alfresco_layout_HorizontalWidgets__createWidget(config, domNode, callback, callbackScope, index) {
+      createWidget: function alfresco_layout_HorizontalWidgets__createWidget(config, /*jshint unused:false*/ domNode, callback, callbackScope, index) {
          var widget = this.inherited(arguments);
-         if (widget != null)
+         if (widget)
          {
-            if (config.widthPx != null && !isNaN(config.widthPx))
+            if ((config.widthPx || config.widgetPx === 0) && !isNaN(config.widthPx))
             {
                widget.widthPx = config.widthPx;
             }
-            else if (config.widthPc != null && !isNaN(config.widthPc))
+            else if ((config.widthPc || config.widthPc === 0) && !isNaN(config.widthPc))
             {
                widget.widthPc = config.widthPc;
             }

--- a/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
@@ -251,8 +251,8 @@ define(["alfresco/core/ProcessWidgets",
             {
                widgets = array.filter(widgets, function(widget) {
                   var visibleInitialValue = lang.getObject("config.visibilityConfig.initialValue", false, widget);
-                  var invisibleInitialValue = lang.getObject("config.visibilityConfig.initialValue", false, widget);
-                  return visibleInitialValue === false || invisibleInitialValue === true;
+                  var invisibleInitialValue = lang.getObject("config.invisibilityConfig.initialValue", false, widget);
+                  return visibleInitialValue !== false && invisibleInitialValue !== true;
                });
             }
             else

--- a/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
@@ -172,33 +172,17 @@ define(["alfresco/core/ProcessWidgets",
        * @since 1.0.33
        */
       getVisibilityRuleTopics: function alfresco_layout_HorizontalWidgets__getVisibilityRuleTopics(widgets) {
-         var topics = [];
-         var ruleTopicsObject = {};
+         var topicNames = {};
          array.forEach(widgets, function(widget) {
-            var visibilityRules = lang.getObject("config.visibilityConfig.rules", false, widget);
-            array.forEach(visibilityRules, function(rule) {
-               if (rule.topic && !ruleTopicsObject[rule.topic])
-               {
-                  ruleTopicsObject[rule.topic] = true;
-               }
-            });
-            var invisibilityRules = lang.getObject("config.invisibilityConfig.rules", false, widget);
-            array.forEach(invisibilityRules, function(rule) {
-               if (rule.topic && !ruleTopicsObject[rule.topic])
-               {
-                  ruleTopicsObject[rule.topic] = true;
+            var visibilityRules = lang.getObject("config.visibilityConfig.rules", false, widget) || [];
+            var invisibilityRules = lang.getObject("config.invisibilityConfig.rules", false, widget) || [];
+            array.forEach(visibilityRules.concat(invisibilityRules), function(rule) {
+               if (rule.topic) {
+                  topicNames[rule.topic] = true;
                }
             });
          });
-
-         for (var key in ruleTopicsObject) 
-         {
-            if (ruleTopicsObject.hasOwnProperty(key))
-            {
-               topics.push(key);
-            }
-         }
-         return topics;
+         return Object.keys(topicNames);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ * @since 1.0.33
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, TestCommon) {
+
+      var browser;
+      registerSuite({
+         name: "Dynamic Horizontal Layout Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/DynamicHorizontalLayout", "Dynamic Horizontal Layout Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      });
+   });

--- a/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
@@ -28,18 +28,261 @@ define(["intern!object",
    function(registerSuite, assert, TestCommon) {
 
       var browser;
+      var scrollbarWidth;             // We'll calculate this by deducting the body width from the window width
+      var windowSize = 1050;          // The size we'll set the window
+      var pagePaddingAllocation = 20; // The page has 20px of padding
+      var widgetPadding = 20;         // Each ClassicWindow widget has 20px of padding
+      var scrollbarAllocation = 30;   // 30px is reserved for scrollbar allocation (to prevent accidental overflow)
+      var fixedWidthWidget = 200;     // The fixed width of WIDGET_1
+      var availableWidth;             // We'll calculate this in the setup
+
       registerSuite({
          name: "Dynamic Horizontal Layout Tests",
 
          setup: function() {
             browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/DynamicHorizontalLayout", "Dynamic Horizontal Layout Tests").end();
+            return TestCommon.loadTestWebScript(this.remote, "/DynamicHorizontalLayout", "Dynamic Horizontal Layout Tests").end()
+               // Set a window size and calculate the scrollbar width to assist width calculations...
+               .setWindowSize(null, windowSize, 400)
+               .findByCssSelector("body")
+                  .getSize()
+                  .then(function(size) {
+                     scrollbarWidth = windowSize - size.width;
+                     availableWidth = size.width - pagePaddingAllocation - scrollbarAllocation;
+                  });
          },
 
          beforeEach: function() {
             browser.end();
          },
 
+         // Width calculations...
+         // Window width 1050
+         // Padding = 20px
+         // Scrollbar allocation 30px
+         // Widget 1 = 200px
+         // Widget 2 = 50%
+         // Widget 3, 4, 5 equal share of remaining space
+         // IMPORTANT: All widgets should have 20px deducted for their margins
+
+         "Widget 1 should be 200px on load": function() {
+            return browser.findById("WIDGET_1")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.width, 180, "Widget 1 was not the correct size");
+               });
+         },
+
+         "Widget 2 should be half the remaining space": function() {
+            // Widgets 3 and 4 should be hidden so the width of widget 2 should be 50% of the available space
+            // (minus the fixed widget width)...
+            var expectedWidth = ((availableWidth - fixedWidthWidget) / 2) - widgetPadding;
+            return browser.findById("WIDGET_2")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 2 was not the correct size");
+               });
+         },
+
+         "Widget 3 is hidden on load": function() {
+            return browser.findById("WIDGET_3")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Widget 3 should not have been displayed when the page was loaded");
+               });
+         },
+
+         "Widget 4 is hidden on load": function() {
+            return browser.findById("WIDGET_4")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Widget 4 should not have been displayed when the page was loaded");
+               });
+         },
+
+         "Widget 5 should get half the remaining space": function() {
+            // Widget 5 should get an even share of the remaining space after fixed and percentage width widgets
+            // have had their widths deducted from the available space. Because Widgets 3 and 4 are initially 
+            // hidden, this means that widget 5 should get 50% of the available space (after Widget 1 is deducted)
+            var expectedWidth = ((availableWidth - fixedWidthWidget) / 2) - widgetPadding;
+            return browser.findById("WIDGET_5")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 5 was not the correct size");
+               });
+         },
+
+         "Show Widget 3 (visibility rule)": function() {
+            // Revealing Widget 3 should cause the widgets to recalculate their sizes, Widgets 1 and 2 should
+            // stay the same size, but Widget 3 should consume half of the space that Widget 5 previously had
+            var expectedWidth = ((availableWidth - fixedWidthWidget) / 4) - widgetPadding;
+            return browser.findById("SHOW_WIDGET_3_BUTTON_label")
+               .click()
+            .end()
+            .findById("WIDGET_3")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Widget 3 should have been revealed");
+               })
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 3 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_5")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 5 was not the correct size");
+               });
+         },
+
+         "Show Widget 4 (invisibility rule)": function() {
+            // Revealing Widget 4 should cause the widgets to recalculate their sizes, Widgets 1 and 2 should
+            // stay the same size, but Widgets 3, 4 and 5 should share the space that Widgets 3 and 5 previously
+            // shared
+            var remainingSpace = (availableWidth - ((availableWidth - fixedWidthWidget) / 2)) - fixedWidthWidget;
+            var expectedWidth = (remainingSpace / 3) - widgetPadding;
+            return browser.findById("SHOW_WIDGET_4_BUTTON_label")
+               .click()
+            .end()
+            .findById("WIDGET_4")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Widget 4 should have been revealed");
+               })
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 4 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_3")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 3 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_5")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 5 was not the correct size");
+               });
+         },
+
+         "Hide Widget 1": function() {
+            // Hiding Widget 1 should cause all the remaining widgets to recalculate their sizes
+            // such that Widget 2 has half the available space and Widgets 3,4 and 5 share the remaining space
+            
+            var widget2ExpectedWidth = (availableWidth / 2) - widgetPadding;
+            var otherWidgetsExpectedWidth = ((availableWidth - widget2ExpectedWidth) / 3) - widgetPadding;
+            
+            return browser.findById("HIDE_WIDGET_1_BUTTON_label")
+               .click()
+            .end()
+            .findById("WIDGET_1")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Widget 1 should have been hidden");
+               })
+            .end()
+            .findById("WIDGET_2")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, widget2ExpectedWidth, 10, "Widget 2 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_3")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, otherWidgetsExpectedWidth, 10, "Widget 3 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_4")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, otherWidgetsExpectedWidth, 10, "Widget 4 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_5")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, otherWidgetsExpectedWidth, 10, "Widget 5 was not the correct size");
+               });
+         },
+
+         "Resize the window": function() {
+            // Resizing the window should cause all the widgets to adjust their sizes appropriately to accomodate
+            // the new window size...
+            var widget2ExpectedWidth;
+            var otherWidgetsExpectedWidth;
+            windowSize = 850;
+            return browser.setWindowSize(null, windowSize, 400)
+               .findByCssSelector("body")
+                  .getSize()
+                  .then(function(size) {
+                     scrollbarWidth = windowSize - size.width;
+                     availableWidth = size.width - pagePaddingAllocation - scrollbarAllocation;
+                     widget2ExpectedWidth = (availableWidth / 2) - widgetPadding;
+                     otherWidgetsExpectedWidth = ((availableWidth - widget2ExpectedWidth) / 3) - widgetPadding;
+                  })
+               .end()
+               .findById("WIDGET_2")
+                  .getSize()
+                  .then(function(size) {
+                     assert.closeTo(size.width, widget2ExpectedWidth, 10, "Widget 2 was not the correct size");
+                  })
+               .end()
+               .findById("WIDGET_3")
+                  .getSize()
+                  .then(function(size) {
+                     assert.closeTo(size.width, otherWidgetsExpectedWidth, 10, "Widget 3 was not the correct size");
+                  })
+               .end()
+               .findById("WIDGET_4")
+                  .getSize()
+                  .then(function(size) {
+                     assert.closeTo(size.width, otherWidgetsExpectedWidth, 10, "Widget 4 was not the correct size");
+                  })
+               .end()
+               .findById("WIDGET_5")
+                  .getSize()
+                  .then(function(size) {
+                     assert.closeTo(size.width, otherWidgetsExpectedWidth, 10, "Widget 5 was not the correct size");
+                  });
+         },
+
+         "Hide Widget 2": function() {
+            // Hiding Widget 1 should cause all the remaining widgets to recalculate their sizes
+            // such that Widget 2 has half the available space and Widgets 3,4 and 5 share the remaining space
+            var expectedWidth = (availableWidth / 3) - widgetPadding;
+            
+            return browser.findById("HIDE_WIDGET_2_BUTTON_label")
+               .click()
+            .end()
+            .findById("WIDGET_2")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Widget 1 should have been hidden");
+               })
+            .end()
+            .findById("WIDGET_3")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 3 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_4")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 4 was not the correct size");
+               })
+            .end()
+            .findById("WIDGET_5")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, expectedWidth, 10, "Widget 5 was not the correct size");
+               });
+         },
+         
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,8 +31,8 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest"
+   baseFunctionalSuites: [
+      "src/test/resources/alfresco/layout/BasicLayoutTest"
    ],
 
    /**
@@ -41,7 +41,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,9 +31,8 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   baseFunctionalSuites: [
-      "src/test/resources/alfresco/layout/BasicLayoutTest",
-      "src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest"
+   xbaseFunctionalSuites: [
+      "src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest"
    ],
 
    /**
@@ -42,7 +41,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   xbaseFunctionalSuites: [
+   baseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,8 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    baseFunctionalSuites: [
-      "src/test/resources/alfresco/layout/BasicLayoutTest"
+      "src/test/resources/alfresco/layout/BasicLayoutTest",
+      "src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest"
    ],
 
    /**
@@ -135,6 +136,7 @@ define({
       "src/test/resources/alfresco/layout/AlfStackContainerTest",
       "src/test/resources/alfresco/layout/AlfTabContainerTest",
       "src/test/resources/alfresco/layout/BasicLayoutTest",
+      "src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest",
       "src/test/resources/alfresco/layout/FixedHeaderFooterTest",
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
       "src/test/resources/alfresco/layout/StripedContentTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Dynamic Horizontal Layout</shortname>
+  <description>Demonstrates horizontally laid out widgets resizing as widgets are hidden and revealed</description>
+  <family>aikau-unit-tests</family>
+  <url>/DynamicHorizontalLayout</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.js
@@ -147,7 +147,7 @@ model.jsonModel = {
                   config: {
                      title: "Widget 3",
                      visibilityConfig: {
-                       initialValue: true,
+                       initialValue: false,
                        rules: [
                          {
                            topic: "WIDGET_3_VISIBILITY",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicHorizontalLayout.get.js
@@ -1,0 +1,194 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         id: "HIDE_WIDGET_1_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide widget 1",
+            publishTopic: "WIDGET_1_VISIBILITY",
+            publishPayload: {
+               show: false
+            }
+         }
+      },
+      {
+         id: "SHOW_WIDGET_1_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show widget 1",
+            publishTopic: "WIDGET_1_VISIBILITY",
+            publishPayload: {
+               show: true
+            }
+         }
+      },
+      {
+         id: "HIDE_WIDGET_2_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide widget 2",
+            publishTopic: "WIDGET_2_VISIBILITY",
+            publishPayload: {
+               show: false
+            }
+         }
+      },
+      {
+         id: "SHOW_WIDGET_2_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show widget 2",
+            publishTopic: "WIDGET_2_VISIBILITY",
+            publishPayload: {
+               show: true
+            }
+         }
+      },
+      {
+         id: "HIDE_WIDGET_3_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide widget 3",
+            publishTopic: "WIDGET_3_VISIBILITY",
+            publishPayload: {
+               show: false
+            }
+         }
+      },
+      {
+         id: "SHOW_WIDGET_3_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show widget 3",
+            publishTopic: "WIDGET_3_VISIBILITY",
+            publishPayload: {
+               show: true
+            }
+         }
+      },
+      {
+         id: "HIDE_WIDGET_4_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide widget 4",
+            publishTopic: "WIDGET_4_VISIBILITY",
+            publishPayload: {
+               show: false
+            }
+         }
+      },
+      {
+         id: "SHOW_WIDGET_4_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show widget 4",
+            publishTopic: "WIDGET_4_VISIBILITY",
+            publishPayload: {
+               show: true
+            }
+         }
+      },
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "WIDGET_1",
+                  name: "alfresco/layout/ClassicWindow",
+                  widthPx: 200,
+                  config: {
+                     title: "Widget 1",
+                     visibilityConfig: {
+                       initialValue: true,
+                       rules: [
+                         {
+                           topic: "WIDGET_1_VISIBILITY",
+                           attribute: "show",
+                           is: [true],
+                           strict: true
+                         }
+                       ]
+                     }
+                  }
+               },
+               {
+                  id: "WIDGET_2",
+                  name: "alfresco/layout/ClassicWindow",
+                  widthPc: 50,
+                  config: {
+                     title: "Widget 2",
+                     visibilityConfig: {
+                       initialValue: true,
+                       rules: [
+                         {
+                           topic: "WIDGET_2_VISIBILITY",
+                           attribute: "show",
+                           is: [true],
+                           strict: true
+                         }
+                       ]
+                     }
+                  }
+               },
+               {
+                  id: "WIDGET_3",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Widget 3",
+                     visibilityConfig: {
+                       initialValue: true,
+                       rules: [
+                         {
+                           topic: "WIDGET_3_VISIBILITY",
+                           attribute: "show",
+                           is: [true],
+                           strict: true
+                         }
+                       ]
+                     }
+                  }
+               },
+               {
+                  id: "WIDGET_4",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Widget 4",
+                     invisibilityConfig: {
+                       initialValue: true,
+                       rules: [
+                         {
+                           topic: "WIDGET_4_VISIBILITY",
+                           attribute: "show",
+                           is: [false],
+                           strict: true
+                         }
+                       ]
+                     }
+                  }
+               },
+               {
+                  id: "WIDGET_5",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Widget 5"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-478 to update the alfresco/layout/HorizontalWidgets to take the visibilityConfig and invisibilityConfig of it's child widgets into consideration when calculating the widths of those widgets. It sets up a subscription for each unique topic used across all the visibility rules where each subscription is bound to the onResize function. This means that each time a child of a HorizontalWidgets changes visibility the widths of all the children will be re-calculated to ensure that all the available horizontal space is consumed without overflow.