### PR TITLE
Further updates from the user assistance team

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -994,7 +994,9 @@ define(["dojo/_base/declare",
          {
             this.inlineHelpImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.inlineHelpImg;
          }
-         this.inlineHelpAltText = this.message(this.inlineHelpAltText) + " " + this.message(this.label);
+         this.inlineHelpAltText = this.message(this.inlineHelpAltText, {
+            0: this.message(this.label)
+         });
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/forms/controls/i18n/BaseFormControl.properties
+++ b/aikau/src/main/resources/alfresco/forms/controls/i18n/BaseFormControl.properties
@@ -1,3 +1,3 @@
 validation.control.invalid=invalid
 validation.inprogress.alttext=Validating
-inlinehelp.alttext=Help for:
+inlinehelp.alttext=Click for more information about {0}.


### PR DESCRIPTION
This is a further recommended update from the user assistance team to make the help popup alt text more accessible (it also ensures that localization is used properly with token substitution)