### PR TITLE
AKU-581: Set explicit CSS selector for form control label

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -55,6 +55,7 @@
 .alfresco-forms-controls-BaseFormControl > .title-row > label {
    font-size: @normal-font-size;
    line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
+   display: inline-block;
 }
 
 .alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form > .alfresco-forms-controls-BaseFormControl > .title-row > label:after {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-581. This is a strange issue that only seems to impact the Chrome browser that results in form control labels being hidden when an unrelated HTML element has a class removed from it (resizing the browser resolves the issue, but this is not a resize issue). This doesn't impact Firefox and there are no CSS selectors being triggered. There are no tests because this was an incredibly tricky issue to reproduce. It only seems to occur when the field is required. But setting the display value for the label explicitly seems to resolve the issue.