### PR TITLE
AKU-573: No duplicate tabs

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -296,6 +296,7 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_layout_AlfTabContainer__postCreate() {
          // Initialise a TabContainer instance and watch its selectedChildWidget event
          this.tabContainerWidget = new TabContainer({
+            id: this.id + "_TABCONTAINER",
             style: "height: " + this.height + "; width: " + this.width + ";",
             doLayout: this.doLayout
          }, this.tabNode);
@@ -363,6 +364,8 @@ define(["dojo/_base/declare",
          domClass.add(this.domNode, "alfresco-layout-AlfTabContainer--tabsDisplayed");
       },
 
+
+
       /**
        * This function adds widgets to the TabContainer widget
        * 
@@ -371,67 +374,101 @@ define(["dojo/_base/declare",
        * @param {integer} index The index of the required tab position
        */
       addWidget: function alfresco_layout_AlfTabContainer__addWidget(widget, /*jshint unused:false*/ index) {
-         // NOTE: It's important that the DOM structure of the tab is created and added to the page before 
-         //       creating each child widget in order that the child widget has access to the initial dimensions
-         //       of the tab (e.g. for an AlfSideBarContainer to calculate it's height appropriately)...
-         var domNode = domConstruct.create("div", {});
-         var cp = new ContentPane();
-         domClass.add(cp.domNode, "alfresco-layout-AlfTabContainer__OuterTab");
-         this.tabContainerWidget.addChild(cp, widget.tabIndex);
-
-         // Add content to the ContentPane
-         if(widget.content && typeof widget.content === "string")
+         var indexOfDuplicateTab = this.indexOfTabId(widget.id);
+         if (indexOfDuplicateTab !== -1)
          {
-            cp.set("content", widget.content);
+            // A tab with the requested ID has already been added, so just select it...
+            this.tabContainerWidget.selectChild(this.tabContainerWidget.getChildren()[indexOfDuplicateTab]);
          }
-
-         // Add a title to the ContentPane
-         if(widget.title && typeof widget.title === "string")
-         {
-            cp.set("title", this.message(widget.title));
-         }
-
-         // Add an iconClass to the ContentPane
-         if(widget.iconClass && typeof widget.iconClass === "string")
-         {
-            cp.set("iconClass", widget.iconClass);
-         }
-
-         // Should the ContentPane be closable?
-         if(widget.closable && typeof widget.closable === "boolean")
-         {
-            cp.set("closable", widget.closable);
-         }
-
-         // Should the ContentPane be disabled?
-         if(widget.disabled && typeof widget.disabled === "boolean")
-         {
-            cp.set("disabled", widget.disabled);
-         }
-
-         // If not delayed processing, create the widget and add to the panel
-         if(!widget.delayProcessing)
-         {
-            var widgetNode = this.createWidgetDomNode(widget, cp.domNode);
-            var w = this.createWidget(widget, widgetNode);
-         }
-         // Otherwise record the widget for processing later on
          else
          {
-            this._delayedProcessingWidgets.push(
-               {
-                  "domNode": cp.domNode,
-                  "contentPane": cp,
-                  "widget": widget
-               }
-            );
-         }
+            // NOTE: It's important that the DOM structure of the tab is created and added to the page before 
+            //       creating each child widget in order that the child widget has access to the initial dimensions
+            //       of the tab (e.g. for an AlfSideBarContainer to calculate it's height appropriately)...
+            var domNode = domConstruct.create("div", {});
+            var cp = new ContentPane({
+               id: widget.id || null
+            });
+            domClass.add(cp.domNode, "alfresco-layout-AlfTabContainer__OuterTab");
+            this.tabContainerWidget.addChild(cp, widget.tabIndex);
 
-         // If we have an index add the ContentPane at a particular position otherwise just add it
-         if (widget.selected === true)
-         {
-            this.tabContainerWidget.selectChild(cp);
+            // Add content to the ContentPane
+            if(widget.content && typeof widget.content === "string")
+            {
+               cp.set("content", widget.content);
+            }
+
+            // Add a title to the ContentPane
+            if(widget.title && typeof widget.title === "string")
+            {
+               cp.set("title", this.message(widget.title));
+            }
+
+            // Add an iconClass to the ContentPane
+            if(widget.iconClass && typeof widget.iconClass === "string")
+            {
+               cp.set("iconClass", widget.iconClass);
+            }
+
+            // Should the ContentPane be closable?
+            if(widget.closable && typeof widget.closable === "boolean")
+            {
+               cp.set("closable", widget.closable);
+            }
+
+            // Should the ContentPane be disabled?
+            if(widget.disabled && typeof widget.disabled === "boolean")
+            {
+               cp.set("disabled", widget.disabled);
+            }
+
+            // If not delayed processing, create the widget and add to the panel
+            if(!widget.delayProcessing)
+            {
+               var widgetNode = this.createWidgetDomNode(widget, cp.domNode);
+               var w = this.createWidget(widget, widgetNode);
+            }
+            // Otherwise record the widget for processing later on
+            else
+            {
+               this._delayedProcessingWidgets.push(
+                  {
+                     "domNode": cp.domNode,
+                     "contentPane": cp,
+                     "widget": widget
+                  }
+               );
+            }
+
+            // If we have an index add the ContentPane at a particular position otherwise just add it
+            if (widget.selected === true)
+            {
+               this.tabContainerWidget.selectChild(cp);
+            }
          }
+      },
+
+      /**
+       * 
+       * @instance
+       * @param {string} id The ID of an existing tab to search for
+       * @return {number} The index of the duplicate tab and -1 if a duplicate does not exist
+       * @since 1.0.35
+       */
+      indexOfTabId: function alfresco_layout_AlfTabContainer__indexOfTabId(id) {
+         var duplicateTabIndex = -1;
+         if (id)
+         {
+            array.some(this.tabContainerWidget.getChildren(), function(tab, tabIndex) {
+               var match = tab.id === id;
+               if (match)
+               {
+                  duplicateTabIndex = tabIndex;
+               }
+               return match;
+            }, this);
+         }
+         return duplicateTabIndex;
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -25,10 +25,9 @@
 define(["intern!object",
         "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, expect, assert, require, TestCommon, keys) {
+        function (registerSuite, expect, assert, TestCommon, keys) {
 
    var browser;
    registerSuite({
@@ -166,7 +165,7 @@ define(["intern!object",
    });
 
 
-   // This test reloads the page to clear any previous focus and make keyboard actions more predictable
+   // // This test reloads the page to clear any previous focus and make keyboard actions more predictable
    registerSuite({
       name: "Tab Container Tests (keyboard)",
 
@@ -266,37 +265,31 @@ define(["intern!object",
       },
 
       "Checking 3rd panel is visible": function () {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(3)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 3rd panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 3rd panel should not be hidden");
-               });
+         return browser.findById("Logo3")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 3rd panel should have been initially visible on page load");
+            });
       },
 
       "Checking 1st panel is visible after external selection by index": function() {
          return browser.findById("SELECT_TAB_1")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:first-of-type")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 1st panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 1st panel should not be hidden");
-               });
+         .findById("Logo1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 1st panel should have been visible after selection via publication");
+            });
       },
 
       "Checking 3rd panel is hidden after external selection by index": function() {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(3)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitHidden", "The 3rd panel should be hidden");
-                  expect(currClasses).to.not.contain("dijitVisible", "The 3rd panel should not be visible");
-               });
+         return browser.findById("Logo3")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The 3rd panel should have been hidden");
+            });
       },
 
       "Checking 2nd panel is visible after external selection by index": function() {
@@ -304,23 +297,19 @@ define(["intern!object",
             .click()
          .end()
 
-         .findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(2)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 2nd panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 2nd panel should not be hidden");
-               });
+         .findById("Logo2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 2nd panel should have been displayed");
+            });
       },
 
       "Checking 1st panel is hidden after external selection by index": function() {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:first-of-type")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitHidden", "The 1st panel should be hidden");
