### PR TITLE
AKU-507: Track removal of filters accurately

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -100,6 +100,20 @@ define(["dojo/_base/declare",
       useLocalStorageHashFallbackKey: "ALF_LOCAL_STORAGE_HASH",
 
       /**
+       * This is used to keep track of any filters that are removed from the URL hash. It is reset in each call to
+       * [onFiltersUpdated]{@link module:alfresco/lists/AlfHashList#onFiltersUpdated} and then incremented each time
+       * a filter is removed (because it has become the empty string). This is then referenced in the
+       * [onHashChange]{@link module:alfresco/lists/AlfHashList#onHashChange} in order to determine whether or not 
+       * data reloading needs to occur as a result of filter removal.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.34
+       */
+      ___filtersRemoved: 0,
+
+      /**
        * The AlfHashList is intended to work co-operatively with other widgets on a page to assist with
        * setting the data that should be retrieved. As related widgets are created and publish their initial
        * state they may trigger requests to load data. As such, data loading should not be started until
@@ -242,10 +256,8 @@ define(["dojo/_base/declare",
        */
       onHashChanged: function alfresco_lists_AlfHashList__onHashChanged(payload) {
          // Process the hash...
-         var dataLoaded = false,
-            numCurrentFilters = lang.getObject("currentData.filters.length", false, this),
-            filtersRemoved = !this.dataFilters.length && numCurrentFilters;
-         if(this.doHashVarUpdate(payload, this.updateInstanceValues) || filtersRemoved)
+         var dataLoaded = false;
+         if(this.doHashVarUpdate(payload, this.updateInstanceValues) || this.___filtersRemoved)
          {
             this._updateCoreHashVars(payload);
             if (this._readyToLoad)
@@ -297,23 +309,29 @@ define(["dojo/_base/declare",
        * Handle filters being updated
        *
        * @instance
-       * @override
        */
       onFiltersUpdated: function alfresco_lists_AlfHashList__onFiltersUpdated() {
+         // Reset the filtersRemoved count
+         this.___filtersRemoved = 0;
          if (this.useHash) {
             var filterValues = {};
-            array.forEach(this.dataFilters, function(dataFilter){
+            array.forEach(this.dataFilters, function(dataFilter) {
                var filterValue = dataFilter.value;
-               if(filterValue !== null && typeof filterValue !== "undefined") {
-                  if(typeof filterValue === "string") {
+               if(filterValue !== null && typeof filterValue !== "undefined") 
+               {
+                  if(typeof filterValue === "string") 
+                  {
                      filterValue = lang.trim(filterValue);
-                     if(!filterValue.length) {
-                        filterValue = null; // Remove empty strings from hash
+                     if(!filterValue.length) 
+                     {
+                        // Remove empty strings from hash and update the count of filters removed
+                        filterValue = null; 
+                        this.___filtersRemoved++;
                      }
                   }
                }
                filterValues[dataFilter.name] = filterValue;
-            });
+            }, this);
             hashUtils.updateHash(filterValues);
          } else {
             this.clearViews();

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -185,7 +185,7 @@ define(["alfresco/TestCommon",
             .pressKeys(keys.TAB)
             .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500, "Didn't reload list after filter removal")
+         .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED", 1500, "Didn't reload list after filter removal")
             .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")


### PR DESCRIPTION
This PR addresses the 2nd bug described in the re-opened https://issues.alfresco.com/jira/browse/AKU-507 issue. The problem was that filter removal was not being correctly tracked. Strangely there was a unit test for this that was not failing, however I suspect that this was to do with the topic being searched for.