### PR TITLE
AKU-518: Set call-to-action on certain buttons

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfFormDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfFormDialog.js
@@ -124,7 +124,7 @@ define(["dojo/_base/declare",
                      config: {
                         label: this.dialogConfirmationButtonTitle,
                         disableOnInvalidControls: true,
-                        additionalCssClasses: "alfresco-dialogs-_AlfCreateFormDialogMixin confirmation",
+                        additionalCssClasses: "alfresco-dialogs-_AlfCreateFormDialogMixin confirmation call-to-action",
                         publishTopic: this._formConfirmationTopic
                      }
                   },

--- a/aikau/src/main/resources/alfresco/dialogs/_AlfCreateFormDialogMixin.js
+++ b/aikau/src/main/resources/alfresco/dialogs/_AlfCreateFormDialogMixin.js
@@ -166,7 +166,7 @@ define(["dojo/_base/declare",
                      config: {
                         label: this.dialogConfirmationButtonTitle,
                         disableOnInvalidControls: true,
-                        additionalCssClasses: "alfresco-dialogs-_AlfCreateFormDialogMixin confirmation",
+                        additionalCssClasses: "alfresco-dialogs-_AlfCreateFormDialogMixin confirmation call-to-action",
                         publishTopic: this._formConfirmationTopic
                      }
                   },

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -619,6 +619,17 @@ define(["dojo/_base/declare",
       okButtonLabel: "form.button.ok.label",
       
       /**
+       * Additional CSS clases to apply to the confirmation button on the form. This defaults to
+       * have the "call-to-action" style, but this can be overridden as required.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.33
+       */
+      okButtonClass: "call-to-action",
+
+      /**
        * @instance 
        * @type {string}
        * @default

--- a/aikau/src/main/resources/alfresco/forms/controls/DocumentPicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DocumentPicker.js
@@ -84,7 +84,8 @@ define(["alfresco/forms/controls/Picker",
                                  config: {
                                     label: "picker.ok.label",
                                     publishTopic: "ALF_ITEMS_SELECTED",
-                                    pubSubScope: "{itemSelectionPubSubScope}"
+                                    pubSubScope: "{itemSelectionPubSubScope}",
+                                    additionalCssClasses: "call-to-action"
                                  }
                               },
                               {

--- a/aikau/src/main/resources/alfresco/forms/controls/Picker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Picker.js
@@ -346,7 +346,8 @@ define(["alfresco/forms/controls/BaseFormControl",
                                  config: {
                                     label: "picker.ok.label",
                                     publishTopic: "ALF_ITEMS_SELECTED",
-                                    pubSubScope: "{itemSelectionPubSubScope}"
+                                    pubSubScope: "{itemSelectionPubSubScope}",
+                                    additionalCssClasses: "call-to-action"
                                  }
                               },
                               {

--- a/aikau/src/main/resources/alfresco/forms/controls/SitePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/SitePicker.js
@@ -160,7 +160,8 @@ define(["alfresco/forms/controls/Picker",
                                     config: {
                                        label: "picker.ok.label",
                                        publishTopic: "ALF_ITEMS_SELECTED",
-                                       pubSubScope: "{itemSelectionPubSubScope}"
+                                       pubSubScope: "{itemSelectionPubSubScope}",
+                                       additionalCssClasses: "call-to-action"
                                     }
                                  },
                                  {

--- a/aikau/src/main/resources/alfresco/header/CurrentUserStatus.js
+++ b/aikau/src/main/resources/alfresco/header/CurrentUserStatus.js
@@ -181,7 +181,8 @@ define(["dojo/_base/declare",
                      config: {
                         label: this.message("post.button.label"),
                         publishTopic: this.postNewUserStatusTopic,
-                        publishPayload: payload
+                        publishPayload: payload,
+                        additionalCssClasses: "call-to-action"
                      }
                   },
                   {

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -605,7 +605,8 @@ define(["dojo/_base/declare",
                      name: "alfresco/buttons/AlfButton",
                      config: {
                         label: this.message("thumbnail.preview.dialog.close"),
-                        publishTopic: "NO_OP"
+                        publishTopic: "NO_OP",
+                        additionalCssClasses: "call-to-action"
                      }
                   }
                ],

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -647,7 +647,7 @@ define(["dojo/_base/declare",
                         id: (config.dialogConfirmationButtonId) ? config.dialogConfirmationButtonId : dialogId + "_OK",
                         label: config.dialogConfirmationButtonTitle,
                         disableOnInvalidControls: true,
-                        additionalCssClasses: "confirmationButton",
+                        additionalCssClasses: "confirmationButton call-to-action",
                         publishTopic: this._formConfirmationTopic,
                         publishPayload: {
                            formSubmissionTopic: config.formSubmissionTopic,

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -328,7 +328,7 @@ define(["dojo/_base/declare",
                   name: "alfresco/buttons/AlfButton",
                   config: {
                      label: this.message("services.ActionService.button.cancel"),
-                     additionalCssClasses: "alfresco-dialogs-AlfProgress cancellation",
+                     additionalCssClasses: "alfresco-dialogs-AlfProgress cancellation call-to-action",
                      publishTopic: "ALF_CLOSE_DIALOG"
                   }
                }

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -120,7 +120,8 @@ define(["dojo/_base/declare",
                   {
                      name: "alfresco/buttons/AlfButton",
                      config: {
-                        label: "notification.ok.label"
+                        label: "notification.ok.label",
+                        additionalCssClasses: "call-to-action"
                      }
                   }
                ]

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -480,7 +480,8 @@ define(["dojo/_base/declare",
                         url: "user/" + originalRequestConfig.user + "/dashboard",
                         type: "PAGE_RELATIVE",
                         target: "CURRENT"
-                     }
+                     },
+                     additionalCssClasses: "call-to-action"
                   }
                }
             ]
@@ -613,7 +614,8 @@ define(["dojo/_base/declare",
                   config: {
                      label: this.message("button.leave-site.confirm-label"),
                      publishTopic: "ALF_LEAVE_SITE_CONFIRMATION",
-                     publishPayload: payload
+                     publishPayload: payload,
+                     additionalCssClasses: "call-to-action"
                   }
                },
                {

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -190,7 +190,8 @@ define(["dojo/_base/declare",
                      name: "alfresco/buttons/AlfButton",
                      config: {
                         label: this.message("progress-dialog.ok-button.label"),
-                        publishTopic: okButtonClickTopic
+                        publishTopic: okButtonClickTopic,
+                        additionalCssClasses: "call-to-action"
                      }
                   },
                   {

--- a/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
@@ -147,7 +147,8 @@ define(["dojo/_base/declare",
                      publishPayload: publishPayload,
                      disableOnInvalidControls: true,
                      validTopic: "ALF_PICKER_VALID",
-                     invalidTopic: "ALF_PICKER_INVALID"
+                     invalidTopic: "ALF_PICKER_INVALID",
+                     additionalCssClasses: "call-to-action"
                   }
                },
                {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-518 to set the primary button style (via the "call-to-action" CSS class) onto certain buttons that are created within Aikau.