### PR TITLE
AKU-556: Added support for site deletion with redirect

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -116,6 +116,22 @@ define([],function() {
       DELETE_CONTENT: "ALF_DELETE_CONTENT_REQUEST",
 
       /**
+       * This topic is published to request the deletion of a site.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       *
+       * @event module:alfresco/core/topics~DELETE_SITE
+       * @property {object} [redirect] - The redirect data to use after successfully deleting the site
+       * @property {string} [redirect.url] - The URL to navigate to
+       * @property {string} [redirect.type="PAGE_RELATIVE"] - The type of navigation, either "PAGE_RELATIVE", "CONTEXT_RELATIVE", "FULL_PATH" or "HASH"
+       * @property {string} [redirect.target=CURRENT"] - Whether to use the current tab ("CURRENT") or open in a new tab ("NEW")
+       */
+      DELETE_SITE: "ALF_DELETE_SITE",
+
+      /**
        * This topic is published to request either the download of a single document or folder (or a selection
        * of documents and folder) as a ZIP file.
        * 
@@ -201,6 +217,21 @@ define([],function() {
       GET_PREFERENCE: "ALF_PREFERENCE_GET",
 
       /**
+       * This topic can be published to request navigation to another URL.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       *
+       * @event module:alfresco/core/topics~NAVIGATE_TO_PAGE
+       * @property {string} url - The URL to navigate to
+       * @property {string} [type="PAGE_RELATIVE"] - The type of navigation, either "PAGE_RELATIVE", "CONTEXT_RELATIVE", "FULL_PATH" or "HASH"
+       * @property {string} [target=CURRENT"] - Whether to use the current tab ("CURRENT") or open in a new tab ("NEW")
+       */
+      NAVIGATE_TO_PAGE: "ALF_NAVIGATE_TO_PAGE",
+
+      /**
        * This topic is fired automatically whenever a notification is destroyed.
        *
        * @instance
@@ -232,6 +263,22 @@ define([],function() {
       PATH_CHANGED: "ALF_DOCUMENTLIST_PATH_CHANGED",
 
       /**
+       * This topic can be published to request to POST data to a new page
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       *
+       * @event module:alfresco/core/topics~POST_TO_PAGE
+       * @property {string} url - The URL to navigate to
+       * @property {string} [type="PAGE_RELATIVE"] - The type of navigation, either "PAGE_RELATIVE", "CONTEXT_RELATIVE", "FULL_PATH" or "HASH"
+       * @property {string} [target=CURRENT"] - Whether to use the current tab ("CURRENT") or open in a new tab ("NEW")
+       * @property {object} [parameters={}] - The parameters to include in the POST
+       */
+      POST_TO_PAGE: "ALF_POST_TO_PAGE",
+
+      /**
        * This topic is published to indicate that data needs to be uploaded. This is typically list based data but can
        * be used by other widgets.
        *
@@ -241,6 +288,18 @@ define([],function() {
        * @since 1.0.34
        */
       RELOAD_DATA_TOPIC: "ALF_DOCLIST_RELOAD_DATA",
+
+      /**
+       * This topic can be published to request to reload the current page
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       *
+       * @event module:alfresco/core/topics~RELOAD_PAGE
+       */
+      RELOAD_PAGE: "ALF_RELOAD_PAGE",
 
       /**
        * Called to start off the archiving process.

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -61,6 +61,9 @@ define(["dojo/_base/declare",
        * @listens reloadPageTopic
        * @listens postToPageTopic
        * @since 1.0.32
+       * @listens module:alfresco/core/topics~event:NAVIGATE_TO_PAGE
+       * @listens module:alfresco/core/topics~event:RELOAD_PAGE
+       * @listens module:alfresco/core/topics~event:POST_TO_PAGE
        */
       registerSubscriptions: function alfresco_services_NavigationService__registerSubscriptions() {
          this.alfSubscribe(this.navigateToPageTopic, lang.hitch(this, this.navigateToPage));
@@ -97,6 +100,7 @@ define(["dojo/_base/declare",
        * @return {string} The built URL
        */
       buildUrl: function alfresco_services_NavigationService__buildUrl(data) {
+         // jshint maxcomplexity:false
          var url;
          if (!data.type || data.type === this.sharePageRelativePath || data.type === this.pageRelativePath)
          {

--- a/aikau/src/main/resources/alfresco/services/_NavigationServiceTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_NavigationServiceTopicMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -26,8 +26,9 @@
  * @module alfresco/services/_NavigationServiceTopicMixin
  * @author Dave Draper
  */
-define(["dojo/_base/declare"],
-        function(declare) {
+define(["dojo/_base/declare",
+        "alfresco/core/topics"],
+        function(declare, topics) {
 
    return declare(null, {
 
@@ -35,31 +36,28 @@ define(["dojo/_base/declare"],
        * This topic is used to request that the browser displays a new page.
        *
        * @instance
-       * @event navigateToPageTopic
        * @type {string}
        * @default
        */
-      navigateToPageTopic: "ALF_NAVIGATE_TO_PAGE",
+      navigateToPageTopic: topics.NAVIGATE_TO_PAGE,
 
       /**
        * This topic is used to request that the current page be reloaded
        *
        * @instance
-       * @event reloadPageTopic
        * @type {string}
        * @default
        */
-      reloadPageTopic: "ALF_RELOAD_PAGE",
+      reloadPageTopic: topics.RELOAD_PAGE,
 
       /**
        * This topic is used to request a post to the page
        *
        * @instance
-       * @event postToPageTopic
        * @type {string}
        * @default
        */
-      postToPageTopic: "ALF_POST_TO_PAGE",
+      postToPageTopic: topics.POST_TO_PAGE,
 
       /**
        * This value is used to indicate that the supplied URL is relative to the Alfresco Page context (e.g. /share/page)
@@ -77,7 +75,6 @@ define(["dojo/_base/declare"],
        * @instance
        * @type {string}
        * @default
-       * @deprecated Since 1.0.17 - Use 
        */
       pageRelativePath: "PAGE_RELATIVE",
 

--- a/aikau/src/test/resources/alfresco/services/DeleteSiteTest.js
+++ b/aikau/src/test/resources/alfresco/services/DeleteSiteTest.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "Delete Site Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/DeleteSite", "Delete Site Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Delete with redirect": function () {
+         // Open the drop-down menu...
+         return browser.findById("MENUBAR_POPUP_text")
+            .click()
+         .end()
+
+         // Click the delete with redirect menu item...
+         .findById("DELETE_WITH_REDIRECT_text")
+            .click()
+         .end()
+
+         // Wait for the confirmation dialog...
+         .findByCssSelector("#ALF_SITE_SERVICE_DIALOG.dialogDisplayed")
+         .end()
+
+         // Confirm deletion...
+         .findById("ALF_SITE_SERVICE_DIALOG_CONFIRMATION_label")
+            .click()
+         .end()
+
+         // Check for redirect...
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", "user/guest/dashboard", "Wrong URL");
+               assert.propertyVal(payload, "type", "PAGE_RELATIVE", "Wrong type");
+               assert.propertyVal(payload, "target", "CURRENT", "Wrong target");
+            })
+
+         // Clear the logs for the next test
+         .clearLog();
+      },
+
+      "Delete with reload": function () {
+         // Open the drop-down menu...
+         return browser.findById("MENUBAR_POPUP_text")
+            .click()
+         .end()
+
+         // Click the delete with reload menu item...
+         .findById("DELETE_WITH_RELOAD_text")
+            .click()
+         .end()
+
+         // Wait for the confirmation dialog...
+         .findByCssSelector("#ALF_SITE_SERVICE_DIALOG.dialogDisplayed")
+         .end()
+
+         // Confirm deletion...
+         .findById("ALF_SITE_SERVICE_DIALOG_CONFIRMATION_label")
+            .click()
+         .end()
+
+         // Check for redirect...
+         .getLastPublish("ALF_DOCLIST_RELOAD_DATA", "No reload topic published")
+
+         // Clear the logs for the next test
+         .clearLog();
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/upload/UploadTargetTest"
+      "src/test/resources/alfresco/services/DeleteSiteTest"
    ],
 
    /**
@@ -225,6 +225,7 @@ define({
       "src/test/resources/alfresco/services/ActionServiceTest",
       "src/test/resources/alfresco/services/ContentServiceTest",
       "src/test/resources/alfresco/services/CrudServiceTest",
+      "src/test/resources/alfresco/services/DeleteSiteTest",
       "src/test/resources/alfresco/services/DialogServiceTest",
       "src/test/resources/alfresco/services/NavigationServiceTest",
       "src/test/resources/alfresco/services/NotificationServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DeleteSite.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DeleteSite.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Delete Site (via SiteService)</shortname>
+  <description>Displays buttons that exercise the site delete capabilities of the SiteService.</description>
+  <family>aikau-unit-tests</family>
+  <url>/DeleteSite</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DeleteSite.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DeleteSite.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DeleteSite.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DeleteSite.get.js
@@ -1,0 +1,71 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/SiteService",
+      "alfresco/services/DialogService"
+   ],
+   widgets:[
+      {
+         id: "MENUBAR",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "MENUBAR_POPUP",
+                  name: "alfresco/menus/AlfMenuBarPopup",
+                  config: {
+                     label: "Delete Site Actions",
+                     widgets: [
+                        {
+                           id: "DELETE_WITH_REDIRECT",
+                           name: "alfresco/menus/AlfMenuItem",
+                           config: {
+                              label: "Delete site (redirect)",
+                              iconClass: "alf-delete-20-icon",
+                              publishTopic: "ALF_DELETE_SITE",
+                              publishPayload: {
+                                 shortName: "site1",
+                                 redirect: {
+                                    url: "user/guest/dashboard",
+                                    type: "PAGE_RELATIVE",
+                                    target: "CURRENT"
+                                 }
+                              }
+                           }
+                        },
+                        {
+                           id: "DELETE_WITH_RELOAD",
+                           name: "alfresco/menus/AlfMenuItem",
+                           config: {
+                              label: "Delete site (reload)",
+                              iconClass: "alf-delete-20-icon",
+                              publishTopic: "ALF_DELETE_SITE",
+                              publishPayload: {
+                                 shortName: "site1"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/SiteMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -185,7 +185,7 @@ model.jsonModel = {
          config: {
             id: "GET_SITE_MEMBERSHIPS_BAD1",
             label: "Get Site Memberships Bad 1",
-            publishTopic: "ALF_GET_SITE_MEMBERSHIPS",
+            publishTopic: "ALF_GET_SITE_MEMBERSHIPS"
          }
       },
       {
@@ -369,7 +369,7 @@ model.jsonModel = {
          config: {
             id: "GET_RECENT_SITES_BAD1",
             label: "Get Recent Sites Bad 1",
-            publishTopic: "ALF_GET_RECENT_SITES",
+            publishTopic: "ALF_GET_RECENT_SITES"
          }
       },
 
@@ -389,7 +389,7 @@ model.jsonModel = {
          config: {
             id: "GET_FAVOURITE_SITES_BAD1",
             label: "Get Favourite Sites Bad 1",
-            publishTopic: "ALF_GET_FAVOURITE_SITES",
+            publishTopic: "ALF_GET_FAVOURITE_SITES"
          }
       },
 
@@ -589,9 +589,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-566 to add support for optional redirect when deleting sites.