### PR TITLE
AKU-538: Created HeightMixin module

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -180,7 +180,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_dialogs_AlfDialog__postCreate() {
-         // jshint maxcomplexity:false
+         // jshint maxcomplexity:false, maxstatements:false
          this.inherited(arguments);
 
          // Listen for requests to resize the dialog...
@@ -206,6 +206,12 @@ define(["dojo/_base/declare",
          this.bodyNode = domConstruct.create("div", {
             "class" : "dialog-body"
          }, this.containerNode, "last");
+
+         // Workout a maximum height for the dialog as it should always fit in the window...
+         var docHeight = $(document).height(),
+             clientHeight = $(window).height();
+         var h = (docHeight < clientHeight) ? docHeight : clientHeight;
+         var maxHeight = h - 200;
 
          // Set the dimensions of the body if required...
          domStyle.set(this.bodyNode, {
@@ -239,20 +245,32 @@ define(["dojo/_base/declare",
 
          if (this.widgetsContent)
          {
-            // Workout a maximum height for the dialog as it should always fit in the window...
-            var docHeight = $(document).height(),
-                clientHeight = $(window).height();
-            var h = (docHeight < clientHeight) ? docHeight : clientHeight;
-
+            // This is a slightly unpleasant convergence of CSS and JS, but will suffice for the time being...
+            // There is a "no-padding" CSS class that can be applied which will remove the default padding applied
+            // to the dialog body, if we detect this setting then we should not compensate the content height 
+            // for this padding.
+            var paddingAdjustment = 24;
+            if (this.additionalCssClasses && this.additionalCssClasses.indexOf("no-padding") !== -1)
+            {
+               paddingAdjustment = 0;
+            }
+            
+            var simplePanelHeight = null;
+            if (this.contentHeight)
+            {
+               simplePanelHeight = (parseInt(this.contentHeight, 10) - paddingAdjustment) + "px";
+            }
+            
             // Add widget content to the container node...
             var widgetsNode = domConstruct.create("div", {
-               style: "max-height:" + (h - 200) + "px"
+               style: "max-height:" + maxHeight + "px"
             }, this.bodyNode, "last");
             var bodyModel = [{
                name: "alfresco/layout/SimplePanel",
                assignTo: "_dialogPanel",
                config: {
-                  height: this.contentHeight,
+                  handleOverflow: false,
+                  height: simplePanelHeight,
                   widgets: this.widgetsContent
                }
             }];

--- a/aikau/src/main/resources/alfresco/layout/HeightMixin.js
+++ b/aikau/src/main/resources/alfresco/layout/HeightMixin.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This mixin module provides functions for setting the height of a widget based on a configured 
+ * [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} attribute. By default the standard
+ * approach is for the height to consume the available space from it's initial position down to the
+ * bottom of the screen (assuming the page is initially displayed from the start of the page). However
+ * it is also possible to specify that the height should be taken from a 
+ * [dialog]{@link module:alfresco/dialogs/AlfDialog} in which the widget is placed or for it to be
+ * given a specific height or (if a negative value is provided) for a number of pixels to be deducted
+ * from the available height.
+ * 
+ * @module alfresco/core/HeightMixin
+ * @author Dave Draper
+ * @since 1.0.34
+ */
+define(["dojo/_base/declare",
+        "dojo/aspect",
+        "dojo/_base/lang",
+        "dojo/Deferred",
+        "dojo/dom-style",
+        "dojo/when",
+        "dojo/window",
+        "dijit/registry",
+        "jquery",
+        "jqueryui"], 
+        function(declare, aspect, lang, Deferred, domStyle, when, win, registry, $) {
+   
+   return declare([], {
+      
+      /**
+       * This property allows for the height being set to be compensated for a number of different factors
+       * such as sticky footers or configured padding or margins that might increase the height of the widget
+       * DOM element.
+       * 
+       * @instance
+       * @type {number} 
+       * @default
+       */
+      heightAdjustment: 0,
+      
+      /**
+       * <p>This should be configured to indicate how the height of the widget should be calculated.
+       *   <ul>
+       *     <li>"AUTO" (the default) indicates that the height will be calculated to be the available space from the widgets position
+       * to the bottom of the screen (minus any [heightAdjustment]{@link module:alfresco/layout/HeightMixin#heightAdjustment}).<li>
+       *     <li>"DIALOG" indicates that the height should be taken from the available height of the dialog in which the widget
+       * is displayed.</li>
+       *     <li>Any negative number indicates that the "AUTO" height minus the supplied value will be used.</li>
+       *     <li>Any positive number indicates a fixed height (in pixels) that should be used for the height</li>
+       *   </ul>
+       * </p>
+       * 
+       * @instance
+       * @type {string|number}
+       * @default
+       */
+      heightMode: "AUTO",
+
+      /**
+       * Calculates the height of the supplied element based on the available space using the configured 
+       * [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} setting.
+       * 
+       * @instance
+       * @param {element} domNode The DOM element to calculate the height for.
+       * @returns {number|promise} Either an actual height or a promise of the height (when using the "DIALOG" height mode)
+       */
+      calculateHeight: function alfresco_layout_HeightMixin__calculateHeight(domNode) {
+         var calculatedHeight;
+         if (domNode)
+         {
+            // Get the position of the DOM node and the available view port height...
+            var winBox = win.getBox();
+            
+            // We're using JQuery here to get the offset as it has proved more reliable than either the Dojo margin box
+            // or native browser offsetTop options...
+            var offset = $(domNode).offset().top;
+            var availableHeight = winBox.h - offset - this.heightAdjustment;
+            var heightMode = this.heightMode;
+            if (heightMode === "DIALOG")
+            {
+               calculatedHeight = $(domNode).parentsUntil(".alfresco-dialog-AlfDialog .dialog-body").last().innerHeight();
+               if (!calculatedHeight)
+               {
+                  // When using the DIALOG mode it is necessary to return a promise of the height because it won't 
+                  // be possible to know the height until the dialog is displayed.
+                  var containingDialog = registry.byNode($(domNode).parents(".alfresco-dialog-AlfDialog")[0]);
+                  if (containingDialog)
+                  {
+                     var heightAdjustment = this.heightAdjustment; // Required to compensate for lack of *this*
+                     calculatedHeight = new Deferred();
+                     this.own(aspect.after(containingDialog, "_onFocus", function() {
+                        var dialogHeight = $(domNode).parentsUntil(".alfresco-dialog-AlfDialog .dialog-body").first().innerHeight();
+                        calculatedHeight.resolve(dialogHeight - heightAdjustment);
+                     }, true));
+                  }
+               }
+               else
+               {
+                  calculatedHeight -= this.heightAdjustment; // Deduct the adjustment value...
+               }
+            }
+            else if (!heightMode || heightMode === "AUTO" || isNaN(heightMode))
+            {
+               calculatedHeight =  availableHeight;
+            }
+            else if (heightMode < 0)
+            {
+               // If the height mode is a number less than zero, then deduct that height from the available space.
+               calculatedHeight = availableHeight + heightMode; // NOTE: Not a mistake, remember adding a negative number substracts! :)
+            }
+            else
+            {
+               calculatedHeight = heightMode;
+            }
+         }
+         return calculatedHeight;
+      },
+
+      /**
+       * This sets the height of the supplied DOM element with the height returned from a call to the
+       * [calculateHeight]{@link module:alfresco/layout/HeightMixin#calculateHeight} function.
+       * 
+       * @instance
+       * @param {element} domNode The DOM element to set the height for.
+       */
+      setHeight: function alfresco_layout_HeightMixin__setHeight(domNode) {
+         var height = this.calculateHeight(domNode);
+         if (height || height === 0)
+         {
+            when(height, lang.hitch(this, function(value) {
+               domStyle.set(domNode, "height", value + "px");
+            }));
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
@@ -28,6 +28,7 @@
  * @mixes external:dojo/_TemplatedMixin
  * @mixes external:dojo/_OnDijitClickMixin
  * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/layout/HeightMixin
  * @mixes module:alfresco/core/ResizeMixin
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
  * @author Dave Draper
@@ -37,6 +38,7 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dijit/_OnDijitClickMixin",
         "alfresco/core/Core",
+        "alfresco/layout/HeightMixin",
         "alfresco/core/ResizeMixin",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/topics",
@@ -46,12 +48,11 @@ define(["dojo/_base/declare",
         "dojo/dom-class",
         "dojo/dom-construct",
         "dojo/dom-style",
-        "dojo/dom-geometry",
-        "dojo/window"],
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, AlfCore, ResizeMixin, _MultiItemRendererMixin, 
-                 topics, template, lang, array, domClass, domConstruct, domStyle, domGeom, win) {
+        "dojo/dom-geometry"],
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, AlfCore, HeightMixin, ResizeMixin, _MultiItemRendererMixin, 
+                 topics, template, lang, array, domClass, domConstruct, domStyle, domGeom) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ResizeMixin, _MultiItemRendererMixin, AlfCore], {
+   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, HeightMixin, ResizeMixin, _MultiItemRendererMixin, AlfCore], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -223,13 +224,7 @@ define(["dojo/_base/declare",
             }
             else
             {
-               // Calculate a suitable height...
-               // We're going to set the height to be as big as the viewing port allows
-               // from the starting vertical position of the node
-               var position = domGeom.position(this.domNode);
-               var viewPort = win.getBox();
-               this.height = viewPort.h - position.y;
-               this.height += "px";
+               this.height = this.calculateHeight(this.domNode) + "px";
             }
          }
       },

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/PdfJs.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/PdfJs.js
@@ -503,7 +503,6 @@ define(["dojo/_base/declare",
 
          // Set height of the container and the viewer area
          this._setPreviewerElementHeight();
-         this._setViewerHeight();
 
          // Load the PDF itself
          this._loadPdf();
@@ -587,47 +586,44 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      _setViewerHeight: function alfresco_preview_PdfJs_PdfJs__setViewerHeight() {
-         var pE = this.previewManager.getPreviewerElement();
-         if (pE)
+      setHeight: function alfresco_preview_PdfJs_PdfJs__setHeight(/*jshint unused:false*/ domNode) {
+         this.inherited(arguments);
+         var computedStyle = domStyle.getComputedStyle(this.viewer.parentNode);
+         var previewRegion = domGeom.getContentBox(this.viewer.parentNode, computedStyle);
+         computedStyle = domStyle.getComputedStyle(this.controls);
+         var controlRegion = domGeom.getContentBox(this.controls, computedStyle);
+         var controlHeight = !this.fullscreen ? controlRegion.h : 0;
+         var newHeight = previewRegion.h - controlHeight -1; // Allow for bottom border
+         
+         if (newHeight === 0)
          {
-            var computedStyle = domStyle.getComputedStyle(this.viewer.parentNode);
-            var previewRegion = domGeom.getContentBox(this.viewer.parentNode, computedStyle);
-            computedStyle = domStyle.getComputedStyle(this.controls);
-            var controlRegion = domGeom.getContentBox(this.controls, computedStyle);
-            var controlHeight = !this.fullscreen ? controlRegion.h : 0;
-            var newHeight = previewRegion.h - controlHeight -1; // Allow for bottom border
-            
-            if (newHeight === 0)
+            if (!this.maximized)
             {
-               if (!this.maximized)
-               {
-                  // var dialogPane;
-                  var previewHeight;
-                  var docHeight = $(document).height(),
-                      clientHeight = $(window).height();
-                  // Take the smaller of the two
-                  previewHeight = ((docHeight < clientHeight) ? docHeight : clientHeight) - 220;
-                  // Leave space for header etc.
-                  newHeight = previewHeight - 10 - controlHeight -1; // Allow for bottom border of 1px
-               }
-               else
-               {
-                  newHeight = $(window).height() - controlHeight - 1;
-               }
-            }
-            
-            if (!this.fullscreen)
-            {
-               this.alfLog("log","Setting viewer height to " + newHeight + "px (toolbar " + controlHeight + "px, container " + previewRegion.h + "px");
-               domStyle.set(this.viewer, "height", newHeight.toString() + "px");
-               domStyle.set(this.sidebar, "height", newHeight.toString() + "px");
+               // var dialogPane;
+               var previewHeight;
+               var docHeight = $(document).height(),
+                   clientHeight = $(window).height();
+               // Take the smaller of the two
+               previewHeight = ((docHeight < clientHeight) ? docHeight : clientHeight) - 220;
+               // Leave space for header etc.
+               newHeight = previewHeight - 10 - controlHeight -1; // Allow for bottom border of 1px
             }
             else
             {
-               this.alfLog("log","Setting viewer height to 100% (full-screen)");
-               domStyle.set(this.viewer, "height", "100%");
+               newHeight = $(window).height() - controlHeight - 1;
             }
+         }
+         
+         if (!this.fullscreen)
+         {
+            this.alfLog("log","Setting viewer height to " + newHeight + "px (toolbar " + controlHeight + "px, container " + previewRegion.h + "px");
+            domStyle.set(this.viewer, "height", newHeight.toString() + "px");
+            domStyle.set(this.sidebar, "height", newHeight.toString() + "px");
+         }
+         else
+         {
+            this.alfLog("log","Setting viewer height to 100% (full-screen)");
+            domStyle.set(this.viewer, "height", "100%");
          }
       },
 
@@ -1561,7 +1557,6 @@ define(["dojo/_base/declare",
       onMaximizeClick : function alfresco_preview_PdfJs_PdfJs__onMaximizeClick(payload) {
          this.maximized = payload.selected;
          this._setPreviewerElementHeight();
-         this._setViewerHeight();
          this.documentView.setScale(this.documentView.parseScale(this.currentScaleSelection ? this.currentScaleSelection : this.attributes.defaultScale));
          this._scrollToPage(this.pageNum);
          this.documentView.alignRows();
@@ -1612,7 +1607,6 @@ define(["dojo/_base/declare",
          {
             this.alfLog("log","onRecalculatePreviewLayout");
             this._setPreviewerElementHeight();
-            this._setViewerHeight();
             this.documentView.onResize();
             this.documentView.setScale(this.documentView.parseScale(this.currentScaleSelection ? this.currentScaleSelection : this.attributes.defaultScale));
             this._scrollToPage(this.pageNum);

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -581,7 +581,7 @@ define(["dojo/_base/declare",
             this.publishTopic = "ALF_CREATE_DIALOG_REQUEST";
             this.publishPayload = {
                contentWidth: (vs.w*0.7) + "px",
-               contentHeight: (vs.h-64) + "px",
+               contentHeight: (vs.h-250) + "px",
                handleOverflow: false,
                dialogTitle: this.imgTitle,
                additionalCssClasses: "no-padding",

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest.js
@@ -629,8 +629,25 @@ define([
          },
 
          "Clicking folder loads new folder": function() {
-            // Not yet implemented
-            // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
+            return browser.findByCssSelector("body").clearLog().end()
+               
+            .findByCssSelector("#PAGED_PAGINATOR_PAGE_SELECTOR")
+               .click()
+            .end()
+
+            .findByCssSelector("#PAGED_PAGINATOR_PAGE_SELECTOR_dropdown .alfresco-menus-AlfMenuItem:first-child")
+               .click()
+            .end()
+
+            .getLastPublish("PAGED_ALF_DOCLIST_REQUEST_FINISHED", true, "Did not load first page of results")
+
+            .clearLog()
+
+            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS li:first-child .alfresco-renderers-Thumbnail .inner img")
+               .click()
+            .end()
+
+            .getLastPublish("PAGED_ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS", "Did not load data");
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
+++ b/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a unit test for the HeightMixin
+ *
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+       function(registerSuite, assert, TestCommon) {
+
+   var windowHeight;
+   var browser;
+   registerSuite({
+      name: "HeightMixin tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/HeightMixin", "HeightMixin Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowHeight = size.height - 20; // PLEASE NOTE: 20 pixels deducted for test page padding
+            })
+         .end();
+      },
+
+      "Check AUTO height": function() {
+         return browser.findById("AUTO")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, windowHeight, "Height not calculated correctly");
+            });
+      },
+
+      "Check AUTO height (with adjustment)": function() {
+         return browser.findById("AUTO_WITH_ADJUSTMENT")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, windowHeight - 50, "Height not calculated correctly");
+            });
+      },
+
+      "Check FIXED height": function() {
+         return browser.findById("FIXED")
+            .getSize()
+            .then(function(size) {
+               // NOTE: Extra 2 pixels for border compensation
+               assert.equal(size.height, 202, "Height not calculated correctly");
+            });
+      },
+
+      "Check MINUS height": function() {
+         return browser.findById("MINUS")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, windowHeight - 100, "Height not calculated correctly");
+            });
+      },
+
+      "Show dialog with no padding and fixed height": function() {
+         return browser.findById("LAUNCH_DIALOG_1_label")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_1.dialogDisplayed")
+         .end()
+         .findById("DIALOG_1_TEST")
+            .getSize()
+            .then(function(size) {
+               // Height is the dialog content height minus 2px adjustment to show border
+               assert.equal(size.height, 300, "Height not calculated correctly");
+            })
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_1 .dijitDialogCloseIcon")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_1.dialogHidden")
+         .end();
+      },
+
+      "Show dialog with padding and fixed height": function() {
+         return browser.findById("LAUNCH_DIALOG_2_label")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_2.dialogDisplayed")
+         .end()
+         .findById("DIALOG_2_TEST")
+            .getSize()
+            .then(function(size) {
+               // Height is minus the standard border adjustment of 24 pixels
+               assert.equal(size.height, 76, "Height not calculated correctly");
+            })
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_2 .dijitDialogCloseIcon")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_2.dialogHidden")
+         .end();
+      },
+
+      "Show dialog with defaults": function() {
+         return browser.findById("LAUNCH_DIALOG_3_label")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_3.dialogDisplayed")
+         .end()
+         .findById("DIALOG_3_TEST")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, 18, "Height not calculated correctly");
+            })
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_3 .dijitDialogCloseIcon")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_3.dialogHidden")
+         .end();
+      },
+
+      "Show dialog with buttons": function() {
+         return browser.findById("LAUNCH_DIALOG_4_label")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_4.dialogDisplayed")
+         .end()
+         .findById("DIALOG_4_TEST")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.height, 18, "Height not calculated correctly");
+            })
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_4 .dijitDialogCloseIcon")
+            .click()
+         .end()
+         .findByCssSelector("#HEIGHT_DIALOG_4.dialogHidden")
+         .end();
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -140,6 +140,7 @@ define({
       "src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest",
       "src/test/resources/alfresco/layout/FixedHeaderFooterTest",
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
+      "src/test/resources/alfresco/layout/HeightMixinTest",
       "src/test/resources/alfresco/layout/StripedContentTest",
       "src/test/resources/alfresco/layout/TwisterTest",
       "src/test/resources/alfresco/layout/VerticalRevealTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>HeightMixin Test Page</shortname>
+  <description>This WebScript defines the test page for testing the alfresco/layout/HeightMixin module</description>
+  <family>aikau-unit-tests</family>
+  <url>/HeightMixin</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.js
@@ -1,0 +1,174 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DialogService"
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgetMarginLeft: 10,
+            widgetMarginRight: 10,
+            widgets: [
+               {
+                  id: "AUTO",
+                  name: "aikauTesting/widgets/TestHeight",
+                  config: {
+                     heightMode: "AUTO",
+                     label: "Client height"
+                  }
+               },
+               {
+                  id: "AUTO_WITH_ADJUSTMENT",
+                  name: "aikauTesting/widgets/TestHeight",
+                  config: {
+                     heightMode: "AUTO",
+                     heightAdjustment: 50,
+                     label: "Client height with adjustment"
+                  }
+               },
+               {
+                  id: "FIXED",
+                  name: "aikauTesting/widgets/TestHeight",
+                  config: {
+                     heightMode: 200,
+                     label: "200px"
+                  }
+               },
+               {
+                  id: "MINUS",
+                  name: "aikauTesting/widgets/TestHeight",
+                  config: {
+                     heightMode: -100,
+                     label: "Client height minus 100px"
+                  }
+               },
+               {
+                  id: "DIALOG_LAUNCH_PANEL",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Dialog launch panel",
+                     widgets: [
+                        {
+                           id: "LAUNCH_DIALOG_1",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "No padding, 300px",
+                              publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                              publishPayload: {
+                                 dialogId: "HEIGHT_DIALOG_1",
+                                 dialogTitle: "Dialog",
+                                 contentWidth: "700px",
+                                 contentHeight: "300px",
+                                 additionalCssClasses: "no-padding",
+                                 widgetsContent: [
+                                    {
+                                       id: "DIALOG_1_TEST",
+                                       name: "aikauTesting/widgets/TestHeight",
+                                       config: {
+                                          heightMode: "DIALOG",
+                                          heightAdjustment: 2,
+                                          label: "Dialog body height (300px)"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        },
+                        {
+                           id: "LAUNCH_DIALOG_2",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Padding, 100px",
+                              publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                              publishPayload: {
+                                 dialogId: "HEIGHT_DIALOG_2",
+                                 dialogTitle: "Dialog",
+                                 contentWidth: "700px",
+                                 contentHeight: "100px",
+                                 widgetsContent: [
+                                    {
+                                       id: "DIALOG_2_TEST",
+                                       name: "aikauTesting/widgets/TestHeight",
+                                       config: {
+                                          heightMode: "DIALOG",
+                                          heightAdjustment: 2,
+                                          label: "Dialog body height (200px)"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        },
+                        {
+                           id: "LAUNCH_DIALOG_3",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "No height, defaults",
+                              publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                              publishPayload: {
+                                 dialogId: "HEIGHT_DIALOG_3",
+                                 dialogTitle: "Dialog",
+                                 widgetsContent: [
+                                    {
+                                       id: "DIALOG_3_TEST",
+                                       name: "aikauTesting/widgets/TestHeight",
+                                       config: {
+                                          heightMode: "DIALOG",
+                                          heightAdjustment: 2,
+                                          label: "Dialog body height (auto)"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        },
+                        {
+                           id: "LAUNCH_DIALOG_4",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Height, defaults, buttons",
+                              publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                              publishPayload: {
+                                 dialogId: "HEIGHT_DIALOG_4",
+                                 dialogTitle: "Dialog",
+                                 widgetsContent: [
+                                    {
+                                       id: "DIALOG_4_TEST",
+                                       name: "aikauTesting/widgets/TestHeight",
+                                       config: {
+                                          heightMode: "DIALOG",
+                                          heightAdjustment: 2,
+                                          label: "Dialog body height (auto)"
+                                       }
+                                    }
+                                 ],
+                                 widgetsButtons: [
+                                    {
+                                       name: "alfresco/buttons/AlfButton",
+                                       config: {
+                                          label: "Done",
+                                          publishTopic: "NO_OP"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+               
+            ]
+         }
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/TestHeight.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/TestHeight.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @module aikauTesting/widgets/TestHeight
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/layout/HeightMixin
+ * @mixes module:alfresco/core/Core
+ * @author Dave Draper
+ * @since 1.0.34
+ */
+define(["dojo/_base/declare",
+        "dijit/_WidgetBase", 
+        "dijit/_TemplatedMixin",
+        "dojo/text!./templates/TestHeight.html",
+        "alfresco/layout/HeightMixin",
+        "alfresco/core/Core"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, HeightMixin, AlfCore) {
+   
+   return declare([_WidgetBase, _TemplatedMixin, HeightMixin, AlfCore], {
+
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance cssRequirements {Array}
+       * @type {object[]}
+       * @default [{cssFile:"./css/TestHeight.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/TestHeight.css"}],
+      
+      /**
+       * The HTML template to use for the widget.
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
+
+      /**
+       * Call setHeight to set the height
+       * @instance
+       */
+      postMixInProperties: function aikauTesting_widgets_TestHeight__postMixInProperties() {
+         this.label = this.label || "";
+      },
+
+      /**
+       * Call setHeight to set the height
+       * @instance
+       */
+      postCreate: function aikauTesting_widgets_TestHeight__postCreate() {
+         this.setHeight(this.domNode);
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/css/TestHeight.css
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/css/TestHeight.css
@@ -1,0 +1,3 @@
+.aikauTesting-layout-TestHeight {
+   border: @standard-border;
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/templates/TestHeight.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/templates/TestHeight.html
@@ -1,0 +1,1 @@
+<div class="aikauTesting-layout-TestHeight">${label}</div>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-538 to primarily ensure that the preview carousel in the FilmStripView is the correct height but also provides a new mixin that can be used for setting height of widgets. Tests have been updated and tweaks have been made to the way that dialogs and previews are displayed in order to get the optimum sizes.