### PR TITLE
AKU-556: Ensure "In folder" link is correct in AlfSearchResult

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -362,8 +362,8 @@ define(["dojo/_base/declare",
          else
          {
             // Create processed path as pathLink on this.currentItem
-            var repo = lang.getObject("site.title", false, this.currentItem) || true;
-            this.currentItem.pathLink = repo ?
+            var isRepo = !lang.exists("site.title", this.currentItem);
+            this.currentItem.pathLink = isRepo ?
                encodeURIComponent("/" + this.currentItem.path.split("/").slice(2).join("/")) :
                encodeURIComponent("/" + this.currentItem.path);
 
@@ -380,7 +380,7 @@ define(["dojo/_base/declare",
                publishPayloadType: "PROCESS",
                publishPayloadModifiers: ["processCurrentItemTokens"],
                publishPayload: {
-                  url: repo ? "repository?path={pathLink}" : "site/{site.shortName}/documentlibrary?path={pathLink}",
+                  url: isRepo ? "repository?path={pathLink}" : "site/{site.shortName}/documentlibrary?path={pathLink}",
                   type: "PAGE_RELATIVE"
                }
             }, this.pathNode);

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -90,6 +90,17 @@ define(["intern!object",
                });
          },
 
+         "Click on 'In folder' link": function() {
+            return browser.findByCssSelector(".alfresco-search-AlfSearchResult:first-child .pathCell .alfresco-renderers-PropertyLink > .inner")
+               .click()
+            .end()
+            
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2F%2Fone%2Ftwo%2Fthree%2Ffour", "In folder link goes to the correct path");
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-556 to ensure that the "In Folder" links in the alfresco/search/AlfSearchResult publish the correct information to link to. The problem was caused by fault logic on determining whether or not the result should be viewed in the context of a site or in the context of the repository.