### PR TITLE
Removed obsolete negative margin from Warning component (used in Alfresco Share)

### DIFF
--- a/aikau/src/main/resources/alfresco/header/css/Warning.css
+++ b/aikau/src/main/resources/alfresco/header/css/Warning.css
@@ -7,7 +7,6 @@
    }
 
    .alfresco-header-Warning__warnings {
-      margin: 0 -10px;
       padding: 0.5em 0;
       color: @warning-font-color;
       text-align: center;


### PR DESCRIPTION
Since the warning component is now used to display Share Services AMP version mismatch, it is more visible and shows that an old margin setting is still present - not needed and adds an unwanted horizontal scrollbar.