### PR TITLE
AKU-558: Suppress text-decoration on menu links

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -168,6 +168,8 @@ define(["dojo/_base/declare",
          this.set("label", this.label);
          this.inherited(arguments);
 
+         domClass.add(this.domNode, "alfresco-menus-_AlfMenuItemMixin");
+
          // Set up a handler for onContextMenu actions (e.g. right-clicks), although by default this will perform no action...
          on(this.domNode, "contextmenu", lang.hitch(this, "onContextMenu"));
          this.makeAnchor(this.targetUrl, this.targetUrlType);

--- a/aikau/src/main/resources/alfresco/menus/css/_AlfMenuItemMixin.css
+++ b/aikau/src/main/resources/alfresco/menus/css/_AlfMenuItemMixin.css
@@ -23,6 +23,11 @@
    height: 20px;
 }
 
+.alfresco-menus-_AlfMenuItemMixin a.alfresco-navigation-_HtmlAnchorMixin,
+.alfresco-menus-_AlfMenuItemMixin a.alfresco-navigation-_HtmlAnchorMixin:hover {
+    text-decoration: none;
+}
+
 .alfresco-share .dijitIcon.dijitMenuItemIcon.alf-edit-icon {
    background: url("./images/Edit.png");
    background-repeat: no-repeat;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-558 to suppress text-decoration in any menu item regardless of whether or not it is a link.