### PR TITLE
AKU-575: Update ComboBox change events to include item selection

### DIFF
--- a/aikau/src/test/resources/alfresco/forms/controls/ComboBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ComboBoxTest.js
@@ -42,6 +42,28 @@ define(["alfresco/TestCommon",
          browser.end();
       },
 
+      "Check that mouse selection of option updates value": function() {
+         return browser.findByCssSelector("#PROPERTIES label.label")
+            .click()
+         .end()
+
+         .findByCssSelector("#PROPERTIES .dijitArrowButtonInner")
+            .click()
+         .end()
+         .findByCssSelector("#PROPERTIES_CONTROL_popup0")
+            .click()
+         .end()
+
+         .findByCssSelector(".confirmationButton > span")
+            .click()
+            .end()
+
+         .getLastPublish("POST_FORM")
+            .then(function(payload) {
+               assert.propertyVal(payload, "property", "act:actionExecutionTitle", "Property value not set from mouse selection");
+            });
+      },
+
       "Checking the number of tag options...": function() {
          return browser.findByCssSelector("#TAGS .dijitArrowButtonInner")
             .click()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ComboBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ComboBox.get.js
@@ -26,6 +26,7 @@ model.jsonModel = {
                   id: "TAGS",
                   name: "alfresco/forms/controls/ComboBox", 
                   config: {
+                     fieldId: "TAGS",
                      label: "Tags",
                      name: "tag",
                      value: "",
@@ -42,6 +43,7 @@ model.jsonModel = {
                   id: "PROPERTIES",
                   name: "alfresco/forms/controls/ComboBox", 
                   config: {
+                     fieldId: "PROPERTIES",
                      label: "Properties",
                      name: "property",
                      value: "",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-575 to ensure that the alfresco/forms/controls/ComboBox widget listens to selection of items in the drop-down as well as keyboard entry to trigger value change updates.