-                  expect(currClasses).to.not.contain("dijitVisible", "The 1st panel should not be visible");
-               });
+         return browser.findById("Logo1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The 1st panel should have been hidden");
+            });
       },
 
       "Checking 1st panel is visible after external selection by title": function() {
@@ -328,23 +317,19 @@ define(["intern!object",
             .click()
          .end()
 
-         .findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:first-of-type")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 1st panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 1st panel should not be hidden");
-               });
+         .findById("Logo1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 1st panel should be visible");
+            });
       },
 
       "Checking 2nd panel is hidden after external selection by title": function() {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(4)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitHidden", "The 2nd panel should be hidden");
-                  expect(currClasses).to.not.contain("dijitVisible", "The 2nd panel should not be visible");
-               });
+         return browser.findById("Logo2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The 2nd panel should have been hidden");
+            });
       },
 
       "Checking 2nd panel is visible after external selection by title": function() {
@@ -352,23 +337,19 @@ define(["intern!object",
             .click()
          .end()
 
-         .findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(2)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 2nd panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 2nd panel should not be hidden");
-               });
+         .findById("Logo2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 2nd panel should have been displayed");
+            });
       },
 
       "Checking 1st panel is hidden after external selection by title": function() {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:first-of-type")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitHidden", "The 1st panel should be hidden");
