### PR TITLE
AKU-563: Inline Edit update re-rendering support

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ObjectTypeUtils.js
+++ b/aikau/src/main/resources/alfresco/core/ObjectTypeUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -49,7 +49,7 @@ define(["dojo/_base/lang"],
        * @returns {boolean} Returns true if the supplied value is a boolean
        */
       isBoolean: function(value) {
-        return typeof value === 'boolean';
+        return typeof value === "boolean";
       },
 
       /**
@@ -60,7 +60,7 @@ define(["dojo/_base/lang"],
        * @returns {boolean} Returns true if the supplied value is a number
        */
       isNumber: function(value) {
-        return typeof value === 'number' && isFinite(value);
+        return typeof value === "number" && isFinite(value);
       },
       
       /**
@@ -93,7 +93,7 @@ define(["dojo/_base/lang"],
        * @returns {boolean} Returns true if the supplied value is undefined
        */
       isUndefined: function alfresco_core_ObjectTypeUtils__isUndefined(value) {
-        return typeof value === 'undefined';
+        return typeof value === "undefined";
       },
 
       /**
@@ -105,7 +105,7 @@ define(["dojo/_base/lang"],
        * @return {boolean} Flag indicating whether the value is set or not.
        */
       isValueSet: function alfresco_core_ObjectTypeUtils__isValueSet(value, allowEmptyString) {
-         if (this.isUndefined(value) || value == null)
+         if (this.isUndefined(value) || value === null)
          {
             return false;
          }

--- a/aikau/src/main/resources/alfresco/core/ValueDisplayMapMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ValueDisplayMapMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -32,10 +32,8 @@
  * @module alfresco/core/ValueDisplayMapMixin
  * @author Dave Draper
  */
-define(["dojo/_base/declare",
-        "dojo/_base/lang",
-        "dojo/_base/array"], 
-        function(declare, lang, array) {
+define(["dojo/_base/declare"], 
+        function(declare) {
    
    return declare(null, {
       
@@ -58,7 +56,7 @@ define(["dojo/_base/declare",
        */
       mapValueToDisplayValue: function alfresco_core_ValueDisplayMapMixin__mapValueToDisplayValue(value) {
          var displayValue = value;
-         if (this.valueDisplayMap != null)
+         if (this.valueDisplayMap)
          {
             var mappedValue = null;
             for (var i=0; i<this.valueDisplayMap.length && mappedValue === null; i++) {

--- a/aikau/src/main/resources/alfresco/renderers/DateLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/DateLink.js
@@ -63,14 +63,14 @@ define(["dojo/_base/declare",
       onLinkClick: function alfresco_renderers_DateLink__onLinkClick(evt) {
          event.stop(evt);
          var publishTopic = this.getPublishTopic();
-         if (publishTopic == null || lang.trim(publishTopic) == "")
+         if (!publishTopic || !lang.trim(publishTopic))
          {
             this.alfLog("warn", "No publishTopic provided for DateLink", this);
          }
          else
          {
-            var publishGlobal = (this.publishGlobal != null) ? this.publishGlobal : false;
-            var publishToParent = (this.publishToParent != null) ? this.publishToParent : false;
+            var publishGlobal = this.publishGlobal || false;
+            var publishToParent = this.publishToParent || false;
             this.alfPublish(publishTopic, this.getPublishPayload(), publishGlobal, publishToParent);
          }
       },
@@ -96,7 +96,7 @@ define(["dojo/_base/declare",
        * @returns {string} The currentItem being renderered.
        */ 
       getPublishPayload: function alfresco_renderers_DateLink__getPublishTopic() {
-         if (this.useCurrentItemAsPayload == true)
+         if (this.useCurrentItemAsPayload === true)
          {
             return this.currentItem;
          }

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -480,15 +480,12 @@ define(["dojo/_base/declare",
          {
             lang.setObject(this.propertyToRender, this.originalRenderedValue, this.currentItem);
          }
-
-         // This is a bit ugly... there will be better ways to handle this...
-         // Basically it's handling the situation where the prefix/suffix for cleared when data wasn't originally available...
-         var prefix = (this.requestedValuePrefix) ? this.requestedValuePrefix : this.renderedValuePrefix;
-         var suffix = (this.requestedValueSuffix) ? this.requestedValueSuffix : this.renderedValueSuffix;
          
-         html.set(this.renderedValueNode, prefix + this.renderedValue + suffix);
-         domClass.remove(this.renderedValueNode, "hidden faded");
+         this.renderedValue = this.generateRendering(this.renderedValue);
+         html.set(this.renderedValueNode, this.renderedValue);
+         domClass.remove(this.renderedValueNode, "hidden");
          domClass.add(this.editNode, "hidden");
+         this.updateCssClasses();
          this.renderedValueNode.focus();
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditSelect.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditSelect.js
@@ -30,7 +30,7 @@
 define(["dojo/_base/declare",
         "alfresco/renderers/InlineEditProperty",
         "alfresco/forms/controls/Select"], 
-        function(declare, InlineEditProperty, DojoSelect) {
+        function(declare, InlineEditProperty) {
 
    return declare([InlineEditProperty], {
 

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -287,7 +287,7 @@ define(["dojo/_base/declare",
          var valueRendering;
 
          // If the renderedValue is not set then display a warning message if requested...
-         if (this.renderedValue === null || this.renderedValue === "" || typeof this.renderedValue === "undefined") 
+         if (!ObjectTypeUtils.isValueSet(value, false)) 
          {
             if (this.warnIfNotAvailable)
             {

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -257,13 +257,16 @@ define(["dojo/_base/declare",
        * @since 1.0.35
        */
       updateCssClasses: function alfresco_renderers_Property__updateCssClasses() {
-         if (this.warningDisplayed)
+         if (this.renderedValueNode)
          {
-            domClass.add(this.renderedValueNode, "faded");
-         }
-         else
-         {
-            domClass.remove(this.renderedValueNode, "faded");
+            if(this.warningDisplayed)
+            {
+               domClass.add(this.renderedValueNode, "faded");
+            }
+            else
+            {
+               domClass.remove(this.renderedValueNode, "faded");
+            }
          }
       },
 
@@ -284,7 +287,7 @@ define(["dojo/_base/declare",
          var valueRendering;
 
          // If the renderedValue is not set then display a warning message if requested...
-         if (!value || value === 0) 
+         if (this.renderedValue === null || this.renderedValue === "" || typeof this.renderedValue === "undefined") 
          {
             if (this.warnIfNotAvailable)
             {

--- a/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
@@ -1,5 +1,5 @@
 <span class="alfresco-renderers-InlineEditProperty ${renderedValueClass}">
-   <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${renderedValuePrefix}${renderedValue}${renderedValueSuffix}</span>
+   <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${renderedValue}</span>
    <span data-dojo-attach-point="editNode" class="editor hidden" data-dojo-attach-event="onkeypress:onValueEntryKeyPress,onclick:suppressFocusRequest">
       <span data-dojo-attach-point="formWidgetNode"></span>
       <span class="action save" data-dojo-attach-point="saveLinkNode" data-dojo-attach-event="ondijitclick:onSave" tabindex="0">${saveLabel}</span>

--- a/aikau/src/main/resources/alfresco/renderers/templates/Property.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/Property.html
@@ -1,6 +1,6 @@
 <span class="alfresco-renderers-Property ${renderedValueClass}" data-dojo-attach-point="renderedValueNode" tabindex="0">
    <span class="inner">
       <span class="label">${label}</span>
-      <span class="value">${renderedValuePrefix}${!renderedValue}${renderedValueSuffix}</span>
+      <span class="value">${!renderedValue}</span>
    </span>
 </span>

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
@@ -97,19 +97,19 @@ define(["intern!object",
       },
 
       "Description populated when specified": function() {
-         return browser.findAllByCssSelector(".detail-item__description:not(.faded)")
+         return browser.findAllByCssSelector(".detail-item__description .alfresco-renderers-Property:not(.faded)")
             .then(function(elements) {
                assert.lengthOf(elements, 2, "Incorrect number of description widgets populated");
             })
             .end()
 
-         .findAllByCssSelector(".detail-item__description.faded")
+         .findAllByCssSelector(".detail-item__description .alfresco-renderers-Property.faded")
             .then(function(elements) {
                assert.lengthOf(elements, 2, "Incorrect number of empty description widgets");
             })
             .end()
 
-         .findAllByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(1) .detail-item__description:not(.faded), .alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(4) .detail-item__description:not(.faded)")
+         .findAllByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(1) .detail-item__description .alfresco-renderers-Property:not(.faded), .alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(4) .detail-item__description:not(.faded)")
             .then(function(elements) {
                assert.lengthOf(elements, 2, "Description widgets not populated for correct items");
             });

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -319,6 +319,64 @@ define(["intern!object",
             });
       },
 
+      "Check warning message on item with no value": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "(No property set)", "Value not rendered correctly");
+            });
+      },
+
+      "Check fade class applied to warning value": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
+      },
+
+      "Edit and save item check rendered value has prefix/suffix": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .editIcon")
+            .click()
+         .end()
+         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .alfresco-forms-controls-TextBox .dijitInputContainer input")
+            .clearValue()
+            .type("Updated")
+         .end()
+         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .action.save")
+            .click()
+         .end()
+         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "(Updated)", "Value not rendered correctly");
+            });
+      },
+
+      "Check that faded style has been removed": function() {
+         return browser.findAllByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "Faded style was not removed when a value was provided");
+            });
+      },
+
+      "Edit and save item to remove value to check warning returns": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .editIcon")
+            .click()
+         .end()
+         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .alfresco-forms-controls-TextBox .dijitInputContainer input")
+            .clearValue()
+         .end()
+         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .action.save")
+            .click()
+         .end()
+         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "(No property set)", "Value not rendered correctly");
+            });
+      },
+
+      "Check that faded style has been reapplied": function() {
+         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
@@ -124,6 +124,34 @@ model.jsonModel = {
                                        ],
                                        renderOnNewLine: true
                                     }
+                                 },
+                                 {
+                                    id: "INLINE_EDIT_NO_VALUE_WITH_WARNING",
+                                    name: "alfresco/renderers/InlineEditProperty",
+                                    config: {
+                                       propertyToRender: "title",
+                                       permissionProperty: "node.permissions.user.Write",
+                                       publishTopic: "ALF_CRUD_UPDATE",
+                                       publishPayloadType: "PROCESS",
+                                       publishPayloadModifiers: ["processCurrentItemTokens"],
+                                       publishPayloadItemMixin: true,
+                                       publishPayload: {
+                                          url: "api/solr/facet-config/{name}"
+                                       },
+                                       hiddenDataRules: [
+                                          {
+                                             name: "hiddenData",
+                                             rulePassValue: "hidden_update",
+                                             ruleFailValue: "",
+                                             is: ["New"]
+                                          }
+                                       ],
+                                       renderOnNewLine: true,
+                                       renderedValuePrefix: "(",
+                                       renderedValueSuffix: ")",
+                                       warnIfNotAvailable: true,
+                                       warnIfNotAvailableMessage: "No property set"
+                                    }
                                  }
                               ]
                            }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-563 to ensure that when InlineEditProperty widgets (and their sub-classes) are edited that the new value is rendered using all the original configuration to ensure that appropriate warnings and styles are applied.