### PR TITLE
Extracted top-level CSS selector as LESS variable

### DIFF
--- a/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/web-application-config.xml
+++ b/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/web-application-config.xml
@@ -137,4 +137,15 @@
          </list>
       </property>
    </bean>
+   
+   <!-- Override DependencyAggregator to set compression exclusions -->
+   <bean id="dependency.aggregator" parent="dependency.aggregator.abstract" class="org.springframework.extensions.surf.DependencyAggregator">
+      <property name="compressionExclusions">
+         <list>
+            <!-- required for Aikau 1.0.36 to avoid LESS errors util Surf dependencies can be updated -->
+            <value>*.css</value>
+         </list>
+      </property>
+   </bean>
+   
 </beans>

--- a/aikau/src/main/resources/alfresco/core/css/Core.css
+++ b/aikau/src/main/resources/alfresco/core/css/Core.css
@@ -27,7 +27,7 @@ body {
    margin: 0;
 }
 
-.alfresco-share
+.@{alfresco}
 {
    font:13px/1.231 Open Sans,arial,helvetica,clean,sans-serif;
 }

--- a/aikau/src/main/resources/alfresco/core/css/Icons.css
+++ b/aikau/src/main/resources/alfresco/core/css/Icons.css
@@ -1,4 +1,4 @@
-.alfresco-share .dijitIcon {
+.@{alfresco} .dijitIcon {
 
    &.alf-sites-icon {
       background-image: url("../../css/images/site-24.png");

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -1,3 +1,6 @@
+// Root selector
+@alfresco: alfresco-share;
+
 // Main palette
 @primary-background-color: #fff;
 @primary-font-color: #333;

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/AlfGalleryViewSlider.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/AlfGalleryViewSlider.css
@@ -4,37 +4,37 @@
   width: 100px;
 }
 
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider div.dijitSliderBar > div.dijitSliderMoveable > div.dijitSliderImageHandle,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider.dijitSliderHover div.dijitSliderBar.dijitSliderProgressBarH > div.dijitSliderMoveable > div.dijitSliderImageHandle.dijitSliderThumbHover,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider div.dijitSliderBar.dijitSliderProgressBarH > div.dijitSliderMoveable > div.dijitSliderImageHandle.dijitSliderFocused {
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider div.dijitSliderBar > div.dijitSliderMoveable > div.dijitSliderImageHandle,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider.dijitSliderHover div.dijitSliderBar.dijitSliderProgressBarH > div.dijitSliderMoveable > div.dijitSliderImageHandle.dijitSliderThumbHover,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider div.dijitSliderBar.dijitSliderProgressBarH > div.dijitSliderMoveable > div.dijitSliderImageHandle.dijitSliderFocused {
    background-image: url("./images/thumb-n.png");
    height: 16px;
    width: 18px;
    background-position: 0 0;
 }
 
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderImageHandleH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderImageHandleH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderProgressBarH .dijitSliderImageHandleH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderThumbHover.dijitSliderImageHandleH {
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderImageHandleH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderImageHandleH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderProgressBarH .dijitSliderImageHandleH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderThumbHover.dijitSliderImageHandleH {
   background-image: url("./images/thumb-n.png");
   height: 16px;
   width: 18px;
   background-position: 0 0;
 }
 
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderDecrementIconH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderDecrementIconV,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderIncrementIconV,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderIncrementIconH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderDecrementIconH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderDecrementIconV,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderIncrementIconV,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderIncrementIconH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderDecrementIconH,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderDecrementIconV,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderIncrementIconV,
-.alfresco-share .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderIncrementIconH {
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderDecrementIconH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderDecrementIconV,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderIncrementIconV,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderIncrementIconH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderDecrementIconH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderDecrementIconV,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderIncrementIconV,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderActive .dijitSliderIncrementIconH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderDecrementIconH,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderDecrementIconV,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderIncrementIconV,
+.@{alfresco} .alfresco-documentlibrary-AlfGalleryViewSlider .dijitSliderHover .dijitSliderIncrementIconH {
    background-color: transparent;
    background-position: 0 0;
    height: 16px;

--- a/aikau/src/main/resources/alfresco/header/css/AlfCascadingMenu.css
+++ b/aikau/src/main/resources/alfresco/header/css/AlfCascadingMenu.css
@@ -1,8 +1,8 @@
-.alfresco-share .alfresco-header-AlfCascadingMenu .dijitMenu .dijitMenuItemHover td,
-.alfresco-share .alfresco-header-AlfCascadingMenu .dijitMenu .dijitMenuItemSelected td,
-.alfresco-share .alfresco-header-AlfCascadingMenu .dijitMenu .dijitMenuItemHover,
-.alfresco-share .alfresco-header-AlfCascadingMenu .dijitComboBoxMenu .dijitMenuItemHover,
-.alfresco-share .alfresco-header-AlfCascadingMenu .dijitMenuItemSelected {
+.@{alfresco} .alfresco-header-AlfCascadingMenu .dijitMenu .dijitMenuItemHover td,
+.@{alfresco} .alfresco-header-AlfCascadingMenu .dijitMenu .dijitMenuItemSelected td,
+.@{alfresco} .alfresco-header-AlfCascadingMenu .dijitMenu .dijitMenuItemHover,
+.@{alfresco} .alfresco-header-AlfCascadingMenu .dijitComboBoxMenu .dijitMenuItemHover,
+.@{alfresco} .alfresco-header-AlfCascadingMenu .dijitMenuItemSelected {
    background-color: @header-hover-background-color;
    background-image: none;
    background-repeat: no-repeat;
@@ -11,7 +11,7 @@
 
 /* This has been added to set the display for cascading menus - TODO this needs to be changed
    for cases where groups have not been specified. */
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu {
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu {
   border: 1px solid @header-focus-background-color;
   background-color: @header-focus-background-color;
   box-shadow: 0.33px 2px 8px rgba(0, 0, 0, 0.3);
@@ -19,16 +19,16 @@
 }
 
 /* This ensures that the menu text color is white */
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitMenuItem {
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitMenuItem {
   color: @header-focus-font-color;
   background-color: @header-focus-background-color;
 }
 
 /* This overrides whatever Dojo theme is used */
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitSelectMenu .dijitMenuItemHover td, 
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitSelectMenu .dijitMenuItemSelected td, 
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitMenuItemHover,
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitMenuItemSelected {
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitSelectMenu .dijitMenuItemHover td, 
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitSelectMenu .dijitMenuItemSelected td, 
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitMenuItemHover,
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu .dijitMenuItemSelected {
   background-color: @header-hover-background-color;
   background-image: none;
   background-repeat: no-repeat;
@@ -43,7 +43,7 @@
   padding: 5px;
 }
 
-.alfresco-share .dijitPopup.Popup .alfresco-header-AlfCascadingMenu {
+.@{alfresco} .dijitPopup.Popup .alfresco-header-AlfCascadingMenu {
   background-color: transparent;
   border: medium none;
   box-shadow: none;

--- a/aikau/src/main/resources/alfresco/header/css/AlfMenuBarPopup.css
+++ b/aikau/src/main/resources/alfresco/header/css/AlfMenuBarPopup.css
@@ -1,10 +1,10 @@
-.alfresco-share .alf-menu-arrow {
+.@{alfresco} .alf-menu-arrow {
    margin-left: 3px;
    width: 20px;
    height: 20px;
 }
 
-.alfresco-share .alf-popup-menu-bar-image-item {
+.@{alfresco} .alf-popup-menu-bar-image-item {
    background: url("./images/MenuSearch.PNG");
    background-repeat: no-repeat;
    height: 20px;

--- a/aikau/src/main/resources/alfresco/header/css/AlfMenuItem.css
+++ b/aikau/src/main/resources/alfresco/header/css/AlfMenuItem.css
@@ -1,8 +1,8 @@
-.alfresco-share .alf-header-menu-bar .dijitMenu .dijitMenuItemHover td,
-.alfresco-share .alf-header-menu-bar .dijitMenu .dijitMenuItemSelected td,
-.alfresco-share .alf-header-menu-bar .dijitMenu .dijitMenuItemHover,
-.alfresco-share .alf-header-menu-bar .dijitComboBoxMenu .dijitMenuItemHover,
-.alfresco-share .alf-header-menu-bar .dijitMenuItemSelected {
+.@{alfresco} .alf-header-menu-bar .dijitMenu .dijitMenuItemHover td,
+.@{alfresco} .alf-header-menu-bar .dijitMenu .dijitMenuItemSelected td,
+.@{alfresco} .alf-header-menu-bar .dijitMenu .dijitMenuItemHover,
+.@{alfresco} .alf-header-menu-bar .dijitComboBoxMenu .dijitMenuItemHover,
+.@{alfresco} .alf-header-menu-bar .dijitMenuItemSelected {
    background-color: @header-hover-background-color;
    background-image: none;
    background-repeat: no-repeat;

--- a/aikau/src/main/resources/alfresco/header/css/Header.css
+++ b/aikau/src/main/resources/alfresco/header/css/Header.css
@@ -1,4 +1,4 @@
-.alfresco-share .alf-home-icon {
+.@{alfresco} .alf-home-icon {
    background: url("./images/home.png");
    background-repeat: no-repeat;
    height: 16px;
@@ -7,15 +7,15 @@
    float: left;
 }
 
-.alfresco-share .navigation-menu {
+.@{alfresco} .navigation-menu {
    margin-top: 23px;
 }
 
-.alfresco-share .title-menu {
+.@{alfresco} .title-menu {
    margin-top: 23px;
 }
 
-.alfresco-share .alfresco-header-Header {
+.@{alfresco} .alfresco-header-Header {
    background-color: @header-primary-background-color;
    color: @header-primary-font-color;
    font-family: Open Sans,arial,helvetica,clean,sans-serif;
@@ -24,31 +24,31 @@
 }
 
 /* Sets the highlight on the menu bar items in the header bar ONLY */
-.alfresco-share .alfresco-header-Header .alfresco-menus-AlfMenuBar .dijitMenuPassive .dijitMenuItemHover {
+.@{alfresco} .alfresco-header-Header .alfresco-menus-AlfMenuBar .dijitMenuPassive .dijitMenuItemHover {
    background-color: @header-hover-background-color;
    color: @header-hover-font-color;
 }
 
-.alfresco-share .alf-header-menu-bar .dijitMenuItem {
+.@{alfresco} .alf-header-menu-bar .dijitMenuItem {
    color: @header-dropdown-menu-font-color;
 }
 
 /* Sets the highlight on popup menu items in the header bar ONLY. Note that we need to use "alf-header-menu-bar" and not
    just "alf-header" because the popup is not a direct child of the node set with the "alf-header" class */
-.alfresco-share .alf-header-menu-bar .alf-menu-group .dijitMenuPassive .dijitMenuItemHover, 
-.alfresco-share .alf-header-menu-bar .alf-menu-group .dijitMenuItemSelected {
+.@{alfresco} .alf-header-menu-bar .alf-menu-group .dijitMenuPassive .dijitMenuItemHover, 
+.@{alfresco} .alf-header-menu-bar .alf-menu-group .dijitMenuItemSelected {
    background-color: @header-hover-background-color;
    color: @header-hover-font-color;
 }
 
 /* Sets the selection highlight colour on header menu items - more specific than class in AlfMenuBar */
-.alfresco-share .alfresco-header-Header .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItemSelected.dijitMenuItem {
+.@{alfresco} .alfresco-header-Header .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItemSelected.dijitMenuItem {
    background-color: @header-focus-background-color;
 }
 
 /* Sets the correct height for the header menu bar items. This may need to be changed for different browsers and
  * possible adjusted if items in the header are changed */
-.alfresco-share .alfresco-header-Header .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
+.@{alfresco} .alfresco-header-Header .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
    height: 22px;
    margin: 0 8px;
    padding-top: 4px;
@@ -56,24 +56,24 @@
 }
 
 /* Sets the dark grey colour in the drop-down menus in header menus ONLY. */
-.alfresco-share .alf-header-menu-bar.alf-menu-groups {
+.@{alfresco} .alf-header-menu-bar.alf-menu-groups {
    background-color: @header-focus-background-color;
    border: 1px solid @header-focus-background-color;
    box-shadow: 0.33px 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* Sets the dark grey colour in the menu groups in the header menu ONLY */
-.alfresco-share .alf-header-menu-bar .dijitMenuTable {
+.@{alfresco} .alf-header-menu-bar .dijitMenuTable {
    background-color: @header-focus-background-color;
    color: @header-focus-font-color;
 }
 
 /* Sets the menu group title background colour in the header menu ONLY */
-.alfresco-share .alf-header-menu-bar .alf-menu-group.dijitMenu {
+.@{alfresco} .alf-header-menu-bar .alf-menu-group.dijitMenu {
    background-color: @header-focus-background-color;
 }
 
 /* Stops the line appearing between menu items in the header bar menu ONLY */
-.alfresco-share .alf-header-menu-bar .alf-menu-group .dijitReset.dijitMenuItem {
+.@{alfresco} .alf-header-menu-bar .alf-menu-group .dijitReset.dijitMenuItem {
    border-bottom: none;
 }

--- a/aikau/src/main/resources/alfresco/header/css/SearchBox.css
+++ b/aikau/src/main/resources/alfresco/header/css/SearchBox.css
@@ -2,7 +2,7 @@
    top: 2px;
 }
 
-.alfresco-share .alfresco-header-SearchBox {
+.@{alfresco} .alfresco-header-SearchBox {
    margin: 2px 10px 0px 10px;
    background-color: @primary-title-color;
    border-radius: 12px;
@@ -156,7 +156,7 @@
 }
 
 /* This overrides the header menu bar settings to ensure that the popup menu item is the right height */
-.alfresco-share .alfresco-header-SearchBox-menu .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
+.@{alfresco} .alfresco-header-SearchBox-menu .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
     height: 16px;
     margin-top: 0;
     margin-left: 1px;

--- a/aikau/src/main/resources/alfresco/header/css/Title.css
+++ b/aikau/src/main/resources/alfresco/header/css/Title.css
@@ -1,6 +1,6 @@
 @shareTitleBG: #fafafa;
 
-.alfresco-share {
+.@{alfresco} {
    h1.alfresco-header-Title {
       font-size: 185%;
       font-weight: normal;

--- a/aikau/src/main/resources/alfresco/menus/css/AlfCheckableMenuItem.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfCheckableMenuItem.css
@@ -3,7 +3,7 @@
   width: 12px;
 }
 
-.alfresco-share .dijitMenu .alf-checkable-menu-item.alf-selected-icon {
+.@{alfresco} .dijitMenu .alf-checkable-menu-item.alf-selected-icon {
    background: url("./images/12x12-selected-icon.png");
    background-repeat: no-repeat;
    background-position: 4px 4px;

--- a/aikau/src/main/resources/alfresco/menus/css/AlfContextMenu.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfContextMenu.css
@@ -1,4 +1,4 @@
-.alfresco-share .dijitPopup.dijitMenuPopup {
+.@{alfresco} .dijitPopup.dijitMenuPopup {
    box-shadow: none;
 }
 

--- a/aikau/src/main/resources/alfresco/menus/css/AlfDropDownMenu.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfDropDownMenu.css
@@ -1,4 +1,4 @@
-.alfresco-share .dijit.dijitMenu.dijitMenuPassive.dijitReset.dijitMenuTable.alf-dropdown-menu {
+.@{alfresco} .dijit.dijitMenu.dijitMenuPassive.dijitReset.dijitMenuTable.alf-dropdown-menu {
    width: 100%;
    border: medium none;
 }

--- a/aikau/src/main/resources/alfresco/menus/css/AlfMenuBar.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfMenuBar.css
@@ -1,8 +1,8 @@
-.alfresco-share .alf-menu-groups {
+.@{alfresco} .alf-menu-groups {
    font-family: Open Sans,arial,sans-serif;
 }
 
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitMenuBar {
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitMenuBar {
    font-family: Open Sans,arial,sans-serif;
    background-color: transparent;
    background-image: none;
@@ -12,21 +12,21 @@
    padding: 0;
 }
 
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitSelectMenu .dijitMenuItemHover,
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitSelectMenu .dijitMenuItemSelected {
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitSelectMenu .dijitMenuItemHover,
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitSelectMenu .dijitMenuItemSelected {
    background-image: none;
    background-repeat: no-repeat;
 }
 
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuItem {
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuItem {
    margin: 0;
    padding: 0;
    color: #333;
 }
 
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuPassive .dijitMenuItemHover,
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuItemHover,
-.alfresco-share .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuItemSelected {
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuPassive .dijitMenuItemHover,
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuItemHover,
+.@{alfresco} .alfresco-menus-AlfMenuBar .dijitMenuBar .dijitMenuItemSelected {
     background-color: #ddd;
     background-image: none;
     background-repeat: no-repeat;
@@ -34,23 +34,23 @@
     padding: 2px 5px;
 }
 
-.alfresco-share .alf-menu-group .dijitMenuPassive .dijitMenuItemHover,
-.alfresco-share .alf-menu-group .dijitMenuItemHover 
-.alfresco-share .alf-menu-group .dijitMenuItemSelected {
+.@{alfresco} .alf-menu-group .dijitMenuPassive .dijitMenuItemHover,
+.@{alfresco} .alf-menu-group .dijitMenuItemHover 
+.@{alfresco} .alf-menu-group .dijitMenuItemSelected {
     background-image: none;
     background-repeat: no-repeat;
     background-color: #ddd;
     color: #717171;
 }
 
-.alfresco-share .alf-menu-groups {
+.@{alfresco} .alf-menu-groups {
    background-color: #fff;
    color: #333 !important;
    border: 1px solid #ccc;
    padding: 4px;
 }
 
-.alfresco-share .alf-menu-group-title {
+.@{alfresco} .alf-menu-group-title {
    font-family: Open Sans,arial,sans-serif;
    border-bottom: 1px solid #ccc;
    color: #ccc;

--- a/aikau/src/main/resources/alfresco/menus/css/AlfMenuBarPopup.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfMenuBarPopup.css
@@ -1,4 +1,4 @@
-.alfresco-share .alf-menu-arrow {
+.@{alfresco} .alf-menu-arrow {
    margin-left: 3px;
    width: 20px;
    height: 20px;
@@ -7,17 +7,17 @@
 
 
 /* This overrides the default Dojo box shadow for popups. Our box shadow is defined elsewhere */
-.alfresco-share div.dijitPopup.Popup {
+.@{alfresco} div.dijitPopup.Popup {
     box-shadow: none;
 }
 
 /* This is added to the container node of the menu bar popup to make room for an icon when required */
-.alfresco-share .alf-menu-bar-popup-label-node {
+.@{alfresco} .alf-menu-bar-popup-label-node {
    margin-left: 6px;
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-configure-icon {
+.@{alfresco} .alf-configure-icon {
    background: url("./images/Configure.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -27,7 +27,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-user-icon {
+.@{alfresco} .alf-user-icon {
    background: url("./images/User.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -37,7 +37,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-upload-icon {
+.@{alfresco} .alf-upload-icon {
    background: url("./images/Upload.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -47,7 +47,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-create-icon {
+.@{alfresco} .alf-create-icon {
    background: url("./images/Create.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -57,7 +57,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-allselected-icon {
+.@{alfresco} .alf-allselected-icon {
    background: url("./images/AllSelected.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -67,7 +67,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-someselected-icon {
+.@{alfresco} .alf-someselected-icon {
    background: url("./images/SomeSelected.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -77,7 +77,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-noneselected-icon {
+.@{alfresco} .alf-noneselected-icon {
    background: url("./images/NoneSelected.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -87,7 +87,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-back-icon {
+.@{alfresco} .alf-back-icon {
    background: url("./images/back-arrow.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -97,7 +97,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-forward-icon {
+.@{alfresco} .alf-forward-icon {
    background: url("./images/forward-arrow-16.png");
    background-repeat: no-repeat;
    height: 20px;

--- a/aikau/src/main/resources/alfresco/menus/css/AlfMenuBarToggle.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfMenuBarToggle.css
@@ -1,5 +1,5 @@
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-sort-ascending-icon {
+.@{alfresco} .alf-sort-ascending-icon {
    background: url("./images/sort-ascending-16.png");
    background-repeat: no-repeat;
    height: 16px;
@@ -9,7 +9,7 @@
 }
 
 /* This is used for Popup items - NOT menu items */
-.alfresco-share .alf-sort-descending-icon {
+.@{alfresco} .alf-sort-descending-icon {
    background: url("./images/sort-descending-16.png");
    background-repeat: no-repeat;
    height: 16px;

--- a/aikau/src/main/resources/alfresco/menus/css/AlfMenuGroup.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfMenuGroup.css
@@ -1,4 +1,4 @@
-.alfresco-share div.alf-menu-group.dijitMenu {
+.@{alfresco} div.alf-menu-group.dijitMenu {
   border: none;
 }
 
@@ -6,6 +6,6 @@
    of menus occupy a fixed width of the popup area. This is required because where there
    are multiple groups in a single popup the space between icon and label can vary.
    TODO: This fixes the width even when no icon is available */
-.alfresco-share .alf-menu-group-items td.dijitMenuItemIconCell {
+.@{alfresco} .alf-menu-group-items td.dijitMenuItemIconCell {
     width: 25px;
 }

--- a/aikau/src/main/resources/alfresco/menus/css/_AlfMenuItemMixin.css
+++ b/aikau/src/main/resources/alfresco/menus/css/_AlfMenuItemMixin.css
@@ -1,19 +1,19 @@
-.alfresco-share .dijitMenu .dijitMenuItemHover td,
-.alfresco-share .dijitMenu .dijitMenuItemSelected td,
-.alfresco-share .dijitMenu .dijitMenuItemHover,
-.alfresco-share .dijitComboBoxMenu .dijitMenuItemHover,
-.alfresco-share .dijitMenuItemSelected {
+.@{alfresco} .dijitMenu .dijitMenuItemHover td,
+.@{alfresco} .dijitMenu .dijitMenuItemSelected td,
+.@{alfresco} .dijitMenu .dijitMenuItemHover,
+.@{alfresco} .dijitComboBoxMenu .dijitMenuItemHover,
+.@{alfresco} .dijitMenuItemSelected {
    background-color: #f0f0f0;
    background-image: none;
    background-repeat: no-repeat;
 }
 
-.alfresco-share .dijitMenu .dijitMenuItem td, .alfresco-share .dijitComboBoxMenu .dijitMenuItem {
+.@{alfresco} .dijitMenu .dijitMenuItem td, .@{alfresco} .dijitComboBoxMenu .dijitMenuItem {
   border-style: none;
   border-width: 0;
 }
 
-.alfresco-share .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
+.@{alfresco} .dijitReset.dijitInline.dijitMenuItemLabel.dijitMenuItem {
    margin: 0 5px;
    padding: 2px 5px;
    text-overflow: ellipsis;
@@ -28,182 +28,182 @@
     text-decoration: none;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-edit-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-edit-icon {
    background: url("./images/Edit.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-cog-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-cog-icon {
    background: url("./images/Cog.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-leave-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-leave-icon {
    background: url("./images/Right_Arrow.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-profile-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-profile-icon {
    background: url("./images/Profile.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-password-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-password-icon {
    background: url("./images/Password.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-help-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-help-icon {
    background: url("./images/Help.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-logout-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-logout-icon {
    background: url("./images/Logout.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-simplelist-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-simplelist-icon {
    background: url("./images/simple-view-on-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-detailedlist-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-detailedlist-icon {
    background: url("./images/detailed-view-on-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-gallery-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-gallery-icon {
    background: url("./images/gallery-view-on-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-tableview-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-tableview-icon {
    background: url("./images/table-view-on-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-filmstrip-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-filmstrip-icon {
    background: url("./images/filmstrip-view-on-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-showfolders-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-showfolders-icon {
    background: url("./images/folders-show-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-showpath-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-showpath-icon {
    background: url("./images/navbar-show-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-showsidebar-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-showsidebar-icon {
    background: url("./images/ShowSidebar.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-textdoc-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-textdoc-icon {
    background: url("./images/TextDocument.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-htmldoc-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-htmldoc-icon {
    background: url("./images/HtmlDocument.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-xmldoc-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-xmldoc-icon {
    background: url("./images/XmlDocument.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-all-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-all-icon {
    background: url("./images/AllSelected.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-some-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-some-icon {
    background: url("./images/SomeSelected.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-none-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-none-icon {
    background: url("./images/NoneSelected.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-delete-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-delete-icon {
    background: url("./images/delete-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-delete-20-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-delete-20-icon {
    background: url("./images/delete-20.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-fullscreen-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-fullscreen-icon {
    background: url("./images/fullscreen-enter.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-enabled-on-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-enabled-on-icon {
    background: url("./images/enabled-on-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-enabled-off-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-enabled-off-icon {
    background: url("./images/enabled-off-16.png");
    background-repeat: no-repeat;
    height: 20px;

--- a/aikau/src/main/resources/alfresco/navigation/css/Link.css
+++ b/aikau/src/main/resources/alfresco/navigation/css/Link.css
@@ -1,4 +1,4 @@
-.alfresco-share .alfresco-navigation-Link {
+.@{alfresco} .alfresco-navigation-Link {
    color: @link-font-color;
    text-decoration: @link-text-decoration;
    cursor: pointer;

--- a/aikau/src/main/resources/alfresco/navigation/css/_HtmlAnchorMixin.css
+++ b/aikau/src/main/resources/alfresco/navigation/css/_HtmlAnchorMixin.css
@@ -1,4 +1,4 @@
-.alfresco-share a.alfresco-navigation-_HtmlAnchorMixin {
+.@{alfresco} a.alfresco-navigation-_HtmlAnchorMixin {
    color: inherit;
    text-decoration: @link-text-decoration;
    &:hover {

--- a/aikau/src/main/resources/alfresco/renderers/css/QuickShare.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/QuickShare.css
@@ -18,7 +18,7 @@
   display: inline-block;
 }
 
-.alfresco-share .alf-quick-share-enabled-icon {
+.@{alfresco} .alf-quick-share-enabled-icon {
    background: url("./images/quickshare-action-enabled-16.png");
    background-repeat: no-repeat;
    height: 20px;
@@ -27,28 +27,28 @@
    float: left;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-social-email-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-social-email-icon {
    background: url("./images/social-email-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-social-facebook-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-social-facebook-icon {
    background: url("./images/social-facebook-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-social-twitter-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-social-twitter-icon {
    background: url("./images/social-twitter-16.png");
    background-repeat: no-repeat;
    height: 20px;
    width: 20px;
 }
 
-.alfresco-share .dijitIcon.dijitMenuItemIcon.alf-social-google-plus-icon {
+.@{alfresco} .dijitIcon.dijitMenuItemIcon.alf-social-google-plus-icon {
    background: url("./images/social-google-16.png");
    background-repeat: no-repeat;
    height: 20px;

--- a/aikau/src/main/resources/alfresco/renderers/css/_ActionsMixin.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/_ActionsMixin.css
@@ -1,4 +1,4 @@
-.alfresco-share {
+.@{alfresco} {
    .dijitIcon {
       &.dijitMenuItemIcon {
          &.alf-doclib-action {

--- a/aikau/src/test/resources/testApp/WEB-INF/config/web-application-config.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/config/web-application-config.xml
@@ -105,4 +105,14 @@
 
    <bean id="webscript.alfresco.UnitTestList.get" class="org.alfresco.aikau.UnitTestList" parent="webscript" scope="prototype" />
    
+   <!-- Override DependencyAggregator to set compression exclusions -->
+   <bean id="dependency.aggregator" parent="dependency.aggregator.abstract" class="org.springframework.extensions.surf.DependencyAggregator">
+      <property name="compressionExclusions">
+         <list>
+            <!-- required for Aikau 1.0.36 to avoid LESS errors util Surf dependencies can be updated -->
+            <value>*.css</value>
+         </list>
+      </property>
+   </bean>
+   
 </beans>


### PR DESCRIPTION
This change allows Aikau app developers the freedom to change the top-level selector from "alfresco-share" to something else and still make use of the standard Aikau widget CSS.

The top-level selector is now defined as a LESS default in src/main/resources/alfresco/css/less/defaults.less:
```css
// Root selector
@alfresco: alfresco-share;
```

In a custom theme an example override would be:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<theme>
   <id>sfs-theme</id>
   <title>SFS Theme</title>
   <css-tokens>
      <less-variables>
         @alfresco: somevalue;
      </less-variables>
   </css-tokens>
</theme>
```

NOTE! This has a dependency on fixing the compression of CSS files in Surf - this is currently achieved with the following *mandatory* application context bean override to remove *.css from compression step - example for Alfresco Share:
```xml
   <bean id="dependency.aggregator" parent="dependency.aggregator.abstract" class="org.springframework.extensions.surf.DependencyAggregator">
      <property name="compressionExclusions">
          <list>
             <value>*.css</value>
             <value>*-min.js</value>
             <value>*/lib/code-mirror/*.js</value>
          </list>
       </property>
   </bean>
```
The `*.css` is the important line. This is *required* or LESS errors will occur with this change!