### PR TITLE
AKU-574: Sidebar contents hidden on collapse

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -379,7 +379,7 @@ define(["dojo/_base/declare",
             // not. We're using the classes applied to the drag handle node to determine whether or not
             // to show or hide the sidebar.
             this.alfPublish("ALF_DOCLIST_SHOW_SIDEBAR", {
-               selected: domClass.contains(this.resizeHandlerButtonNode, "pop-out")
+               selected: domClass.contains(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--closed")
             });
          }
       },
@@ -407,42 +407,23 @@ define(["dojo/_base/declare",
             var width = (this.hiddenSidebarWidth) ? this.hiddenSidebarWidth : this.initialSidebarWidth;
             domStyle.set(this.sidebarNode, "width", width + "px");
 
-            // Add some right padding so that the resize bar doesn't appear over the content, this is
-            // particular important with regards to scrollbars that might be present (see AKU-514)
-            domStyle.set(this.sidebarNode, "padding-right", "10px");
             this.lastSidebarWidth = width;
             this.resizeHandler();
-            if (this.resizeHandlerButtonNode)
-            {
-               domClass.remove(this.resizeHandlerButtonNode, "pop-out");
-               domClass.add(this.resizeHandlerButtonNode, "pop-in");
-            }
+
+            domClass.add(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--open");
+            domClass.remove(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--closed");
          }
          else
          {
             // Hide the sidebar...
             domStyle.set(this.sidebarNode, "width", "9px");
 
-            // Remove the right-padding to ensure that the resize bar snaps cleanly to the outer edge of
-            // the container
-            domStyle.set(this.sidebarNode, "padding-right", "0");
             this.lastSidebarWidth = 9;
             this.resizeHandler();
             $(this.sidebarNode).resizable("disable"); // Lock the resizer when the sidebar is not shown...
-            if (this.resizeHandlerButtonNode)
-            {
-               domClass.add(this.resizeHandlerButtonNode, "pop-out");
-               domClass.remove(this.resizeHandlerButtonNode, "pop-in");
-            }
-            
-            // Hide all the child nodes of the side bar (except for the resize handle)...
-            for (var j=0; j<this.sidebarNode.children.length - 1; j++)
-            {
-               if (this.sidebarNode.children[j] !== this.resizeHandlerNode)
-               {
-                  domClass.add(this.sidebarNode.children[j], "share-hidden");
-               }
-            }
+
+            domClass.remove(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--open");
+            domClass.add(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--closed");
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -410,7 +410,6 @@ define(["dojo/_base/declare",
             this.lastSidebarWidth = width;
             this.resizeHandler();
 
-            domClass.add(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--open");
             domClass.remove(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--closed");
          }
          else
@@ -422,7 +421,6 @@ define(["dojo/_base/declare",
             this.resizeHandler();
             $(this.sidebarNode).resizable("disable"); // Lock the resizer when the sidebar is not shown...
 
-            domClass.remove(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--open");
             domClass.add(this.sidebarNode, "alfresco-layout-AlfSideBarContainer__sidebar--closed");
          }
       }

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -16,7 +16,12 @@
       .alfresco-layout-AlfSideBarContainer__sidebar {
          color: @general-font-color;
          border: none;
-         /*border-right: @standard-border; */
+         padding-right: 10px;
+
+         /* Default display for all children in the sidebar when it's open */
+         > *:nth-child(n+2) {
+            display: inherit;
+         }
 
          /* Convert the YUI resize handle to be transparent and slightly wider
             to accommodate our custom image for popping the sidebar in and out */
@@ -41,6 +46,7 @@
                position: fixed;
                top: 50%;
                z-index: 500;
+               background-image: url("./images/PopInArrow.png");
             }
          }
 
@@ -55,20 +61,6 @@
          /* Ensure that the resize handle gets some colour when being used */ 
          .resize-handle.active{
             background-color: #dfdfdf;
-         }
-      }
-
-      .alfresco-layout-AlfSideBarContainer__sidebar--open {
-         padding-right: 10px;
-
-         /* Default display for all children in the sidebar when it's open */
-         > *:nth-child(n+2) {
-            display: inherit;
-         }
-
-         /* This selector should be applied when the sidebar is shown */
-         .alfresco-layout-AlfSideBarContainer__resizeButton {
-            background-image: url("./images/PopInArrow.png");
          }
       }
 

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -1,65 +1,89 @@
-.alfresco-layout-AlfSideBarContainer > .container {
-   overflow: hidden;
-}
+.alfresco-layout-AlfSideBarContainer {
 
-.alfresco-layout-AlfSideBarContainer > .container > .sidebar,
-.alfresco-layout-AlfSideBarContainer > .container > .main {
-   overflow: hidden;
-   float: none;
-   display: inline-block;
-   vertical-align: top;
-   background: none;
-   border: none;
-}
+   .alfresco-layout-AlfSideBarContainer__container {
+      overflow: hidden;
 
-.alfresco-layout-AlfSideBarContainer > .container > ui-widget-content {
-   color: @general-font-color;
-   border: none;
-   border-right: @standard-border;
-}
+      .alfresco-layout-AlfSideBarContainer__sidebar,
+      .alfresco-layout-AlfSideBarContainer__main {
+         overflow: hidden;
+         float: none;
+         display: inline-block;
+         vertical-align: top;
+         background: none;
+         border: none;
+      }
 
-/* Convert the YUI resize handle to be transparent and slightly wider
-   to accommodate our custom image for popping the sidebar in and out */
-.alfresco-layout-AlfSideBarContainer .resize-handle {
-   background-color: #ffffff;
-   width: 9px;
-   right: 0;
-   border-right: @standard-border;
-   border-left: @standard-border;
-}
+      .alfresco-layout-AlfSideBarContainer__sidebar {
+         color: @general-font-color;
+         border: none;
+         /*border-right: @standard-border; */
 
-/* Overrides JQuery default behaviour to hide the handle when disabled, but this would
-   make our pop-out control hidden as well which we don't want */
-.alfresco-layout-AlfSideBarContainer .ui-resizable-disabled > .resize-handle{
-   display: inherit;
-}
+         /* Convert the YUI resize handle to be transparent and slightly wider
+            to accommodate our custom image for popping the sidebar in and out */
+         .alfresco-layout-AlfSideBarContainer__resizeHandle {
+            background-color: #ffffff;
+            width: 9px;
+            right: 0;
+            border-right: @standard-border;
+            border-left: @standard-border;
 
-/* Ensure that the resize handle gets some colour when being used */ 
-.alfresco-layout-AlfSideBarContainer .resize-handle.active{
-   background-color: #dfdfdf;
-}
+            /* Override the default drag handle image */
+            .alfresco-layout-AlfSideBarContainer__resizeButton {
+               background-position: 0 6px;
+               background-color: transparent;
+               background-repeat: no-repeat;
+               border: @standard-border;
+               border-left: none;
+               border-right: none;
+               width: 8px;
+               height: 21px;
+               cursor: pointer;
+               position: fixed;
+               top: 50%;
+               z-index: 500;
+            }
+         }
 
-/* Override the default drag handle image */
-.alfresco-layout-AlfSideBarContainer .resize-handle-button {
-   background-position: 0 6px;
-   background-color: transparent;
-   background-repeat: no-repeat;
-   border: @standard-border;
-   border-left: none;
-   border-right: none;
-   width: 8px;
-   height: 21px;
-   cursor: pointer;
-   position: fixed;
-   top: 50%;
-}
+         /* Overrides JQuery default behaviour to hide the handle when disabled, but this would
+            make our pop-out control hidden as well which we don't want */
+         &.ui-resizable-disabled {
+            .alfresco-layout-AlfSideBarContainer__resizeHandle {
+               display: inherit;
+            }
+         }
 
-/* This selector should be applied when the sidebar is shown */
-.alfresco-layout-AlfSideBarContainer .resize-handle-button.pop-in {
-   background-image: url("./images/PopInArrow.png");
-}
+         /* Ensure that the resize handle gets some colour when being used */ 
+         .resize-handle.active{
+            background-color: #dfdfdf;
+         }
+      }
 
-/* This selector should be applied when the sidebar is hidden */
-.alfresco-layout-AlfSideBarContainer .resize-handle-button.pop-out {
-   background-image: url("./images/PopOutArrow.png");
+      .alfresco-layout-AlfSideBarContainer__sidebar--open {
+         padding-right: 10px;
+
+         /* Default display for all children in the sidebar when it's open */
+         > *:nth-child(n+2) {
+            display: inherit;
+         }
+
+         /* This selector should be applied when the sidebar is shown */
+         .alfresco-layout-AlfSideBarContainer__resizeButton {
+            background-image: url("./images/PopInArrow.png");
+         }
+      }
+
+      .alfresco-layout-AlfSideBarContainer__sidebar--closed {
+         padding-right: 0;
+
+         /* Hide all children EXCEPT the resize handle when the sidebar is closed */
+         > *:nth-child(n+2) {
+            display: none;
+         }
+
+         /* This selector should be applied when the sidebar is hidden */
+         .alfresco-layout-AlfSideBarContainer__resizeButton {
+            background-image: url("./images/PopOutArrow.png");
+         }
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/layout/templates/AlfSideBarContainer.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/AlfSideBarContainer.html
@@ -1,10 +1,10 @@
 <div class="alfresco-layout-AlfSideBarContainer" data-dojo-attach-point="containerNode">
-   <div class="container">
-      <div class="sidebar ui-widget-content" data-dojo-attach-point="sidebarNode">
-         <div class="resize-handle ui-resizable-handle ui-resizable-e" data-dojo-attach-point="resizeHandlerNode">
-            <div class="resize-handle-button" data-dojo-attach-point="resizeHandlerButtonNode"></div>
+   <div class="alfresco-layout-AlfSideBarContainer__container">
+      <div class="alfresco-layout-AlfSideBarContainer__sidebar ui-widget-content" data-dojo-attach-point="sidebarNode">
+         <div class="alfresco-layout-AlfSideBarContainer__resizeHandle resize-handle ui-resizable-handle ui-resizable-e" data-dojo-attach-point="resizeHandlerNode">
+            <div class="alfresco-layout-AlfSideBarContainer__resizeButton resize-handle-button" data-dojo-attach-point="resizeHandlerButtonNode"></div>
          </div>
       </div>
-      <div class="main" data-dojo-attach-point="mainNode"></div>
+      <div class="alfresco-layout-AlfSideBarContainer__main" data-dojo-attach-point="mainNode"></div>
    </div>
 </div>

--- a/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
@@ -61,7 +61,7 @@ define(["intern!object",
       },
 
       "Test Sidebar Placement": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar #SIDEBAR_LOGO")
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar #SIDEBAR_LOGO")
             .then(
                function() {
                   // No action required - found logo in sidebar
@@ -72,7 +72,7 @@ define(["intern!object",
       },
 
       "Test Main Panel Placement": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__main #MAIN_LOGO")
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__main #MAIN_LOGO")
             .then(
                function() {
                   // No action required - found logo in main panel
@@ -83,7 +83,7 @@ define(["intern!object",
       },
 
       "Test Initial Widths": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                // NOTE: The width has to take the 10px right padding into account
@@ -95,7 +95,7 @@ define(["intern!object",
          return browser.findByCssSelector(".resize-handle-button")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                assert.equal(size.width, 9, "The sidebar wasn't hidden via the bar control");
@@ -106,7 +106,7 @@ define(["intern!object",
          return browser.findByCssSelector(".resize-handle-button")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                // NOTE: The width has to take the 10px right padding into account
@@ -118,7 +118,7 @@ define(["intern!object",
          return this.remote.findByCssSelector("#HIDE_BUTTON")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                assert.equal(size.width, 9, "The sidebar wasn't hidden via publication");
@@ -129,7 +129,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SHOW_BUTTON")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                // NOTE: The width has to take the 10px right padding into account
@@ -140,7 +140,7 @@ define(["intern!object",
 
       "Increase window size and check sidebar height": function() {
          var bodyHeight;
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
             .end()
             .clearLog() // Clear the logs otherwise they'll force the size of the window
             .setWindowSize(null, 1024, 968)
@@ -150,7 +150,7 @@ define(["intern!object",
                   // We need the body size, not the window size because the window size includes all the OS chrome
                   bodyHeight = size.height;
                })
-            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
                   // Substracting the padding from the height!
@@ -160,7 +160,7 @@ define(["intern!object",
 
       "Decrease window size and check sidebar height": function() {
          var bodyHeight;
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
             .end()
             .clearLog() // Clear the logs otherwise they'll force the size of the window
             .setWindowSize(null, 1024, 568)
@@ -170,7 +170,7 @@ define(["intern!object",
                   // We need the body size, not the window size because the window size includes all the OS chrome
                   bodyHeight = size.height;
                })
-            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
                   // Substracting the padding from the height!

--- a/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
@@ -61,7 +61,7 @@ define(["intern!object",
       },
 
       "Test Sidebar Placement": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar #SIDEBAR_LOGO")
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar #SIDEBAR_LOGO")
             .then(
                function() {
                   // No action required - found logo in sidebar
@@ -72,7 +72,7 @@ define(["intern!object",
       },
 
       "Test Main Panel Placement": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .main #MAIN_LOGO")
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__main #MAIN_LOGO")
             .then(
                function() {
                   // No action required - found logo in main panel
@@ -83,7 +83,7 @@ define(["intern!object",
       },
 
       "Test Initial Widths": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                // NOTE: The width has to take the 10px right padding into account
@@ -95,7 +95,7 @@ define(["intern!object",
          return browser.findByCssSelector(".resize-handle-button")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                assert.equal(size.width, 9, "The sidebar wasn't hidden via the bar control");
@@ -106,7 +106,7 @@ define(["intern!object",
          return browser.findByCssSelector(".resize-handle-button")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                // NOTE: The width has to take the 10px right padding into account
@@ -118,7 +118,7 @@ define(["intern!object",
          return this.remote.findByCssSelector("#HIDE_BUTTON")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                assert.equal(size.width, 9, "The sidebar wasn't hidden via publication");
@@ -129,7 +129,7 @@ define(["intern!object",
          return browser.findByCssSelector("#SHOW_BUTTON")
             .click()
          .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+         .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
             .getSize()
             .then(function(size) {
                // NOTE: The width has to take the 10px right padding into account
@@ -140,7 +140,7 @@ define(["intern!object",
 
       "Increase window size and check sidebar height": function() {
          var bodyHeight;
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar") // Need to find something before clearing logs!
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
             .end()
             .clearLog() // Clear the logs otherwise they'll force the size of the window
             .setWindowSize(null, 1024, 968)
@@ -150,7 +150,7 @@ define(["intern!object",
                   // We need the body size, not the window size because the window size includes all the OS chrome
                   bodyHeight = size.height;
                })
-            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
                   // Substracting the padding from the height!
@@ -160,7 +160,7 @@ define(["intern!object",
 
       "Decrease window size and check sidebar height": function() {
          var bodyHeight;
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar") // Need to find something before clearing logs!
+         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
             .end()
             .clearLog() // Clear the logs otherwise they'll force the size of the window
             .setWindowSize(null, 1024, 568)
@@ -170,7 +170,7 @@ define(["intern!object",
                   // We need the body size, not the window size because the window size includes all the OS chrome
                   bodyHeight = size.height;
                })
-            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .sidebar")
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer .alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
                   // Substracting the padding from the height!
@@ -185,7 +185,7 @@ define(["intern!object",
       // ,
       // "Test Resize": function () {
       //    var browser = this.remote;
-      //    return this.remote.findByCssSelector(".sidebar")
+      //    return this.remote.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
       //       .getSize()
       //       .then(function(size) {
       //          console.log("Initial sidebar width: " + size.width);
@@ -207,7 +207,7 @@ define(["intern!object",
       //       .sleep(2000)
       //       .releaseMouseButton()
       //    .end()
-      //    .findByCssSelector(".sidebar")
+      //    .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
       //       .getSize()
       //       .then(function(endSize) {
       //          console.log("Final sidebar width: " + endSize.width);


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-574. I've gone through the implementation to use LESS with a BEM approach. But the fix is somewhat hidden in that all the children of the sidebar element (apart from the resize bar) have display:none applied when the sidebar is closed. This means that they cannot prevent the open/close toggle from being used. But as an added measure I've increased the z-index as well (making sure that it is less than the dialog z-index)