### PR TITLE
AKU-584: Ensure correct scope on SearchService XHR

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -389,6 +389,19 @@ define([],function() {
       REQUEST_DELAYED_ARCHIVE_PROGRESS: "ALF_ARCHIVE_DELAYED_PROGRESS_REQUEST",
 
       /**
+       * Published to indicate that list data requests have been completed. Typically used to track whether or not
+       * XHR requests for data are in progress.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.36
+       *
+       * @event module:alfresco/core/topics~REQUEST_FINISHED_TOPIC
+       */
+      REQUEST_FINISHED_TOPIC: "ALF_DOCLIST_REQUEST_FINISHED",
+
+      /**
        * <p>This topic is used to indicate that a navigable collection has been scrolled to
        * "near" its bottom. Since its creation, this topic's meaning has extended to go beyond
        * just scrolling (sometimes it's clicking arrows) and to not necessarily being the

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -318,9 +318,9 @@ define(["dojo/_base/declare",
        * @event requestFinishedTopic
        * @instance
        * @type {string}
-       * @default
+       * @default [topics.REQUEST_FINISHED_TOPIC]{@link module:alfresco/core/topics#REQUEST_FINISHED_TOPIC}
        */
-      requestFinishedTopic: "ALF_DOCLIST_REQUEST_FINISHED",
+      requestFinishedTopic: topics.REQUEST_FINISHED_TOPIC,
 
       /**
        * This topic should be published to indicate that a path has been changed. It is used by both the

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -32,9 +32,10 @@ define(["dojo/_base/declare",
         "service/constants/Default",
         "alfresco/core/PathUtils",
         "alfresco/core/NodeUtils",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/json"],
-        function(declare, BaseService, CoreXhr, AlfConstants, PathUtils, NodeUtils, lang, dojoJson) {
+        function(declare, BaseService, CoreXhr, AlfConstants, PathUtils, NodeUtils, topics, lang, dojoJson) {
 
    return declare([BaseService, CoreXhr, PathUtils], {
 
@@ -167,6 +168,7 @@ define(["dojo/_base/declare",
          if (!payload || !payload.term)
          {
             this.alfLog("warn", "A request was made to perform a search but no 'term' attribute was provided", payload, this);
+            this.alfPublish(payload.alfResponseScope + payload.alfResponseTopic + "_FAILURE");
          }
          else
          {
@@ -239,7 +241,7 @@ define(["dojo/_base/declare",
                sort: sort,
                site: payload.site || this.site,
                rootNode: payload.rootNode || this.rootNode,
-               repo: payload.repo || this.repo,
+               repo: (payload.repo || payload.repo === false) ? payload.repo : this.repo,
                query: query,
                pageSize: payload.pageSize || this.pageSize, // It makes no sense for page size to ever be 0
                maxResults: payload.maxResults || 0,

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -168,7 +168,7 @@ define(["dojo/_base/declare",
          if (!payload || !payload.term)
          {
             this.alfLog("warn", "A request was made to perform a search but no 'term' attribute was provided", payload, this);
-            this.alfPublish(payload.alfResponseScope + payload.alfResponseTopic + "_FAILURE");
+            this.alfPublish(payload.alfResponseTopic + "_FAILURE", {}, false, false, payload.alfResponseScope);
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -20,15 +20,12 @@
 /**
  * This test uses a MockXhr service to test the search service responds as required.
  * 
- * @author Richard Smith
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
    var browser;
    registerSuite({
@@ -43,26 +40,29 @@ define(["intern!object",
          browser.end();
       },
 
+      // Because there is no searchTerm the SearchService publishes a failure. Hence the failure message displayed.
      "Check there are no results yet": function () {
          return browser.findById("FCTSRCH_SEARCH_RESULTS_LIST")
             .getVisibleText()
             .then(function (text){
-               expect(text).to.equal("No results found", "There should not be any results found yet");
-            });
+               assert.equal(text, "There was an error loading search results", "There should not be any results found yet");
+            })
+         .end()
+         .clearLog();
       },
 
       "Check there are the expected number of mocked results": function() {
          return browser.findByCssSelector("#FCTSRCH_SEARCH_FORM div.alfresco-forms-controls-TextBox div.control input[name='searchTerm']")
             .type("test")
-            .end()
+         .end()
 
          .findByCssSelector("#FCTSRCH_SEARCH_FORM div.buttons span.dijitButtonNode")
             .click()
-            .end()
+         .end()
 
          .findAllByCssSelector("#FCTSRCH_SEARCH_RESULTS_LIST tr.alfresco-search-AlfSearchResult")
             .then(function (results){
-               expect(results).to.have.length(24, "There should be 24 mocked results");
+               assert.lengthOf(results, 24, "There should be 24 mocked results");
             });
       },
 
@@ -72,7 +72,7 @@ define(["intern!object",
 
          .findAllByCssSelector("#FCTSRCH_SEARCH_RESULTS_LIST tr.alfresco-search-AlfSearchResult")
             .then(function (results){
-               expect(results).to.have.length(24, "There should still be 24 mocked results");
+               assert.lengthOf(results, 24, "There should still be 24 mocked results");
             });
       },
 
@@ -82,6 +82,87 @@ define(["intern!object",
             .then(function(text) {
                assert(decodeURIComponent(text).indexOf("&query={") === -1, "unexpected query found");
             });
+      },
+
+      "Repository scope should be used by default": function() {
+         return browser.findByCssSelector("body").end().getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", true, "Repository scope not requested");
+            })
+         .end()
+         .findByCssSelector("tr.mx-row:nth-child(1) td.mx-url")
+            .getVisibleText()
+            .then(function(url) {
+               assert.include(url, "repo=true", "Repository scope not used in XHR");
+            })
+         .end()
+         .clearLog();
+      },
+
+      "Switch to All Sites scope": function() {
+         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+            .click()
+         .end()
+         .findById("FCTSRCH_SET_ALL_SITES_SCOPE_text")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", false, "Repository scope used");
+               assert.propertyVal(payload, "site", "", "Site incorrect");
+            })
+         .end()
+         .findByCssSelector("tr.mx-row:nth-child(3) td.mx-url")
+            .getVisibleText()
+            .then(function(url) {
+               assert.include(url, "repo=false", "Repository scope not used in XHR");
+            })
+         .end()
+         .clearLog();
+      },
+
+      "Switch to Site scope": function() {
+         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+            .click()
+         .end()
+         .findById("FCTSRCH_SET_SPECIFIC_SITE_SCOPE_text")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", false, "Repository scope used");
+               assert.propertyVal(payload, "site", "site", "Site incorrect");
+            })
+         .end()
+         .findByCssSelector("tr.mx-row:nth-child(4) td.mx-url")
+            .getVisibleText()
+            .then(function(url) {
+               assert.include(url, "repo=false", "Repository scope not used in XHR");
+               assert.include(url, "site=site", "Repository scope not used in XHR");
+            })
+         .end()
+         .clearLog();
+      },
+
+      "Switch to Repository scope": function() {
+         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+            .click()
+         .end()
+         .findById("FCTSRCH_SET_REPO_SCOPE_text")
+            .click()
+         .end()
+         .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", true, "Repository scope NOT used");
+            })
+         .end()
+         .findByCssSelector("tr.mx-row:nth-child(5) td.mx-url")
+            .getVisibleText()
+            .then(function(url) {
+               assert.include(url, "repo=true", "Repository scope not used in XHR");
+            })
+         .end()
+         .clearLog();
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -107,11 +107,10 @@ define(["intern!object",
             .click()
          .end()
          .getLastPublish("ALF_SEARCH_REQUEST")
-            .then(function(payload) {
-               assert.propertyVal(payload, "repo", false, "Repository scope used");
-               assert.propertyVal(payload, "site", "", "Site incorrect");
-            })
-         .end()
+         .then(function(payload) {
+            assert.propertyVal(payload, "repo", false, "Repository scope used");
+            assert.propertyVal(payload, "site", "", "Site incorrect");
+         })
          .findByCssSelector("tr.mx-row:nth-child(3) td.mx-url")
             .getVisibleText()
             .then(function(url) {
@@ -129,11 +128,10 @@ define(["intern!object",
             .click()
          .end()
          .getLastPublish("ALF_SEARCH_REQUEST")
-            .then(function(payload) {
-               assert.propertyVal(payload, "repo", false, "Repository scope used");
-               assert.propertyVal(payload, "site", "site", "Site incorrect");
-            })
-         .end()
+         .then(function(payload) {
+            assert.propertyVal(payload, "repo", false, "Repository scope used");
+            assert.propertyVal(payload, "site", "site", "Site incorrect");
+         })
          .findByCssSelector("tr.mx-row:nth-child(4) td.mx-url")
             .getVisibleText()
             .then(function(url) {
@@ -152,10 +150,9 @@ define(["intern!object",
             .click()
          .end()
          .getLastPublish("ALF_SEARCH_REQUEST")
-            .then(function(payload) {
-               assert.propertyVal(payload, "repo", true, "Repository scope NOT used");
-            })
-         .end()
+         .then(function(payload) {
+            assert.propertyVal(payload, "repo", true, "Repository scope NOT used");
+         })
          .findByCssSelector("tr.mx-row:nth-child(5) td.mx-url")
             .getVisibleText()
             .then(function(url) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SearchService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SearchService.get.js
@@ -9,98 +9,170 @@ model.jsonModel = {
             }
          }
       },
-      {
-         name: "alfresco/services/NavigationService"
-      },
-      {
-         name: "alfresco/services/SearchService"
-      },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/NavigationService",
+      "alfresco/services/SearchService"
    ],
    widgets:[
       {
-         id: "FCTSRCH_SEARCH_FORM",
-         name: "alfresco/forms/SingleTextFieldForm",
+         name: "aikauTesting/WaitForMockXhrService",
          config: {
-            useHash: true,
-            okButtonLabel: "Ok",
-            okButtonPublishTopic: "ALF_SET_SEARCH_TERM",
-            okButtonPublishGlobal: true,
-            okButtonIconClass: "alf-white-search-icon",
-            okButtonClass: "call-to-action",
-            textFieldName: "searchTerm",
-            textBoxIconClass: "alf-search-icon",
-            textBoxCssClasses: "long hiddenlabel",
-            textBoxLabel: "Search box"
-         }
-      },
-      {
-         id: "FCTSRCH_SEARCH_RESULTS_LIST",
-         name: "alfresco/search/AlfSearchList",
-         config: {
-            viewPreferenceProperty: "org.alfresco.share.searchList.viewRendererName",
-            view: "simple",
-            waitForPageWidgets: true,
-            useHash: true,
-            hashVarsForUpdate: [
-               "searchTerm",
-               "facetFilters",
-               "sortField",
-               "sortAscending",
-               "allSites",
-               "repo",
-               "searchScope",
-               "query"
-            ],
-            selectedScope: "REPO",
-            useInfiniteScroll: true,
-            siteId: null,
-            rootNode: null,
-            repo: true,
-            additionalControlsTarget: "FCTSRCH_RESULTS_MENU_BAR",
             widgets: [
                {
-                  id: "FCTSRCH_SEARCH_ADVICE_NO_RESULTS",
-                  name: "alfresco/search/AlfSearchListView",
+                  id: "FCTSRCH_TOP_MENU_BAR_SCOPE_MENU_BAR",
+                  name: "alfresco/menus/AlfMenuBar",
                   config: {
-                     searchAdviceTitle: "faceted-search.advice.title",
-                     searchAdvice: [
-                        "faceted-search.advice.suggestion1",
-                        "faceted-search.advice.suggestion2",
-                        "faceted-search.advice.suggestion3"
-                     ],
-                     a11yCaption: "Faceted Search Results",
-                     a11yCaptionClass: "hiddenAccessible",
-                     widgetsForHeader: [
+                     widgets: [
                         {
-                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           id: "FCTSRCH_SCOPE_SELECTION_MENU",
+                           name: "alfresco/menus/AlfMenuBarSelect",
                            config: {
-                              label: "Thumbnail",
-                              class: "hiddenAccessible",
-                              a11yScope: "col"
-                           }
-                        },
-                        {
-                           name: "alfresco/lists/views/layouts/HeaderCell",
-                           config: {
-                              label: "Details",
-                              class: "hiddenAccessible",
-                              a11yScope: "col"
-                           }
-                        },
-                        {
-                           name: "alfresco/lists/views/layouts/HeaderCell",
-                           config: {
-                              label: "Actions",
-                              class: "hiddenAccessible",
-                              a11yScope: "col"
+                              selectionTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                              widgets: [
+                                 {
+                                    id: "FCTSRCH_SCOPE_SELECTION_MENU_GROUP",
+                                    name: "alfresco/menus/AlfMenuGroup",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "FCTSRCH_SET_SPECIFIC_SITE_SCOPE",
+                                             name: "alfresco/menus/AlfCheckableMenuItem",
+                                             config: {
+                                                label: "Site",
+                                                value: "site",
+                                                group: "SEARCHLIST_SCOPE",
+                                                publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                                                checked: false,
+                                                hashName: "scope",
+                                                publishPayload: {
+                                                   label: "Site",
+                                                   value: "site"
+                                                }
+                                             }
+                                          },
+                                          {
+                                             id: "FCTSRCH_SET_ALL_SITES_SCOPE",
+                                             name: "alfresco/menus/AlfCheckableMenuItem",
+                                             config: {
+                                                label: "All Sites",
+                                                value: "all_sites",
+                                                group: "SEARCHLIST_SCOPE",
+                                                publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                                                checked: false,
+                                                hashName: "scope",
+                                                publishPayload: {
+                                                   label: "All Sites",
+                                                   value: "all_sites"
+                                                }
+                                             }
+                                          },
+                                          {
+                                             id: "FCTSRCH_SET_REPO_SCOPE",
+                                             name: "alfresco/menus/AlfCheckableMenuItem",
+                                             config: {
+                                                label: "Repository",
+                                                value: "repo",
+                                                group: "SEARCHLIST_SCOPE",
+                                                publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
+                                                checked: true,
+                                                hashName: "scope",
+                                                publishPayload: {
+                                                   label: "Repository",
+                                                   value: "repo"
+                                                }
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
                            }
                         }
                      ]
                   }
                },
                {
-                  name: "alfresco/documentlibrary/AlfDocumentListInfiniteScroll"
+                  id: "FCTSRCH_SEARCH_FORM",
+                  name: "alfresco/forms/SingleTextFieldForm",
+                  config: {
+                     useHash: true,
+                     okButtonLabel: "Ok",
+                     okButtonPublishTopic: "ALF_SET_SEARCH_TERM",
+                     okButtonPublishGlobal: true,
+                     okButtonIconClass: "alf-white-search-icon",
+                     okButtonClass: "call-to-action",
+                     textFieldName: "searchTerm",
+                     textBoxIconClass: "alf-search-icon",
+                     textBoxCssClasses: "long hiddenlabel",
+                     textBoxLabel: "Search box"
+                  }
+               },
+               {
+                  id: "FCTSRCH_SEARCH_RESULTS_LIST",
+                  name: "alfresco/search/AlfSearchList",
+                  config: {
+                     viewPreferenceProperty: "org.alfresco.share.searchList.viewRendererName",
+                     view: "simple",
+                     waitForPageWidgets: false,
+                     useHash: true,
+                     hashVarsForUpdate: [
+                        "searchTerm",
+                        "facetFilters",
+                        "sortField",
+                        "sortAscending",
+                        "allSites",
+                        "repo",
+                        "searchScope",
+                        "query"
+                     ],
+                     selectedScope: "REPO",
+                     useInfiniteScroll: true,
+                     siteId: null,
+                     rootNode: null,
+                     repo: true,
+                     additionalControlsTarget: "FCTSRCH_RESULTS_MENU_BAR",
+                     widgets: [
+                        {
+                           id: "FCTSRCH_SEARCH_ADVICE_NO_RESULTS",
+                           name: "alfresco/search/AlfSearchListView",
+                           config: {
+                              searchAdviceTitle: "faceted-search.advice.title",
+                              searchAdvice: [
+                                 "faceted-search.advice.suggestion1",
+                                 "faceted-search.advice.suggestion2",
+                                 "faceted-search.advice.suggestion3"
+                              ],
+                              a11yCaption: "Faceted Search Results",
+                              a11yCaptionClass: "hiddenAccessible",
+                              widgetsForHeader: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/HeaderCell",
+                                    config: {
+                                       label: "Thumbnail",
+                                       className: "hiddenAccessible",
+                                       a11yScope: "col"
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/HeaderCell",
+                                    config: {
+                                       label: "Details",
+                                       className: "hiddenAccessible",
+                                       a11yScope: "col"
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/HeaderCell",
+                                    config: {
+                                       label: "Actions",
+                                       className: "hiddenAccessible",
+                                       a11yScope: "col"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
                }
             ]
          }
@@ -109,10 +181,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/SearchMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SearchMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SearchMockXhr.js
@@ -43,7 +43,7 @@ define(["dojo/_base/declare",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      templateToUse]);
-            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY");
          }
          catch(e)
          {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SearchMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SearchMockXhr.js
@@ -39,10 +39,11 @@ define(["dojo/_base/declare",
          {
             var templateToUse = xhrSearchResponse;
             this.server.respondWith("GET",
-                                    /\/aikau\/proxy\/alfresco\/slingshot\/search/,
+                                    /(.*)/,
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      templateToUse]);
+            this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
          }
          catch(e)
          {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-584 to ensure that the SearchService uses the correct scope when making XHR requests. The unit tests have been updated to prevent future regressions.