-                  expect(currClasses).to.not.contain("dijitVisible", "The 1st panel should not be visible");
-               });
+         return browser.findById("Logo1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The 1st panel should have been hidden");
+            });
       },
 
       "Checking 1st panel is visible after external selection by id": function() {
@@ -376,23 +357,19 @@ define(["intern!object",
             .click()
          .end()
 
-         .findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:first-of-type")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 1st panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 1st panel should not be hidden");
-               });
+         .findById("Logo1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 1st panel should have been displayed");
+            });
       },
 
       "Checking 2nd panel is hidden after external selection by id": function() {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(4)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitHidden", "The 2nd panel should be hidden");
-                  expect(currClasses).to.not.contain("dijitVisible", "The 2nd panel should not be visible");
-               });
+         return browser.findById("Logo2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The 2nd panel should have been hidden");
+            });
       },
 
       "Checking 2nd panel is visible after external selection by id": function() {
@@ -400,23 +377,19 @@ define(["intern!object",
             .click()
          .end()
 
-         .findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:nth-of-type(2)")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitVisible", "The 2nd panel should be visible");
-                  expect(currClasses).to.not.contain("dijitHidden", "The 2nd panel should not be hidden");
-               });
+         .findById("Logo2")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The 2nd panel should have been displayed");
+            });
       },
 
       "Checking 1st panel is hidden after external selection by id": function() {
-         return browser.findByCssSelector("div.dijitTabPaneWrapper > div.dijitTabContainerTopChildWrapper:first-of-type")
-            .getAttribute("class")
-            .then(
-               function(currClasses) {
-                  expect(currClasses).to.contain("dijitHidden", "The 1st panel should be hidden");
-                  expect(currClasses).to.not.contain("dijitVisible", "The 1st panel should not be visible");
-               });
+         return browser.findById("Logo1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed, "The 1st panel should have been hidden");
+            });
       },
 
       "Checking 1st tab is disabled after external selection by index": function() {
@@ -546,7 +519,7 @@ define(["intern!object",
       },
 
       "Check that delayed processing form control is displayed correctly": function() {
-         return browser.findById("dijit_layout_TabContainer_0_tablist_dijit_layout_ContentPane_9")
+         return browser.findById("TC_TABCONTAINER_tablist_FormControl1")
             .click()
          .end()
          .findByCssSelector("#FormControl1 .label")
@@ -557,7 +530,7 @@ define(["intern!object",
       },
 
        "Check that non-delayed processing form control is displayed correctly": function() {
-         return browser.findById("dijit_layout_TabContainer_0_tablist_dijit_layout_ContentPane_10")
+         return browser.findById("TC_TABCONTAINER_tablist_FormControl2")
             .click()
          .end()
          .findByCssSelector("#FormControl2 .label")
@@ -676,6 +649,30 @@ define(["intern!object",
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "The list was not displayed");
+            });
+      },
+
+      "Attempt to create the same tab": function() {
+         // Switch back to the 2nd tab...
+         return browser.findById("TC1_TABCONTAINER_tablist_SEARCH_LIST")
+            .click()
+         .end()
+
+         // Click to create the tab again...
+         .findById("CREATE_TAB_label")
+            .click()
+         .end()
+
+         .findAllByCssSelector("div.dijitTabListWrapper > div.dijitTabContainerTop-tabs > div.dijitTab")
+            .then(function (tabs) {
+               assert.lengthOf(tabs, 3, "Wrong number of tabs!");
+            })
+         .end()
+
+         .findById("ADDED_FIXED_HEADER_FOOTER")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "The existing tab was not re-selected");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfTabContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfTabContainer.get.js
@@ -21,6 +21,7 @@ model.jsonModel = {
                   config: {
                      widgets: [
                         {
+                           id: "TC",
                            name: "alfresco/layout/AlfTabContainer",
                            config: {
                               tabSelectionTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
@@ -108,7 +109,6 @@ model.jsonModel = {
                                     id: "FormControl1",
                                     name: "alfresco/forms/controls/Select",
                                     title: "DP Form Control",
-                                    // tabId: "FORM_CONTROL_TAB_1",
                                     delayProcessing: true,
                                     config: {
                                        fieldId: "SELECT",
@@ -128,7 +128,6 @@ model.jsonModel = {
                                  {
                                     id: "FormControl2",
                                     name: "alfresco/forms/controls/Select",
-                                    tabId: "FORM_CONTROL_TAB_2",
                                     title: "Non-DP Form Control",
                                     delayProcessing: false,
                                     config: {
@@ -157,9 +156,9 @@ model.jsonModel = {
                   config: {
                      widgets: [
                         {
+                           id: "SELECT_TAB_1",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "SELECT_TAB_1",
                               label: "Select tab 1 (idx 0)",
                               publishTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               publishPayload: {
@@ -168,9 +167,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "SELECT_TAB_2",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "SELECT_TAB_2",
                               label: "Select tab 2 (idx 1)",
                               publishTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               publishPayload: {
@@ -179,9 +178,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "SELECT_TAB_3",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "SELECT_TAB_3",
                               label: "Select tab titled 'Logo 1'",
                               publishTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               publishPayload: {
@@ -190,9 +189,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "SELECT_TAB_4",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "SELECT_TAB_4",
                               label: "Select tab titled 'Logo 2'",
                               publishTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               publishPayload: {
@@ -201,24 +200,24 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "SELECT_TAB_5",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "SELECT_TAB_5",
-                              label: "Select tab with id 'dijit_layout_ContentPane_0'",
+                              label: "Select tab with id 'Logo1'",
                               publishTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               publishPayload: {
-                                 id: "dijit_layout_ContentPane_0"
+                                 id: "Logo1"
                               }
                            }
                         },
                         {
+                           id: "SELECT_TAB_6",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "SELECT_TAB_6",
-                              label: "Select tab with id 'dijit_layout_ContentPane_1'",
+                              label: "Select tab with id 'Logo2'",
                               publishTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               publishPayload: {
-                                 id: "dijit_layout_ContentPane_1"
+                                 id: "Logo2"
                               }
                            }
                         }
@@ -230,9 +229,9 @@ model.jsonModel = {
                   config: {
                      widgets: [
                         {
+                           id: "DISABLE_TAB_1",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DISABLE_TAB_1",
                               label: "Disable tab 1 (idx 0)",
                               publishTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               publishPayload: {
@@ -242,9 +241,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "DISABLE_TAB_2",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DISABLE_TAB_2",
                               label: "Enable tab 1 (idx 0)",
                               publishTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               publishPayload: {
@@ -254,9 +253,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "DISABLE_TAB_3",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DISABLE_TAB_3",
                               label: "Disable tab titled 'Logo 1'",
                               publishTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               publishPayload: {
@@ -266,9 +265,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "DISABLE_TAB_4",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DISABLE_TAB_4",
                               label: "Enable tab titled 'Logo 1'",
                               publishTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               publishPayload: {
@@ -278,25 +277,25 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "DISABLE_TAB_5",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DISABLE_TAB_5",
-                              label: "Disable tab with id 'dijit_layout_ContentPane_0'",
+                              label: "Disable tab with id 'Logo1'",
                               publishTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               publishPayload: {
-                                 id: "dijit_layout_ContentPane_0",
+                                 id: "Logo1",
                                  value: true
                               }
                            }
                         },
                         {
+                           id: "DISABLE_TAB_6",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DISABLE_TAB_6",
-                              label: "Enable tab with id 'dijit_layout_ContentPane_0'",
+                              label: "Enable tab with id 'Logo1'",
                               publishTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               publishPayload: {
-                                 id: "dijit_layout_ContentPane_0",
+                                 id: "Logo1",
                                  value: false
                               }
                            }
@@ -309,9 +308,9 @@ model.jsonModel = {
                   config: {
                      widgets: [
                         {
+                           id: "DELETE_TAB_1",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DELETE_TAB_1",
                               label: "Delete tab 7 (idx 6)",
                               publishTopic: "TABCONTAINER_DELETE_TAB_TOPIC",
                               publishPayload: {
@@ -320,9 +319,9 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "DELETE_TAB_2",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DELETE_TAB_2",
                               label: "Delete tab titled 'Logo 8'",
                               publishTopic: "TABCONTAINER_DELETE_TAB_TOPIC",
                               publishPayload: {
@@ -331,13 +330,13 @@ model.jsonModel = {
                            }
                         },
                         {
+                           id: "DELETE_TAB_3",
                            name: "alfresco/buttons/AlfButton",
                            config: {
-                              id: "DELETE_TAB_3",
-                              label: "Delete tab with id 'dijit_layout_ContentPane_8'",
+                              label: "Delete tab with id 'Logo9'",
                               publishTopic: "TABCONTAINER_DELETE_TAB_TOPIC",
                               publishPayload: {
-                                 id: "dijit_layout_ContentPane_8"
+                                 id: "Logo9"
                               }
                            }
                         }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/TabContainerUseCase2.get.js
@@ -12,6 +12,7 @@ model.jsonModel = {
    ],
    widgets:[ 
       {
+         id: "TC1",
          name: "alfresco/layout/AlfTabContainer",
          config: {
             tabSelectionTopic: "ALF_SELECT_TAB",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-573 to prevent multiple tabs with the same ID being added to a tab container. Instead, if a tab with the ID is found to already exist the existing tab will be re-selected. I've also improved the way in which the tabs are given "id" attributes in the DOM to make the AlfTabContainer easier to test and as such have updated the existing unit tests.