### PR TITLE
AKU-557: Support for full screen dialogs

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -101,6 +101,52 @@ define(["dojo/_base/declare",
       duration: 0,
 
       /**
+       * If this is set to true then the dialog will retain it's opening width regardless of what happens
+       * to it's contents. This is especially useful when the dialog contains widgets that resize themselves
+       * that could result in the dialog shrinking (this can occur when using
+       * [HorizontalWidgets]{@link module:alfresco/layout/HorizontalWidgets}.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      fixedWidth: false,
+      
+      /**
+       * Indicates whether or not to override all dimension settings and to make the dialog consume all
+       * the available space on the screen (minus any [padding]{@link module:alfresco/dialogs/AlfDialog#fullScreenPadding}).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.35
+       */
+      fullScreenMode: false,
+
+      /**
+       * When [full screen mode]{@link module:alfresco/dialogs/AlfDialog#fullScreenMode} is used this is the value in pixels
+       * that will be left as a padding between the edge of the dialog and the edge the screen.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.35
+       */
+      fullScreenPadding: 10,
+
+      /**
+       * In some cases the content placed within the dialog will handle overflow itself, in that
+       * case this should be set to false. However, in most cases the dialog will want to manage
+       * overflow itself. Effectively this means that scroll bars will be added as necessary to 
+       * ensure that the user can see all of the dialog content.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      handleOverflow: true,
+
+      /**
        * Widgets to be processed into the main node
        * 
        * @instance
@@ -117,18 +163,6 @@ define(["dojo/_base/declare",
        * @default
        */
       widgetsButtons: null,
-
-      /**
-       * In some cases the content placed within the dialog will handle overflow itself, in that
-       * case this should be set to false. However, in most cases the dialog will want to manage
-       * overflow itself. Effectively this means that scroll bars will be added as necessary to 
-       * ensure that the user can see all of the dialog content.
-       *
-       * @instance
-       * @type {boolean}
-       * @default
-       */
-      handleOverflow: true,
 
       /**
        * Extends the default constructor to adjust for changes between 1.9.x and 1.10.x versions
@@ -158,18 +192,6 @@ define(["dojo/_base/declare",
          this.buttonCancel = this.message("button.close");
       },
 
-      /**
-       * If this is set to true then the dialog will retain it's opening width regardless of what happens
-       * to it's contents. This is especially useful when the dialog contains widgets that resize themselves
-       * that could result in the dialog shrinking (this can occur when using
-       * [HorizontalWidgets]{@link module:alfresco/layout/HorizontalWidgets}.
-       *
-       * @instance
-       * @type {boolean}
-       * @default
-       */
-      fixedWidth: false,
-      
       /**
        * Extends the superclass implementation to process the widgets defined by 
        * [widgetButtons]{@link module:alfresco/dialogs/AlfDialog#widgetButtons} into the buttons bar
@@ -364,6 +386,30 @@ define(["dojo/_base/declare",
          
          // Publish the widgets ready
          this.alfPublish(topics.PAGE_WIDGETS_READY, {}, true);
+      },
+
+      /**
+       * Extends the default resize function to to provide the 
+       * [full screen mode]{@link module:alfresco/dialogs/AlfDialog#fullScreenMode} capability.
+       * 
+       * @instance
+       * @since 1.0.35
+       */
+      resize: function alfresco_dialogs_AlfDialog__resize() {
+         if (this.fullScreenMode === true)
+         {
+            var dimensionAdjustment = this.fullScreenPadding * 2;
+            this.inherited(arguments, [{
+               t: this.fullScreenPadding,
+               l: this.fullScreenPadding,
+               w: $(window).width() - dimensionAdjustment,
+               h: $(window).height() - dimensionAdjustment
+            }]);
+         }
+         else
+         {
+            this.inherited(arguments);
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -140,6 +140,8 @@
  * @property {boolean} [handleOverflow=false] - Should scrollbars be added to if the content is bigger than the dialog
  * @property {boolean} [fixedWidth=false] - If set to true, prevents the dialog resizing to fit the content
  * @property {string} [hideTopic=null] - Topic to subscribe to to trigger a dialog hide. If this is set
+ * @property {boolean} [fullScreenMode=false] Whether or not to create the dialog the size of the screen
+ * @property {boolean} [fullScreenPadding=10] The padding to leave around the dialog when in full screen mode
  */
 
 /**
@@ -158,6 +160,8 @@
  * @property {Boolean} [handleOverflow=false] - Should scrollbars be added to if the content is bigger than the dialog
  * @property {Boolean} [fixedWidth=false] - If set to true, prevents the dialog resizing to fit the content
  * @property {Array} [publishOnShow=null] - An array of publications objects to make when the dialog is displayed
+ * @property {boolean} [fullScreenMode=false] Whether or not to create the dialog the size of the screen
+ * @property {boolean} [fullScreenPadding=10] The padding to leave around the dialog when in full screen mode
  */
 
 define(["dojo/_base/declare",
@@ -423,6 +427,8 @@ define(["dojo/_base/declare",
             title: this.message(payload.dialogTitle || ""),
             content: payload.textContent,
             duration: payload.duration || 0,
+            fullScreenMode: payload.fullScreenMode || false,
+            fullScreenPadding: payload.fullScreenPadding || 10,
             widgetsContent: payload.widgetsContent,
             widgetsButtons: payload.widgetsButtons,
             additionalCssClasses: payload.additionalCssClasses ? payload.additionalCssClasses : "",
@@ -483,6 +489,7 @@ define(["dojo/_base/declare",
        * @param {module:alfresco/services/DialogService~event:ALF_CREATE_FORM_DIALOG_REQUEST} payload The payload published on the request topic.
        */
       onCreateFormDialogRequest: function alfresco_services_DialogService__onCreateFormDialogRequest(payload) {
+         // jshint maxstatements:false
          this.cleanUpAnyPreviousDialog(payload);
          if (!payload.widgets)
          {
@@ -649,6 +656,8 @@ define(["dojo/_base/declare",
             duration: config.duration || 0,
             handleOverflow: handleOverflow,
             fixedWidth: fixedWidth,
+            fullScreenMode: config.fullScreenMode || false,
+            fullScreenPadding: config.fullScreenPadding || 10,
             parentPubSubScope: config.parentPubSubScope,
             additionalCssClasses: config.additionalCssClasses ? config.additionalCssClasses : "",
             suppressCloseClasses: suppressCloseClasses,

--- a/aikau/src/test/resources/alfresco/services/FullScreenDialogTest.js
+++ b/aikau/src/test/resources/alfresco/services/FullScreenDialogTest.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+       function(registerSuite, assert, TestCommon) {
+
+   var browser;
+   registerSuite({
+
+      name: "Full Screen Dialog Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/FullScreenDialogs", "Full Screen Dialog Tests").end();
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Create full screen dialog": function() {
+         var windowSize;
+         return browser.setWindowSize(null, 1024, 400).findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowSize = size;
+            })
+         .end()
+         .findById("FULL_SCREEN_DIALOG_label")
+            .click()
+         .end()
+         .findByCssSelector("#FSD1.dialogDisplayed")
+            .getSize()
+            .then(function(size) {
+               assert.equal(windowSize.height - 40, size.height, "Height wrong");
+               assert.equal(windowSize.width - 40, size.width, "Width wrong");
+            });
+      },
+
+      "Resize window (1)": function() {
+         var windowSize;
+         return browser.setWindowSize(null, 1024, 600).end()
+            .findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowSize = size;
+            })
+         .end()
+         .findByCssSelector("#FSD1.dialogDisplayed")
+            .getSize()
+            .then(function(size) {
+               assert.equal(windowSize.height - 40, size.height, "Height wrong");
+               assert.equal(windowSize.width - 40, size.width, "Width wrong");
+            })
+         .end()
+         .findById("FULL_SCREEN_DIALOG_CLOSE_label")
+            .click()
+         .end()
+         .findByCssSelector("#FSD1.dialogHidden");
+      },
+
+      "Create full screen form dialog": function() {
+         var windowSize;
+         return browser.findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowSize = size;
+            })
+         .end()
+         .findById("FULL_SCREEN_FORM_DIALOG_label")
+            .click()
+         .end()
+         .findByCssSelector("#FSD2.dialogDisplayed")
+            .getSize()
+            .then(function(size) {
+               assert.equal(windowSize.height - 80, size.height, "Height wrong");
+               assert.equal(windowSize.width - 80, size.width, "Width wrong");
+            });
+      },
+
+      "Resize window (2)": function() {
+         var windowSize;
+         return browser.setWindowSize(null, 1024, 700)
+            .findByCssSelector("body")
+            .getSize()
+            .then(function(size) {
+               windowSize = size;
+            })
+         .end()
+         .findByCssSelector("#FSD2.dialogDisplayed")
+            .getSize()
+            .then(function(size) {
+               assert.equal(windowSize.height - 80, size.height, "Height wrong");
+               assert.equal(windowSize.width - 80, size.width, "Width wrong");
+            })
+         .end()
+         .findById("FSD2_OK_label")
+            .click()
+         .end()
+         .findByCssSelector("#FSD2.dialogHidden");
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -227,6 +227,7 @@ define({
       "src/test/resources/alfresco/services/CrudServiceTest",
       "src/test/resources/alfresco/services/DeleteSiteTest",
       "src/test/resources/alfresco/services/DialogServiceTest",
+      "src/test/resources/alfresco/services/FullScreenDialogTest",
       "src/test/resources/alfresco/services/NavigationServiceTest",
       "src/test/resources/alfresco/services/NotificationServiceTest",
       "src/test/resources/alfresco/services/SearchServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
   <shortname>DialogService Test</shortname>
+  <description>This page is used to test the alfresco/services/DialogSerice and can create various different styles of dialog</description>
   <family>aikau-unit-tests</family>
   <url>/DialogService</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -450,6 +450,65 @@ model.jsonModel = {
          }
       },
       {
+         id: "FULL_SCREEN_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create Full Screen Dialog",
+            publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "FSD1",
+               dialogTitle: "Full Screen Dialog",
+               fullScreenMode: true,
+               fullScreenPadding: 20,
+               textContent: "Hello World",
+               publishOnShow: [
+                  {
+                     publishTopic: "DISPLAYED_FD1",
+                     publishPayload: {}
+                  }
+               ],
+               widgetsButtons: [
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     config: {
+                        label: "OK",
+                        additionalCssClasses: "cancellationButton",
+                        publishTopic: "ALF_ITEMS_SELECTED"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "FULL_SCREEN_FORM_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create Form Dialog (with custom scoping)",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "FSD2",
+               dialogTitle: "Full Screen Form Dialog",
+               fullScreenMode: true,
+               fullScreenPadding: 40,
+               formSubmissionTopic: "FULL_SCREEN_TOPIC",
+               formSubmissionGlobal: false,
+               formSubmissionScope: "FULL_SCREEN__SCOPE_",
+               widgets: [
+                  {
+                     id: "FS_FORM_TEXTBOX",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text",
+                        value: "This is some sample text"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FullScreenDialogs.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FullScreenDialogs.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Full Screen Dialogs</shortname>
+  <description>This page uses the alfresco/services/DialogService to create dialogs that take up the full screen</description>
+  <family>aikau-unit-tests</family>
+  <url>/FullScreenDialogs</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FullScreenDialogs.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FullScreenDialogs.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FullScreenDialogs.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FullScreenDialogs.get.js
@@ -1,0 +1,88 @@
+/*jshint maxlen:500*/
+model.jsonModel = {
+   services: [
+      {
+            name: "alfresco/services/LoggingService",
+            config: {
+               loggingPreferences: {
+                  enabled: true,
+                  all: true
+               }
+            }
+      },
+      "alfresco/services/DialogService",
+      "aikauTesting/mockservices/FormDialogMockService"
+   ],
+   widgets: [
+      {
+         id: "LAYOUT",
+         name: "alfresco/layout/FixedHeaderFooter",
+         config: {
+            autoHeightPaddingAllowance: 10,
+            widgets: [
+               {
+                  id: "FULL_SCREEN_DIALOG",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Create Full Screen Dialog",
+                     publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                     publishPayload: {
+                        dialogId: "FSD1",
+                        dialogTitle: "Full Screen Dialog",
+                        fullScreenMode: true,
+                        fullScreenPadding: 20,
+                        textContent: "Hello World",
+                        publishOnShow: [
+                           {
+                              publishTopic: "DISPLAYED_FD1",
+                              publishPayload: {}
+                           }
+                        ],
+                        widgetsButtons: [
+                           {
+                              id: "FULL_SCREEN_DIALOG_CLOSE",
+                              name: "alfresco/buttons/AlfButton",
+                              config: {
+                                 label: "OK",
+                                 additionalCssClasses: "cancellationButton",
+                                 publishTopic: "ALF_ITEMS_SELECTED"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  id: "FULL_SCREEN_FORM_DIALOG",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Create Form Dialog (with custom scoping)",
+                     publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+                     publishPayload: {
+                        dialogId: "FSD2",
+                        dialogTitle: "Full Screen Form Dialog",
+                        fullScreenMode: true,
+                        fullScreenPadding: 40,
+                        formSubmissionTopic: "FULL_SCREEN_TOPIC",
+                        formSubmissionGlobal: false,
+                        formSubmissionScope: "FULL_SCREEN__SCOPE_",
+                        widgets: [
+                           {
+                              id: "FS_FORM_TEXTBOX",
+                              name: "alfresco/forms/controls/TextBox",
+                              config: {
+                                 name: "text",
+                                 label: "Enter some text",
+                                 value: "This is some sample text"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               }
+            ]
+         }
+      }
+      
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-557 to provide for full screen dialog support. This new feature can be used by including fullScreenMode and fullScreenPadding attributes in dialog creation payloads consumed by the alfresco/services/DialogService