### PR TITLE
AKU-559: Update CoreWidgetProcessing to use promises

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -248,14 +248,7 @@ define(["dojo/_base/declare",
          array.forEach(widgets, lang.hitch(this, function(widget) {
             widget.placeAt(this.contentNode);
          }), this);
-      },
 
-      /**
-       * Creates a "disclosure twister" UI control from existing mark-up.
-       *
-       * @instance
-       */
-      createTwister: function alfresco_layout_Twister__createTwister() {
          if (this.preferencePrefix && this.preferenceName)
          {
             this.alfPublish(this.getPreferenceTopic, {
@@ -264,7 +257,14 @@ define(["dojo/_base/declare",
                callbackScope: this
             });
          }
+      },
 
+      /**
+       * Creates a "disclosure twister" UI control from existing mark-up.
+       *
+       * @instance
+       */
+      createTwister: function alfresco_layout_Twister__createTwister() {
          // Initial State
          domClass.add(this.labelNode, this.initiallyOpen ? this.CLASS_OPEN : this.CLASS_CLOSED);
          domStyle.set(this.contentNode, "display", this.initiallyOpen ? "block" : "none");

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -31,10 +31,8 @@ define(["dojo/_base/declare",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dijit/registry",
-        "alfresco/util/hashUtils",
-        "dojo/Deferred",
-        "dojo/when"], 
-        function(declare, AlfSortablePaginatedList, ObjectProcessingMixin, lang, array, domConstruct, domClass, registry, hashUtils, Deferred, when) {
+        "alfresco/util/hashUtils"], 
+        function(declare, AlfSortablePaginatedList, ObjectProcessingMixin, lang, array, domConstruct, domClass, registry, hashUtils) {
    
    return declare([AlfSortablePaginatedList, ObjectProcessingMixin], {
       
@@ -90,7 +88,6 @@ define(["dojo/_base/declare",
          // that have not had there dependencies correctly analysed by Surf. This is the case for the ComboBox
          // when used in a non-standard locale as language specific validation.js and common.js files are requested.
          // Using a promise ensures that filters are only used when they're actually available. See AKU-559 for details
-         this._filtersWidgetsProcesed = new Deferred();
          if (this.widgetsForFilters)
          {
             var filtersModel = lang.clone(this.widgetsForFilters);
@@ -100,7 +97,6 @@ define(["dojo/_base/declare",
          else
          {
             this._filterWidgets = {};
-            this._filtersWidgetsProcesed.resolve();
          }
          this.inherited(arguments);
       },
@@ -153,24 +149,22 @@ define(["dojo/_base/declare",
          // Only do this when we are mirroring the filters in the hash
          if (this.mapHashVarsToPayload) {
 
-            when(this._filtersWidgetsProcesed, lang.hitch(this, function() {
-               // Initialise the data-filters to be all of the filters we have specified, without values
-               this.dataFilters = array.map(Object.keys(this._filterWidgets), function(filterName) {
-                  return {
-                     name: filterName
-                  };
-               });
+            // Initialise the data-filters to be all of the filters we have specified, without values
+            this.dataFilters = array.map(Object.keys(this._filterWidgets), function(filterName) {
+               return {
+                  name: filterName
+               };
+            });
 
-               // Filter to only include items currently in the hash and update values
-               var currHash = hashUtils.getHash();
-               this.dataFilters = array.filter(this.dataFilters, function(dataFilter) {
-                  dataFilter.value = currHash[dataFilter.name];
-                  return !!dataFilter.value;
-               });
+            // Filter to only include items currently in the hash and update values
+            var currHash = hashUtils.getHash();
+            this.dataFilters = array.filter(this.dataFilters, function(dataFilter) {
+               dataFilter.value = currHash[dataFilter.name];
+               return !!dataFilter.value;
+            });
 
-               // Update the filter fields
-               this._updateFilterFieldsFromHash();
-            }));
+            // Update the filter fields
+            this._updateFilterFieldsFromHash();
          }
 
          // Call inherited
@@ -190,8 +184,6 @@ define(["dojo/_base/declare",
                return childWidget.name === filterName;
             })[0];
          }, this);
-
-         this._filtersWidgetsProcesed.resolve();
       },
 
       /**
@@ -205,40 +197,38 @@ define(["dojo/_base/declare",
          var currHash = hashUtils.getHash();
 
          // Run through all of the filter widgets
-         when(this._filtersWidgetsProcesed, lang.hitch(this, function() {
-            array.forEach(Object.keys(this._filterWidgets), function(widgetName) {
+         array.forEach(Object.keys(this._filterWidgets), function(widgetName) {
 
-               // Get the widget and the filter value, normalising non-values to null
-               var widget = this._filterWidgets[widgetName],
-                  filterValue = currHash[widgetName];
-               if (typeof filterValue === "undefined") {
-                  filterValue = null;
-               }
+            // Get the widget and the filter value, normalising non-values to null
+            var widget = this._filterWidgets[widgetName],
+               filterValue = currHash[widgetName];
+            if (typeof filterValue === "undefined") {
+               filterValue = null;
+            }
 
-               // Update the dataFilters
-               if (filterValue === null) {
-                  this.dataFilters = array.filter(this.dataFilters, function(filter) {
-                     return filter.name !== widgetName;
-                  });
-               } else {
-                  var filterFound = array.some(this.dataFilters, function(filter) {
-                     if (filter.name === widgetName) {
-                        filter.value = filterValue;
-                        return true;
-                     }
-                  });
-                  if (!filterFound) {
-                     this.dataFilters.push({
-                        name: widgetName,
-                        value: filterValue
-                     });
+            // Update the dataFilters
+            if (filterValue === null) {
+               this.dataFilters = array.filter(this.dataFilters, function(filter) {
+                  return filter.name !== widgetName;
+               });
+            } else {
+               var filterFound = array.some(this.dataFilters, function(filter) {
+                  if (filter.name === widgetName) {
+                     filter.value = filterValue;
+                     return true;
                   }
+               });
+               if (!filterFound) {
+                  this.dataFilters.push({
+                     name: widgetName,
+                     value: filterValue
+                  });
                }
+            }
 
-               // Set the widget value
-               widget && widget.setValue && widget.setValue(filterValue);
-            }, this);
-         }));
+            // Set the widget value
+            widget && widget.setValue && widget.setValue(filterValue);
+         }, this);
       },
 
       /**


### PR DESCRIPTION
This PR is another (hopefully the final) attempt at resolving https://issues.alfresco.com/jira/browse/AKU-559. This time I've updated CoreWidgetProcessing to make use of promises to ensure that the allWidgetsProcessed function is only called when widgets have really finished being created.