### PR TITLE
AKU-567: Added defensive code into DebugLog

### DIFF
--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -445,7 +445,7 @@ define(["alfresco/core/ObjectTypeUtils",
             var collapsedClass = this.rootClass + "__log__entry__data--collapsed",
                expandedDataClass = this.rootClass + "__log__entry__data__full",
                clickedOnExpandedData = domClass.contains(evt.target, expandedDataClass);
-            if (!clickedOnExpandedData) {
+            if (!clickedOnExpandedData && dataNode) {
                domClass.toggle(dataNode, collapsedClass);
             }
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-567 to add defensive code to prevent a potential JS exception that was reported as occurring in the DebugLog