### PR TITLE
AKU-551: Retain item selection when switching views

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -132,6 +132,62 @@ define([],function() {
       DELETE_SITE: "ALF_DELETE_SITE",
 
       /**
+       * Publish this to indicate the de-selection of an individual item
+       * 
+       * @instance
+       * @type {string} 
+       * @default
+       * @since 1.0.35
+       *
+       * @event module:alfresco/core/topics~DOCUMENT_DESELECTED
+       * @parameter {object} value - The item de-selected
+       */
+      DOCUMENT_DESELECTED: "ALF_DOCLIST_DOCUMENT_DESELECTED",
+      
+      /**
+       * Publish this to indicate the selection of an individual item.
+       * 
+       * @instance
+       * @type {string} 
+       * @default
+       * @since 1.0.35
+       *
+       * @event module:alfresco/core/topics~DOCUMENT_SELECTED
+       * @parameter {object} value - The item selected
+       */
+      DOCUMENT_SELECTED: "ALF_DOCLIST_DOCUMENT_SELECTED",
+      
+      /**
+       * This can be used to publish bulk changes in document selection. This differs from the 
+       * [DOCUMENT_SELECTED]{@link module:alfresco/core/topics#DOCUMENT_SELECTED} as it is used to make general selection 
+       * requests, e.g. "selectAll". Alternatively a "selectedItems" attribute can be used to list specific items that
+       * should be selected.
+       * 
+       * @instance
+       * @type {string} 
+       * @default
+       * @since 1.0.35
+       * 
+       * @event module:alfresco/core/topics~DOCUMENT_SELECTION_UPDATE
+       * @parameter {string} [value=null] - The selection type, either "selectAll", "selectNone", "selectInvert", "selectFolders" or "selectDocuments"
+       * @parameter {object[]} [selectedItems=null] A specific set of items to be selected
+       */
+      DOCUMENT_SELECTION_UPDATE: "ALF_DOCLIST_FILE_SELECTION",
+      
+      /**
+       * Used to indicate the list of currently selected documents has changed and provides the details of those items.
+       * 
+       * @instance
+       * @type {string} 
+       * @default
+       * @since 1.0.35
+       * 
+       * @event module:alfresco/core/topics~SELECTED_DOCUMENTS_CHANGED
+       * @parameter {object[]} selectedItems - The items that are selected
+       */
+      SELECTED_DOCUMENTS_CHANGED: "ALF_SELECTED_FILES_CHANGED",
+
+      /**
        * This topic is published to request either the download of a single document or folder (or a selection
        * of documents and folder) as a ZIP file.
        * 

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -29,9 +29,9 @@
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarSelectItems",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "dojo/_base/lang",
-        "dojo/dom-class"], 
-        function(declare, AlfMenuBarSelectItems, _AlfDocumentListTopicMixin, lang, domClass) {
+        "alfresco/core/topics",
+        "dojo/_base/lang"], 
+        function(declare, AlfMenuBarSelectItems, _AlfDocumentListTopicMixin, topics, lang) {
    
    return declare([AlfMenuBarSelectItems, _AlfDocumentListTopicMixin], {
       
@@ -60,7 +60,7 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      documentSelectionTopic: "ALF_DOCLIST_DOCUMENT_SELECTED",
+      documentSelectionTopic: topics.DOCUMENT_SELECTED,
 
       /**
        * The topic that is subscribed to in order to count the number of individual items that
@@ -70,14 +70,14 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      documentDeselectionTopic: "ALF_DOCLIST_DOCUMENT_DESELECTED",
+      documentDeselectionTopic: topics.DOCUMENT_DESELECTED,
       
       /**
        * @instance
        */
       postCreate: function alfresco_documentlibrary_AlfSelectDocumentListItems__postCreate() {
          this.selectionTopic = this.selectedDocumentsChangeTopic;
-         this.alfSubscribe(this.documentsLoadedTopic, lang.hitch(this, "onDocumentsLoaded"));
+         this.alfSubscribe(this.documentsLoadedTopic, lang.hitch(this, this.onDocumentsLoaded));
          this.inherited(arguments);
 
          // Subscribe to topics for detecting individual changes...
@@ -111,7 +111,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The details of the selected document
        */
-      onDocumentSelected: function alfresco_documentlibrary_AlfSelectDocumentListItems__onDocumentSelected(payload) {
+      onDocumentSelected: function alfresco_documentlibrary_AlfSelectDocumentListItems__onDocumentSelected(/*jshint unused:false*/ payload) {
          this.documentsSelected++;
          if (this.documentsSelected > this.documentsAvailable)
          {
@@ -130,7 +130,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The details of the selected document
        */
-      onDocumentDeselected: function alfresco_documentlibrary_AlfSelectDocumentListItems__onDocumentDeselected(payload) {
+      onDocumentDeselected: function alfresco_documentlibrary_AlfSelectDocumentListItems__onDocumentDeselected(/*jshint unused:false*/ payload) {
          this.documentsSelected--;
          if (this.documentsSelected < 0)
          {
@@ -151,7 +151,7 @@ define(["dojo/_base/declare",
        */
       onDocumentsLoaded: function alfresco_documentlibrary_AlfSelectDocumentListItems__onDocumentsLoaded(payload) {
          this.alfLog("log", "New Documents Loaded", payload);
-         if (payload && payload.documents && payload.documents.length != null)
+         if (payload && payload.documents && (payload.documents.length || payload.documents.length === 0))
          {
             this.documentsAvailable = payload.documents.length;
          }
@@ -165,9 +165,9 @@ define(["dojo/_base/declare",
        * @param {object} payload The publication of the selected item change.
        */
       determineSelection: function alfresco_menus_AlfMenuBarSelectItems__determineSelection(payload) {
-         if (payload.selectedFiles != null && payload.selectedFiles.length != null)
+         if (payload.selectedFiles && (payload.selectedFiles.length || payload.selectedFiles.length === 0))
          {
-            if (this.documentsAvailable == 0 || payload.selectedFiles.length == 0)
+            if (this.documentsAvailable === 0 || payload.selectedFiles.length === 0)
             {
                this.renderNoneSelected();
                this.documentsSelected = 0;
@@ -176,7 +176,7 @@ define(["dojo/_base/declare",
             {
                this.renderSomeSelected();
             }
-            else if (this.documentsAvailable == payload.selectedFiles.length)
+            else if (this.documentsAvailable === payload.selectedFiles.length)
             {
                this.renderAllSelected();
                this.documentsSelected = this.documentsAvailable;
@@ -197,8 +197,8 @@ define(["dojo/_base/declare",
                   {
                      name: "alfresco/menus/AlfMenuItem",
                      config: {
-                        label: "All",
-                        publishTopic: "ALF_DOCLIST_FILE_SELECTION",
+                        label: "select.all.label",
+                        publishTopic: topics.DOCUMENT_SELECTION_UPDATE,
                         publishPayload: {
                            label: "select.all.label",
                            value: "selectAll"
@@ -208,8 +208,8 @@ define(["dojo/_base/declare",
                   {
                      name: "alfresco/menus/AlfMenuItem",
                      config: {
-                        label: "None",
-                        publishTopic: "ALF_DOCLIST_FILE_SELECTION",
+                        label: "select.none.label",
+                        publishTopic: topics.DOCUMENT_SELECTION_UPDATE,
                         publishPayload: {
                            label: "select.none.label",
                            value: "selectNone"
@@ -219,8 +219,8 @@ define(["dojo/_base/declare",
                   {
                      name: "alfresco/menus/AlfMenuItem",
                      config: {
-                        label: "Invert",
-                        publishTopic: "ALF_DOCLIST_FILE_SELECTION",
+                        label: "invert.selection.label",
+                        publishTopic: topics.DOCUMENT_SELECTION_UPDATE,
                         publishPayload: {
                            label: "invert.selection.label",
                            value: "selectInvert"
@@ -230,8 +230,8 @@ define(["dojo/_base/declare",
                   {
                      name: "alfresco/menus/AlfMenuItem",
                      config: {
-                        label: "Documents",
-                        publishTopic: "ALF_DOCLIST_FILE_SELECTION",
+                        label: "select.documents.label",
+                        publishTopic: topics.DOCUMENT_SELECTION_UPDATE,
                         publishPayload: {
                            label: "select.documents.label",
                            value: "selectDocuments"
@@ -241,8 +241,8 @@ define(["dojo/_base/declare",
                   {
                      name: "alfresco/menus/AlfMenuItem",
                      config: {
-                        label: "Folders",
-                        publishTopic: "ALF_DOCLIST_FILE_SELECTION",
+                        label: "select.folders.label",
+                        publishTopic: topics.DOCUMENT_SELECTION_UPDATE,
                         publishPayload: {
                            label: "select.folders.label",
                            value: "selectFolders"

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -166,42 +166,38 @@ define(["dojo/_base/declare",
       /**
        * This differs from the "documentSelectedTopic" attribute as it is used to make general selection requests, e.g. "selectAll"
        * 
-       * @event documentSelectionTopic
        * @instance
        * @type {string} 
        * @default
        */
-      documentSelectionTopic: "ALF_DOCLIST_FILE_SELECTION",
+      documentSelectionTopic: topics.DOCUMENT_SELECTION_UPDATE,
       
       /**
        * This differs from the "documentSelectionTopic" attribute as it should be used for individual documents
        * 
-       * @event documentSelectedTopic
        * @instance
        * @type {string} 
        * @default
        */
-      documentSelectedTopic: "ALF_DOCLIST_DOCUMENT_SELECTED",
+      documentSelectedTopic: topics.DOCUMENT_SELECTED,
       
       /**
        * Used to indicate the list of currently selected documents has changed and provides the details of those items.
        * 
-       * @event selectedDocumentsChangeTopic
        * @instance
        * @type {string} 
        * @default
        */
-      selectedDocumentsChangeTopic: "ALF_SELECTED_FILES_CHANGED",
+      selectedDocumentsChangeTopic: topics.SELECTED_DOCUMENTS_CHANGED,
       
       /**
        * Use to indicate that an individual document has been deselected (e.g. that it should no longer be included in group actions).
        * 
-       * @event documentDeselectedTopic
        * @instance
        * @type {string} 
        * @default
        */
-      documentDeselectedTopic: "ALF_DOCLIST_DOCUMENT_DESELECTED",
+      documentDeselectedTopic: topics.DOCUMENT_DESELECTED,
       
       /**
        * @event sortRequestTopic

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfSimpleView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfSimpleView.js
@@ -78,6 +78,7 @@ define(["dojo/_base/declare",
                      config: {
                         widgets: [
                            {
+                              id: "SIMPLE_VIEW_SELECTOR",
                               name: "alfresco/renderers/Selector"
                            }
                         ]
@@ -88,6 +89,7 @@ define(["dojo/_base/declare",
                      config: {
                         widgets: [
                            {
+                              id: "SIMPLE_VIEW_INDICATORS",
                               name: "alfresco/renderers/Indicators"
                            }
                         ]
@@ -98,6 +100,7 @@ define(["dojo/_base/declare",
                      config: {
                         widgets: [
                            {
+                              id: "SIMPLE_VIEW_THUMBNAIL",
                               name: "alfresco/renderers/SmallThumbnail"
                            }
                         ]
@@ -116,6 +119,7 @@ define(["dojo/_base/declare",
                                        config: {
                                           widgets: [
                                              {
+                                                id: "SIMPLE_VIEW_NAME",
                                                 name: "alfresco/renderers/InlineEditPropertyLink",
                                                 config: {
                                                    propertyToRender: "node.properties.cm:name",
@@ -125,6 +129,7 @@ define(["dojo/_base/declare",
                                                 }
                                              },
                                              {
+                                                id: "SIMPLE_VIEW_TITLE",
                                                 name: "alfresco/renderers/InlineEditProperty",
                                                 config: {
                                                    propertyToRender: "node.properties.cm:title",
@@ -145,24 +150,29 @@ define(["dojo/_base/declare",
                                        config: {
                                           widgets: [
                                              {
+                                                id: "SIMPLE_VIEW_DATE",
                                                 name: "alfresco/renderers/Date"
                                              },
                                              {
+                                                id: "SIMPLE_VIEW_SIZE",
                                                 name: "alfresco/renderers/Size"
                                              },
                                              {
+                                                id: "SIMPLE_VIEW_FAVOURITE",
                                                 name: "alfresco/renderers/Favourite"
                                              },
                                              {
                                                 name: "alfresco/renderers/Separator"
                                              },
                                              {
+                                                id: "SIMPLE_VIEW_LIKE",
                                                 name: "alfresco/renderers/Like"
                                              },
                                              {
                                                 name: "alfresco/renderers/Separator"
                                              },
                                              {
+                                                id: "SIMPLE_VIEW_COMMENTS",
                                                 name: "alfresco/renderers/Comments"
                                              }
                                           ]
@@ -179,6 +189,7 @@ define(["dojo/_base/declare",
                      config: {
                         widgets: [
                            {
+                              id: "SIMPLE_VIEW_ACTIONS",
                               name: "alfresco/renderers/Actions"
                            }
                         ]

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -201,6 +201,10 @@ define(["dojo/_base/declare",
                this._itemsSelected = this._UNKNOWN;
             }
          }
+         else
+         {
+            this.alfLog("warn", "Invalid item selection requested", payload, this);
+         }
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -96,7 +96,7 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          if (this.iconNode)
          {
-            on(this.iconNode, "click", lang.hitch(this, "handleIconClick"));
+            on(this.iconNode, "click", lang.hitch(this, this.handleIconClick));
          }
       },
       
@@ -176,20 +176,22 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       determineSelection: function alfresco_menus_AlfMenuBarSelectItems__determineSelection(payload) {
-         if ((payload.availableItemCount || payload.availableItemCount === 0) && 
-             (payload.selectedItemCount || payload.selectedItemCount === 0)) 
+         var available = parseInt(payload.availableItemCount, 10);
+         var selected = parseInt(payload.selectedItemCount, 10);
+         if ((available || available === 0) && 
+             (selected || selected === 0)) 
          {
             // If no value is provided the selected items indicator is calculated based
             // on available and selected item counts...
-            if (payload.selectedItemCount === 0)
+            if (selected === 0)
             {
                this.renderNoneSelected();
             }
-            else if (payload.availableItemCount > payload.selectedItemCount)
+            else if (available > selected)
             {
                this.renderSomeSelected();
             }
-            else if (payload.availableItemCount === payload.selectedItemCount)
+            else if (available === selected)
             {
                this.renderAllSelected();
             }

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -24,11 +24,12 @@
  */
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarSelect",
+        "alfresco/core/topics",
         "dojo/dom-class",
         "dojo/_base/lang",
         "dojo/on",
         "dojo/_base/event"], 
-        function(declare, AlfMenuBarSelect, domClass, lang, on, event) {
+        function(declare, AlfMenuBarSelect, topics, domClass, lang, on, event) {
    
    return declare([AlfMenuBarSelect], {
       
@@ -84,17 +85,16 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      notificationTopic: "ALF_DOCLIST_FILE_SELECTION",
+      notificationTopic: topics.DOCUMENT_SELECTION_UPDATE,
 
       /**
        * Extends the inherited implementation to set up the listener for clicks on the iconNode
        * 
        * @instance
        */
-      postCreate: function alfresco_menus_AlfMenuBarSelectItems__postCreate() 
-      {
+      postCreate: function alfresco_menus_AlfMenuBarSelectItems__postCreate() {
          this.inherited(arguments);
-         if (this.iconNode != null)
+         if (this.iconNode)
          {
             on(this.iconNode, "click", lang.hitch(this, "handleIconClick"));
          }
@@ -109,19 +109,19 @@ define(["dojo/_base/declare",
          
          // Close the popup if it's open...
          this.closePopupMenu();
-         if (this._itemsSelected == this._NONE)
+         if (this._itemsSelected === this._NONE)
          {
             // Select all...
             this.renderAllSelected();
             this.alfPublish(this.notificationTopic, { value: "selectAll" });
          }
-         else if (this._itemsSelected == this._SOME)
+         else if (this._itemsSelected === this._SOME)
          {
             // Select all...
             this.renderAllSelected();
             this.alfPublish(this.notificationTopic, { value: "selectAll" });
          }
-         else if (this._itemsSelected == this._ALL)
+         else if (this._itemsSelected === this._ALL)
          {
             // Select none...
             this.renderNoneSelected();
@@ -150,11 +150,11 @@ define(["dojo/_base/declare",
             // Default support is provided for "selectAll" and "selectNone" values (this function
             // could be extended to support additional values) so that the overall label/icon responds
             // to menu item clicks (and not just external selection events).
-            if (payload.value == "selectAll")
+            if (payload.value === "selectAll")
             {
                this.renderAllSelected();
             }
-            else if (payload.value == "selectNone")
+            else if (payload.value === "selectNone")
             {
                this.renderNoneSelected();
             }
@@ -176,11 +176,12 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       determineSelection: function alfresco_menus_AlfMenuBarSelectItems__determineSelection(payload) {
-         if (payload.availableItemCount != null && payload.selectedItemCount != null) 
+         if ((payload.availableItemCount || payload.availableItemCount === 0) && 
+             (payload.selectedItemCount || payload.selectedItemCount === 0)) 
          {
             // If no value is provided the selected items indicator is calculated based
             // on available and selected item counts...
-            if (payload.selectedItemCount == 0)
+            if (payload.selectedItemCount === 0)
             {
                this.renderNoneSelected();
             }
@@ -188,7 +189,7 @@ define(["dojo/_base/declare",
             {
                this.renderSomeSelected();
             }
-            else if (payload.availableItemCount == payload.selectedItemCount)
+            else if (payload.availableItemCount === payload.selectedItemCount)
             {
                this.renderAllSelected();
             }

--- a/aikau/src/main/resources/alfresco/menus/AlfSelectedItemsMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfSelectedItemsMenuItem.js
@@ -93,7 +93,7 @@ define(["dojo/_base/declare",
                label: "select.none.label",
                value: "selectNone"
             });
-            this.alfPublish("ALF_DOCLIST_FILE_SELECTION", {
+            this.alfPublish(topics.DOCUMENT_SELECTION_UPDATE, {
                label: "select.none.label",
                value: "selectNone"
             });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -214,6 +214,53 @@ define(["intern!object",
          });
       },
 
+      // NOTE: These tests do not need to be duplicated across both non-hashing and hashing Document Libraries
+      
+      "Select items and switch views": function() {
+         // Select an item and make sure it is shown as selected...
+         return browser.findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.unchecked")
+            .click()
+         .end()
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.checked")
+         .end()
+
+         // Select another item and make sure it is shown as selected...
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.unchecked")
+            .click()
+         .end()
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.checked")
+         .end()
+
+         // Clear the log so that we can tell when view switching is complete...
+         .clearLog()
+
+         // Open the config menu...
+         .findByCssSelector("#DOCLIB_CONFIG_MENU img.alf-configure-icon")
+            .click()
+         .end()
+
+         // Select a new view...
+         .findByCssSelector("#DOCLIB_CONFIG_MENU_VIEW_SELECT_GROUP tr:nth-child(1) td.dijitMenuItemLabel")
+            .click()
+         .end()
+
+         // Check selected files publication occurs...
+         .getLastPublish("ALF_SELECTED_FILES_CHANGED")
+         .end()
+
+         // Check the item selection has been retained...
+         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_0.checked")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Item 0 selection was not retained switching views");
+            })
+         .end()
+
+         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_2.checked")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1, "Item 2 selection was not retained switching views");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest.js
@@ -24,9 +24,8 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
    var browser;
    registerSuite({
@@ -41,231 +40,199 @@ define(["intern!object",
          browser.end();
       },
 
-      "Tests": function () {
-         // Test #1
-         // Check that the subscription is set-up correctly
+      "A subscription for the widget could not be found": function () {
          return browser.findByCssSelector(TestCommon.topicSelector("MENU_BAR_SELECT_ITEMS"))
                .then(null, function() {
-                  assert(false, "Test #1 - A subscription for the widget could not be found");
-               })
-               .end()
-
-            // Test #2
-            // Check that nothing is selected on page load...
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "0", "Test #2 - There should be nothing selected on page load");
-               })
-               .end()
-
-            // Test #3
-            // Check clicking on the "Select All" item...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS")
-               .click()
-               .end()
-            .findByCssSelector("#SELECT_ALL")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "2", "Test #3 - _itemsSelected should be 2 after clicking on ALL");
-               })
-
-            .findByCssSelector(TestCommon.topicSelector("MENU_BAR_SELECT_ITEMS", "publish", "last"))
-               .then(null, function() {
-                  assert(false, "Test #3 - Mouse selection of ALL didn't publish correctly (missing publish topic)");
-               })
-               .end()
-
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "selectAll"))
-               .then(null, function() {
-                  assert(false, "Test #3 - Mouse selection of ALL didn't publish correctly (incorrect \"value\" payload attribute");
-               })
-               .end()
-            
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #3 - Mouse selection of ALL set the correct CSS class.");
-               })
-               .end()
-
-            // Test #4
-            // Clicking on the "checkbox" should now deselect everything...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img")
-               .click()
-               .end()
-
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "0", "Test #4 - _itemsSelected should be 0 after clicking on checkbox image");
-               })
-               .end()
-
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "selectNone"))
-               .then(null, function() {
-                  assert(false, "Test #4 - Mouse click on ALL checkbox image didn't publish correctly (incorrect \"value\" payload attribute");
-               })
-               .end()
-
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #4 - Mouse click on ALL checkbox didn't set the correct CSS class.");
-               })
-               .end()
-            
-            // Test #5
-            // Check clicking on the "Some" menu item...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS")
-               .click()
-               .end()
-            .findByCssSelector("#SELECT_SOME_BY_ITEMS")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "1", "Test #5 - _itemsSelected should be 1 after clicking on SOME");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "availableItemCount", "2"))
-               .then(null, function() {
-                  assert(false, "Test #5 - Mouse selection of SOME didn't publish correctly (incorrect \"availableItemCount\" payload attribute");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selectedItemCount", "1"))
-               .then(null, function() {
-                  assert(false, "Test #5 - Mouse selection of SOME didn't publish correctly (incorrect \"selectedItemCount\" payload attribute");
-               })
-               .end()
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-someselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #5 - Mouse selection of SOME set the correct CSS class.");
-               })
-               .end()
-
-            // Test #6
-            // Clicking on the "checkbox" should move "SOME" to "ALL"...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "2", "Test #6 - _itemsSelected should be 2 after clicking on the SOME checkbox image");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "selectAll"))
-               .then(null, function() {
-                  assert(false, "Test #6 - Mouse click on SOME checkbox image didn't publish correctly (incorrect \"value\" payload attribute");
-               })
-               .end()
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #6 - Mouse click on SOME checkbox didn't set the correct CSS class.");
-               })
-               .end()
-
-            // Test #7
-            // Check clicking on the "None (by Items)" menu item will set the none state...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS")
-               .click()
-               .end()
-            .findByCssSelector("#SELECT_NONE_BY_ITEMS")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "0", "Test #7 - _itemsSelected should be 0 after clicking on NONE (by items)");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "availableItemCount", "2"))
-               .then(null, function() {
-                  assert(false, "Test #7 - Mouse selection of NONE (by items) didn't publish correctly (incorrect \"availableItemCount\" payload attribute");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selectedItemCount", "0"))
-               .then(null, function() {
-                  assert(false, "Test #7 - Mouse selection of NONE (by items) didn't publish correctly (incorrect \"selectedItemCount\" payload attribute");
-               })
-               .end()
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #7 - Mouse selection of NONE (by items) set the correct CSS class.");
-               })
-               .end()
-
-            // Test #8
-            // Check clicking on the "All (by Items)" menu item will set the all state...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS")
-               .click()
-               .end()
-            .findByCssSelector("#SELECT_ALL_BY_ITEMS")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "2", "Test #8 - _itemsSelected should be 2 after clicking on ALL (by items)");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "availableItemCount", "2"))
-               .then(null, function() {
-                  assert(false, "Test #8 - Mouse selection of ALL (by items) didn't publish correctly (incorrect \"availableItemCount\" payload attribute");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selectedItemCount", "2"))
-               .then(null, function() {
-                  assert(false, "Test #8 - Mouse selection of ALL (by items) didn't publish correctly (incorrect \"selectedItemCount\" payload attribute");
-               })
-               .end()
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #8 - Mouse selection of ALL (by items) set the correct CSS class.");
-               })
-               .end()
-
-            // Test #9
-            // Check clicking on the "Select None" item...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS")
-               .click()
-               .end()
-            .findByCssSelector("#SELECT_NONE")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "0", "Test #9 - _itemsSelected should be 0 after clicking on NONE");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "selectNone"))
-               .then(null, function() {
-                  assert(false, "Test #9 - Mouse selection of NONE didn't publish correctly (incorrect \"value\" payload attribute");
-               })
-               .end()
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #9 - Mouse selection of NONE set the correct CSS class.");
-               })
-               .end()
-
-            // Test #10
-            // Clicking on the "checkbox" should move "NONE" to "ALL"...
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img")
-               .click()
-               .end()
-            .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
-               .then(function(result) {
-                  assert(result === "2", "Test #10 - _itemsSelected should be 2 after clicking on the NONE checkbox image");
-               })
-               .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "selectAll"))
-               .then(null, function() {
-                  assert(false, "Test #10 - Mouse click on NONE checkbox image didn't publish correctly (incorrect \"value\" payload attribute");
-               })
-               .end()
-            .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
-               .then(null, function() {
-                  assert(false, "Test #10 - Mouse click on NONE checkbox didn't set the correct CSS class.");
+                  assert.isFalse(false, "A subscription for the widget could not be found");
                });
       },
 
+      "There should be nothing selected on page load": function() {
+         return browser.execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "0", "There should be nothing selected on page load");
+            });
+      },
+
+      "Click ALL": function() {
+         return browser.findByCssSelector("#MENU_BAR_SELECT_ITEMS")
+            .click()
+         .end()
+         .findByCssSelector("#SELECT_ALL")
+            .click()
+            .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "2", "Items selected should be 2 after clicking on ALL");
+            })
+         .end()
+         .getLastPublish("MENU_BAR_SELECT_ITEMS", "Mouse selection of ALL didn't publish correctly (missing publish topic)")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "selectAll", "Mouse selection of ALL didn't publish correctly");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+
+      "Click checkbox to deselect everything": function() {
+            // Clicking on the "checkbox" should now deselect everything...
+         return browser.findByCssSelector("#MENU_BAR_SELECT_ITEMS>img")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "0", "Items selected should be 0 after clicking on checkbox image");
+            })
+         .end()
+         .getLastPublish("ITEMS_SELECTED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "selectNone", "Mouse selection of NONE didn't publish correctly");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+
+      "Click 'Some (by Items)' menu item": function() {
+         return browser.findById("MENU_BAR_SELECT_ITEMS_text")
+            .click()
+         .end()
+         .findById("SELECT_SOME_BY_ITEMS_text")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "1", "Items selected should be 1 after clicking on SOME");
+            })
+         .end()
+         .getLastPublish("MENU_BAR_SELECT_ITEMS")
+            .then(function(payload) {
+               assert.propertyVal(payload, "availableItemCount", "2", "Incorrect availableItemCount");
+               assert.propertyVal(payload, "selectedItemCount", "1", "Incorrect selectedItemCount");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-someselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+            
+      "Click checkbox to go from some to all": function() {
+         return browser.findByCssSelector("#MENU_BAR_SELECT_ITEMS>img")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "2", "ItemsSelected should be 2 after clicking on the SOME checkbox image");
+            })
+         .end()
+         .getLastPublish("ITEMS_SELECTED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "selectAll", "Clicking on checkbox didn't publish correctly");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+            
+      "Click 'None (by Items)' menu item": function() {
+         return browser.findById("MENU_BAR_SELECT_ITEMS_text")
+            .click()
+         .end()
+         .findById("SELECT_NONE_BY_ITEMS_text")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "0", "Items selected should be 0 after clicking on NONE (by items)");
+            })
+         .end()
+         .getLastPublish("MENU_BAR_SELECT_ITEMS")
+            .then(function(payload) {
+               assert.propertyVal(payload, "availableItemCount", "2", "Incorrect availableItemCount");
+               assert.propertyVal(payload, "selectedItemCount", "0", "Incorrect selectedItemCount");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+
+      "Click 'All (by Items)' menu item": function() {
+         return browser.findById("MENU_BAR_SELECT_ITEMS_text")
+            .click()
+         .end()
+         .findById("SELECT_ALL_BY_ITEMS_text")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "2", "Items selected should be 2 after clicking on NONE (by items)");
+            })
+         .end()
+         .getLastPublish("MENU_BAR_SELECT_ITEMS")
+            .then(function(payload) {
+               assert.propertyVal(payload, "availableItemCount", "2", "Incorrect availableItemCount");
+               assert.propertyVal(payload, "selectedItemCount", "2", "Incorrect selectedItemCount");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+
+      "Click 'Select None' menu item": function() {
+         return browser.findById("MENU_BAR_SELECT_ITEMS_text")
+            .click()
+         .end()
+         .findById("SELECT_NONE_text")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "0", "Items selected should be 0 after clicking on NONE (by items)");
+            })
+         .end()
+         .getLastPublish("MENU_BAR_SELECT_ITEMS")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "selectNone", "Clicking on checkbox didn't publish correctly");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+
+      "Click checkbox to go from none to all": function() {
+         return browser.findByCssSelector("#MENU_BAR_SELECT_ITEMS>img")
+            .click()
+         .end()
+         .execute("return dijit.registry.byId(\"MENU_BAR_SELECT_ITEMS\")._itemsSelected.toString()")
+            .then(function(result) {
+               assert.equal(result, "2", "ItemsSelected should be 2 after clicking on the SOME checkbox image");
+            })
+         .end()
+         .getLastPublish("ITEMS_SELECTED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "selectAll", "Clicking on checkbox didn't publish correctly");
+            })
+         .end()
+         .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
+            .then(null, function() {
+               assert(false, "Expected CSS class not found on checkbox");
+            });
+      },
+      
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfFormDialogMenuItem.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfFormDialogMenuItem.get.js
@@ -45,10 +45,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
-}
-;
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarSelect.get.js
@@ -137,4 +137,3 @@ model.jsonModel = {
       }
    ]
 }
-;

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarSelectItems.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarSelectItems.get.js
@@ -1,6 +1,14 @@
 model.jsonModel = {
    services: [
-      "alfresco/services/ErrorReporter"
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
    ],
    widgets: [
       {
@@ -20,9 +28,9 @@ model.jsonModel = {
                            config: {
                               widgets: [
                                  {
+                                    id: "SELECT_ALL",
                                     name: "alfresco/menus/AlfMenuItem",
                                     config: {
-                                       id: "SELECT_ALL",
                                        label: "All",
                                        publishTopic: "MENU_BAR_SELECT_ITEMS",
                                        publishPayload: {
@@ -32,9 +40,9 @@ model.jsonModel = {
                                     }
                                  },
                                  {
+                                    id: "SELECT_ALL_BY_ITEMS",
                                     name: "alfresco/menus/AlfMenuItem",
                                     config: {
-                                       id: "SELECT_ALL_BY_ITEMS",
                                        label: "All (by items)",
                                        publishTopic: "MENU_BAR_SELECT_ITEMS",
                                        publishPayload: {
@@ -44,9 +52,9 @@ model.jsonModel = {
                                     }
                                  },
                                  {
+                                    id: "SELECT_SOME_BY_ITEMS",
                                     name: "alfresco/menus/AlfMenuItem",
                                     config: {
-                                       id: "SELECT_SOME_BY_ITEMS",
                                        label: "Some (by items)",
                                        publishTopic: "MENU_BAR_SELECT_ITEMS",
                                        publishPayload: {
@@ -56,9 +64,9 @@ model.jsonModel = {
                                     }
                                  },
                                  {
+                                    id: "SELECT_NONE_BY_ITEMS",
                                     name: "alfresco/menus/AlfMenuItem",
                                     config: {
-                                       id: "SELECT_NONE_BY_ITEMS",
                                        label: "None (by items)",
                                        publishTopic: "MENU_BAR_SELECT_ITEMS",
                                        publishPayload: {
@@ -68,9 +76,9 @@ model.jsonModel = {
                                     }
                                  },
                                  {
+                                    id: "SELECT_NONE",
                                     name: "alfresco/menus/AlfMenuItem",
                                     config: {
-                                       id: "SELECT_NONE",
                                        label: "None",
                                        publishTopic: "MENU_BAR_SELECT_ITEMS",
                                        publishPayload: {
@@ -90,11 +98,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
-}
-;
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-551 to ensure that when switching views any item selection on one view is retained on the next.