### PR TITLE
AKU-543: Removed use of bold font on buttons

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -143,7 +143,7 @@
 @standard-button-font-color-focus: @button-color-hover;
 @standard-button-font-color-active: @button-color-active;
 @standard-button-font-color-disabled: @button-color-disabled;
-@standard-button-font-family: @bold-font;
+@standard-button-font-family: @standard-font;
 @standard-button-font-size: @normal-font-size;
 @standard-button-font-weight: normal;
 @standard-button-height: 28px;
@@ -191,7 +191,6 @@
    @standard-button-font-color-focus: @legacy-button-color-text;
    @standard-button-font-color-active: @legacy-button-color-text;
    @standard-button-font-color-disabled: fade(@legacy-button-color-text, 40%);
-   @standard-button-font-family: @standard-font;
    @call-to-action-button-background: @legacy-action-button-color;
    @call-to-action-button-background-focus: @legacy-action-button-color;
    @call-to-action-button-background-active: @legacy-action-button-color;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-543 to remove the use of bold fonts on buttons.