### PR TITLE
AKU-549: Remove default facets from search service

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -230,9 +230,8 @@ define(["dojo/_base/declare",
                sort = (payload.sortField || this.sort) + "|" + (payload.sortAscending || this.sortAscending);
             }
 
-            var defaultFacetFields = "{http://www.alfresco.org/model/content/1.0}content.mimetype,{http://www.alfresco.org/model/content/1.0}modifier.__,{http://www.alfresco.org/model/content/1.0}creator.__,{http://www.alfresco.org/model/content/1.0}description.__";
             var data = {
-               facetFields: payload.facetFields || defaultFacetFields,
+               facetFields: payload.facetFields || "",
                filters: payload.filters || "",
                term: payload.term,
                tag: payload.tag || this.tag,


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-549 to remove the default facets sent by the SearchService on XHR requests to the Search API. We shouldn't be including any default facets if the admin has configured Share to remove all facets.