### PR TITLE
AKU-541: RulesEngine updates

### DIFF
--- a/aikau/src/test/resources/alfresco/forms/controls/utilities/RulesEngineTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/utilities/RulesEngineTest.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"], 
+        function (registerSuite, assert, require, TestCommon, keys) {
+
+   // PLEASE NOTE: There is additional testing for the original rules engine code (that was originally
+   //              part of BaseFormControl) in the TextBoxTest. This test covers updates specific to
+   //              ANY/ALL configuration (See AKU-451)...
+   
+   var browser;
+   registerSuite({
+      name: "Rules Engine Test",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/RulesEngine", "Rules Engine Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "ANY rules widget should NOT be visible on page load": function() {
+         return browser.findById("RULES1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The ANY rules widget should not have been displayed");
+            });
+      },
+
+      "ALL rules widget should NOT be visible on page load": function() {
+         return browser.findById("RULES2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The ALL rules widget should not have been displayed");
+            });
+      },
+
+      "Entering text into first text box should reveal ANY rules widget": function() {
+         return browser.findByCssSelector("#SOURCE1 .dijitInputContainer input")
+            .clearValue()
+            .type("hello")
+         .end()
+         .findById("RULES1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The ANY rules widget should be displayed when one of the source fields has data");
+            })
+         .end()
+         .findById("RULES2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The ALL rules widget should remain hidden when one of the source fields has data");
+            });
+      },
+
+      "Entering text into second text box should reveal ALL rules widget": function() {
+         return browser.findByCssSelector("#SOURCE2 .dijitInputContainer input")
+            .clearValue()
+            .type("hello")
+         .end()
+         .findById("RULES1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The ANY rules widget should remain displayed when both of the source fields have data");
+            })
+         .end()
+         .findById("RULES2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The ALL rules widget should be displayed when both of the source fields have data");
+            });
+      },
+
+      "Removing text from first text box should hide ALL rules widget": function() {
+         return browser.findByCssSelector("#SOURCE2 .dijitInputContainer input")
+            .clearValue()
+            .type(keys.BACKSPACE)
+         .end()
+         .findById("RULES1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The ANY rules widget should remain displayed when the first source field is cleared");
+            })
+         .end()
+         .findById("RULES2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The ALL rules widget should be hidden when the first source field is cleared");
+            });
+      },
+
+      "Removing text from second text box should hide ANY rules widget": function() {
+         return browser.findByCssSelector("#SOURCE1 .dijitInputContainer input")
+            .clearValue()
+            .type(keys.BACKSPACE)
+         .end()
+         .findById("RULES1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The ANY rules widget should be hidden when the first source field is cleared");
+            })
+         .end()
+         .findById("RULES2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The ALL rules widget should remain hidden when the first source field is cleared");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -124,6 +124,8 @@ define({
       "src/test/resources/alfresco/forms/controls/ValidationTest",
       "src/test/resources/alfresco/forms/controls/XssPreventionTest",
 
+      "src/test/resources/alfresco/forms/controls/utilities/RulesEngineTest",
+
       "src/test/resources/alfresco/header/HeaderWidgetsTest",
       "src/test/resources/alfresco/header/SearchBoxTest",
       "src/test/resources/alfresco/header/WarningTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/utilities/RulesEngine.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/utilities/RulesEngine.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Rules Engine Test</shortname>
+  <description>Tests out the ANY/ALL configuration options used by the Rules Engine for controlling visibility, requirement and enablement states.</description>
+  <family>aikau-unit-tests</family>
+  <url>/RulesEngine</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/utilities/RulesEngine.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/utilities/RulesEngine.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/utilities/RulesEngine.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/utilities/RulesEngine.get.js
@@ -1,0 +1,94 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "FORM1",
+         name: "alfresco/forms/Form",
+         config: {
+            widgets: [
+               {
+                  id: "SOURCE1",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "SOURCE1",
+                     name: "test1",
+                     label: "One",
+                     description: "This field is used for evaluating rules"
+                  }
+               },
+               {
+                  id: "SOURCE2",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "SOURCE2",
+                     name: "test2",
+                     label: "Two",
+                     description: "This field is used for evaluating rules"
+                  }
+               },
+               {
+                  id: "RULES1",
+                  name: "alfresco/forms/controls/TextBox", 
+                  config: {
+                     label: "ANY evaluation",
+                     description: "This is displayed is EITHER 'One' or 'Two' is not blank",
+                     value: "",
+                     visibilityConfig: {
+                        initialValue: false,
+                        rulesMethod: "ANY",
+                        rules: [
+                           {
+                              targetId: "SOURCE1",
+                              isNot: ["", null]
+                           },
+                           {
+                              targetId: "SOURCE2",
+                              isNot: ["", null]
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  id: "RULES2",
+                  name: "alfresco/forms/controls/TextBox", 
+                  config: {
+                     label: "ALL evaluation",
+                     description: "This is displayed is BOTH 'One' or 'Two' are not blank",
+                     value: "",
+                     visibilityConfig: {
+                        initialValue: false,
+                        rulesMethod: "ALL",
+                        rules: [
+                           {
+                              targetId: "SOURCE1",
+                              isNot: ["", null]
+                           },
+                           {
+                              targetId: "SOURCE2",
+                              isNot: ["", null]
+                           }
+                        ]
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-541 to provide an additional attribute that can be added to visibilityConfig, requirementConfig and disablementConfig to support OR based evaluation (the default remains as AND based evaluation). The new attribute is "rulesMethod" and if set to any value other than "ANY" will behave exactly as before.