### PR TITLE
AKU-576: Gallery view slider preferences

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -87,6 +87,16 @@ define(["dojo/_base/declare",
        */
       columns: 4,
 
+       /**
+       * The preference property to use for retrieving and setting the users preferred number of columns
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       */
+      columnsPreferenceProperty: "org.alfresco.share.documentList.galleryColumns",
+
       /**
        * This function updates the [columns]{@link module:alfresco/documentlibrary/views/AlfGalleryView#columns}
        * attribute with the value attribute of the payload argument and then calls the
@@ -126,7 +136,8 @@ define(["dojo/_base/declare",
             relatedViewName: this.getViewName(),
             pubSubScope: this.pubSubScope,
             parentPubSubScope: this.parentPubSubScope,
-            columns: this.columns
+            columns: this.columns,
+            columnsPreferenceProperty: this.columnsPreferenceProperty
          })];
       },
       

--- a/aikau/src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   var browser;
+   registerSuite({
+      name: "AlfGalleryViewSlider Preferences Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/AlfGalleryViewSlider", "AlfGalleryViewSlider Preferences Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Default config uses preference": function() {
+         return browser.findByCssSelector("body").end()
+            .getLastPublish("GS1_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", 3, "Incorrect column value set");
+               });
+      },
+
+      "Preference overrides config": function() {
+         return browser.findByCssSelector("body").end()
+            .getLastPublish("GS2_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", 7, "Incorrect column value set");
+               });
+      },
+
+      "Config overrides default (when no preferences available)": function() {
+         return browser.findByCssSelector("body").end()
+            .getLastPublish("GS3_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", 10, "Incorrect column value set");
+               });
+      },
+
+      "Default used with invalid config (string) when no preferences available": function() {
+         return browser.findByCssSelector("body").end()
+            .getLastPublish("GS4_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", 4, "Incorrect column value set");
+               });
+      },
+
+      "Default used with invalid config (null) when no preferences available": function() {
+         return browser.findByCssSelector("body").end()
+            .getLastPublish("GS5_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", 4, "Incorrect column value set");
+               });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -74,6 +74,7 @@ define({
       "src/test/resources/alfresco/dnd/NestedConfigurationTest",
       "src/test/resources/alfresco/dnd/NestedReorderTest",
 
+      "src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest",
       "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest",
       "src/test/resources/alfresco/documentlibrary/CreateContentTest",
       "src/test/resources/alfresco/documentlibrary/DocumentLibraryTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/GalleryViewSlider.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/GalleryViewSlider.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfGalleryViewSlider</shortname>
+  <description>Renders an alfresco/documentlibrary/AlfGalleryViewSlider in order to test preferences handling</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfGalleryViewSlider</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/GalleryViewSlider.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/GalleryViewSlider.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/GalleryViewSlider.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/GalleryViewSlider.get.js
@@ -1,0 +1,64 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "aikauTesting/mockservices/MockPreferenceService"
+   ],
+   widgets: [
+      {
+         // Should end up as 3 (from default preferences)
+         name: "alfresco/documentlibrary/AlfGalleryViewSlider",
+         config: {
+            pubSubScope: "GS1_"
+         }
+      },
+      {
+         // Should end up as 7 (from searchlist preferences)
+         name: "alfresco/documentlibrary/AlfGalleryViewSlider",
+         config: {
+            pubSubScope: "GS2_",
+            columns: 10,
+            columnsPreferenceProperty: "org.alfresco.share.searchList.galleryColumns"
+         }
+      },
+      {
+         // Should end up as 10 (from config)
+         name: "alfresco/documentlibrary/AlfGalleryViewSlider",
+         config: {
+            pubSubScope: "GS3_",
+            columns: 10,
+            columnsPreferenceProperty: "org.alfresco.share.no.prefs"
+         }
+      },
+      {
+         // Should end up as 4 (from defauls on invalid config)
+         name: "alfresco/documentlibrary/AlfGalleryViewSlider",
+         config: {
+            pubSubScope: "GS4_",
+            columns: "bob",
+            columnsPreferenceProperty: "org.alfresco.share.no.prefs"
+         }
+      },
+      {
+         // Should end up as 4 (from defauls on invalid config)
+         name: "alfresco/documentlibrary/AlfGalleryViewSlider",
+         config: {
+            pubSubScope: "GS5_",
+            columns: null,
+            columnsPreferenceProperty: "org.alfresco.share.no.prefs"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/MockPreferenceService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/MockPreferenceService.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define(["dojo/_base/declare",
+        "alfresco/services/BaseService",
+        "alfresco/core/topics",
+        "dojo/_base/lang"],
+        function(declare, BaseService, topics, lang) {
+   
+   return declare([BaseService], {
+      
+      /**
+       * 
+       * @instance
+       * @param {array} args Constructor arguments
+       */
+      
+      registerSubscriptions: function alfresco_testing_mockservices_MockPreferenceService__registerSubscriptions(args) {
+         lang.mixin(this, args);
+         this.alfSubscribe(topics.GET_PREFERENCE, lang.hitch(this, this.onGetPreference));
+         this.alfSubscribe(topics.SET_PREFERENCE, lang.hitch(this, this.onSetPreference));
+      },
+
+      /**
+       *
+       * @instance
+       * @param {object} payload The payload defining the document to retrieve the details for.
+       */
+      onGetPreference: function alfresco_testing_mockservices_MockPreferenceService__onGetPreference(payload) {
+         switch (payload.preference) {
+            case "org.alfresco.share.documentList.galleryColumns": 
+               payload.callback.apply(payload.callbackScope, [3]);
+               break;
+
+            case "org.alfresco.share.searchList.galleryColumns": 
+               payload.callback.apply(payload.callbackScope, [7]);
+               break;
+
+            case "org.alfresco.share.no.prefs": 
+               payload.callback.apply(payload.callbackScope, [null]);
+               break;
+
+            default:
+               // No action
+               break;
+         }
+      },
+
+      /**
+       *
+       * @instance
+       * @param {object} payload The payload defining the document to retrieve the details for.
+       */
+      onSetPreference: function alfresco_testing_mockservices_MockPreferenceService__onGetPreference(/*jshint unused:false*/ payload) {
+         
+      }
+   });
+});


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-576 to ensure that the AlfGalleryViewSlider uses the configured columns default when a user preference isn't available (with a fallback to a default value when the configured value is invalid). It also adds support for customizing the columns preference property.