### PR TITLE
AKU-468: TextArea font not same as TextBox font

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/TextArea.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/TextArea.css
@@ -1,13 +1,17 @@
-.alfresco-forms-controls-TextArea div.control .dijitTextArea {
-   border-color: @standard-border-color;
-}
-
-.alfresco-forms-controls-TextArea div.control .dijitTextAreaHover {
-   border-color: @hover-border-color;
-   background-image: none;
-   background-color: inherit;
-}
-
-.alfresco-forms-controls-TextArea div.control .dijitTextAreaFocused {
-   border-color: @focused-border-color;
+.alfresco-forms-controls-TextArea {
+   div.control {
+      .dijitTextArea {
+         border-color: @standard-border-color;
+         font-family: @standard-font;
+         font-size: @normal-font-size;
+      }
+      .dijitTextAreaHover {
+         background-color: inherit;
+         background-image: none;
+         border-color: @hover-border-color;
+      }
+      .dijitTextAreaFocused {
+         border-color: @focused-border-color;
+      }
+   }
 }

--- a/aikau/src/test/resources/alfresco/forms/controls/TextAreaTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TextAreaTest.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @author Martin Doyle
+ */
+define(["alfresco/TestCommon",
+        "intern!object", 
+        "intern/chai!assert"], 
+        function(TestCommon, registerSuite, assert) {
+
+   var browser;
+   registerSuite({
+      name: "TextArea Tests",
+
+      setup: function() {
+         browser = this.remote;
+         return TestCommon.loadTestWebScript(this.remote, "/TextArea", "TextArea Tests");
+      },
+
+      beforeEach: function() {
+         browser.end();
+      },
+
+      "Label is rendered correctly": function() {
+         return browser.findByCssSelector("#BASIC_TEXTAREA .label")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "Basic textarea");
+            });
+      },
+
+      "Rows/cols are set correctly": function() {
+         return browser.findByCssSelector("#SIZED_TEXTAREA textarea")
+            .getProperty("rows")
+            .then(function(rows) {
+               assert.equal(rows, 3);
+            })
+            .getProperty("cols")
+            .then(function(cols) {
+               assert.equal(cols, 100);
+            });
+      },
+
+      "Initial value is set correctly": function() {
+         return browser.findByCssSelector("#TEXTAREA_WITH_CONTENT textarea")
+            .getProperty("value")
+            .then(function(value) {
+               assert.equal(value, "A some arguable jeepers cheerful pled impalpable yikes nosily however irresolute so tortoise amphibious.");
+            });
+      },
+
+      "Correct font is used": function() {
+         return browser.findByCssSelector("#TEXTAREA_WITH_CONTENT textarea")
+            .getComputedStyle("fontFamily")
+            .then(function(fontFamily) {
+               assert.include(fontFamily, "Open Sans");
+            })
+            .getComputedStyle("fontSize")
+            .then(function(fontSize) {
+               assert.equal(fontSize, "13px");
+            });
+      },
+
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/PublishingDropDownMenuTest"
+      "src/test/resources/alfresco/forms/controls/TextAreaTest"
    ],
 
    /**
@@ -120,6 +120,7 @@ define({
       "src/test/resources/alfresco/forms/controls/SelectTest",
       "src/test/resources/alfresco/forms/controls/SimplePickerTest",
       "src/test/resources/alfresco/forms/controls/SitePickerTest",
+      "src/test/resources/alfresco/forms/controls/TextAreaTest",
       "src/test/resources/alfresco/forms/controls/TextBoxTest",
       "src/test/resources/alfresco/forms/controls/TinyMCETest",
       "src/test/resources/alfresco/forms/controls/ValidationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextArea.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextArea.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>TextArea Test</shortname>
+  <description>Test page for the alfresco/forms/controls/TextArea widget</description>
+  <family>aikau-unit-tests</family>
+  <url>/TextArea</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextArea.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextArea.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextArea.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextArea.get.js
@@ -1,0 +1,57 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/forms/Form",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/TextArea",
+                  id: "BASIC_TEXTAREA",
+                  config: {
+                     name: "basic_textarea",
+                     label: "Basic textarea",
+                     description: "This is a textarea with minimum configuration"
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/TextArea",
+                  id: "SIZED_TEXTAREA",
+                  config: {
+                     name: "sized_textarea",
+                     label: "Sized textarea",
+                     rows: 3,
+                     cols: 100,
+                     description: "This is a textarea with the number of rows and columns specified"
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/TextArea",
+                  id: "TEXTAREA_WITH_CONTENT",
+                  config: {
+                     name: "textarea_with_content",
+                     label: "Textarea with content",
+                     description: "This is a textarea with some default content provided",
+                     value: "A some arguable jeepers cheerful pled impalpable yikes nosily however irresolute so tortoise amphibious."
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses [AKU-468](https://issues.alfresco.com/jira/browse/AKU-468), which is about the TextArea font not being the same as the TextBox font. Have updated the CSS and created a test page/suite to prevent regression.