### PR TITLE
AKU-569: Updated PublishingDropDownMenu to support disabled state

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
@@ -70,7 +70,7 @@ define(["dojo/_base/declare",
       publishTopic: null,
 
       /**
-       * This will be set to reference the [DojoSelect]{@link module:alfresco/forms/controls/Select} that is
+       * This will be set to reference the [Select]{@link module:alfresco/forms/controls/Select} that is
        * wrapped by this widget.
        *
        * @instance
@@ -180,6 +180,19 @@ define(["dojo/_base/declare",
       cancellationPublishPayloadModifiers: null,
 
       /**
+       * This is the dot-property that will be evaluated on the current item being rendered to determine whether or not
+       * the wrapped [select]{@link module:alfresco/forms/controls/Select} widget should be disabled. The value of the 
+       * evaluated property is expected to be a boolean (or it will be evalutated as a "truthy"/"falsy" value, e.g. 0
+       * would be false and 1 would be true, the empty string false, any other string true, etc).
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       */
+      disablementProperty: null,
+
+      /**
        *
        * @instance
        */
@@ -196,6 +209,8 @@ define(["dojo/_base/declare",
             var fieldId = "DROPDOWN";
             var subscriptionTopic = uuid + "_valueChangeOf_" + fieldId;
 
+            var isDisabled = this.disablementProperty && lang.getObject(this.disablementProperty, false, this.currentItem);
+
             // Create the widget...
             this._dropDownWidget = new Select({
                id: this.id + "_SELECT",
@@ -203,7 +218,10 @@ define(["dojo/_base/declare",
                pubSubScope: uuid,
                fieldId: fieldId,
                value: this.value,
-               optionsConfig: this.optionsConfig
+               optionsConfig: this.optionsConfig,
+               disablementConfig: {
+                  initialValue: isDisabled
+               }
             }, this.dropDownNode);
 
             // Create the subscription AFTER the widget has been instantiated so that we don't

--- a/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
@@ -275,6 +275,45 @@ define(["intern!object",
             });
       },
 
+      "Test that second drop-down is disabled (in main view)": function() {
+         return browser.findByCssSelector("#PDM_ITEM_1_SELECT_CONTROL.dijitDisabled")
+            .getAttribute("aria-disabled")
+            .then(function(attribute) {
+               assert.equal(attribute, "true", "The drop-down was not disabled");
+            });
+      },
+
+      "Test that second drop-down is NOT disabled (in dialog)": function() {
+         return browser.findByCssSelector("#SHOW_DIALOG_label")
+            .click()
+         .end()
+         // Wait for dialog...
+         .findByCssSelector("#DIALOG1.dialogDisplayed")
+         .end()
+
+         // Check the 
+         .findAllByCssSelector("#DIALOG_PDM_ITEM_1_SELECT_CONTROL.dijitDisabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The drop-down was disabled");
+            })
+         .end()
+         .findById("DIALOG_PDM_ITEM_1_SELECT_CONTROL")
+            .getAttribute("aria-disabled")
+            .then(function(attribute) {
+               assert.equal(attribute, "false", "The drop-down was not disabled (aria)");
+            })
+         .end()
+        
+         // Close dialog
+         .findByCssSelector(".dijitDialogCloseIcon")
+            .click()
+         .end()
+
+         // Wait for dialog to be hidden...
+         .findAllByCssSelector("#DIALOG1.dialogHidden")
+         .end();
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishingDropDownMenu.get.js
@@ -1,96 +1,93 @@
 /* global widgetUtils */
 
 // Define a list model that will be used in both the main list on the page and then again in a dialog...
-var widgets = {
-   id: "LIST_VIEW_1",
-   name: "alfresco/lists/views/AlfListView",
-   config: {
-      subscribeToDocRequests: true,
-      currentData: {
-         items: [
-            {col1:"Test1", col2:"PUBLIC"},
-            {col1:"Test2", col2:"MODERATED"},
-            {col1:"Test3", col2:"PRIVATE"}
-         ]
-      },
-      widgetsForHeader: [
-         {
-            name: "alfresco/lists/views/layouts/HeaderCell",
-            config: {
-               label: "Heading 1"
-            }
+function getView(viewId, pdmId, disablementProperty) {
+   var widgets = {
+      id: viewId,
+      name: "alfresco/lists/views/AlfListView",
+      config: {
+         subscribeToDocRequests: true,
+         currentData: {
+            items: [
+               {col1:"Test1", col2:"PUBLIC", disabled: false},
+               {col1:"Test2", col2:"MODERATED", disabled: true},
+               {col1:"Test3", col2:"PRIVATE", disabled: false}
+            ]
          },
-         {
-            name: "alfresco/lists/views/layouts/HeaderCell",
-            config: {
-               label: "Heading 2"
+         widgetsForHeader: [
+            {
+               name: "alfresco/lists/views/layouts/HeaderCell",
+               config: {
+                  label: "Heading 1"
+               }
+            },
+            {
+               name: "alfresco/lists/views/layouts/HeaderCell",
+               config: {
+                  label: "Heading 2"
+               }
             }
-         }
-      ],
-      widgets:[
-         {
-            name: "alfresco/lists/views/layouts/Row",
-            config: {
-               widgets: [
-                  {
-                     name: "alfresco/lists/views/layouts/Cell",
-                     config: {
-                        widgets: [
-                           {
-                              name: "alfresco/renderers/Property",
-                              config: {
-                                 propertyToRender: "col1",
-                                 renderAsLink: false
+         ],
+         widgets:[
+            {
+               name: "alfresco/lists/views/layouts/Row",
+               config: {
+                  widgets: [
+                     {
+                        name: "alfresco/lists/views/layouts/Cell",
+                        config: {
+                           widgets: [
+                              {
+                                 name: "alfresco/renderers/Property",
+                                 config: {
+                                    propertyToRender: "col1",
+                                    renderAsLink: false
+                                 }
                               }
-                           }
-                        ]
-                     }
-                  },
-                  {
-                     name: "alfresco/lists/views/layouts/Cell",
-                     config: {
-                        widgets: [
-                           {
-                              id: "PDM",
-                              name: "alfresco/renderers/PublishingDropDownMenu",
-                              config: {
-                                 additionalCssClasses: "custom-css",
-                                 publishTopic: "ALF_PUBLISHING_DROPDOWN_MENU",
-                                 publishPayload: {
-                                    shortName: {
-                                       alfType: "item",
-                                       alfProperty: "col1"
-                                    }
-                                 },
-                                 propertyToRender: "col2",
-                                 optionsConfig: {
-                                    fixed: [
-                                       {label: "Public", value: "PUBLIC"},
-                                       {label: "Moderated", value: "MODERATED"},
-                                       {label: "Private", value: "PRIVATE"}
-                                    ]
-                                 },
-                                 cancellationPublishTopic: "CANCEL_UPDATE",
-                                 cancellationPublishPayloadType: "CURRENT_ITEM"
+                           ]
+                        }
+                     },
+                     {
+                        name: "alfresco/lists/views/layouts/Cell",
+                        config: {
+                           widgets: [
+                              {
+                                 id: pdmId,
+                                 name: "alfresco/renderers/PublishingDropDownMenu",
+                                 config: {
+                                    additionalCssClasses: "custom-css",
+                                    publishTopic: "ALF_PUBLISHING_DROPDOWN_MENU",
+                                    publishPayload: {
+                                       shortName: {
+                                          alfType: "item",
+                                          alfProperty: "col1"
+                                       }
+                                    },
+                                    disablementProperty: disablementProperty,
+                                    propertyToRender: "col2",
+                                    optionsConfig: {
+                                       fixed: [
+                                          {label: "Public", value: "PUBLIC"},
+                                          {label: "Moderated", value: "MODERATED"},
+                                          {label: "Private", value: "PRIVATE"}
+                                       ]
+                                    },
+                                    cancellationPublishTopic: "CANCEL_UPDATE",
+                                    cancellationPublishPayloadType: "CURRENT_ITEM"
+                                 }
                               }
-                           }
-                        ]
+                           ]
+                        }
                      }
-                  }
-               ]
+                  ]
+               }
             }
-         }
-      ]
-   }
-};
+         ]
+      }
+   };
+   return widgets;
+}
 
-// Clone the widgets model so that we can override the ID for the PublishingDropDownMenu
-// This needs to be done because otherwise a duplicate ID will attempt to be registered and
-// will then be swapped out with an automatically generated one (which will make testing harder)...
-var widgetsCopy = JSON.parse(JSON.stringify(widgets));
-widgetsCopy.id = "LIST_VIEW_2";
-var pdm = widgetUtils.findObject(widgetsCopy, "id", "PDM");
-pdm.id = "DIALOG_PDM";
 
 model.jsonModel = {
    services: [
@@ -108,7 +105,7 @@ model.jsonModel = {
       "alfresco/services/DialogService"
    ],
    widgets:[
-      widgets,
+      getView("LIST_VIEW_1", "PDM", "disabled"),
       {
          id: "SHOW_DIALOG",
          name: "alfresco/buttons/AlfButton",
@@ -118,7 +115,7 @@ model.jsonModel = {
             publishPayload: {
                dialogId: "DIALOG1",
                dialogTitle: "Test dialog",
-               widgetsContent: [widgetsCopy]
+               widgetsContent: [getView("LIST_VIEW_2", "DIALOG_PDM", null)]
             }
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-569 to add support for having alfresco/renderers/PublishingDropDownMenu renderers disabled based on evaluation each item being rendered. 