### PR TITLE
AKU-559: FilteredList fix

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -64,6 +64,7 @@ define(["dojo/_base/declare",
         "alfresco/services/_PreferenceServiceTopicMixin",
         "dojo/_base/lang",
         "dojo/_base/array",
+        "alfresco/menus/AlfMenuBarItem",
         "alfresco/menus/AlfMenuBarSelect",
         "alfresco/menus/AlfMenuGroups",
         "alfresco/menus/AlfMenuGroup",
@@ -73,7 +74,7 @@ define(["dojo/_base/declare",
         "dojo/Deferred",
         "dojo/when"], 
         function(declare, AlfMenuBar, _AlfDocumentListTopicMixin, _PreferenceServiceTopicMixin, lang, array, 
-                 AlfMenuBarSelect, AlfMenuGroups, AlfMenuGroup, AlfCheckableMenuItem, registry, domClass, Deferred, when) {
+                 AlfMenuBarItem, AlfMenuBarSelect, AlfMenuGroups, AlfMenuGroup, AlfCheckableMenuItem, registry, domClass, Deferred, when) {
 
    return declare([AlfMenuBar, _AlfDocumentListTopicMixin, _PreferenceServiceTopicMixin], {
       


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-559 to resolve an issue with filtered lists. The main cause of the problem was a missing dependency in the paginator widget (which resulted in an XHR request being made and through processing out of order) however I've also tidied up the code flow to make it more consistent.