### PR TITLE
AKU-585: Integrate new test reporter

### DIFF
--- a/aikau/src/grunt/_config.js
+++ b/aikau/src/grunt/_config.js
@@ -14,6 +14,7 @@ module.exports = {
       js: "src/main/resources/alfresco/**/*.js",
       jsdocConfig: "conf.json",
       jsdocReadme: "src/jsdoc-templates/alfresco/README.md",
+      reporter: "src/test/resources/reporters/AikauConcurrentReporter.js",
       test: "tests/alfresco/**",
       testApp: "src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/**",
       testFramework: "src/test/resources/testApp/js/aikau/testing/**",

--- a/aikau/src/grunt/testing.js
+++ b/aikau/src/grunt/testing.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
    // Register test tasks for local/vagrant/SauceLabs/grid respectively
    grunt.registerTask("test_local", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:local"]);
    grunt.registerTask("test", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:dev"]);
+   grunt.registerTask("test_bs", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:bs"]);
    grunt.registerTask("test_sl", ["startUnitTestApp", "waitServer", "clean:testScreenshots", "generate-require-everything", "intern:sl"]);
    grunt.registerTask("test_grid", ["waitServer", "clean:testScreenshots", "generate-require-everything", "intern:grid"]);
 
@@ -75,11 +76,20 @@ module.exports = function(grunt) {
    // Update the grunt config
    grunt.config.merge({
       intern: {
+         options: {
+            rowsCols: process.stdout.rows + "|" + process.stdout.columns // Used by ConcurrentReporter
+         },
+         bs: {
+            options: {
+               runType: "runner",
+               config: "src/test/resources/intern_bs",
+               useLocalhost: true
+            }
+         },
          dev: {
             options: {
                runType: "runner",
-               config: "src/test/resources/intern",
-               doCoverage: false
+               config: "src/test/resources/intern"
             }
          },
          dev_coverage: {
@@ -92,22 +102,19 @@ module.exports = function(grunt) {
          local: {
             options: {
                runType: "runner",
-               config: "src/test/resources/intern_local",
-               doCoverage: false
+               config: "src/test/resources/intern_local"
             }
          },
          sl: {
             options: {
                runType: "runner",
-               config: "src/test/resources/intern_sl",
-               doCoverage: false
+               config: "src/test/resources/intern_sl"
             }
          },
          grid: {
             options: {
                runType: "runner",
-               config: "src/test/resources/intern_grid",
-               doCoverage: false
+               config: "src/test/resources/intern_grid"
             }
          }
       }

--- a/aikau/src/test/resources/alfresco/CodeCoverageBalancer.js
+++ b/aikau/src/test/resources/alfresco/CodeCoverageBalancer.js
@@ -23,40 +23,40 @@
  * @author Dave Draper
  */
 define(["intern!object",
-      "intern/chai!assert",
-      "intern",
-      "require",
-      "alfresco/TestCommon"
-   ],
-   function(registerSuite, assert, intern, require, TestCommon) {
+        "intern/chai!assert",
+        "intern", 
+        "require", 
+        "alfresco/TestCommon"], 
+        function(registerSuite, assert, intern, require, TestCommon) {
 
-      registerSuite(function() {
-         var browser;
+   registerSuite(function() {
+      var browser;
 
-         return {
-            name: "Code Coverage Balancer",
+      return {
+         name: "Code Coverage Balancer",
 
-            setup: function() {
-               browser = this.remote;
-            },
+         setup: function() {
+            browser = this.remote;
+         },
 
-            "Balance": function() {
-               if (intern.args.doCoverage === "true") {
-                  return TestCommon.loadTestWebScript(this.remote, "/RequireEverything", "Coverage Balancer")
-                     .end()
+         "Balance": function() {
+            if (intern.args.doCoverage === true)
+            {
+               return TestCommon.loadTestWebScript(this.remote, "/RequireEverything", "Coverage Balancer")
+                  .end()
 
-                  .findByCssSelector("#LABEL")
-                     .getVisibleText()
-                     .then(function(text) {
-                        assert(text === "Coverage Balanced!", "Code Coverage Balancer Didn't Load - coverage results will be invalid");
-                     })
-                     .end();
-               }
-            },
-
-            "Post Coverage Results": function() {
-               TestCommon.alfPostCoverageResults(this, browser);
+               .findByCssSelector("#LABEL")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert(text === "Coverage Balanced!", "Code Coverage Balancer Didn't Load - coverage results will be invalid");
+                  })
+                  .end();
             }
-         };
-      });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
+});

--- a/aikau/src/test/resources/alfresco/CodeCoverageBalancer.js
+++ b/aikau/src/test/resources/alfresco/CodeCoverageBalancer.js
@@ -23,43 +23,40 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!assert",
-        "intern",
-        "require",
-        "alfresco/TestCommon"], 
-        function (registerSuite, assert, intern, require, TestCommon) {
+      "intern/chai!assert",
+      "intern",
+      "require",
+      "alfresco/TestCommon"
+   ],
+   function(registerSuite, assert, intern, require, TestCommon) {
 
-   var browser;
-   registerSuite({
-      name: "Code Coverage Balancer",
+      registerSuite(function() {
+         var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/RequireEverything", "Coverage Balancer").end();
-      },
+         return {
+            name: "Code Coverage Balancer",
 
-      beforeEach: function() {
-         browser.end();
-      },
+            setup: function() {
+               browser = this.remote;
+            },
 
-      "Balance": function () {
-         if(intern.args.doCoverage === "true")
-         {
-            return browser.findByCssSelector("#LABEL")
-               .getVisibleText()
-               .then(function(text) {
-                  assert(text === "Coverage Balanced!", "Code Coverage Balancer Didn't Load - coverage results will be invalid");
-               })
-            .end();
-          }
-          else
-          {
-            return browser.end();
-          }
-      },
+            "Balance": function() {
+               if (intern.args.doCoverage === "true") {
+                  return TestCommon.loadTestWebScript(this.remote, "/RequireEverything", "Coverage Balancer")
+                     .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+                  .findByCssSelector("#LABEL")
+                     .getVisibleText()
+                     .then(function(text) {
+                        assert(text === "Coverage Balanced!", "Code Coverage Balancer Didn't Load - coverage results will be invalid");
+                     })
+                     .end();
+               }
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
    });
-});

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -32,8 +32,9 @@ define(["intern/dojo/node!fs",
         "config/Config",
         "intern/dojo/Promise",
         "intern/dojo/node!leadfoot/helpers/pollUntil",
-        "intern/chai!assert"],
-        function(fs, http, os, lang, intern, Config, Promise, pollUntil, assert) {
+        "intern/chai!assert",
+        "intern/dojo/node!leadfoot/keys"], 
+        function(fs, http, os, lang, intern, Config, Promise, pollUntil, assert, keys) {
    return {
 
       /**
@@ -45,7 +46,8 @@ define(["intern/dojo/node!fs",
        */
       testWebScriptURL: function (webScriptURL, webScriptPrefix) {
          if (!Config.urls.unitTestAppBaseUrl) {
-            var testServer = "http://" + this._getLocalIP() + ":8089";
+            var serverAddress = (intern.args.useLocalhost === "true") ? "localhost" : this._getLocalIP(),
+               testServer = "http://" + serverAddress + ":8089";
             Config.urls.unitTestAppBaseUrl = testServer;
             // console.log("Using test-server URL: " + testServer);
          }
@@ -144,7 +146,7 @@ define(["intern/dojo/node!fs",
        * @param {string} testWebScriptPrefix Optional prefix to use before the WebScript URL
        * @param {boolean} noPageLoadError Optional boolean to suppress page load failure errors
        */
-      loadTestWebScript: function (browser, testWebScriptURL, testName, testWebScriptPrefix, noPageLoadError) {
+      loadTestWebScript: function(browser, testWebScriptURL, testName, testWebScriptPrefix, noPageLoadError) {
          this._applyTimeouts(browser);
          this._maxWindow(browser);
          this._cancelModifierKeys(browser);
@@ -158,7 +160,7 @@ define(["intern/dojo/node!fs",
             .then(
                function (element) {
                },
-               function (error) {
+               function(error) {
                   // Failed to load, trying again...
                   browser.refresh();
                })
@@ -169,10 +171,10 @@ define(["intern/dojo/node!fs",
                   return elements.length > 0 ? true : null;
                }, [], 10000, 1000))
             .then(
-               function (element) {
+               function(element) {
                   // Loaded successfully
                },
-               function (error) {
+               function(error) {
                   // Failed to load after two attempts
                   if (noPageLoadError === true)
                   {
@@ -184,8 +186,8 @@ define(["intern/dojo/node!fs",
                   }
                })
             .end();
-         command.session.alfPostCoverageResults = function (newBrowser) { 
-            return newBrowser; 
+         command.session.alfPostCoverageResults = function(newBrowser) {
+            return newBrowser;
          };
          command.session.screenieIndex = 0;
          command.session.screenie = function(description) {
@@ -207,16 +209,16 @@ define(["intern/dojo/node!fs",
                   var urlDisplay = document.createElement("DIV");
                   urlDisplay.id = id;
                   urlDisplay.style.background = "#666";
-                  urlDisplay.style.borderRadius = "0 0 0 5px";
+                  urlDisplay.style.borderRadius = "5px 0 0 5px";
                   urlDisplay.style.color = "#fff";
                   urlDisplay.style.fontFamily = "Open Sans Bold, sans-serif";
                   urlDisplay.style.fontSize = "12px";
                   urlDisplay.style.lineHeight = "18px";
-                  urlDisplay.style.opacity = ".9";
+                  urlDisplay.style.opacity = ".85";
                   urlDisplay.style.padding = "10px";
                   urlDisplay.style.position = "fixed";
                   urlDisplay.style.right = "0";
-                  urlDisplay.style.top = "0";
+                  urlDisplay.style.bottom = "10px";
                   urlDisplay.appendChild(document.createTextNode("Time: " + (new Date()).toISOString()));
                   urlDisplay.appendChild(document.createElement("BR"));
                   urlDisplay.appendChild(document.createTextNode("URL: " + location.href));
@@ -354,8 +356,8 @@ define(["intern/dojo/node!fs",
                      // Construct the error message
                      var customMessage = messageIfError ? messageIfError + ": " : "",
                         entryType = opts.type || "PUBorSUB",
-                        topic = opts.isGlobal ? opts.topic : "*" + opts.topic,
-                        errorMessage = "Unable to find a " + entryType + " of " + topic + " (timeout=" + opts.queryTimeout + "ms)";
+                        topic = opts.isGlobal ? opts.topic + " (global)" : "*" + opts.topic,
+                        errorMessage = "Unable to find a " + entryType + " of " + topic + " with timeout of " + opts.queryTimeout + "ms)";
 
                      // Throw the error
                      throw new Error(customMessage + errorMessage);
@@ -369,8 +371,82 @@ define(["intern/dojo/node!fs",
                   throw error;
                });
          };
+         command.session.tabToElement = function(selector, collectionIndex, maxTabs) {
+
+            // Setup variables
+            var tabbedToElement = false,
+               numTabs = 0,
+               dfd = new Promise.Deferred();
+
+            // Sanitise arguments
+            collectionIndex = collectionIndex || 0;
+            maxTabs = maxTabs || 10;
+            if (!selector) {
+               throw new Error("No valid selector provided in tabToElement()");
+            }
+
+            // Define tabAndCheck function
+            function tabAndCheck() {
+               return browser.pressKeys(keys.TAB)
+                  .execute(function(targetElemSelector, index) {
+                     var targetElem = document.querySelectorAll(targetElemSelector)[index];
+                     return targetElem && targetElem === document.activeElement;
+                  }, [selector, collectionIndex])
+                  .then(function(foundElem) {
+                     if (typeof foundElem === "undefined") {
+                        throw new Error("Unable to find target element with selector \"" + selector + "\" and index " + collectionIndex);
+                     } else if (!foundElem && numTabs++ < maxTabs) {
+                        return tabAndCheck();
+                     } else if (!foundElem) {
+                        throw new Error("Unable to tab to element with selector \"" + selector + "\" after " + maxTabs + " attempts");
+                     } else {
+                        return true;
+                     }
+                  });
+            }
+
+            // Tab until found
+            tabAndCheck().then(function(foundElem) {
+               dfd.resolve();
+            }, function(err) {
+               dfd.reject(err);
+            });
+
+            // Pass back the base promise
+            return dfd.promise;
+         };
 
          return command;
+      },
+
+      /**
+       * Skip the supplied test if all the search strings are found in the environment
+       *
+       * @instance
+       * @param {Object} testObj The test object (normally passed as "this")
+       * @param {string} conditionType The condition type (only supported one atm is "environment")
+       * @param {string|string[]} searchString The search strings, normalised to an array
+       *                                       if just a single-string, which all must
+       *                                       match for the test to skip
+       */
+      skipIf: function(testObj, conditionType, searchString) {
+         if (conditionType !== "environment") {
+            throw new Error("Unknown condition type in skipIf(): \"" + conditionType + "\"");
+         }
+         var parentTest = testObj,
+            searchRegex = new RegExp(searchString, "i"),
+            maxLoops = 5,
+            loopIndex = 0,
+            envName;
+         do {
+            envName = parentTest.name;
+            if (loopIndex++ >= maxLoops) {
+               throw new Error("Error finding root suite (too many loops)");
+            }
+         } while ((parentTest = parentTest.parent));
+         if (searchRegex.test(envName)) {
+            testObj.skip("Test skipped because test environment is \"" + envName + "\"");
+         }
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -129,11 +129,6 @@ define(["intern/dojo/node!fs",
                   dfd.reject(e);
                });
          }
-         else
-         {
-            console.log("Skipping coverage");
-            return browser;
-         }
       },
 
       /**
@@ -156,20 +151,20 @@ define(["intern/dojo/node!fs",
                   /*jshint browser:true*/
                   var elements = document.getElementsByClassName("aikau-reveal");
                   return elements.length > 0 ? true : null;
-               }, [], 10000, 1000))
+               }, null, 10000))
             .then(
                function (element) {
                },
                function(error) {
                   // Failed to load, trying again...
                   browser.refresh();
-               })
+            })
             .then(pollUntil(
                function() {
                   /*jshint browser:true*/
                   var elements = document.getElementsByClassName("aikau-reveal");
                   return elements.length > 0 ? true : null;
-               }, [], 10000, 1000))
+               }, null, 10000))
             .then(
                function(element) {
                   // Loaded successfully
@@ -184,7 +179,7 @@ define(["intern/dojo/node!fs",
                   {
                      assert.fail(null, null, "Test page could not be loaded");
                   }
-               })
+            })
             .end();
          command.session.alfPostCoverageResults = function(newBrowser) {
             return newBrowser;

--- a/aikau/src/test/resources/alfresco/accessibility/AccessibilityMenuTest.js
+++ b/aikau/src/test/resources/alfresco/accessibility/AccessibilityMenuTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AccessibilityMenu Tests",
 
       setup: function() {
@@ -93,5 +95,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest.js
+++ b/aikau/src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest.js
@@ -26,9 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   
-   registerSuite({
+
+   return {
       name: "SemanticWrapperMixin Test",
 
       setup: function() {
@@ -79,5 +80,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/buttons/DynamicPayloadButtonTest.js
+++ b/aikau/src/test/resources/alfresco/buttons/DynamicPayloadButtonTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
       function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Dynamic Payload Button Tests",
 
       setup: function() {
@@ -148,5 +150,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/charts/ccc/PieChartTest.js
+++ b/aikau/src/test/resources/alfresco/charts/ccc/PieChartTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
       function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "PieChart Tests",
 
       setup: function() {
@@ -73,5 +75,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/AdvancedVisibilityConfigTest.js
+++ b/aikau/src/test/resources/alfresco/core/AdvancedVisibilityConfigTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Advanced VisibilityConfig Tests",
 
       setup: function() {
@@ -115,5 +117,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/CoreRwdTest.js
+++ b/aikau/src/test/resources/alfresco/core/CoreRwdTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "CoreRwd Tests",
 
       setup: function() {
@@ -99,5 +101,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/NotificationUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/core/NotificationUtilsTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "NotificationUtils Mixin Tests",
 
       setup: function() {
@@ -56,5 +58,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/PublishPayloadMixinTest.js
+++ b/aikau/src/test/resources/alfresco/core/PublishPayloadMixinTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "PublishPayloadMixin Tests",
 
       setup: function() {
@@ -278,5 +280,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/RenderFilterTest.js
+++ b/aikau/src/test/resources/alfresco/core/RenderFilterTest.js
@@ -39,8 +39,10 @@ define(["intern!object",
    // MBI6 - failed AND condition
    // MI2 - failed filter rule following inherited currentItem change
          
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "RenderFilter Tests",
 
       setup: function() {
@@ -160,5 +162,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/ResponseScopeTest.js
+++ b/aikau/src/test/resources/alfresco/core/ResponseScopeTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Response Scope Tests",
 
       setup: function() {
@@ -155,5 +157,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/TemporalUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/core/TemporalUtilsTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "TemporalUtils Tests",
 
       setup: function() {
@@ -287,5 +289,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/VisibilityConfigTest.js
+++ b/aikau/src/test/resources/alfresco/core/VisibilityConfigTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "VisibilityConfig Tests",
 
       setup: function() {
@@ -120,5 +122,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/core/WidgetCreationTest.js
+++ b/aikau/src/test/resources/alfresco/core/WidgetCreationTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Widget Creation Tests",
 
       setup: function() {
@@ -73,5 +75,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/creation/WidgetConfigTest.js
+++ b/aikau/src/test/resources/alfresco/creation/WidgetConfigTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Page Creation Widgets Tests",
 
@@ -83,5 +85,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
@@ -28,8 +28,10 @@ define(["alfresco/TestCommon",
    ],
    function(TestCommon, assert, registerSuite) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "Dashlet Tests",
 
          setup: function() {
@@ -101,7 +103,9 @@ define(["alfresco/TestCommon",
          },
 
          // This does not work in Chrome currently, however we expect the FF test to pass, so this provides some level of regression testability
-         "Resizing dashlet stores height (NOT EXPECTED TO WORK IN CHROME)": function() {
+         "Resizing dashlet stores height": function() {
+            TestCommon.skipIf(this, "environment", "chrome");
+
             return browser.findByCssSelector("#VALID_ID_DASHLET .alfresco-dashlets-Dashlet__resize-bar__icon")
                .moveMouseTo(0, 0)
                .pressMouseButton()
@@ -118,5 +122,6 @@ define(["alfresco/TestCommon",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/InfiniteScrollDashletTest.js
@@ -28,105 +28,110 @@ define(["alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
         function(TestCommon, assert, registerSuite, keys) {
 
-   var browser;
-   registerSuite({
-      name: "Infinite Scrolling Dashlet Tests",
+   registerSuite(function() {
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollDashlet", "Infinite Scrolling Dashlet Tests").end();
-      },
+      return {
+         name: "Infinite Scrolling Dashlet Tests",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollDashlet", "Infinite Scrolling Dashlet Tests").end();
+         },
 
-      "Scroll to bottom of first dashlet body": function() {
-         var numRowsBeforeResize;
-         return browser.findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
-            .then(function(elements) {
-               numRowsBeforeResize = elements.length;
-            })
-            .end()
+         beforeEach: function() {
+            browser.end();
+         },
 
-         .findByCssSelector("#INFINITE_SCROLL_LIST_1 tr:nth-child(1) .alfresco-renderers-Property")
-            .click()
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .end()
+         "Scroll to bottom of first dashlet body": function() {
+            var numRowsBeforeResize;
+            return browser.findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
+               .then(function(elements) {
+                  numRowsBeforeResize = elements.length;
+               })
+               .end()
 
-         .getLastPublish("BELOW_ALF_EVENTS_SCROLL", "List scroll event not registered")
-            .end()
+            .findByCssSelector("#INFINITE_SCROLL_LIST_1 tr:nth-child(1) .alfresco-renderers-Property")
+               .click()
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .end()
 
-         .findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
-            .then(function(elements) {
-               assert(elements.length > numRowsBeforeResize, "Additional rows were not loaded when the bottom of the list was reached");
-            });
-      },
+            .getLastPublish("BELOW_ALF_EVENTS_SCROLL", "List scroll event not registered")
+               .end()
 
-      "Scroll to bottom of second dashlet body": function() {
-         // Click on the first row to give it focus...
-         return browser.findByCssSelector("#INFINITE_SCROLL_LIST_2 tr:nth-child(1) .alfresco-renderers-Property")
-            .clearLog()
-            .click()
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .end()
+            .findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
+               .then(function(elements) {
+                  assert(elements.length > numRowsBeforeResize, "Additional rows were not loaded when the bottom of the list was reached");
+               });
+         },
 
-         .getLastPublish("ABOVE_ALF_EVENTS_SCROLL", "List scroll event not registered")
+         "Scroll to bottom of second dashlet body": function() {
+            // Click on the first row to give it focus...
+            return browser.findByCssSelector("#INFINITE_SCROLL_LIST_2 tr:nth-child(1) .alfresco-renderers-Property")
+               .clearLog()
+               .click()
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .end()
 
-         .getLastPublish("ABOVE_ALF_DOCLIST_REQUEST_FINISHED", "More data not loaded")
+            .getLastPublish("ABOVE_ALF_EVENTS_SCROLL", "List scroll event not registered")
 
-         .findAllByCssSelector("#INFINITE_SCROLL_LIST_2 tr")
-            .then(function(elements) {
-               assert.lengthOf(elements, 40, "Additional rows were not loaded when the bottom of the list was reached");
-            });
-      },
+            .getLastPublish("ABOVE_ALF_DOCLIST_REQUEST_FINISHED", "More data not loaded")
 
-      // This does not work in Chrome currently, however we expect the FF test to pass, so this provides some level of regression testability
-      "Resizing first dashlet prompts data-load (NOT EXPECTED TO WORK IN CHROME)": function() {
-         var numRowsBeforeResize;
-         return browser.findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
-            .then(function(elements) {
-               numRowsBeforeResize = elements.length;
-            })
-            .end()
+            .findAllByCssSelector("#INFINITE_SCROLL_LIST_2 tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 40, "Additional rows were not loaded when the bottom of the list was reached");
+               });
+         },
 
-         .findByCssSelector("#BELOW_DASHLET .alfresco-dashlets-Dashlet__resize-bar__icon")
-            .moveMouseTo(0, 0)
-            .pressMouseButton()
-            .moveMouseTo(0, 50)
-            .releaseMouseButton()
-            .end()
+         // This does not work in Chrome currently, however we expect the FF test to pass, so this provides some level of regression testability
+         "Resizing first dashlet prompts data-load": function() {
+            TestCommon.skipIf(this, "environment", "chrome");
 
-         .findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
-            .then(function(elements) {
-               assert(elements.length > numRowsBeforeResize, "Additional rows were not loaded when the dashlet was resized");
-            });
-      },
+            var numRowsBeforeResize;
+            return browser.findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
+               .then(function(elements) {
+                  numRowsBeforeResize = elements.length;
+               })
+               .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+            .findByCssSelector("#BELOW_DASHLET .alfresco-dashlets-Dashlet__resize-bar__icon")
+               .moveMouseTo(0, 0)
+               .pressMouseButton()
+               .moveMouseTo(0, 50)
+               .releaseMouseButton()
+               .end()
+
+            .findAllByCssSelector("#INFINITE_SCROLL_LIST_1 tr")
+               .then(function(elements) {
+                  assert(elements.length > numRowsBeforeResize, "Additional rows were not loaded when the dashlet was resized");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
+++ b/aikau/src/test/resources/alfresco/debug/WidgetInfoTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Widget Info Tests",
 
       setup: function() {
@@ -115,5 +117,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/AlternateEditorTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/AlternateEditorTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "DND Alternative Editing Tests",
 
@@ -99,5 +101,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -27,8 +27,12 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+var pause = 150;
+
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Basic DND tests",
 
@@ -132,9 +136,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "DND items provided by list",
 
@@ -158,10 +166,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   var pause = 150;
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "Accessibility DND tests",
 
@@ -314,9 +325,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "DND Nesting Tests",
 
@@ -340,9 +355,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "DND Modelling Tests",
 
@@ -447,5 +466,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/FormCreationTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/FormCreationTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         function (registerSuite, assert, require, TestCommon, keys) {
 
    var pause = 150;
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Form Creation DND tests",
 
@@ -190,5 +192,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/ModelCreationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/ModelCreationServiceTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "DND Model Creation Service Tests",
 
@@ -84,5 +86,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
@@ -27,9 +27,11 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
-   var pause = 150;
+var pause = 150;
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Multi-source DND tests",
 
@@ -114,9 +116,10 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   var setupDroppedItems = function() {
+   var setupDroppedItems = function(browser) {
       // Select the item in the first source...
       return browser.pressKeys(keys.TAB)
          .sleep(pause)
@@ -163,7 +166,10 @@ define(["intern!object",
             .end();
    };
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "Multi-source DND tests (clear using publication)",
 
@@ -179,7 +185,7 @@ define(["intern!object",
 
       "Nest single use item in multiple use item": function() {
          return browser.then(function() {
-               return setupDroppedItems();
+               return setupDroppedItems(browser);
             })
 
             // Make sure everything is setup correctly
@@ -208,9 +214,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "Multi-source DND tests (clear with no restore using publication)",
 
@@ -226,7 +236,7 @@ define(["intern!object",
 
       "Nest single use item in multiple use item": function() {
          return browser.then(function() {
-               return setupDroppedItems();
+               return setupDroppedItems(browser);
             })
 
             .findByCssSelector("#BRUTAL_CLEAR_BUTTON_label")
@@ -248,9 +258,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
 
       name: "Multi-source DND tests (test preset value loading)",
 
@@ -296,5 +310,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/NestedConfigurationTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/NestedConfigurationTest.js
@@ -27,9 +27,11 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var pause = 150;
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Inherited DND Configuration Tests",
 
@@ -211,5 +213,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/dnd/NestedReorderTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/NestedReorderTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Nested item re-ordering, moving and deleting tests",
 
@@ -173,5 +175,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest.js
@@ -25,8 +25,11 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
+
       name: "AlfGalleryViewSlider Preferences Tests",
 
       setup: function() {
@@ -81,5 +84,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Breadcrumb Trail Tests",
 
       setup: function() {
@@ -210,5 +212,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Create Content Tests",
 
       setup: function() {
@@ -92,9 +94,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Create Content (Denied Permission) Tests",
 
       setup: function() {
@@ -187,9 +193,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Create Content (Change Path) Tests",
 
       setup: function() {
@@ -282,9 +292,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Create Templates Tests",
 
       setup: function() {
@@ -389,5 +403,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -27,20 +27,18 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
-   var browser;
-
    // PLEASE NOTE:
    // We're going to run the same tests on the Document Library with URL hashing enabled and then disabled
    // so the tests are abstracted to their own individual functions for re-use (this is slightly different
    // that other tests)...
-   var countInitialBreadcrumbs = function() {
+   var countInitialBreadcrumbs = function(browser) {
       return browser.setFindTimeout(10000).findAllByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb")
          .then(function(elements) {
             assert.lengthOf(elements, 1, "No breadcrumbs were rendered on page load");
          }); 
    };
 
-   var checkInitialBreadcrumbText = function() {
+   var checkInitialBreadcrumbText = function(browser) {
       return browser.findByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb .breadcrumb")
          .getVisibleText()
          .then(function(text) {
@@ -48,7 +46,7 @@ define(["intern!object",
          });
    };
 
-   var clickOnFolderLink = function() {
+   var clickOnFolderLink = function(browser) {
       return browser.findByCssSelector("#DETAILED_VIEW_NAME_ITEM_0 .alfresco-renderers-Property")
          .clearLog()
             .click()
@@ -60,7 +58,7 @@ define(["intern!object",
             });
          };
 
-   var checkAddedBreadcrumbText = function() {
+   var checkAddedBreadcrumbText = function(browser) {
       return browser.findByCssSelector("#DOCLIB_BREADCRUMB_TRAIL .alfresco-documentlibrary-AlfBreadcrumb:nth-child(2) .breadcrumb")
          .getVisibleText()
          .then(function(text) {
@@ -68,7 +66,7 @@ define(["intern!object",
          });
    };
 
-   var returnToRoot = function() {
+   var returnToRoot = function(browser) {
       return browser.findByCssSelector("#DOCLIB_BREADCRUMB_TRAIL .alfresco-documentlibrary-AlfBreadcrumb:nth-child(1) .breadcrumb")
          .clearLog()
          .click()
@@ -86,7 +84,7 @@ define(["intern!object",
          });
    };
 
-   var switchToFilter = function(pubSubScope) {
+   var switchToFilter = function(browser, pubSubScope) {
       return browser.findByCssSelector(".alfresco-documentlibrary-AlfDocumentFilter:last-child span")
          .clearLog()
          .click()
@@ -103,7 +101,10 @@ define(["intern!object",
    // NOTE: For some as yet undetermined reason the first time we attempt to load the Document Library test page 
    //       with clear dependency caches it will fail. Therefore we register a dummy test suite that absorbs this
    //       failure so that subsequent tests can pass.
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Document Library Test (dummy load)",
 
       setup: function() {
@@ -111,9 +112,13 @@ define(["intern!object",
          return TestCommon.loadTestWebScript(this.remote, "/DocLib", "Document Library Test (dummy load)", null, true).end();
       }
       
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Document Library Test (default)",
 
       setup: function() {
@@ -127,46 +132,50 @@ define(["intern!object",
 
       "Count the initial breadcrumbs": function() {
          return browser.then(function() {
-            return countInitialBreadcrumbs();
+            return countInitialBreadcrumbs(browser);
          });
       },
 
       "Check the initial breadcrumb text": function() {
          return browser.then(function() {
-            return checkInitialBreadcrumbText();
+            return checkInitialBreadcrumbText(browser);
          });
       },
 
       "Click on a folder link and check for updated breadcrumb": function() {
          return browser.then(function() {
-            return clickOnFolderLink();
+            return clickOnFolderLink(browser);
          });
       },
 
       "Check the added breadcrumb text": function() {
          return browser.then(function() {
-            return checkAddedBreadcrumbText();
+            return checkAddedBreadcrumbText(browser);
          });
       },
 
       "Use the breadcrumb trail to return to the root": function() {
          return browser.then(function() {
-            return returnToRoot();
+            return returnToRoot(browser);
          });
       },
 
       "Switch to favourites filter": function() {
          return browser.then(function() {
-            return switchToFilter("SCOPED_");
+            return switchToFilter(browser, "SCOPED_");
          });
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Document Library Test (no URL hashing)",
 
       setup: function() {
@@ -180,37 +189,37 @@ define(["intern!object",
 
       "Count the initial breadcrumbs": function() {
          return browser.then(function() {
-            return countInitialBreadcrumbs();
+            return countInitialBreadcrumbs(browser);
          });
       },
 
       "Check the initial breadcrumb text": function() {
          return browser.then(function() {
-            return checkInitialBreadcrumbText();
+            return checkInitialBreadcrumbText(browser);
          });
       },
 
       "Click on a folder link and check for updated breadcrumb": function() {
          return browser.then(function() {
-            return clickOnFolderLink();
+            return clickOnFolderLink(browser);
          });
       },
 
       "Check the added breadcrumb text": function() {
          return browser.then(function() {
-            return checkAddedBreadcrumbText();
+            return checkAddedBreadcrumbText(browser);
          });
       },
 
       "Use the breadcrumb trail to return to the root": function() {
          return browser.then(function() {
-            return returnToRoot();
+            return returnToRoot(browser);
          });
       },
 
       "Switch to favourites filter": function() {
          return browser.then(function() {
-            return switchToFilter("");
+            return switchToFilter(browser, "");
          });
       },
 
@@ -264,5 +273,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentListTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "DocumentList Tests",
 
       setup: function() {
@@ -224,5 +225,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
@@ -48,8 +48,10 @@ define(["intern!object",
       return "#VIEW tr:nth-child(" + row + ") .alfresco-renderers-Selector.unchecked";
    };
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Document Selector Tests",
 
       setup: function() {
@@ -173,5 +175,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Pagination Tests",
 
       setup: function() {
@@ -314,10 +315,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // See AKU-330...
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Pagination Tests (Custom page sizes)",
 
       setup: function() {
@@ -330,71 +335,75 @@ define(["intern!object",
       },
 
       "Starting page is initialised and working (useHash=false)": function() {
-         return checkPage("CUSTOM_", 1)()
-            .then(gotoNextPage("CUSTOM_"))
-            .then(checkPage("CUSTOM_", 2));
+         return checkPage(browser, "CUSTOM_", 1)()
+            .then(gotoNextPage(browser, "CUSTOM_"))
+            .then(checkPage(browser, "CUSTOM_", 2));
       },
 
       "Changing filter changes to page 1 (useHash=false)": function() {
-         return clickButton("CHANGE_FILTER")
-            .then(checkPage("CUSTOM_", 1))
-            .then(gotoNextPage("CUSTOM_"));
+         return clickButton(browser, "CHANGE_FILTER")
+            .then(checkPage(browser, "CUSTOM_", 1))
+            .then(gotoNextPage(browser, "CUSTOM_"));
       },
 
       "Changing tag changes to page 1 (useHash=false)": function() {
-         return clickButton("CHANGE_TAG")
-            .then(checkPage("CUSTOM_", 1))
-            .then(gotoNextPage("CUSTOM_"));
+         return clickButton(browser, "CHANGE_TAG")
+            .then(checkPage(browser, "CUSTOM_", 1))
+            .then(gotoNextPage(browser, "CUSTOM_"));
       },
 
       "Changing category changes to page 1 (useHash=false)": function() {
-         return clickButton("CHANGE_CATEGORY")
-            .then(checkPage("CUSTOM_", 1))
-            .then(gotoNextPage("CUSTOM_"));
+         return clickButton(browser, "CHANGE_CATEGORY")
+            .then(checkPage(browser, "CUSTOM_", 1))
+            .then(gotoNextPage(browser, "CUSTOM_"));
       },
 
       "Changing path changes to page 1 (useHash=false)": function() {
-         return clickButton("CHANGE_PATH")
-            .then(checkPage("CUSTOM_", 1))
-            .then(gotoNextPage("CUSTOM_"));
+         return clickButton(browser, "CHANGE_PATH")
+            .then(checkPage(browser, "CUSTOM_", 1))
+            .then(gotoNextPage(browser, "CUSTOM_"));
       },
 
       "Starting page is initialised and working (useHash=true)": function() {
-         return checkPage("HASH_CUSTOM_", 1)()
-            .then(gotoNextPage("HASH_CUSTOM_"))
-            .then(checkPage("HASH_CUSTOM_", 2));
+         return checkPage(browser, "HASH_CUSTOM_", 1)()
+            .then(gotoNextPage(browser, "HASH_CUSTOM_"))
+            .then(checkPage(browser, "HASH_CUSTOM_", 2));
       },
 
       "Changing filter changes to page 1 (useHash=true)": function() {
-         return clickButton("HASH_CHANGE_FILTER")
-            .then(checkPage("HASH_CUSTOM_", 1))
-            .then(gotoNextPage("HASH_CUSTOM_"));
+         return clickButton(browser, "HASH_CHANGE_FILTER")
+            .then(checkPage(browser, "HASH_CUSTOM_", 1))
+            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
       },
 
       "Changing tag changes to page 1 (useHash=true)": function() {
-         return clickButton("HASH_CHANGE_TAG")
-            .then(checkPage("HASH_CUSTOM_", 1))
-            .then(gotoNextPage("HASH_CUSTOM_"));
+         return clickButton(browser, "HASH_CHANGE_TAG")
+            .then(checkPage(browser, "HASH_CUSTOM_", 1))
+            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
       },
 
       "Changing category changes to page 1 (useHash=true)": function() {
-         return clickButton("HASH_CHANGE_CATEGORY")
-            .then(checkPage("HASH_CUSTOM_", 1))
-            .then(gotoNextPage("HASH_CUSTOM_"));
+         return clickButton(browser, "HASH_CHANGE_CATEGORY")
+            .then(checkPage(browser, "HASH_CUSTOM_", 1))
+            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
       },
 
       "Changing path changes to page 1 (useHash=true)": function() {
-         return clickButton("HASH_CHANGE_PATH")
-            .then(checkPage("HASH_CUSTOM_", 1))
-            .then(gotoNextPage("HASH_CUSTOM_"));
+         return clickButton(browser, "HASH_CHANGE_PATH")
+            .then(checkPage(browser, "HASH_CUSTOM_", 1))
+            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Pagination Tests (invalid current page)",
 
       setup: function() {
@@ -449,9 +458,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Pagination Tests (valid current page)",
 
       setup: function() {
@@ -505,10 +518,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // See AKU-330...
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Scroll to item test",
 
       setup: function() {
@@ -537,19 +554,20 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    /********************/
    /* Helper functions */
    /********************/
-   function clickButton(buttonId) {
+   function clickButton(browser, buttonId) {
       return browser.findByCssSelector("[widgetid=\"" + buttonId + "\"] .dijitButtonNode")
          .click()
          .sleep(500)
          .end();
    }
 
-   function gotoNextPage(scope) {
+   function gotoNextPage(browser, scope) {
       return function() {
          return browser.end()
             .findById(scope + "PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
@@ -558,7 +576,7 @@ define(["intern!object",
       };
    }
 
-   function checkPage(scope, pageNum) {
+   function checkPage(browser, scope, pageNum) {
       var firstItem = ((pageNum - 1) * 10) + 1;
       return function() {
          return browser.end()

--- a/aikau/src/test/resources/alfresco/documentlibrary/SearchListScrollTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SearchListScrollTest.js
@@ -27,26 +27,28 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
-   var countResults = function(expected) {
+   var countResults = function(browser, expected) {
       browser.findAllByCssSelector(".alfresco-search-AlfSearchResult")
          .then(function(elements) {
             assert(elements.length === expected, "Counting Result, expected: " + expected + ", found: " + elements.length);
          })
       .end();
    };
-   var scrollToBottom = function() {
+   var scrollToBottom = function(browser) {
       browser.execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
          .sleep(2000)
       .end();
    };
-   var scrollToTop = function() {
+   var scrollToTop = function(browser) {
       browser.execute("return window.scrollTo(0,0)")
          .sleep(2000)
       .end();
    };
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "SearchList Scroll Tests",
 
       setup: function() {
@@ -72,7 +74,7 @@ define(["intern!object",
                assert(false, "Test #1b - Search results not returned");
             })
             .then(function(){
-               countResults(25);
+               countResults(browser, 25);
             });
       },
 
@@ -80,31 +82,32 @@ define(["intern!object",
          return browser.sleep(1000)
             // Trigger Infinite Scroll.
             .then(function(){
-               scrollToBottom();
-               scrollToTop();
-               scrollToBottom();
+               scrollToBottom(browser);
+               scrollToTop(browser);
+               scrollToBottom(browser);
             })
 
             // Count Results. there should be 50. (Request 2)
             .then(function(){
-               countResults(50);
+               countResults(browser, 50);
             });
       },
 
       "Scroll Again": function() {
          // Scroll Again.
          return browser.then(function(){
-            scrollToBottom();
+            scrollToBottom(browser);
          })
 
          // Count Results there should be 75 (Request 3)
          .then(function(){
-            countResults(75);
+            countResults(browser, 75);
          });
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "SearchList Tests",
       
       setup: function() {
@@ -322,5 +324,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest.js
@@ -24,13 +24,14 @@ define(["intern!object",
         "intern/chai!expect",
         "intern/chai!assert",
         "require",
-        "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, expect, assert, require, TestCommon, keys) {
+        "alfresco/TestCommon"], 
+        function (registerSuite, expect, assert, require, TestCommon) {
 
-   registerSuite({
-      name: 'Selected Items Menu Test',
-      'Test Menu Initially Disabled': function () {
+registerSuite(function(){
+
+   return {
+      name: "Selected Items Menu Test",
+      "Test Menu Initially Disabled": function () {
 
          var testname = "Selected Items Menu Test";
          return TestCommon.loadTestWebScript(this.remote, "/SelectedItemsMenu", testname)
@@ -41,7 +42,7 @@ define(["intern!object",
                )
             .end();
       },
-      'Test Selecting Item Enables Menu': function () {
+      "Test Selecting Item Enables Menu": function () {
 
          var browser = this.remote;
 
@@ -64,7 +65,7 @@ define(["intern!object",
             )
          .end();
       },
-      'Test De-Selecting Item Disables Menu': function () {
+      "Test De-Selecting Item Disables Menu": function () {
 
          var browser = this.remote;
 
@@ -84,7 +85,7 @@ define(["intern!object",
             )
          .end();
       },
-      'Test Items Not Cleared': function () {
+      "Test Items Not Cleared": function () {
 
          var browser = this.remote;
 
@@ -125,7 +126,7 @@ define(["intern!object",
             )
          .end();
       },
-      'Test Menu Item Contains Selected Item': function () {
+      "Test Menu Item Contains Selected Item": function () {
 
          var browser = this.remote;
 
@@ -149,11 +150,11 @@ define(["intern!object",
 
          .findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("TEST_ITEMS","selectedItems","data","item_one"))
             .then(function(elements) {
-               assert(elements.length == 1, "Test #3a - Didn't find selected item in publication payload");
+               assert.lengthOf(elements, 1, "Test #3a - Didn't find selected item in publication payload");
             })
          .end();
       },
-      'Test Menu Disabled After Item Click': function () {
+      "Test Menu Disabled After Item Click": function () {
          // Check that after the previous click the menu is disabled again...
          var browser = this.remote;
          return browser.findByCssSelector("#SELECTED_ITEMS.dijitDisabled")
@@ -163,7 +164,7 @@ define(["intern!object",
             )
          .end();
       },
-      'Test Clearing Selected Items Topic Published': function () {
+      "Test Clearing Selected Items Topic Published": function () {
          var browser = this.remote;
          return browser.findByCssSelector(TestCommon.topicSelector("ALF_CLEAR_SELECTED_ITEMS", "publish", "any"))
             .then(
@@ -172,7 +173,7 @@ define(["intern!object",
             )
          .end();
       },
-      'Test Select None Topic Published': function () {
+      "Test Select None Topic Published": function () {
          var browser = this.remote;
          return browser.findByCssSelector(TestCommon.topicSelector("ALF_DOCLIST_FILE_SELECTION", "publish", "any"))
             .then(
@@ -181,7 +182,7 @@ define(["intern!object",
             )
          .end();
       },
-      'Test Multiple Item Selection': function () {
+      "Test Multiple Item Selection": function () {
 
          var browser = this.remote;
 
@@ -207,16 +208,17 @@ define(["intern!object",
 
          .findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("TEST_ITEMS","selectedItems","data","item_one"))
             .then(function(elements) {
-               assert(elements.length == 2, "Test #5a - Didn't find selected item in publication payload");
+               assert.lengthOf(elements, 2, "Test #5a - Didn't find selected item in publication payload");
             })
          .end()
 
          .findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("TEST_ITEMS","selectedItems","data","item_two"))
             .then(function(elements) {
-               assert(elements.length == 1, "Test #6a - Didn't find selected item in publication payload");
+               assert.lengthOf(elements, 1, "Test #6a - Didn't find selected item in publication payload");
             })
          .end()
          .alfPostCoverageResults(browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/SitesListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SitesListTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Sites List Test",
 
       setup: function() {
@@ -74,5 +75,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/ViewPreferencesGroupTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/ViewPreferencesGroupTest.js
@@ -26,9 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "ViewPreferencesGroup Tests",
 
       setup: function() {
@@ -225,5 +226,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest.js
@@ -25,9 +25,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "AlfDetailedView",
 
       setup: function() {
@@ -185,6 +186,8 @@ define(["intern!object",
             .click()
             .end()
 
+         .getLastPublish("ALF_GET_COMMENTS", true)
+
          .findByCssSelector(".alfresco-documentlibrary-views-AlfDetailedViewItem:nth-child(1) .detail-item__commentsReveal > .content")
             .getSize()
             .then(function(size) {
@@ -202,5 +205,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDocumentListWithHeaderTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/AlfDocumentListWithHeaderTest.js
@@ -32,9 +32,11 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, expect, require, TestCommon, keys) {
 
+registerSuite(function(){
    var alfPause = 150;
    var browser;
-   registerSuite({
+
+   return {
       name: "List With Header Tests (Keyboard)",
 
       setup: function() {
@@ -194,9 +196,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "List With Header Tests (Mouse)",
 
       setup: function() {
@@ -228,5 +234,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest.js
@@ -34,11 +34,10 @@ define([
 
       // Setup cross-test variables
       var PREVIEW_CAROUSEL = "preview",
-         ITEMS_CAROUSEL = "items",
-         browser;
+         ITEMS_CAROUSEL = "items";
 
       // Define helper function to check visibility
-      function carouselItemIsDisplayed(itemNum, carouselType, idPrefix, returnDebugInfo) {
+      function carouselItemIsDisplayed(browser, itemNum, carouselType, idPrefix, returnDebugInfo) {
          var elemPrefix = "#" + (idPrefix || "") + "FILMSTRIP_VIEW_",
             carouselId = elemPrefix + (carouselType === PREVIEW_CAROUSEL ? "PREVIEWS" : "ITEMS");
          return browser.execute(function(carouselSelector, num, debugInfo) {
@@ -64,293 +63,297 @@ define([
          }, [carouselId, itemNum, returnDebugInfo]);
       }
 
-      registerSuite({
-         name: "FilmStripView Tests (Infinite scrolling)",
+      registerSuite(function() {
+         var browser;
 
-         setup: function() {
-            browser = this.remote;
-            browser.session.carouselItemIsDisplayed = carouselItemIsDisplayed;
-            return TestCommon.loadTestWebScript(this.remote, "/FilmStripView", "FilmStripView Tests").end();
-         },
+         return {
+            name: "FilmStripView Tests (Infinite scrolling)",
 
-         beforeEach: function() {
-            browser.end();
-         },
+            setup: function() {
+               browser = this.remote;
+               browser.session.carouselItemIsDisplayed = carouselItemIsDisplayed;
+               return TestCommon.loadTestWebScript(this.remote, "/FilmStripView", "FilmStripView Tests").end();
+            },
 
-         "Check initial controls state": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
-               })
-               .end()
+            beforeEach: function() {
+               browser.end();
+            },
 
-            .findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Next preview control should be displayed");
-               })
-               .end()
+            "Check initial controls state": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
+                  })
+                  .end()
 
-            .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "Previous items control should not be displayed");
-               })
-               .end()
+               .findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Next preview control should be displayed");
+                  })
+                  .end()
 
-            .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Next items control should be displayed");
-               });
-         },
+               .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "Previous items control should not be displayed");
+                  })
+                  .end()
 
-         "Previews generated and correct preview displayed": function() {
-            return this.remote.findAllByCssSelector("#FILMSTRIP_VIEW_PREVIEWS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 5, "Incorrect number of preview items");
-               })
-               .end()
+               .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Next items control should be displayed");
+                  });
+            },
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first preview item should be displayed");
-               })
+            "Previews generated and correct preview displayed": function() {
+               return this.remote.findAllByCssSelector("#FILMSTRIP_VIEW_PREVIEWS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 5, "Incorrect number of preview items");
+                  })
+                  .end()
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The second preview item should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first preview item should be displayed");
+                  })
 
-         "Items generated and correct items displayed": function() {
-            return this.remote.findAllByCssSelector("#FILMSTRIP_VIEW_ITEMS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 5, "Incorrect number of items");
-               })
-               .end()
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The second preview item should not be displayed");
+                  });
+            },
 
-            .carouselItemIsDisplayed(1, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first item should be displayed");
-               })
+            "Items generated and correct items displayed": function() {
+               return this.remote.findAllByCssSelector("#FILMSTRIP_VIEW_ITEMS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 5, "Incorrect number of items");
+                  })
+                  .end()
 
-            .carouselItemIsDisplayed(3, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The third item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(4, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The fourth item should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 3, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The third item should be displayed");
+                  })
 
-         "Can select next preview": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next img")
-               .clearLog()
-               .click()
-               .end()
+               .carouselItemIsDisplayed(browser, 4, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The fourth item should not be displayed");
+                  });
+            },
 
-            .getLastPublish("ALF_FILMSTRIP_ITEM_CHANGED", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 1, "Did not select second preview item");
-               })
+            "Can select next preview": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The first preview item should not be displayed");
-               })
+               .getLastPublish("ALF_FILMSTRIP_ITEM_CHANGED", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 1, "Did not select second preview item");
+                  })
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The second preview item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The first preview item should not be displayed");
+                  })
 
-            .carouselItemIsDisplayed(3, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The third preview item should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The second preview item should be displayed");
+                  })
 
-         "Can select previous preview": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev img")
-               .clearLog()
-               .click()
-               .end()
+               .carouselItemIsDisplayed(browser, 3, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The third preview item should not be displayed");
+                  });
+            },
 
-            .getLastPublish("ALF_FILMSTRIP_ITEM_CHANGED", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 0, "Did not select first preview item");
-               })
+            "Can select previous preview": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first preview item should be displayed");
-               })
+               .getLastPublish("ALF_FILMSTRIP_ITEM_CHANGED", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 0, "Did not select first preview item");
+                  })
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The second preview item should not be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first preview item should be displayed");
+                  })
 
-            .findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The second preview item should not be displayed");
+                  })
 
-         "Selecting next page of items loads more data and displays second page": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next img")
-               .clearLog()
-               .click()
-               .end()
+               .findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
+                  });
+            },
 
-            .getLastPublish("ALF_SCROLL_NEAR_BOTTOM", "Did not fire near-end event", true)
+            "Selecting next page of items loads more data and displays second page": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Did not load more documents", true)
+               .getLastPublish("ALF_SCROLL_NEAR_BOTTOM", "Did not fire near-end event", true)
 
-            .findAllByCssSelector("#FILMSTRIP_VIEW_ITEMS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 10, "Did not load another page of five items");
-               })
-               .end()
+               .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Did not load more documents", true)
 
-            .carouselItemIsDisplayed(3, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The third item should not be displayed");
-               })
+               .findAllByCssSelector("#FILMSTRIP_VIEW_ITEMS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 10, "Did not load another page of five items");
+                  })
+                  .end()
 
-            .carouselItemIsDisplayed(4, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The fourth item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 3, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The third item should not be displayed");
+                  })
 
-            .carouselItemIsDisplayed(6, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The sixth item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 4, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The fourth item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(7, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The seventh item should not be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 6, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The sixth item should be displayed");
+                  })
 
-            .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Second page of items should enable previous control");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 7, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The seventh item should not be displayed");
+                  })
 
-         "Navigating to next preview loads first page of items": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next img")
-               .clearLog()
-               .click()
-               .end()
+               .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Second page of items should enable previous control");
+                  });
+            },
 
-            .getLastPublish("ALF_FILMSTRIP_ITEM_CHANGED", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 1, "Did not select second preview item");
-               })
+            "Navigating to next preview loads first page of items": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The second preview item should be displayed");
-               })
+               .getLastPublish("ALF_FILMSTRIP_ITEM_CHANGED", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 1, "Did not select second preview item");
+                  })
 
-            .carouselItemIsDisplayed(1, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The second preview item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(3, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The third item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(4, ITEMS_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The fourth item should not be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 3, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The third item should be displayed");
+                  })
 
-            .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "First page of items should disable previous control");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 4, ITEMS_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The fourth item should not be displayed");
+                  })
 
-         "Clicking on thumbnail updates preview": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_ITEMS li:nth-child(3) .alfresco-renderers-Thumbnail")
-               .clearLog()
-               .click()
-               .end()
+               .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "First page of items should disable previous control");
+                  });
+            },
 
-            .getLastPublish("ALF_FILMSTRIP_SELECT_ITEM", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 2, "Did not select third item from thumbnails list");
-               })
+            "Clicking on thumbnail updates preview": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_ITEMS li:nth-child(3) .alfresco-renderers-Thumbnail")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(3, PREVIEW_CAROUSEL)
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The third preview item should be displayed");
-               });
-         },
+               .getLastPublish("ALF_FILMSTRIP_SELECT_ITEM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 2, "Did not select third item from thumbnails list");
+                  })
 
-         "Navigating to fourth page loads more items on first occasion only": function() {
-            return browser.findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next img")
-               .clearLog()
-               .click()
-               .click()
-               .click()
-               .end()
+               .carouselItemIsDisplayed(browser, 3, PREVIEW_CAROUSEL)
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The third preview item should be displayed");
+                  });
+            },
 
-            .getLastPublish("ALF_SCROLL_NEAR_BOTTOM", "Did not fire near-end event", true)
+            "Navigating to fourth page loads more items on first occasion only": function() {
+               return browser.findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next img")
+                  .clearLog()
+                  .click()
+                  .click()
+                  .click()
+                  .end()
 
-            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Did not load more documents", true)
+               .getLastPublish("ALF_SCROLL_NEAR_BOTTOM", "Did not fire near-end event", true)
 
-            .findAllByCssSelector("#FILMSTRIP_VIEW_ITEMS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 11, "Did not load final item");
-               })
-               .end()
+               .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Did not load more documents", true)
 
-            .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev img")
-               .clearLog()
-               .click()
-               .end()
+               .findAllByCssSelector("#FILMSTRIP_VIEW_ITEMS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 11, "Did not load final item");
+                  })
+                  .end()
 
-            .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next img")
-               .click()
-               .end()
+               .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .prev img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .getAllPublishes("ALF_SCROLL_NEAR_BOTTOM")
-               .then(function(payloads) {
-                  assert.lengthOf(payloads, 0, "Fired scroll event unnecessarily");
-               });
-         },
+               .findByCssSelector("#FILMSTRIP_VIEW_ITEMS .next img")
+                  .click()
+                  .end()
 
-         "Clicking folder updates hash": function() {
-            // Not yet implemented
-            // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
-         },
+               .getAllPublishes("ALF_SCROLL_NEAR_BOTTOM")
+                  .then(function(payloads) {
+                     assert.lengthOf(payloads, 0, "Fired scroll event unnecessarily");
+                  });
+            },
 
-         "New folder contents loaded": function() {
-            // Not yet implemented
-            // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
-         },
+            "Clicking folder updates hash": function() {
+               // Not yet implemented
+               // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
+            },
 
-         "Going back in browser history returns to previous folder": function() {
-            // Not yet implemented
-            // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
-         },
+            "New folder contents loaded": function() {
+               // Not yet implemented
+               // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
+            },
 
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         }
+            "Going back in browser history returns to previous folder": function() {
+               // Not yet implemented
+               // Waiting for problems with layout/resizing/reloading of FilmStripView to be resolved
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
       });
 
       // ------------
@@ -362,271 +365,274 @@ define([
       // START OF SUITE
       // --------------
 
-      registerSuite({
-         name: "FilmStripView Tests (Paginated)",
+      registerSuite(function() {
+         var browser;
 
-         setup: function() {
-            browser = this.remote;
-            browser.session.carouselItemIsDisplayed = carouselItemIsDisplayed;
-            return TestCommon.loadTestWebScript(this.remote, "/FilmStripView", "FilmStripView Tests").end();
-         },
+         return {
+            name: "FilmStripView Tests (Paginated)",
 
-         beforeEach: function() {
-            browser.end();
-         },
+            setup: function() {
+               browser = this.remote;
+               browser.session.carouselItemIsDisplayed = carouselItemIsDisplayed;
+               return TestCommon.loadTestWebScript(this.remote, "/FilmStripView", "FilmStripView Tests").end();
+            },
 
-         "Check initial controls state": function() {
-            return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
-               })
-               .end()
+            beforeEach: function() {
+               browser.end();
+            },
 
-            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .next")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Next preview control should be displayed");
-               })
-               .end()
+            "Check initial controls state": function() {
+               return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
+                  })
+                  .end()
 
-            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "Previous items control should not be displayed");
-               })
-               .end()
+               .findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .next")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Next preview control should be displayed");
+                  })
+                  .end()
 
-            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .next")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Next items control should be displayed");
-               });
-         },
+               .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "Previous items control should not be displayed");
+                  })
+                  .end()
 
-         "Previews generated and correct preview displayed": function() {
-            return this.remote.findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 5, "Incorrect number of preview items");
-               })
-               .end()
+               .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .next")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Next items control should be displayed");
+                  });
+            },
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first preview item should be displayed");
-               })
+            "Previews generated and correct preview displayed": function() {
+               return this.remote.findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 5, "Incorrect number of preview items");
+                  })
+                  .end()
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The second preview item should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first preview item should be displayed");
+                  })
 
-         "Items generated and correct items displayed": function() {
-            return this.remote.findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 5, "Incorrect number of items");
-               })
-               .end()
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The second preview item should not be displayed");
+                  });
+            },
 
-            .carouselItemIsDisplayed(1, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first item should be displayed");
-               })
+            "Items generated and correct items displayed": function() {
+               return this.remote.findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 5, "Incorrect number of items");
+                  })
+                  .end()
 
-            .carouselItemIsDisplayed(3, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The third item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(4, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The fourth item should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 3, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The third item should be displayed");
+                  })
 
-         "Can select next preview": function() {
-            return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .next img")
-               .clearLog()
-               .click()
-               .end()
+               .carouselItemIsDisplayed(browser, 4, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The fourth item should not be displayed");
+                  });
+            },
 
-            .getLastPublish("PAGED_ALF_FILMSTRIP_ITEM_CHANGED", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 1, "Did not select second preview item");
-               })
+            "Can select next preview": function() {
+               return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .next img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The first preview item should not be displayed");
-               })
+               .getLastPublish("PAGED_ALF_FILMSTRIP_ITEM_CHANGED", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 1, "Did not select second preview item");
+                  })
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The second preview item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The first preview item should not be displayed");
+                  })
 
-            .carouselItemIsDisplayed(3, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The third preview item should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The second preview item should be displayed");
+                  })
 
-         "Can select previous preview": function() {
-            return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .prev img")
-               .clearLog()
-               .click()
-               .end()
+               .carouselItemIsDisplayed(browser, 3, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The third preview item should not be displayed");
+                  });
+            },
 
-            .getLastPublish("PAGED_ALF_FILMSTRIP_ITEM_CHANGED", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 0, "Did not select first preview item");
-               })
+            "Can select previous preview": function() {
+               return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .prev img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first preview item should be displayed");
-               })
+               .getLastPublish("PAGED_ALF_FILMSTRIP_ITEM_CHANGED", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 0, "Did not select first preview item");
+                  })
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The second preview item should not be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first preview item should be displayed");
+                  })
 
-            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The second preview item should not be displayed");
+                  })
 
-         "Selecting next page of items displays second page of Page 1 of results": function() {
-            return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .next img")
-               .clearLog()
-               .click()
-               .end()
+               .findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "Previous preview control should not be displayed");
+                  });
+            },
 
-            .getAllPublishes("ALF_SCROLL_NEAR_BOTTOM")
-               .then(function(payloads) {
-                  assert.lengthOf(payloads, 0, "Fired scroll event incorrectly");
-               })
+            "Selecting next page of items displays second page of Page 1 of results": function() {
+               return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .next img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 5, "Loaded more items");
-               })
-               .end()
+               .getAllPublishes("ALF_SCROLL_NEAR_BOTTOM")
+                  .then(function(payloads) {
+                     assert.lengthOf(payloads, 0, "Fired scroll event incorrectly");
+                  })
 
-            .carouselItemIsDisplayed(3, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The third item should not be displayed");
-               })
+               .findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 5, "Loaded more items");
+                  })
+                  .end()
 
-            .carouselItemIsDisplayed(4, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The fourth item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 3, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The third item should not be displayed");
+                  })
 
-            .carouselItemIsDisplayed(5, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The fifth item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 4, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The fourth item should be displayed");
+                  })
 
-            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Second page of items should enable previous control");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 5, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The fifth item should be displayed");
+                  })
 
-         "Navigating to next preview loads first page of items": function() {
-            return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .next img")
-               .clearLog()
-               .click()
-               .end()
+               .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Second page of items should enable previous control");
+                  });
+            },
 
-            .getLastPublish("PAGED_ALF_FILMSTRIP_ITEM_CHANGED", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 1, "Did not select second preview item");
-               })
+            "Navigating to next preview loads first page of items": function() {
+               return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS .next img")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(2, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The second preview item should be displayed");
-               })
+               .getLastPublish("PAGED_ALF_FILMSTRIP_ITEM_CHANGED", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 1, "Did not select second preview item");
+                  })
 
-            .carouselItemIsDisplayed(1, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 2, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The second preview item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(3, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The third item should be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 1, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(4, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "The fourth item should not be displayed");
-               })
+               .carouselItemIsDisplayed(browser, 3, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The third item should be displayed");
+                  })
 
-            .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .prev")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isFalse(isDisplayed, "First page of items should disable previous control");
-               });
-         },
+               .carouselItemIsDisplayed(browser, 4, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "The fourth item should not be displayed");
+                  })
 
-         "Clicking on thumbnail updates preview": function() {
-            return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li:nth-child(3) .alfresco-renderers-Thumbnail")
-               .clearLog()
-               .click()
-               .end()
+               .findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS .prev")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed, "First page of items should disable previous control");
+                  });
+            },
 
-            .getLastPublish("PAGED_ALF_FILMSTRIP_SELECT_ITEM", true)
-               .then(function(payload) {
-                  assert.propertyVal(payload, "index", 2, "Did not select third item from thumbnails list");
-               })
+            "Clicking on thumbnail updates preview": function() {
+               return browser.findByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li:nth-child(3) .alfresco-renderers-Thumbnail")
+                  .clearLog()
+                  .click()
+                  .end()
 
-            .carouselItemIsDisplayed(3, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The third preview item should be displayed");
-               });
-         },
+               .getLastPublish("PAGED_ALF_FILMSTRIP_SELECT_ITEM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "index", 2, "Did not select third item from thumbnails list");
+                  })
 
-         "Navigating to Page 3 of results renders only one item": function() {
-            return browser.findByCssSelector("#PAGED_PAGINATOR_PAGE_SELECTOR")
-               .click()
-               .end()
+               .carouselItemIsDisplayed(browser, 3, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The third preview item should be displayed");
+                  });
+            },
 
-            .findByCssSelector("#PAGED_PAGINATOR_PAGE_SELECTOR_dropdown .alfresco-menus-AlfMenuItem:last-child")
-               .click()
-               .end()
+            "Navigating to Page 3 of results renders only one item": function() {
+               return browser.findByCssSelector("#PAGED_PAGINATOR_PAGE_SELECTOR")
+                  .click()
+                  .end()
 
-            .getLastPublish("PAGED_ALF_DOCLIST_REQUEST_FINISHED", true, "Did not load final page of results")
+               .findByCssSelector("#PAGED_PAGINATOR_PAGE_SELECTOR_dropdown .alfresco-menus-AlfMenuItem:last-child")
+                  .click()
+                  .end()
 
-            .findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Incorrect number of preview items");
-               })
-               .end()
+               .getLastPublish("PAGED_ALF_DOCLIST_REQUEST_FINISHED", true, "Did not load final page of results")
 
-            .carouselItemIsDisplayed(1, PREVIEW_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first preview item should be displayed");
-               })
+               .findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_PREVIEWS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Incorrect number of preview items");
+                  })
+                  .end()
 
-            .findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Incorrect number of items");
-               })
-               .end()
+               .carouselItemIsDisplayed(browser, 1, PREVIEW_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first preview item should be displayed");
+                  })
 
-            .carouselItemIsDisplayed(1, ITEMS_CAROUSEL, "PAGED_")
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "The first item should be displayed");
-               });
-         },
+               .findAllByCssSelector("#PAGED_FILMSTRIP_VIEW_ITEMS li")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Incorrect number of items");
+                  })
+                  .end()
+
+               .carouselItemIsDisplayed(browser, 1, ITEMS_CAROUSEL, "PAGED_")
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "The first item should be displayed");
+                  });
+            },
 
          "Clicking folder loads new folder": function() {
             return browser.findByCssSelector("body").clearLog().end()
@@ -650,8 +656,9 @@ define([
             .getLastPublish("PAGED_ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS", "Did not load data");
          },
 
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         }
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
       });
    });

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
@@ -32,9 +32,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, expect, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "GalleryView Tests",
       
       setup: function() {
@@ -119,10 +120,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
+registerSuite(function(){
+   var browser;
    var alfPause = 500;
-   registerSuite({
+
+   return {
       name: "GalleryView Keyboard Tests",
       
       setup: function() {
@@ -230,5 +235,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/footer/FooterTest.js
+++ b/aikau/src/test/resources/alfresco/footer/FooterTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Footer Tests",
 
       setup: function() {
@@ -67,5 +69,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/AutoSaveFormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/AutoSaveFormsTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AutoSave Forms Tests",
 
       setup: function() {
@@ -86,5 +88,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
+++ b/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "ControlRow Tests",
 
       setup: function() {
@@ -60,5 +62,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/CrudFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/CrudFormTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "CRUD Form Tests",
 
       setup: function() {
@@ -166,5 +168,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/DynamicFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/DynamicFormTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "DynamicForm Tests",
 
       setup: function() {
@@ -104,5 +106,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Form Validation Display Tests",
 
       setup: function() {
@@ -156,5 +158,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/FormWarningsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormWarningsTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Form Warnings Tests",
 
       setup: function() {
@@ -127,5 +128,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/FormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormsTest.js
@@ -26,9 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Forms Tests",
 
       setup: function() {
@@ -250,5 +251,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/HashFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/HashFormTest.js
@@ -26,9 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "HashForm Tests",
 
       setup: function() {
@@ -149,5 +150,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/SingleTextFieldFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/SingleTextFieldFormTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, expect, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "SingleTextFieldForm Tests",
       
       setup: function() {
@@ -89,5 +91,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/TabsInFormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/TabsInFormsTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "TabbedControls Tests",
 
       setup: function() {
@@ -111,5 +113,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Auto Set Form Rules Tests",
 
       setup: function() {
@@ -160,5 +162,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, keys, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Base Form Control Tests",
 
       setup: function() {
@@ -120,7 +122,7 @@ define(["intern!object",
          .findAllByCssSelector("#AUTOSAVE_FORM .confirmationButton, #AUTOSAVE_FORM .cancelButton")
             .then(function(elements) {
                assert.lengthOf(elements, 0, "OK/Cancel buttons found on autosave form");
-            })
+            });
       },
 
       "Updating autosave value publishes form": function() {
@@ -167,5 +169,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon, keys) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "CheckBox Tests",
 
          setup: function() {
@@ -100,5 +102,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/forms/controls/CodeMirrorTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CodeMirrorTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/helpers/pollUntil"], 
         function(registerSuite, assert, require, TestCommon, pollUntil) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "CodeMirror",
 
       setup: function() {
@@ -103,5 +104,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/ComboBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ComboBoxTest.js
@@ -29,8 +29,10 @@ define(["alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"],
         function(TestCommon, registerSuite, assert, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "ComboBox Tests (mouse)",
 
       setup: function() {
@@ -137,9 +139,13 @@ define(["alfresco/TestCommon",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "ComboBox Tests (keyboard)",
 
       setup: function() {
@@ -176,5 +182,6 @@ define(["alfresco/TestCommon",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
       "alfresco/TestCommon"],
       function(registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "ContainerPicker Tests",
       
       setup: function() {
@@ -98,5 +100,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function(registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "DateTextBox Tests",
 
       setup: function() {
@@ -157,5 +159,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest.js
@@ -29,9 +29,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Document Picker Single Item Test",
 
       setup: function() {
@@ -219,5 +220,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DocumentPickerTest.js
@@ -36,9 +36,10 @@ define(["intern!object",
    // TODO: Click on a folder to get sub-results
    // TODO: Check singleItemMode works.
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Document Picker Test",
 
       setup: function() {
@@ -214,5 +215,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/FormButtonDialogTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/FormButtonDialogTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "FormButtonDialog Test",
 
       setup: function() {
@@ -167,5 +169,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -29,8 +29,10 @@ define([
    ],
    function(registerSuite, assert, require, TestCommon, keys) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "Multi Select Input Tests",
 
          // STARTING STATE
@@ -687,10 +689,6 @@ define([
             return browser.findByCssSelector("#FORM3 .alfresco-forms-controls-MultiSelect--disabled");
          },
 
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         },
-
          // STATE AFTER THIS TEST
          // 
          // Control 1
@@ -758,6 +756,7 @@ define([
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    }
 );

--- a/aikau/src/test/resources/alfresco/forms/controls/MultipleEntryFormControlTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultipleEntryFormControlTest.js
@@ -44,8 +44,10 @@ define(["intern!object",
       return "#" + id + " .alfresco-forms-controls-MultipleEntryElementWrapper:nth-child(" + elementIndex + ") .alfresco-forms-controls-MultipleEntryElement > div:first-child";
    };
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "MultipleEntryFormControlTest",
       setup: function() {
          browser = this.remote;
@@ -334,5 +336,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Number Spinner Tests",
 
       setup: function() {
@@ -178,7 +180,7 @@ define(["intern!object",
          .findAllByCssSelector("#NS7 .validation-error")
             .then(function(elements) {
                assert.lengthOf(elements, 0, "'permitEmpty' number spinner should allow empty values");
-            })
+            });
       },
 
       "Empty value submits null value": function() {
@@ -308,5 +310,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -39,8 +39,10 @@ define(["intern!object",
    // Get specific menu option:
    //    #FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Select Menu Tests",
 
       setup: function() {
@@ -285,5 +287,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/SimplePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SimplePickerTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "require",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Simple Picker Tests",
 
       setup: function() {
@@ -142,5 +144,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/SitePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SitePickerTest.js
@@ -28,13 +28,11 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon) {
 
-      var browser,
-         singlePickerLaunchButton,
-         singlePickerResetButton,
-         multiPickerLaunchButton,
-         multiPickerResetButton;
 
-      registerSuite({
+      registerSuite(function(){
+      var browser;
+
+   return {
          name: "Site Picker Tests",
 
          setup: function() {
@@ -121,5 +119,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/forms/controls/TextAreaTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TextAreaTest.js
@@ -26,8 +26,10 @@ define(["alfresco/TestCommon",
         "intern/chai!assert"], 
         function(TestCommon, registerSuite, assert) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "TextArea Tests",
 
       setup: function() {
@@ -82,5 +84,6 @@ define(["alfresco/TestCommon",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Text Box Tests",
 
       setup: function() {
@@ -369,5 +371,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Advanced Form Validation Tests",
 
       setup: function() {
@@ -300,5 +302,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/XssPreventionTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/XssPreventionTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Form Control XSS Prevention Test",
 
       setup: function() {
@@ -96,5 +98,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/utilities/RulesEngineTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/utilities/RulesEngineTest.js
@@ -32,8 +32,10 @@ define(["intern!object",
    //              part of BaseFormControl) in the TextBoxTest. This test covers updates specific to
    //              ANY/ALL configuration (See AKU-451)...
    
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Rules Engine Test",
 
       setup: function() {
@@ -136,5 +138,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function(registerSuite, expect, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Basic Header Widgets Tests",
 
       setup: function() {
@@ -224,9 +226,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Add Favourites Tests",
 
       setup: function() {
@@ -264,9 +270,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Remove Favourites Tests",
 
       setup: function() {
@@ -304,9 +314,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Title Tests",
 
       setup: function() {
@@ -362,9 +376,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Set Title Tests",
 
       setup: function() {
@@ -394,5 +412,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
+++ b/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
@@ -28,9 +28,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"],
         function(registerSuite, assert, require, TestCommon, Config, keys) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Search Box Tests (Repo Context)",
 
       setup: function() {
@@ -135,9 +136,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Search Box Tests (Site Context)",
 
       setup: function() {
@@ -220,9 +225,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Search Box Tests (Configuration options)",
 
       setup: function() {
@@ -333,9 +342,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Search Box Tests (Custom publication)",
 
       setup: function() {
@@ -365,5 +378,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/header/WarningTest.js
+++ b/aikau/src/test/resources/alfresco/header/WarningTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Warning Tests",
 
       setup: function() {
@@ -109,5 +111,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/html/HeadingTest.js
+++ b/aikau/src/test/resources/alfresco/html/HeadingTest.js
@@ -25,8 +25,10 @@ define(["intern!object",
         "require",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Heading Tests",
 
       setup: function() {
@@ -80,5 +82,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/html/LabelTest.js
+++ b/aikau/src/test/resources/alfresco/html/LabelTest.js
@@ -31,8 +31,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Label Tests",
 
       setup: function() {
@@ -96,5 +98,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         function (registerSuite, expect, assert, require, TestCommon) {
 
    // var startSize;
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfSideBarContainer Tests",
 
       setup: function() {
@@ -217,5 +219,6 @@ define(["intern!object",
       //    .end()
       //    .alfPostCoverageResults(browser);
       // }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/AlfStackContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfStackContainerTest.js
@@ -25,12 +25,13 @@
 define(["intern!object",
         "intern/chai!assert",
         "require",
-        "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Stack Container Tests",
 
       setup: function() {
@@ -93,10 +94,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // This test reloads the page to clear any previous focus and make keyboard actions more predictable
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Stack Container Tests (function)",
 
       setup: function() {
@@ -362,10 +367,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // This test reloads the page to clear any previous focus and make keyboard actions more predictable
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Stack Container Tests (add pane)",
 
       setup: function() {
@@ -412,5 +421,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 }); 

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, expect, assert, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Tab Container Tests",
 
       setup: function() {
@@ -162,11 +164,15 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
 
-   // // This test reloads the page to clear any previous focus and make keyboard actions more predictable
-   registerSuite({
+   // This test reloads the page to clear any previous focus and make keyboard actions more predictable
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Tab Container Tests (keyboard)",
 
       setup: function() {
@@ -248,11 +254,15 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
 
    // This test reloads the page to clear any previous focus and make keyboard actions more predictable
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Tab Container Tests (function)",
 
       setup: function() {
@@ -544,9 +554,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Tab Container Tests (example use case)",
 
       setup: function() {
@@ -604,9 +618,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Tab Container Tests (example use case 2)",
 
       setup: function() {
@@ -679,9 +697,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Tab Container Tests (height calculations)",
 
       setup: function() {
@@ -726,5 +748,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/BasicLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/BasicLayoutTest.js
@@ -26,9 +26,11 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
-   var testableDimensions = {};
-   var browser;
-   registerSuite({
+registerSuite(function(){
+   var testableDimensions = {}, 
+      browser;
+
+   return {
       name: "Basic Layout Tests",
 
       setup: function() {
@@ -222,5 +224,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
@@ -27,6 +27,7 @@ define(["intern!object",
    ],
    function(registerSuite, assert, TestCommon) {
 
+   registerSuite(function(){
       var browser;
       var scrollbarWidth;             // We'll calculate this by deducting the body width from the window width
       var windowSize = 1050;          // The size we'll set the window
@@ -36,7 +37,7 @@ define(["intern!object",
       var fixedWidthWidget = 200;     // The fixed width of WIDGET_1
       var availableWidth;             // We'll calculate this in the setup
 
-      registerSuite({
+      return {
          name: "Dynamic Horizontal Layout Tests",
 
          setup: function() {
@@ -286,5 +287,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
        function(registerSuite, assert, TestCommon) {
 
    /* global document*/
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "FixedHeaderFooter tests",
 
       setup: function() {
@@ -88,55 +90,60 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
-   });
+   };
+});
 
-   registerSuite({
-      name: "FixedHeaderFooter tests (auto height calculations)",
+   registerSuite(function(){
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AutoHeightFixedHeaderFooter", "FixedHeaderFooter tests (auto height calculations)").end();
-      },
+      return {
+         name: "FixedHeaderFooter tests (auto height calculations)",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AutoHeightFixedHeaderFooter", "FixedHeaderFooter tests (auto height calculations)").end();
+         },
 
-      "Check height is calculated": function() {
-         var windowHeight;
-         return browser.findByCssSelector("body")
-            .getSize()
-            .then(function(size) {
-               windowHeight = size.height;
-            })
-         .end()
-         .findByCssSelector("#HEADER_FOOTER")
-            .getSize()
-            .then(function(size) {
-               // PLEASE NOTE: 20 pixels deducted for test page padding
-               assert.equal(size.height, windowHeight - 20, "Height not calculated correctly");
-            });
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check auto resizing": function() {
-         var windowHeight;
-         return browser.setWindowSize(null, 1024, 300)
-            .findByCssSelector("body")
-            .getSize()
-            .then(function(size) {
-               windowHeight = size.height;
-            })
-         .end()
-         .findByCssSelector("#HEADER_FOOTER")
-            .getSize()
-            .then(function(size) {
-               // PLEASE NOTE: 20 pixels deducted for test page padding
-               assert.equal(size.height, windowHeight - 20, "Height not calculated correctly");
-            });
-      },
+         "Check height is calculated": function() {
+            var windowHeight;
+            return browser.findByCssSelector("body")
+               .getSize()
+               .then(function(size) {
+                  windowHeight = size.height;
+               })
+            .end()
+            .findByCssSelector("#HEADER_FOOTER")
+               .getSize()
+               .then(function(size) {
+                  // PLEASE NOTE: 20 pixels deducted for test page padding
+                  assert.equal(size.height, windowHeight - 20, "Height not calculated correctly");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+         "Check auto resizing": function() {
+            var windowHeight;
+            return browser.setWindowSize(null, 1024, 300)
+               .findByCssSelector("body")
+               .getSize()
+               .then(function(size) {
+                  windowHeight = size.height;
+               })
+            .end()
+            .findByCssSelector("#HEADER_FOOTER")
+               .getSize()
+               .then(function(size) {
+                  // PLEASE NOTE: 20 pixels deducted for test page padding
+                  assert.equal(size.height, windowHeight - 20, "Height not calculated correctly");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/FullScreenWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FullScreenWidgetsTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, expect, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Full Screen Widgets Tests",
 
       setup: function() {
@@ -159,5 +161,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
+++ b/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
@@ -27,9 +27,11 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function(registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var windowHeight;
    var browser;
-   registerSuite({
+
+   return {
       name: "HeightMixin tests",
 
       setup: function() {
@@ -160,5 +162,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/StripedContentTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StripedContentTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, TestCommon) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "StripedContent tests",
 
          setup: function() {
@@ -90,5 +92,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Twister Tests",
 
       setup: function() {
@@ -267,5 +269,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/VerticalRevealTest.js
+++ b/aikau/src/test/resources/alfresco/layout/VerticalRevealTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "VerticalReveal tests",
 
          setup: function() {
@@ -84,5 +86,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/lists/AlfHashListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfHashListTest.js
@@ -28,8 +28,10 @@ define(["alfresco/TestCommon",
         "intern!object"], 
         function(TestCommon, assert, registerSuite) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfHashList Tests",
 
       setup: function() {
@@ -161,5 +163,6 @@ define(["alfresco/TestCommon",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -23,15 +23,12 @@
 define(["intern!object",
         "intern/chai!assert",
         "require",
-        "alfresco/TestCommon",
-        "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
 
    
 
-   var browser;
-
-   var testClearingDocumentList = function(buttonId, errorMsg) {
+   var testClearingDocumentList = function(browser, buttonId, errorMsg) {
       return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
          .click()
          .end()
@@ -60,7 +57,10 @@ define(["intern!object",
    };
 
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "AlfSortablePaginatedList Tests",
       
       setup: function() {
@@ -102,7 +102,7 @@ define(["intern!object",
             })
             .then(function(payload) {
                assert.propertyVal(payload, "preference", "custom.pageSize.preference", "Incorrect preference used for INFINITE_SCROLL_LIST list");
-            })
+            });
       },
 
       "Check URL hash controls displayed page": function() {
@@ -176,34 +176,38 @@ define(["intern!object",
 
       "Simulate a path change": function() {
          return browser.then(function() {
-            return testClearingDocumentList("#SIMULATE_PATH_CHANGE_label", "Old data not cleared when path change request applied");
+            return testClearingDocumentList(browser, "#SIMULATE_PATH_CHANGE_label", "Old data not cleared when path change request applied");
          });
       },
 
       "Simulate a category change": function() {
          return browser.then(function() {
-            return testClearingDocumentList("#SIMULATE_CATEGORY_CHANGE_label", "Old data not cleared when category change request applied");
+            return testClearingDocumentList(browser, "#SIMULATE_CATEGORY_CHANGE_label", "Old data not cleared when category change request applied");
          });
       },
 
       "Simulate a tag change": function() {
          return browser.then(function() {
-            return testClearingDocumentList("#SIMULATE_TAG_CHANGE_label", "Old data not cleared when tag change request applied");
+            return testClearingDocumentList(browser, "#SIMULATE_TAG_CHANGE_label", "Old data not cleared when tag change request applied");
          });
       },
 
       "Simulate a filter change": function() {
          return browser.then(function() {
-            return testClearingDocumentList("#SIMULATE_FILTER_CHANGE_label", "Old data not cleared when filter change request applied");
+            return testClearingDocumentList(browser, "#SIMULATE_FILTER_CHANGE_label", "Old data not cleared when filter change request applied");
          });
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "AlfSortablePaginatedList Tests (data load failure)",
       
       setup: function() {
@@ -267,5 +271,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -29,239 +29,242 @@ define(["alfresco/TestCommon",
         "intern!object"], 
         function(TestCommon, assert, keys, registerSuite) {
 
-   var browser;
-   registerSuite({
-      name: "FilteredList Tests",
+   registerSuite(function(){
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/FilteredList", "FilteredList Tests").end();
-      },
+      return {
+         name: "FilteredList Tests",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/FilteredList", "FilteredList Tests").end();
+         },
 
-      "Check that results are loaded initially": function() {
-         return browser.findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 8, "The wrong number of results were displayed");
-            })
-            .end()
+         beforeEach: function() {
+            browser.end();
+         },
 
-         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 5, "Did not load first page of results");
-            })
-            .end()
+         "Check that results are loaded initially": function() {
+            return browser.findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 8, "The wrong number of results were displayed");
+               })
+               .end()
 
-         .findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-selector [id$=PAGE_SELECTOR_text]")
-            .getVisibleText()
-            .then(function(visibleText) {
-               assert.equal(visibleText, "1-5 of 8", "Did not display correct page description");
-            });
-      },
+            .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 5, "Did not load first page of results");
+               })
+               .end()
 
-      "Type a filter": function() {
-         return browser.findByCssSelector("#TEXTBOX .dijitInputContainer input")
-            .clearLog()
-            .type("one")
-            .end()
-
-         // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
-
-         .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Only 1 result should be displayed for filter 'one'");
-            });
-      },
-
-      "Delete a couple of characters": function() {
-         return browser.findByCssSelector("#TEXTBOX .dijitInputContainer input")
-            .clearLog()
-            .type(keys.BACKSPACE)
-            .type(keys.BACKSPACE)
-            .end()
-
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
-
-         .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "3 results should be displayed for filter 'o'");
-            });
-      },
-
-      "Select a filter from drop down (useHash=true)": function() {
-         return browser.findByCssSelector("#COMPOSITE_DROPDOWN .dijitArrowButtonInner")
-            .clearLog()
-            .click()
-            .end()
-
-         .findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL_popup1")
-            .click()
-            .end()
-
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
-
-         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "4 results should be displayed for description 'moo'");
-            });
-      },
-
-      "Apply a 2nd filter (useHash=true)": function() {
-         return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
-            .clearLog()
-            .type("t")
-            .end()
-
-         // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
-
-         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "Only 2 result should be displayed for combined filter");
-            });
-      },
-
-      "Hash reflects current filter values (useHash=true)": function() {
-         return browser.getCurrentUrl()
-            .then(function(url) {
-               var hash = url.split("#")[1],
-                  hashParts = (hash && hash.split("&")) || [],
-                  hashObj = {};
-               hashParts.forEach(function(hashPart) {
-                  var nameValuePair = hashPart.split("=");
-                  hashObj[nameValuePair[0]] = nameValuePair[1];
+            .findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-selector [id$=PAGE_SELECTOR_text]")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "1-5 of 8", "Did not display correct page description");
                });
-               assert.propertyVal(hashObj, "description", "moo", "Invalid value in hash");
-               assert.propertyVal(hashObj, "name", "t", "Invalid value in hash");
-            });
-      },
+         },
 
-      "Changing hash value updates filter (useHash=true)": function() {
-         var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#description=woof");
-         return browser.findByCssSelector("body")
-            .clearLog()
-            .get(updatedUrl)
-            .getLastPublish("COMPOSITE_ALF_DOCLIST_REQUEST_FINISHED")
-            .end()
+         "Type a filter": function() {
+            return browser.findByCssSelector("#TEXTBOX .dijitInputContainer input")
+               .clearLog()
+               .type("one")
+               .end()
 
-         .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
-            .getVisibleText()
-            .then(function(visibleText) {
-               var text = visibleText.split("\n").join("|"),
-                  expectedText = "five woof|five and a half woof|six woof|six and a half woof";
-               assert.equal(text, expectedText, "Incorrect results displayed for intended filter");
-            });
-      },
+            // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
+               .end()
 
-      "Filter field reflects applied filter (useHash=true)": function() {
-         return browser.findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL + input")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "woof", "Incorrect filter field value");
-            });
-      },
+            .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Only 1 result should be displayed for filter 'one'");
+               });
+         },
 
-      "Deleting filter field value removes filter (useHash=true)": function() {
-         var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#name=one");
-         return browser.findByCssSelector("body")
-            .clearLog()
-            .get(updatedUrl)
-            .end()
+         "Delete a couple of characters": function() {
+            return browser.findByCssSelector("#TEXTBOX .dijitInputContainer input")
+               .clearLog()
+               .type(keys.BACKSPACE)
+               .type(keys.BACKSPACE)
+               .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Didn't reload list after hash change")
-            .end()
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
+               .end()
 
-         .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
-            .clearLog()
-            .clearValue()
-            .pressKeys(keys.TAB)
-            .end()
+            .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "3 results should be displayed for filter 'o'");
+               });
+         },
+
+         "Select a filter from drop down (useHash=true)": function() {
+            return browser.findByCssSelector("#COMPOSITE_DROPDOWN .dijitArrowButtonInner")
+               .clearLog()
+               .click()
+               .end()
+
+            .findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL_popup1")
+               .click()
+               .end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
+               .end()
+
+            .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "4 results should be displayed for description 'moo'");
+               });
+         },
+
+         "Apply a 2nd filter (useHash=true)": function() {
+            return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
+               .clearLog()
+               .type("t")
+               .end()
+
+            // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
+               .end()
+
+            .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Only 2 result should be displayed for combined filter");
+               });
+         },
+
+         "Hash reflects current filter values (useHash=true)": function() {
+            return browser.getCurrentUrl()
+               .then(function(url) {
+                  var hash = url.split("#")[1],
+                     hashParts = (hash && hash.split("&")) || [],
+                     hashObj = {};
+                  hashParts.forEach(function(hashPart) {
+                     var nameValuePair = hashPart.split("=");
+                     hashObj[nameValuePair[0]] = nameValuePair[1];
+                  });
+                  assert.propertyVal(hashObj, "description", "moo", "Invalid value in hash");
+                  assert.propertyVal(hashObj, "name", "t", "Invalid value in hash");
+               });
+         },
+
+         "Changing hash value updates filter (useHash=true)": function() {
+            var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#description=woof");
+            return browser.findByCssSelector("body")
+               .clearLog()
+               .get(updatedUrl)
+               .getLastPublish("COMPOSITE_ALF_DOCLIST_REQUEST_FINISHED")
+               .end()
+
+            .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  var text = visibleText.split("\n").join("|"),
+                     expectedText = "five woof|five and a half woof|six woof|six and a half woof";
+                  assert.equal(text, expectedText, "Incorrect results displayed for intended filter");
+               });
+         },
+
+         "Filter field reflects applied filter (useHash=true)": function() {
+            return browser.findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL + input")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "woof", "Incorrect filter field value");
+               });
+         },
+
+         "Deleting filter field value removes filter (useHash=true)": function() {
+            var updatedUrl = TestCommon.testWebScriptURL("/FilteredList#name=one");
+            return browser.findByCssSelector("body")
+               .clearLog()
+               .get(updatedUrl)
+               .end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Didn't reload list after hash change")
+               .end()
+
+            .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
+               .clearLog()
+               .clearValue()
+               .pressKeys(keys.TAB)
+               .end()
 
          .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED", 1500, "Didn't reload list after filter removal")
             .end()
 
-         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 5, "All results should be displayed when filter removed");
-            });
-      },
+            .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 5, "All results should be displayed when filter removed");
+               });
+         },
 
-      "Going to next page displays second page of results (useHash=true)": function() {
-         return browser.findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-forward")
-            .click()
-            .end()
+         "Going to next page displays second page of results (useHash=true)": function() {
+            return browser.findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-forward")
+               .click()
+               .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500, "Going to next page did not reload list")
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500, "Going to next page did not reload list")
 
-         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "Should be displaying second page of results");
-            });
-      },
+            .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "Should be displaying second page of results");
+               });
+         },
 
-      "Filter values with spaces in should not be URL escaped (useHash=true)": function() {
-         return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
-            .clearLog()
-            .type("five and")
-            .end()
+         "Filter values with spaces in should not be URL escaped (useHash=true)": function() {
+            return browser.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
+               .clearLog()
+               .type("five and")
+               .end()
 
-         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
+               .end()
 
-         .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputInner")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "five and", "Incorrect filter field value");
-            })
-            .end()
+            .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputInner")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "five and", "Incorrect filter field value");
+               })
+               .end()
 
-         .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "One result should be displayed for filter 'five and'");
-            })
-            .end()
+            .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "One result should be displayed for filter 'five and'");
+               })
+               .end()
 
-         .findByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Cell:nth-child(2) .alfresco-renderers-Property .value")
-            .getVisibleText()
-            .then(function(visibleText) {
-               assert.equal(visibleText, "five and a half", "Incorrect result displayed for filter 'five and'");
-            });
-      },
+            .findByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Cell:nth-child(2) .alfresco-renderers-Property .value")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "five and a half", "Incorrect result displayed for filter 'five and'");
+               });
+         },
 
-      "Navigating to another page and then back will re-apply filter (useHash=true)": function() {
-         var anotherPageUrl = TestCommon.testWebScriptURL("/Index"),
-            returnUrl = TestCommon.testWebScriptURL("/FilteredList#description=woof");
-         return browser.findByCssSelector("body")
-            .clearLog()
-            .end()
+         "Navigating to another page and then back will re-apply filter (useHash=true)": function() {
+            var anotherPageUrl = TestCommon.testWebScriptURL("/Index"),
+               returnUrl = TestCommon.testWebScriptURL("/FilteredList#description=woof");
+            return browser.findByCssSelector("body")
+               .clearLog()
+               .end()
 
-         .get(anotherPageUrl)
-            .findByCssSelector("body")
-            .end()
+            .get(anotherPageUrl)
+               .findByCssSelector("body")
+               .end()
 
-         .get(returnUrl)
-            .findByCssSelector("body")
-            .end()
+            .get(returnUrl)
+               .findByCssSelector("body")
+               .end()
 
-         .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
-            .getVisibleText()
-            .then(function(visibleText) {
-               var text = visibleText.split("\n").join("|"),
-                  expectedText = "five woof|five and a half woof|six woof|six and a half woof";
-               assert.equal(text, expectedText, "Incorrect results displayed for filter 'woof'");
-            });
-      },
+            .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  var text = visibleText.split("\n").join("|"),
+                     expectedText = "five woof|five and a half woof|six woof|six and a half woof";
+                  assert.equal(text, expectedText, "Incorrect results displayed for filter 'woof'");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/FilteredListUseCaseTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListUseCaseTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "FilteredList Tests (Use Case 1)",
 
       setup: function() {
@@ -60,5 +62,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/InfiniteScrollTest.js
+++ b/aikau/src/test/resources/alfresco/lists/InfiniteScrollTest.js
@@ -26,26 +26,28 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
-   var countResults = function(expected) {
+   var countResults = function(browser, expected) {
       browser.findAllByCssSelector(".alfresco-search-AlfSearchResult")
          .then(function(elements) {
             assert(elements.length === expected, "Counting Result, expected: " + expected + ", found: " + elements.length);
          })
       .end();
    };
-   var scrollToBottom = function() {
+   var scrollToBottom = function(browser) {
       browser.execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
          .sleep(2000)
       .end();
    };
-   var scrollToTop = function() {
+   var scrollToTop = function(browser) {
       browser.execute("return window.scrollTo(0,0)")
          .sleep(2000)
       .end();
    };
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Infinite Scroll Tests",
       
       setup: function() {
@@ -61,19 +63,20 @@ define(["intern!object",
          return browser.sleep(1000)
             // Trigger Infinite Scroll.
             .then(function(){
-               scrollToBottom();
-               scrollToTop();
-               scrollToBottom();
+               scrollToBottom(browser);
+               scrollToTop(browser);
+               scrollToBottom(browser);
             })
 
             // Count Results. there should be 50. (Request 2)
             .then(function(){
-               countResults(50);
+               countResults(browser, 50);
             });
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/LocalStorageFallbackTest.js
+++ b/aikau/src/test/resources/alfresco/lists/LocalStorageFallbackTest.js
@@ -26,10 +26,11 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+   // The first test page has a list that does not fallback on local storage and has no current filter...
+registerSuite(function(){
    var browser;
 
-   // The first test page has a list that does not fallback on local storage and has no current filter...
-   registerSuite({
+   return {
       name: "List Local Storage (1)",
       
       setup: function() {
@@ -49,10 +50,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // The second test page sets local storage using the current filter...
-   registerSuite({
+   registerSuite(function(){
+   var browser;
+
+   return {
       name: "List Local Storage (2)",
       
       setup: function() {
@@ -82,10 +87,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // The third test page has a hash which trumps the current filter and is stored...
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Local Storage for Lists Tests (3)",
       
       setup: function() {
@@ -110,10 +119,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // The fourth test page has no hash, and although there is a current filter the locally stored hash is used...
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Local Storage for Lists Tests (4)",
       
       setup: function() {
@@ -138,11 +151,15 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // The fifth test page has no hash, and the list is configured to not use the previously stored
    // hash to the current filter should be used...
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Local Storage for Lists Tests (5)",
       
       setup: function() {
@@ -167,10 +184,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // The sixth test page has a list without a current filter, it should re-use the locally stored hash
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Local Storage for Lists Tests (6)",
       
       setup: function() {
@@ -195,10 +216,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // The sixth test page has a list but sets a hash which should be used...
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Local Storage for Lists Tests (7)",
       
       setup: function() {
@@ -227,5 +252,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/PaginatorVisibilityTest.js
+++ b/aikau/src/test/resources/alfresco/lists/PaginatorVisibilityTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Paginator Visibility Tests",
       
       setup: function() {
@@ -80,5 +82,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/views/AlfListViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/AlfListViewTest.js
@@ -26,8 +26,10 @@ define(["alfresco/TestCommon",
    ],
    function(TestCommon, assert, registerSuite) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "AlfListView Tests",
 
          setup: function() {
@@ -65,5 +67,6 @@ define(["alfresco/TestCommon",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/lists/views/HtmlListViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/HtmlListViewTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "HtmlListView Tests",
       
       setup: function() {
@@ -100,5 +102,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/views/layouts/EditableRowTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/layouts/EditableRowTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Editable Row Tests",
 
       setup: function() {
@@ -132,5 +134,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/views/layouts/RowTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/layouts/RowTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Row Tests",
 
       setup: function() {
@@ -68,5 +70,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/logging/DebugLogTest.js
+++ b/aikau/src/test/resources/alfresco/logging/DebugLogTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon) {
 
-      var browser;
+registerSuite(function(){
+   var browser;
 
-      registerSuite({
+   return {
          name: "DebugLog Tests",
 
          setup: function() {
@@ -55,5 +56,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/logo/LogoTest.js
+++ b/aikau/src/test/resources/alfresco/logo/LogoTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Logo Tests",
 
       setup: function() {
@@ -75,5 +77,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfCheckableMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfCheckableMenuItemTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Checkable Menu Item Tests",
 
       setup: function() {
@@ -269,5 +271,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfContextMenuTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfContextMenuTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfContextMenu Tests",
 
       setup: function() {
@@ -71,5 +73,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfFormDialogMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfFormDialogMenuItemTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Form Dialog Menu Tests",
 
       setup: function() {
@@ -152,5 +154,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfMenuBarSelectItems Tests",
 
       setup: function() {
@@ -236,5 +238,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfMenuBarSelect Tests",
 
       setup: function() {
@@ -242,5 +244,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarToggleTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarToggleTest.js
@@ -33,8 +33,10 @@ define(["intern!object",
         function (registerSuite, expect, assert, require, TestCommon, keys) {
 
    var alfPause = 200;
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfMenuBarToggle Tests (Mouse)",
 
       setup: function() {
@@ -146,10 +148,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "AlfMenuBarToggle Tests (Keyboard)",
 
       setup: function() {
@@ -302,5 +308,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuItemTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfMenuItem Tests",
 
       setup: function() {
@@ -55,5 +57,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuItemWrapperTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuItemWrapperTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfMenuItemWrapper Tests",
 
       setup: function() {
@@ -113,5 +115,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuTextForClipboardTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuTextForClipboardTest.js
@@ -33,8 +33,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfMenuTextForClipboard Tests",
 
       setup: function() {
@@ -105,5 +107,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/AlfVerticalMenuBarTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfVerticalMenuBarTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfVerticalMenuBar Tests",
 
       setup: function() {
@@ -46,5 +48,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/DisableMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/DisableMenuItemTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Disable MenuItem Tests",
 
       setup: function() {
@@ -206,5 +208,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/MenuBarOrientationTest.js
+++ b/aikau/src/test/resources/alfresco/menus/MenuBarOrientationTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Menu Bar Orientation Tests",
 
       setup: function() {
@@ -75,5 +77,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/menus/MenuTests.js
+++ b/aikau/src/test/resources/alfresco/menus/MenuTests.js
@@ -30,8 +30,10 @@ define(["intern!object",
         function (registerSuite, assert, require, TestCommon, keys) {
 
    var alfPause = 250;
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Menus Tests",
 
       setup: function() {
@@ -387,5 +389,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/misc/AlfTooltipTest.js
+++ b/aikau/src/test/resources/alfresco/misc/AlfTooltipTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "AlfTooltip Tests",
 
       setup: function() {
@@ -62,8 +64,7 @@ define(["intern!object",
             .getSize()
             .then(function(size) {
                // width set is 300, 306 accounts for styling
-               assert(size.width == 306, "The tooltip width was incorrect, " +
-               		"expected 306 but was " + size.width); 
+               assert.equal(size.width, 306, "The tooltip width was incorrect"); 
             });
       },
 
@@ -107,5 +108,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/misc/TableAndFormDialogTest.js
+++ b/aikau/src/test/resources/alfresco/misc/TableAndFormDialogTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Table And Form Dialog Tests",
 
       setup: function() {
@@ -140,5 +142,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
    function(registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Path Tree Tests",
       
       setup: function() {
@@ -158,5 +160,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/node/MetadataGroupsTest.js
+++ b/aikau/src/test/resources/alfresco/node/MetadataGroupsTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Metadata Groups Test",
 
       setup: function() {
@@ -104,5 +106,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/preview/ImagePreviewTest.js
+++ b/aikau/src/test/resources/alfresco/preview/ImagePreviewTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Image Preview Tests",
 
       setup: function() {
@@ -64,5 +66,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest.js
+++ b/aikau/src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "PdfJs missing PDF test",
 
       setup: function() {
@@ -84,9 +86,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "PdfJs faulty PDF test",
 
       setup: function() {
@@ -142,9 +148,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "PdfJs password protected PDF test",
 
       setup: function() {
@@ -310,5 +320,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/preview/PdfJsPreviewTest.js
+++ b/aikau/src/test/resources/alfresco/preview/PdfJsPreviewTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
 
       name: "PdfJs Previewer Tests",
 
@@ -556,10 +557,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "PdfJs Previewer Outline Tests",
 
       setup: function() {
@@ -619,5 +624,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/preview/PreviewerTests.js
+++ b/aikau/src/test/resources/alfresco/preview/PreviewerTests.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Video Previewer Tests",
 
       setup: function() {
@@ -55,9 +57,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Audio Previewer Tests",
 
       setup: function() {
@@ -84,5 +90,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
@@ -26,9 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "Action Renderer Test",
 
       setup: function() {
@@ -75,5 +76,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/ActivitySummaryTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ActivitySummaryTest.js
@@ -27,8 +27,7 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon) {
 
-      var browser,
-         renderedValues = [
+      var renderedValues = [
             "Andy Healey previewed file P9111608.jpg in alfresco-uk-photo",
             "Tom Page liked file boats.jpg in alfresco-uk-photo",
             "Pete Philips updated wiki page Security_Blog in security",
@@ -42,7 +41,10 @@ define(["intern!object",
             "Ola Phillips added folder Connectivity Test - New Instructions in eng"
          ];
 
-      registerSuite({
+   registerSuite(function(){
+   var browser;
+
+   return {
          name: "ActivitySummary Tests",
 
          setup: function() {
@@ -74,5 +76,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/AvatarThumbnailTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Avatar Thumbnail Tests",
 
       setup: function() {
@@ -59,5 +61,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/BannerTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/BannerTest.js
@@ -30,8 +30,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Banner and Locked Banner Tests",
 
       setup: function() {
@@ -109,5 +111,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/BooleanTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/BooleanTest.js
@@ -30,8 +30,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Boolean Tests",
 
       setup: function() {
@@ -225,5 +227,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/CategoryTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CategoryTest.js
@@ -31,8 +31,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Category Tests",
 
       setup: function() {
@@ -110,5 +112,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
@@ -23,13 +23,13 @@
 define(["intern!object",
       "intern/chai!assert",
       "require",
-      "alfresco/TestCommon",
-      "intern/dojo/node!leadfoot/keys"],
-      function(registerSuite, assert, require, TestCommon, keys) {
+      "alfresco/TestCommon"],
+      function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "CommentsList Tests",
 
       setup: function() {
@@ -208,5 +208,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/DateLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateLinkTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, expect, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "DateLink Tests",
 
       setup: function() {
@@ -103,5 +105,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/DateTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Date Tests",
 
       setup: function() {
@@ -70,5 +72,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/FileTypeTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/FileTypeTest.js
@@ -31,8 +31,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "FileType Tests",
 
       setup: function() {
@@ -57,7 +59,7 @@ define(["intern!object",
             .getAttribute("src")
             .then(function (imgUrl){
                assert.include(imgUrl, "alfresco/logo/css/images/AlfrescoLogoOnly.PNG", "Expected Alfresco logo, but got: "+imgUrl);
-            })
+            });
       },
 
       "Check non-custom image has loaded": function () {
@@ -65,11 +67,12 @@ define(["intern!object",
             .getAttribute("src")
             .then(function (imgUrl){
                assert.include(imgUrl, "ppt-file-48.png", "Expected ppt-file-48, but got: "+imgUrl);
-            })
+            });
       },
 
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/IndicatorsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/IndicatorsTest.js
@@ -31,8 +31,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Indicators Tests",
 
       setup: function() {
@@ -108,5 +110,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -30,9 +30,10 @@ define(["intern!object",
    ],
    function(registerSuite, expect, assert, require, TestCommon, keys) {
 
-      var browser;
+registerSuite(function(){
+   var browser;
 
-      registerSuite({
+   return {
          name: "InlineEditPropertyLink",
 
          setup: function() {
@@ -318,5 +319,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -29,9 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"],
    function(registerSuite, expect, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "InlineEditProperty",
 
       setup: function() {
@@ -380,5 +381,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/ProgressTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ProgressTest.js
@@ -27,9 +27,11 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
    var width;
-   registerSuite({
+
+   return {
       name: "Progress Renderer Test",
 
       setup: function() {
@@ -143,5 +145,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/PropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PropertyLinkTest.js
@@ -30,8 +30,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "PropertyLink Tests",
 
       setup: function() {
@@ -71,5 +73,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
    ],
    function(registerSuite, expect, assert, require, TestCommon, keys) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "Property Tests",
 
          setup: function() {
@@ -201,5 +203,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/renderers/PublishPayloadMixinOnActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishPayloadMixinOnActionsTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "PublishPayloadMixinOnActions Tests",
 
       setup: function() {
@@ -128,5 +130,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishingDropDownMenuTest.js
@@ -28,9 +28,11 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon, keys) {
 
-      var browser;
-      registerSuite({
-         name: "PublishingDropDownMenu Tests",
+registerSuite(function(){
+   var browser;
+
+   return {
+      name: "PublishingDropDownMenu Tests",
 
          setup: function() {
             browser = this.remote;
@@ -346,8 +348,9 @@ define(["intern!object",
                .end();
          },
 
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         }
-      });
+      "Post Coverage Results": function() {
+         TestCommon.alfPostCoverageResults(this, browser);
+      }
+   };
    });
+});

--- a/aikau/src/test/resources/alfresco/renderers/ReorderTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ReorderTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Reorder Renderer Tests",
 
       setup: function() {
@@ -124,5 +126,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/SearchResultPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SearchResultPropertyLinkTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, expect, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "SearchResultPropertyLink Tests",
 
       setup: function() {
@@ -129,5 +131,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
@@ -31,8 +31,10 @@ define(["intern!object",
       return "#" + id + "_ITEM_0 ." + status;
    };
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Social Renderers Test (Likes)",
 
       setup: function() {
@@ -155,9 +157,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Social Renderers Test (Favourites)",
 
       setup: function() {
@@ -256,10 +262,14 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Social Renderers Test (Comments)",
 
       setup: function() {
@@ -282,5 +292,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Tags Tests",
 
       setup: function() {
@@ -121,9 +123,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Tags Tests (inline creation and save)",
 
       setup: function() {
@@ -190,5 +196,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Thumbnail Tests",
 
       setup: function() {
@@ -109,5 +111,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/XhrActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/XhrActionsTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "XHR Actions Renderer Tests",
 
       setup: function() {
@@ -64,5 +66,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/actions/DeleteActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/actions/DeleteActionTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Delete Action Test",
 
       setup: function() {
@@ -170,5 +172,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/actions/ManageAspectsActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/actions/ManageAspectsActionTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Manage Aspects Action",
 
       setup: function() {
@@ -97,5 +99,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/actions/UploadNewVersionActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/actions/UploadNewVersionActionTest.js
@@ -26,9 +26,7 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function (registerSuite, assert, require, TestCommon) {
 
-   var browser;
-
-   var checkAction = function(row, count, error) {
+   var checkAction = function(browser, row, count, error) {
       return browser.findByCssSelector("#LIST tr:nth-child(" + row + ") .dijitMenuBar")
          .getAttribute("id")
          .then(function(id) {
@@ -49,7 +47,7 @@ define(["intern!object",
          });
    };
 
-   var useAction = function(row) {
+   var useAction = function(browser, row) {
       return browser.findByCssSelector("#LIST tr:nth-child(" + row + ") .dijitMenuBar")
          .getAttribute("id")
          .then(function(id) {
@@ -67,7 +65,10 @@ define(["intern!object",
    };
 
 
-   registerSuite({
+   registerSuite(function(){
+   var browser;
+
+   return {
       name: "Upload New Version Action Test",
 
       setup: function() {
@@ -84,7 +85,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(1, 0, "Upload new version action shouldn't be rendered for a folder");
+            return checkAction(browser, 1, 0, "Upload new version action shouldn't be rendered for a folder");
          });
       },
 
@@ -93,7 +94,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(2, 1, "Upload new version action should be rendered for a basic node");
+            return checkAction(browser, 2, 1, "Upload new version action should be rendered for a basic node");
          });
       },
 
@@ -102,7 +103,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(3, 1, "Upload new version action should be rendered for working copy owned by the current user");
+            return checkAction(browser, 3, 1, "Upload new version action should be rendered for working copy owned by the current user");
          });
       },
 
@@ -111,7 +112,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(4, 0, "Upload new version action should not be rendered for a working copy owned by a different user");
+            return checkAction(browser, 4, 0, "Upload new version action should not be rendered for a working copy owned by a different user");
          });
       },
 
@@ -120,7 +121,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(5, 1, "Upload new version action should be rendered for a node locked by the current user");
+            return checkAction(browser, 5, 1, "Upload new version action should be rendered for a node locked by the current user");
          });
       },
 
@@ -129,7 +130,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(6, 0, "Upload new version action should not be rendered for a node locked by a different user");
+            return checkAction(browser, 6, 0, "Upload new version action should not be rendered for a node locked by a different user");
          });
       },
 
@@ -138,7 +139,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(7, 0, "Upload new version action should not be rendered for a node with lock type NODE_LOCK");
+            return checkAction(browser, 7, 0, "Upload new version action should not be rendered for a node with lock type NODE_LOCK");
          });
       },
 
@@ -147,7 +148,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return checkAction(8, 0, "Upload new version action should not be rendered for a node without user write permissions");
+            return checkAction(browser, 8, 0, "Upload new version action should not be rendered for a node without user write permissions");
          });
       },
 
@@ -156,7 +157,7 @@ define(["intern!object",
             .click()
          .end()
          .then(function() {
-            return useAction(2);
+            return useAction(browser, 2);
          })
          .end()
          // Give the dialog a chance to appear...
@@ -172,5 +173,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -28,9 +28,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, TestCommon) {
 
-      var browser;
+registerSuite(function(){
+   var browser;
 
-      registerSuite({
+   return {
          name: "AlfSearchResult Tests",
 
          setup: function() {
@@ -104,5 +105,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/search/CustomSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/CustomSearchResultTest.js
@@ -25,8 +25,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Custom Search Result Tests",
 
       setup: function() {
@@ -88,5 +90,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
@@ -32,8 +32,10 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, expect, assert, require, TestCommon, keys) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "FacetFilters Tests (Mouse)",
 
       setup: function() {
@@ -232,9 +234,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "FacetFilters Tests (Keyboard)",
 
       setup: function() {
@@ -335,9 +341,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "FacetFilters Tests (URL Hash Tests)",
 
       setup: function() {
@@ -417,12 +427,16 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
    // See AKU-477...
    // FacetFilters publish information about themselves when they are created, but they wait for 
    // page loading to complete so that all widgets have been created before publishing occurs.
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "FacetFilters Tests (delayed creation)",
 
       setup: function() {
@@ -452,5 +466,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/search/NoHashSearchingTest.js
+++ b/aikau/src/test/resources/alfresco/search/NoHashSearchingTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "No URL Hashing Search Tests",
 
       setup: function() {
@@ -132,5 +134,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/search/SearchSuggestionsTest.js
+++ b/aikau/src/test/resources/alfresco/search/SearchSuggestionsTest.js
@@ -29,8 +29,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Search Suggestions Tests (Alternative Searches)",
 
       setup: function() {
@@ -115,9 +117,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Search Suggestions Tests (Suggestions)",
 
       setup: function() {
@@ -169,9 +175,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Search Suggestions Tests (Standard Search)",
 
       setup: function() {
@@ -208,9 +218,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Search Suggestions Tests (Visibility Config)",
 
       setup: function() {
@@ -255,5 +269,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon) {
 
-      var browser;
+registerSuite(function(){
+   var browser;
 
-      registerSuite({
+   return {
 
          name: "ActionService Tests",
 
@@ -68,5 +69,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "ContentService Tests",
 
       setup: function() {
@@ -213,5 +215,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
@@ -27,8 +27,7 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/helpers/pollUntil"],
         function(registerSuite, assert, require, TestCommon, pollUntil) {
 
-   var browser;
-   function closeAllDialogs() {
+   function closeAllDialogs(browser) {
       return browser.end()
          .findAllByCssSelector(".dijitDialogCloseIcon")
          .then(function(closeButtons) {
@@ -47,7 +46,10 @@ define(["intern!object",
          }, 5000));
    }
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "CrudService",
 
       setup: function() {
@@ -94,7 +96,7 @@ define(["intern!object",
       },
 
       "Valid UPDATE call succeeds": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("UPDATE_SUCCESS_BUTTON")
                   .click()
@@ -130,7 +132,7 @@ define(["intern!object",
       },
 
       "Valid CREATE call succeeds": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("CREATE_SUCCESS_BUTTON")
                   .click()
@@ -166,7 +168,7 @@ define(["intern!object",
       },
 
       "GET ALL success": function () {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("GET_ALL_DEFAULT_CACHE_BUTTON")
                   .click()
@@ -204,5 +206,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/DeleteSiteTest.js
+++ b/aikau/src/test/resources/alfresco/services/DeleteSiteTest.js
@@ -25,8 +25,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Delete Site Tests",
 
       setup: function() {
@@ -100,5 +102,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -27,9 +27,7 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/helpers/pollUntil"],
         function(registerSuite, assert, require, TestCommon, pollUntil) {
 
-   var browser;
-
-   function closeAllDialogs() {
+   function closeAllDialogs(browser) {
       // Todo: this fails to close multiple dialogs in Chrome
       return browser.end()
          .findAllByCssSelector(".dijitDialogCloseIcon")
@@ -49,7 +47,10 @@ define(["intern!object",
          }, 5000));
    }
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Dialog Service Tests",
 
       setup: function() {
@@ -79,7 +80,7 @@ define(["intern!object",
       },
 
       "Test recreating dialog with no ID": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("CREATE_FORM_DIALOG_NO_ID")
                   .click()
@@ -93,7 +94,7 @@ define(["intern!object",
       },
 
       "Test creating dialog with an ID": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("CREATE_FORM_DIALOG")
                   .click()
@@ -107,7 +108,7 @@ define(["intern!object",
       },
 
       "Test recreating dialog with an ID": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("CREATE_FORM_DIALOG")
                   .clearLog()
@@ -144,7 +145,7 @@ define(["intern!object",
       },
 
       "Check that form dialog dimensions can be set": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("CREATE_FORM_DIALOG")
                   .click()
@@ -162,7 +163,7 @@ define(["intern!object",
       },
 
       "Dialog is closed when dialogCloseTopic is set": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("LAUNCH_FAILURE_DIALOG")
                   .click()
@@ -186,7 +187,7 @@ define(["intern!object",
       },
 
       "Dialog remains open when dialogCloseTopic is set": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("LAUNCH_FAILURE_DIALOG")
                   .click()
@@ -210,7 +211,7 @@ define(["intern!object",
       },
 
       "Check that non-form dialog dimensions can be set": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
                   .click()
@@ -228,7 +229,7 @@ define(["intern!object",
       },
 
       "Check form dialog has customised IDs for buttons": function () {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function () {
                return browser.findById("LAUNCH_CUSTOM_BUTTON_ID_DIALOG")
                   .click()
@@ -249,7 +250,7 @@ define(["intern!object",
       },
 
       "Count golden path repeating dialog buttons": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("CREATE_AND_CREATE_ANOTHER_1")
                   .click()
@@ -404,7 +405,7 @@ define(["intern!object",
       },
 
       "Can launch dialog within dialog": function() {
-         return closeAllDialogs()
+         return closeAllDialogs(browser)
             .then(function() {
                return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
                   .click()
@@ -449,5 +450,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/FullScreenDialogTest.js
+++ b/aikau/src/test/resources/alfresco/services/FullScreenDialogTest.js
@@ -25,8 +25,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function(registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
 
       name: "Full Screen Dialog Tests",
 
@@ -124,5 +126,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -26,9 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "NavigationService Tests",
 
       setup: function() {
@@ -150,5 +151,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
 
-   registerSuite({
+   return {
       name: "NotificationService",
 
       setup: function() {
@@ -78,5 +79,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Search Service Test",
 
       setup: function() {
@@ -165,5 +167,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/ServiceFilteringTest.js
+++ b/aikau/src/test/resources/alfresco/services/ServiceFilteringTest.js
@@ -27,9 +27,10 @@ define(["intern!object",
    ],
    function(registerSuite, assert, require, TestCommon) {
 
-      var browser;
+registerSuite(function(){
+   var browser;
 
-      registerSuite({
+   return {
 
          name: "Service Filtering Tests",
 
@@ -93,5 +94,6 @@ define(["intern!object",
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
+      };
       });
    });

--- a/aikau/src/test/resources/alfresco/services/ServiceRegistryTest.js
+++ b/aikau/src/test/resources/alfresco/services/ServiceRegistryTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Service Registry Test",
 
       setup: function() {
@@ -79,5 +81,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Site Service Tests (Site details)",
 
       setup: function() {
@@ -74,9 +76,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Site Service Tests (Favourite and recent sites)",
 
       setup: function() {
@@ -167,9 +173,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Site Service Tests (Site memberships)",
 
       setup: function() {
@@ -387,9 +397,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Site Service Tests (Update and delete site)",
 
       setup: function() {
@@ -434,5 +448,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/UserServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/UserServiceTest.js
@@ -30,8 +30,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "User Service Test (successful)",
 
       setup: function() {
@@ -80,9 +82,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "User Service Test (failure)",
 
       setup: function() {
@@ -134,9 +140,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
    
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "User Service Home Page Test",
 
       setup: function() {
@@ -164,5 +174,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
@@ -27,8 +27,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Copy/Move tests",
 
       setup: function() {
@@ -149,9 +151,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Copy/Move tests (overrides and failures)",
 
       setup: function() {
@@ -208,5 +214,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Download as ZIP Action Tests",
 
       setup: function() {
@@ -133,5 +135,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
@@ -28,8 +28,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Manage Aspects Tests",
 
       setup: function() {
@@ -175,5 +177,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/actions/NodeLocationTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/NodeLocationTest.js
@@ -26,8 +26,10 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, require, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Node Location Tests",
 
       setup: function() {
@@ -82,5 +84,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/actions/WorkflowTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/WorkflowTest.js
@@ -25,114 +25,125 @@ define(["intern!object",
         "intern/chai!assert",
         "require",
         "alfresco/TestCommon"],
-        function(registerSuite, assert, require, TestCommon) {
+           function(registerSuite, assert, require, TestCommon) {
 
-   var browser;
-   registerSuite({
-      name: "Assign Workflow Test",
+   registerSuite(function(){
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/WorkflowActions", "Assign Workflow Test").end();
-      },
+      return {
+         name: "Assign Workflow Test",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/WorkflowActions", "Assign Workflow Test").end();
+         },
 
-      "Assign a workflow": function() {
-         return browser.findByCssSelector("#ASSIGN_label")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_POST_TO_PAGE", "url", "/aikau/page/dp/ws/start-workflow"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Workflow not assigned");
-            })
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_POST_TO_PAGE", "type", "FULL_PATH"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Workflow URL type incorrect");
-            });
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+         "Assign a workflow": function() {
+            return browser.findByCssSelector("#ASSIGN_label")
+               .click()
+            .end()
+            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_POST_TO_PAGE", "url", "/aikau/page/dp/ws/start-workflow"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Workflow not assigned");
+               })
+            .end()
+            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_POST_TO_PAGE", "type", "FULL_PATH"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Workflow URL type incorrect");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-   registerSuite({
-      name: "Simple Workflow Actions Tests (Successes)",
+   registerSuite(function(){
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/WorkflowActions?responseCode=200", "Simple Workflow Actions Tests").end();
-      },
+      return {
+         name: "Simple Workflow Actions Tests (Successes)",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/WorkflowActions?responseCode=200", "Simple Workflow Actions Tests").end();
+         },
 
-      "Approve a workflow": function() {
-         return browser.findByCssSelector("#APPROVE_SUCCESS_label")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "File marked as approved"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Simple approval success notification not found");
-            });
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Reject a workflow": function() {
-         return browser.findByCssSelector("#REJECT_SUCCESS_label")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "File marked as rejected"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Simple rejection success notification not found");
-            });
-      },
+         "Approve a workflow": function() {
+            return browser.findByCssSelector("#APPROVE_SUCCESS_label")
+               .click()
+            .end()
+            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "File marked as approved"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Simple approval success notification not found");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+         "Reject a workflow": function() {
+            return browser.findByCssSelector("#REJECT_SUCCESS_label")
+               .click()
+            .end()
+            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "File marked as rejected"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Simple rejection success notification not found");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-   registerSuite({
-      name: "Simple Workflow Actions Tests (Failures)",
+   registerSuite(function(){
+      var browser;
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/WorkflowActions?responseCode=500", "Simple Workflow Actions Tests").end();
-      },
+      return {
+         name: "Simple Workflow Actions Tests (Failures)",
 
-      beforeEach: function() {
-         browser.end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/WorkflowActions?responseCode=500", "Simple Workflow Actions Tests").end();
+         },
 
-      "Approve a workflow": function() {
-         return browser.findByCssSelector("#APPROVE_FAILURE_label")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "Workflow action couldn't be completed."))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Simple approval failure notification not found");
-            });
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Reject a workflow": function() {
-         return browser.findByCssSelector("#REJECT_FAILURE_label")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_DOCLIST_RELOAD_DATA", "publish", "last"))
-         .end()
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "Workflow action couldn't be completed."))
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "Simple rejection failure notification not found");
-            });
-      },
+         "Approve a workflow": function() {
+            return browser.findByCssSelector("#APPROVE_FAILURE_label")
+               .click()
+            .end()
+            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "Workflow action couldn't be completed."))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Simple approval failure notification not found");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+         "Reject a workflow": function() {
+            return browser.findByCssSelector("#REJECT_FAILURE_label")
+               .click()
+            .end()
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_DOCLIST_RELOAD_DATA", "publish", "last"))
+            .end()
+            .findAllByCssSelector(TestCommon.pubDataCssSelector("ALF_DISPLAY_NOTIFICATION", "message", "Workflow action couldn't be completed."))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Simple rejection failure notification not found");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/upload/UploadTargetTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadTargetTest.js
@@ -25,8 +25,10 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+registerSuite(function(){
    var browser;
-   registerSuite({
+
+   return {
       name: "Upload Target and History Tests",
 
       setup: function() {
@@ -99,5 +101,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/upload/UploadTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadTest.js
@@ -27,17 +27,18 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, expect, assert, require, TestCommon) {
 
-   var browser;
    var uploadsSelector = ".alfresco-dialog-AlfDialog .alfresco-upload-AlfUploadDisplay .uploads";
    var successfulUploadsSelector = uploadsSelector + "> .successful table tr";
    var failedUploadsSelector = uploadsSelector + " > .failed table tr";
    var aggProgStatusSelector = uploadsSelector + " .aggregate-progress .percentage";
    var okButtonSelector = ".alfresco-dialog-AlfDialog .footer > span:first-child > span";
    var cancelButtonSelector = ".alfresco-dialog-AlfDialog .footer > span:nth-child(2) > span";
-
    var dialogDelay = 500;
 
-   registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Upload Failure Tests",
 
       setup: function() {
@@ -73,8 +74,13 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
-   registerSuite({
+
+registerSuite(function(){
+   var browser;
+
+   return {
       name: "Upload Tests",
       
       setup: function() {
@@ -197,5 +203,6 @@ define(["intern!object",
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }
+   };
    });
 });

--- a/aikau/src/test/resources/alfresco/util/functionUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/util/functionUtilsTest.js
@@ -28,8 +28,10 @@ define([
    ],
    function(TestCommon, registerSuite, assert, require) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "Function Utils Test",
 
          setup: function() {
@@ -168,6 +170,7 @@ define([
                   assert.closeTo(timeOfExecution, 0, 25, "Did not handle execFirst option in debounce function correctly");
                });
          }
+      };
       });
    }
 );

--- a/aikau/src/test/resources/alfresco/util/urlUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/util/urlUtilsTest.js
@@ -28,8 +28,10 @@ define([
    ],
    function (TestCommon, registerSuite, assert, require) {
 
-      var browser;
-      registerSuite({
+registerSuite(function(){
+   var browser;
+
+   return {
          name: "URL Utils Test",
 
          setup: function() {
@@ -107,6 +109,6 @@ define([
 
                });
          }
-      });
-   }
-);
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,8 +31,10 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/TextAreaTest"
+   baseFunctionalSuites: [
+      "src/test/resources/alfresco/core/AdvancedVisibilityConfigTest",
+      "src/test/resources/alfresco/core/CoreRwdTest",
+      "src/test/resources/alfresco/core/NotificationUtilsTest"
    ],
 
    /**
@@ -41,7 +43,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,10 +31,18 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   baseFunctionalSuites: [
-      "src/test/resources/alfresco/core/AdvancedVisibilityConfigTest",
-      "src/test/resources/alfresco/core/CoreRwdTest",
-      "src/test/resources/alfresco/core/NotificationUtilsTest"
+   xbaseFunctionalSuites: [
+      "src/test/resources/alfresco/lists/AlfHashListTest",
+      "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
+      "src/test/resources/alfresco/lists/FilteredListTest",
+      "src/test/resources/alfresco/lists/FilteredListUseCaseTest",
+      "src/test/resources/alfresco/lists/InfiniteScrollTest",
+      "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
+      "src/test/resources/alfresco/lists/PaginatorVisibilityTest",
+      "src/test/resources/alfresco/lists/views/AlfListViewTest",
+      "src/test/resources/alfresco/lists/views/HtmlListViewTest",
+      "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
+      "src/test/resources/alfresco/lists/views/layouts/RowTest"
    ],
 
    /**
@@ -43,7 +51,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   xbaseFunctionalSuites: [
+   baseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -48,7 +48,7 @@ define(["./config/Suites"],
 
          // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
          // maxConcurrency: 1,
-         maxConcurrency: Infinity,
+         maxConcurrency: 1,
 
          // Terminal information
          terminalInfo: {

--- a/aikau/src/test/resources/intern_bs.js
+++ b/aikau/src/test/resources/intern_bs.js
@@ -1,3 +1,5 @@
+/*globals process*/
+
 // Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
@@ -16,13 +18,22 @@ define(["./config/Suites"],
          }
       });
 
+      // Define "constants"
+      var PROJECT_NAME = "Aikau",
+         SESSION_NAME = "[AKU] BrowserStack Tests @ " + (new Date()).toISOString(),
+         MAC = "OS X",
+         MAC_VERSION = "Yosemite",
+         WINDOWS = "Windows",
+         WINDOWS_VERSION = "7",
+         BS_DEBUG = false;
+
       return {
 
          // The port on which the instrumenting proxy will listen
          proxyPort: 9000,
 
          // A fully qualified URL to the Intern proxy
-         proxyUrl: "http://192.168.56.1:9000/",
+         proxyUrl: "http://localhost:9000/",
 
          // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
          // specified browser environments in the `environments` array below as well. See
@@ -31,7 +42,7 @@ define(["./config/Suites"],
          // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
          // automatically
          capabilities: {
-            "selenium-version": "2.44.0"
+            "selenium-version": "2.45.0"
          },
 
          // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
@@ -41,9 +52,33 @@ define(["./config/Suites"],
             browserName: "Chrome",
             chromeOptions: {
                excludeSwitches: ["ignore-certificate-errors"]
-            }
+            },
+            os: MAC,
+            os_version: MAC_VERSION,
+            platform: MAC,
+            platformVersion: MAC_VERSION,
+            project: PROJECT_NAME,
+            name: SESSION_NAME,
+            "browserstack.debug": BS_DEBUG
          }, {
-            browserName: "Firefox"
+            browserName: "Firefox",
+            os: MAC,
+            os_version: MAC_VERSION,
+            platform: MAC,
+            platformVersion: MAC_VERSION,
+            project: PROJECT_NAME,
+            name: SESSION_NAME,
+            "browserstack.debug": BS_DEBUG
+         }, {
+            browserName: "Internet Explorer",
+            version: ["11", "10", "9"],
+            os: WINDOWS,
+            os_version: WINDOWS_VERSION,
+            platform: WINDOWS,
+            platformVersion: WINDOWS_VERSION,
+            project: PROJECT_NAME,
+            name: SESSION_NAME,
+            "browserstack.debug": BS_DEBUG
          }],
 
          // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
@@ -57,13 +92,7 @@ define(["./config/Suites"],
          },
 
          // Dig Dug tunnel handler
-         tunnel: "NullTunnel",
-
-         // Dig Dug tunnel options
-         tunnelOptions: {
-            hostname: "192.168.56.4",
-            port: 4444
-         },
+         tunnel: "BrowserStackTunnel",
 
          // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
          // used here

--- a/aikau/src/test/resources/reporters/AikauConcurrentReporter.js
+++ b/aikau/src/test/resources/reporters/AikauConcurrentReporter.js
@@ -1,0 +1,1449 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Reporter for running concurrent Intern tests.<br />
+ * <br />
+ * NOTE: If getting unexplained errors, try turning on BreakOnError in the CONFIG constants object.
+ *
+ * @author Martin Doyle
+ * @module AikauConcurrentReporter
+ */
+define([
+   "dojo/node!charm"
+], function(Charm) {
+
+   /**
+    * ANSI codes for terminal text decoration
+    *
+    * @constant
+    * @type {Object}
+    * @see  https://coderwall.com/p/yphywg/printing-colorful-text-in-terminal-when-run-node-js-script
+    */
+   var ANSI_CODES = {
+      Reset: "\x1b[0m",
+      Bright: "\x1b[1m",
+      Dim: "\x1b[2m",
+      Underline: "\x1b[4m",
+      Blink: "\x1b[5m",
+      Reverse: "\x1b[7m",
+      Hidden: "\x1b[8m",
+      FgBlack: "\x1b[30m",
+      FgRed: "\x1b[31m",
+      FgGreen: "\x1b[32m",
+      FgYellow: "\x1b[33m",
+      FgBlue: "\x1b[34m",
+      FgMagenta: "\x1b[35m",
+      FgCyan: "\x1b[36m",
+      FgWhite: "\x1b[37m",
+      BgBlack: "\x1b[40m",
+      BgRed: "\x1b[41m",
+      BgGreen: "\x1b[42m",
+      BgYellow: "\x1b[43m",
+      BgBlue: "\x1b[44m",
+      BgMagenta: "\x1b[45m",
+      BgCyan: "\x1b[46m",
+      BgWhite: "\x1b[47m"
+   };
+
+   /**
+    * Constants relating to charm
+    *
+    * @constant
+    * @type {Object}
+    */
+   var CHARM = {
+      Col: {
+         Default: 3,
+         MessageString: 3,
+         MessageTitle: 3,
+         ProgressBar: 3,
+         ProgressName: 3,
+         ProgressValue: 21,
+         StatusName: 50,
+         StatusValue: 64
+      },
+      Row: {
+         Title: 3,
+         StatusTitle: 6,
+         Environments: 7,
+         Total: 8,
+         Passed: 9,
+         Failed: 10,
+         Skipped: 11,
+         Errors: 12,
+         Warnings: 13,
+         Deprecations: 14,
+         ProgressTitle: 6,
+         PercentComplete: 11,
+         TunnelStatus: 12,
+         TimeTaken: 13,
+         TimeRemaining: 14,
+         ProgressBar: 8,
+         MessagesLine: 16
+      },
+      ProblemIndent: 2,
+      ProblemPrefix: "  - ",
+      ProblemsCroppedMessage: "[previous messages hidden ...]",
+      ProgressBar: {
+         CompleteChar: "=",
+         EmptyChar: ".",
+         Length: 40,
+         LineChar: "-"
+      },
+      ScreenMargin: 2,
+      SpinnerChars: "-\\|/-\\|/".split(""),
+      TitleIndent: 1
+   };
+
+   /**
+    * Configuration constants
+    *
+    * @constant
+    * @type {Object}
+    */
+   var CONFIG = {
+      BreakOnError: false,
+      Title: "AIKAU UNIT TESTS",
+      TitleHelp: "(Ctrl-C to abort)"
+   };
+
+   /**
+    * Problem types
+    * 
+    * @readonly
+    * @enum {string}
+    */
+   var PROBLEM_TYPE = {
+      Deprecation: "deprecations",
+      Error: "errors",
+      Warning: "warnings"
+   };
+
+   /**
+    * Result types
+    * 
+    * @readonly
+    * @enum {string}
+    */
+   var RESULT_TYPE = {
+      Failed: "failed",
+      Skipped: "skipped"
+   };
+
+   /**
+    * The charm instance
+    *
+    * @type {Object}
+    */
+   var charm = null;
+
+   /**
+    * @namespace The helper namespace, which contains the state and functionality to support the Reporter.
+    */
+   var helper = {
+
+      /**
+       * A type that represents a problem-collection, e.g. errors
+       *
+       * @typedef ProblemCollection
+       * @property {Object} group An object under which to group problems (e.g. "Reporter")
+       * @property {Object} group.problem The problem object (key is problem message)
+       * @property {string} group.problem.message The problem's message
+       * @property {int} group.problem.count The number of times this problem has occurred
+       * @property {string} [group.problem.stack] The stacktrace if the problem is an error
+       */
+
+      /**
+       * A type that represents a result-collection, e.g. failures
+       *
+       * @typedef ResultCollection
+       * @property {Object} suite The suite under which to log the result (key is suite name)
+       * @property {Object} suite.test The test that the result came from (key is test name)
+       * @property {string} suite.test.message The failure/skip message, where the key is the
+       *                                       name of the environment the test ran in
+       */
+
+      /**
+       * The deprecations container object. Will contain zero-or-more message properties.
+       *
+       * @instance
+       * @type {Object}
+       * @property {string} _name The name to use when outputting this collection
+       * @property {int} message The deprecation message with its number of occurrences as its value
+       */
+      deprecations: {
+         _name: "Deprecations"
+      },
+
+      /**
+       * The environments within which the tests are being run
+       *
+       * @type {Object}
+       * @property {boolean} envName The name of the environment as the key, with true as the value
+       */
+      environments: {},
+
+      /**
+       * The errors container object
+       *
+       * @instance
+       * @type {Object}
+       * @property {string} _name The name to use when outputting this collection
+       * @property {Object[]} label The errors grouped by label
+       * @property {Object} label.error The Error object
+       * @property {int} label.count The number of times this error occurred (grouped by error message)
+       */
+      errors: {
+         _name: "Errors"
+      },
+
+      /**
+       * Problems (deprecations, errors or warnings) encountered during the test run
+       *
+       * @type {Object}
+       * @property {ProblemCollection} deprecations Deprecations
+       * @property {ProblemCollection} errors Errors
+       * @property {ProblemCollection} warnings Warnings
+       */
+      problems: {
+         deprecations: {},
+         errors: {},
+         warnings: {}
+      },
+
+      /**
+       * The results container object
+       *
+       * @instance
+       * @type {Object}
+       * @property {ResultCollection} failed Failed tests
+       * @property {ResultCollection} skipped Skipped tests
+       */
+      results: {
+         failed: {},
+         skipped: {}
+      },
+
+      /**
+       * The start time of the test run as an epoch value in ms
+       *
+       * @instance
+       * @type {int}
+       */
+      startTime: 0,
+
+      /**
+       * The current state
+       *
+       * @type {Object}
+       * @property {Object} charm State values relating to charm
+       * @property {int} charm.progressBarCurrPos Where the progress bar animation should be drawn (column index)
+       * @property {int} charm.finalRow Where the cursor should finish after redraws (row index)
+       * @property {string} tunnel The current tunnel state
+       */
+      state: {
+         charm: {
+            finalRow: 0,
+            nextSpinnerIndex: 0,
+            progressBarCurrPos: CHARM.Col.ProgressBar
+         },
+         tunnel: "N/A"
+      },
+
+      /**
+       * Information about the terminal window
+       *
+       * @type {Object}
+       * @property {int} cols Number of columns available
+       * @property {int} rows Number of rows available
+       */
+      terminalInfo: null,
+
+      /**
+       * Running totals of test states
+       *
+       * @instance
+       * @type {Object}
+       */
+      testCounts: {
+         deprecations: 0,
+         errors: 0,
+         failed: 0,
+         passed: 0,
+         run: 0,
+         skipped: 0,
+         total: 0,
+         warnings: 0
+      },
+
+      /**
+       * How many rows are available for displaying messages
+       *
+       * @instance
+       * @type {number}
+       */
+      totalMessageRows: 0,
+
+      /**
+       * The warnings container object
+       *
+       * @instance
+       * @type {Object}
+       * @property {string} _name The name to use when outputting this collection
+       * @property {Object[]} label The label under which to group the warnings
+       * @property {string} label.warning The warning message
+       * @property {int} label.count The number of times this warning occurred
+       */
+      warnings: {
+         _name: "Warnings"
+      },
+
+      /**
+       * Augment the suite. Specifically, modify the setup() to: function read the
+       * environment name and populate the environments collection, before continuing
+       * with its normal behaviour.
+       *
+       * @instance
+       * @param {Object} suite The suite
+       */
+      augmentSuite: function(suite) {
+         var setupFunc = suite.setup,
+            environments = this.environments;
+         if (setupFunc) {
+            suite.setup = function() {
+               var envName = helper.getEnv(this);
+               environments[envName] = true;
+               return setupFunc.apply(this, arguments);
+            };
+         } else if (suite.name) {
+            this.addWarning(suite.name, "Suite does not have setup() method");
+         }
+      },
+
+      /**
+       * Debug-only function that will take a message and immediately break and log it to console
+       *
+       * @instance
+       * @param {string} message The message
+       */
+      abortAndLog: function(message) {
+         this.exitWithError(new Error(message));
+      },
+
+      /**
+       * Capitalise the supplied string
+       *
+       * @instance
+       * @param {string} input The string to be capitalised
+       * @returns {string} The capitalised string or the input if it was falsy
+       */
+      capitalise: function(input) {
+         return input && input[0].toUpperCase() + input.substr(1).toLowerCase();
+      },
+
+      /**
+       * Exit the process with the specified error
+       *
+       * @instance
+       * @param {Error} err The offending err
+       * @param {string} [message] An optional extra message string
+       */
+      exitWithError: function(err, message) {
+         if (charm) {
+            this.resetCursor();
+            charm.destroy();
+         }
+         console.error("");
+         message && console.error(message);
+         console.error(err.stack || err);
+         process.exit(1);
+      },
+
+      /**
+       * Finish all update intervals and tidy up the progress bar
+       *
+       * @instance
+       */
+      finishUpdating: function() {
+         
+         // Wrap all in try/catch
+         try {
+
+            // Do final render
+            this.renderPageFramework();
+            this.renderProgressText();
+            this.renderStatus();
+            this.renderProgressBar();
+
+            // Clear the intervals
+            this.intervals.forEach(clearInterval);
+
+            // "Finish" the progress bar
+            charm.position(CHARM.Col.Default, CHARM.Row.ProgressBar);
+            charm.display("bright");
+            for (var i = 0; i < CHARM.ProgressBar.Length; i++) {
+               charm.write(CHARM.ProgressBar.CompleteChar);
+            }
+            charm.display("reset");
+            charm.write(" ");
+
+            // Put the cursor back
+            this.resetCursor();
+
+         } catch (e) {
+            this.exitWithError(e, "Error running finishUpdating()");
+         }
+      },
+
+      /**
+       * Go up through the parent tests to find the current environment
+       *
+       * @instance
+       * @param {Object} testOrSuite The test or suite (technically still a test)
+       * @returns {string} The environment name
+       */
+      getEnv: function(testOrSuite) {
+         var parentTest = testOrSuite,
+            envName;
+         do {
+            envName = parentTest.name;
+         }
+         while ((parentTest = parentTest.parent));
+         return envName;
+      },
+
+      /**
+       * Create shortcut hitch function
+       *
+       * @instance
+       * @param {Object} scope The scope to be used
+       * @param {Function} func The function to call
+       * @returns {Function} The scoped function
+       */
+      hitch: function(scope, func) {
+         return function() {
+            func.apply(scope, arguments);
+         };
+      },
+
+      /**
+       * Increment the specified counter
+       *
+       * @instance
+       * @param {string} counterName The name of the counter to increment
+       */
+      incrementCounter: function(counterName) {
+         this.testCounts[counterName]++;
+      },
+
+      /**
+       * Initialise charm
+       *
+       * @instance
+       */
+      initCharm: function() {
+
+         // Wrap all in try/catch
+         try {
+
+            // Calculate message space
+            this.totalMessageRows = this.terminalInfo.rows - CHARM.Row.MessagesLine - CHARM.ScreenMargin;
+
+            // Setup charm
+            charm = new Charm();
+            charm.pipe(process.stdout);
+            charm.reset();
+
+            // Always cast to string when using charm.write()
+            var originalWriteMethod = charm.write;
+            charm.write = function(str) {
+               originalWriteMethod.call(charm, "" + str);
+            };
+
+            // Do initial page draw
+            this.renderPageFramework();
+
+            // Setup redraw intervals
+            this.intervals = [
+               setInterval(this.hitch(this, this.renderPageFramework), 5000),
+               setInterval(this.hitch(this, this.renderProgressText), 1000),
+               setInterval(this.hitch(this, this.renderStatus), 500),
+               setInterval(this.hitch(this, this.renderProgressBar), 100)
+            ];
+
+         } catch (e) {
+            this.exitWithError(e, "Error running initCharm()");
+         }
+      },
+
+      /**
+       * Log a test result
+       *
+       * @instance
+       * @param {string} resultType The result type (from RESULT_TYPE enum)
+       * @param {Object} test The failed test
+       */
+      logResult: function(resultType, test) {
+
+         // Wrap all in try/catch
+         try {
+
+            // Setup variables
+            var testName = test.name,
+               suiteName = test.parent.name,
+               isFailure = resultType === RESULT_TYPE.Failed,
+               message = (isFailure ? test.error.message : test.skipped) || "N/A",
+               envName = this.getEnv(test);
+
+            // Sanitise the error message
+            message = message.replace(/^([^\n]+)\n?.*$/, "$1");
+
+            // Add to the results object
+            var resultCollection = this.results[resultType],
+               suiteResults = resultCollection[suiteName] || {},
+               testResults = suiteResults[testName] || {};
+            testResults[envName] = message;
+            suiteResults[testName] = testResults;
+            resultCollection[suiteName] = suiteResults;
+
+            // Increment the counter
+            this.incrementCounter(resultType);
+
+         } catch (e) {
+            this.exitWithError(e, "Error handling test result");
+         }
+      },
+
+      /**
+       * Log the occurrence of a problem
+       *
+       * @instance
+       * @param {PROBLEM_TYPE} type The type of problem (use the enum)
+       * @param {string} groupName The name of the problem group (e.g. "Reporter")
+       * @param {Error|string} errorOrMessage An Error object or an error message
+       * @param {boolean} [deferProblem=false] If this is true, then do not immediately
+       *                                       break if charm is not initialised
+       */
+      logProblem: function(type, groupName, errorOrMessage, deferProblem) {
+
+         // Do we need to break out immediately?
+         var isErrorObj = errorOrMessage instanceof Error;
+         if ((!charm && !deferProblem) || (isErrorObj && CONFIG.BreakOnError)) {
+
+            // Break immediately and display error in console
+            this.exitWithError(errorOrMessage, groupName + " error!");
+
+         } else {
+
+            // Catch errors
+            try {
+
+               // Log as normal
+               var collectionObj = this.problems[type],
+                  groupObj = collectionObj[groupName] || {},
+                  message = isErrorObj ? errorOrMessage.message : errorOrMessage,
+                  problem = groupObj[message];
+               if (!problem) {
+                  problem = isErrorObj ? errorOrMessage : {
+                     message: errorOrMessage
+                  };
+                  problem.count = 0;
+               }
+               problem.count++;
+               groupObj[message] = problem;
+               collectionObj[groupName] = groupObj;
+               this.testCounts[type]++;
+
+            } catch (e) {
+               this.exitWithError(e, "Error logging problem");
+            }
+         }
+      },
+
+      /**
+       * Convert a milliseconds value to a human readable minutes and seconds value
+       *
+       * @instance
+       * @param {int} ms The number of milliseconds
+       * @returns {string} The human readable time string
+       */
+      msToHumanReadable: function(ms) {
+         var wholeMins = Math.floor(ms / 1000 / 60),
+            roundedSecs,
+            minText,
+            secText,
+            timeInMinsAndSecs;
+         if (wholeMins) {
+            roundedSecs = Math.floor(ms / 1000) % (wholeMins * 60);
+            minText = wholeMins === 1 ? "minute" : "minutes";
+            secText = roundedSecs === 1 ? "second" : "seconds";
+            if (roundedSecs) {
+               timeInMinsAndSecs = wholeMins + " " + minText + " " + roundedSecs + " " + secText;
+            } else {
+               timeInMinsAndSecs = wholeMins + " " + minText;
+            }
+         } else {
+            roundedSecs = Math.floor(ms / 1000);
+            secText = roundedSecs === 1 ? "second" : "seconds";
+            timeInMinsAndSecs = roundedSecs + " " + secText;
+         }
+         return timeInMinsAndSecs;
+      },
+
+      /**
+       * Convert a milliseconds value to a human readable minutes and seconds value
+       *
+       * @instance
+       * @param {int} ms The number of milliseconds
+       * @returns {string} The human readable time string
+       */
+      msToTimeLeft: function(ms) {
+
+         // Declare result variable
+         var timeLeftMessage;
+
+         // Just go by minutes remaining, unless over 10 minutes, then go by 5 minute intervals
+         var minsRemaining = ms / 1000 / 60,
+            modifiedMins;
+         if (minsRemaining === 0) {
+            timeLeftMessage = "0 mins";
+         } else if (minsRemaining < 1) {
+            timeLeftMessage = "< 1 min";
+         } else {
+            modifiedMins = Math.ceil(minsRemaining);
+            if (modifiedMins > 10) {
+               modifiedMins = Math.ceil(minsRemaining / 5) * 5;
+            }
+            timeLeftMessage = modifiedMins + " mins";
+         }
+         timeLeftMessage += " remaining";
+
+         // Pass back the message
+         return timeLeftMessage;
+      },
+
+      /**
+       * Output final results in full detail
+       *
+       * @instance
+       */
+      outputFinalResults: function() {
+
+         // Function variables
+         var loggedSectionTitle = false;
+
+         // Next, stop using charm ... it's all console logging from now on
+         charm.destroy();
+
+         // Output the "results" (i.e. failures and skipped tests)
+         Object.keys(this.results).forEach(function(resultType) {
+
+            // Log results by environment
+            Object.keys(this.environments).forEach(function(envName) {
+
+               // Group results by suite
+               var thisEnvResultsBySuite = {},
+                  allResultsByType = this.results[resultType];
+               Object.keys(allResultsByType).forEach(function(suiteName) {
+                  var nextSuiteTestResults = allResultsByType[suiteName];
+                  Object.keys(nextSuiteTestResults).forEach(function(testName) {
+                     var environments = nextSuiteTestResults[testName],
+                        resultMessage = environments[envName];
+                     if (resultMessage) {
+                        var thisEnvTestResults = thisEnvResultsBySuite[suiteName] || {};
+                        thisEnvTestResults[testName] = resultMessage;
+                        thisEnvResultsBySuite[suiteName] = thisEnvTestResults;
+                     }
+                  });
+               }, this);
+
+               // Check if there are results to display
+               if (Object.keys(thisEnvResultsBySuite).length) {
+
+                  // Output the section title (need to break to avoid "fail" creating grunt output weirdness—double chevrons)
+                  var sectionTitleText = resultType.toUpperCase().replace(/^(\w{2})(.+)$/, "$1" + ANSI_CODES.Bright + "$2");
+                  if (!loggedSectionTitle) {
+                     console.log("");
+                     console.log(ANSI_CODES.Bright + "====================" + ANSI_CODES.Reset);
+                     console.log(ANSI_CODES.Bright + "===== " + sectionTitleText + " =====" + ANSI_CODES.Reset);
+                     console.log(ANSI_CODES.Bright + "====================" + ANSI_CODES.Reset);
+                     loggedSectionTitle = true;
+                  }
+
+                  // Log the environment name
+                  console.log("");
+                  console.log(ANSI_CODES.Bright + "--- " + envName + " ---" + ANSI_CODES.Reset);
+
+                  // Output the suites/tests/results
+                  Object.keys(thisEnvResultsBySuite).forEach(function(suiteName) {
+                     console.log("");
+                     console.log(ANSI_CODES.Bright + ANSI_CODES.FgRed + suiteName + ANSI_CODES.Reset);
+                     var nextSuiteTestResults = thisEnvResultsBySuite[suiteName];
+                     Object.keys(nextSuiteTestResults).forEach(function(testName) {
+                        var resultMessage = nextSuiteTestResults[testName];
+                        console.log(ANSI_CODES.Bright + "\"" + testName + "\"" + ANSI_CODES.Reset);
+                        console.log(resultMessage);
+                     });
+                  });
+               }
+            }, this);
+
+            // Reset title flag
+            loggedSectionTitle = false;
+
+         }, this);
+
+         // Log the other problems
+         loggedSectionTitle = false;
+         Object.keys(this.problems).forEach(function(problemType) {
+
+            // Run through the problems
+            var problems = this.problems[problemType];
+            Object.keys(problems).forEach(function(groupName) {
+
+               // Log title
+               if (!loggedSectionTitle) {
+                  var sectionTitle = "===== " + problemType.toUpperCase() + " =====",
+                     underOverLine = new Array(sectionTitle.length + 1).join("=");
+                  console.log("");
+                  console.log("");
+                  console.log(ANSI_CODES.Bright + underOverLine + ANSI_CODES.Reset);
+                  console.log(ANSI_CODES.Bright + sectionTitle + ANSI_CODES.Reset);
+                  console.log(ANSI_CODES.Bright + underOverLine + ANSI_CODES.Reset);
+                  loggedSectionTitle = true;
+               }
+
+               // Log group name
+               console.log("");
+               console.log(ANSI_CODES.Bright + ANSI_CODES.FgRed + groupName + ANSI_CODES.Reset);
+
+               // Log groups' problems
+               var groupProblems = problems[groupName];
+               Object.keys(groupProblems).forEach(function(problemMessage) {
+                  var problem = groupProblems[problemMessage],
+                     messageToOutput = "\"" + problemMessage + "\"";
+                  if (problem.count > 1) {
+                     messageToOutput += " (x" + problem.count + ")";
+                  }
+                  console.log(ANSI_CODES.Bright + messageToOutput + ANSI_CODES.Reset);
+                  if (problem.stack) {
+                     console.log(problem.stack);
+                  }
+               });
+            });
+
+            // Reset title flag
+            loggedSectionTitle = false;
+
+         }, this);
+
+         // Couple of lines space
+         console.log("");
+         console.log("");
+      },
+
+      /**
+       * Pad the supplied string
+       *
+       * @instance
+       * @param {string} str The string to pad (will be converted to string if necessary)
+       * @param {int} paddedLength The new length
+       * @param {string} [padChar] The character to use to pad (default is space)
+       * @param {boolean} [padRight] Whether to pad from the right (default is left)
+       * @returns {string} The padded string, or the original if paddedLength is less than original length
+       */
+      pad: function(str, paddedLength, padChar, padRight) {
+         if (!str || (paddedLength || 0) < str.length) {
+            return str;
+         }
+         str = "" + (str || ""); // Cast to string
+         padChar = padChar || " ";
+         var padding = new Array(paddedLength).join(padChar),
+            preTrim = padRight ? str + padding : padding + str;
+         return padRight ? preTrim.slice(0, paddedLength) : preTrim.slice(0 - paddedLength);
+      },
+
+      /**
+       * Clear the page and draw the basic page framework
+       *
+       * @instance
+       * @returns {[type]} [description]
+       */
+      renderPageFramework: function() {
+         /*jshint maxstatements:false*/
+
+         // Wrap all in try/catch
+         try {
+
+            // Delete everything on the page
+            charm.erase("screen");
+
+            // Setup function variables
+            var i;
+
+            // Output the title
+            var titleMessageParts = [CONFIG.Title, CONFIG.TitleHelp],
+               underOverLineLength = titleMessageParts.join(" ").length + (CHARM.TitleIndent * 2);
+            charm.position(CHARM.Col.Default, CHARM.Row.Title - 1);
+            charm.display("bright");
+            for (i = 0; i < underOverLineLength; i++) {
+               charm.write("=");
+            }
+            charm.position(CHARM.Col.Default + CHARM.TitleIndent, CHARM.Row.Title);
+            charm.write(CONFIG.Title);
+            if (CONFIG.TitleHelp) {
+               charm.display("reset");
+               charm.write(" " + CONFIG.TitleHelp);
+               charm.display("bright");
+            }
+            charm.position(CHARM.Col.Default, CHARM.Row.Title + 1);
+            for (i = 0; i < underOverLineLength; i++) {
+               charm.write("=");
+            }
+            charm.display("reset");
+
+            // Create the status section
+            charm.position(CHARM.Col.StatusName, CHARM.Row.StatusTitle);
+            charm.display("bright");
+            charm.write("STATUS");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Environments);
+            charm.display("reset");
+            charm.write("Environments: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Total);
+            charm.write("Total tests: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Passed);
+            charm.write("Passed: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Failed);
+            charm.write("Failed: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Skipped);
+            charm.write("Skipped: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Errors);
+            charm.write("Errors: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Warnings);
+            charm.write("Warnings: ");
+            charm.position(CHARM.Col.StatusName, CHARM.Row.Deprecations);
+            charm.write("Deprecations: ");
+
+            // Create the progress section
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.ProgressTitle);
+            charm.display("bright");
+            charm.write("PROGRESS");
+            charm.display("reset");
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.TunnelStatus);
+            charm.write("Tunnel status: ");
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.PercentComplete);
+            charm.write("Percent complete: ");
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.TimeTaken);
+            charm.write("Time Taken: ");
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.TimeRemaining);
+            charm.write("Time Remaining: ");
+
+            // Draw progress bar
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.ProgressBar - 1);
+            for (i = 0; i < CHARM.ProgressBar.Length; i++) {
+               charm.display("bright");
+               charm.write(CHARM.ProgressBar.LineChar);
+               charm.display("reset");
+            }
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.ProgressBar);
+            for (i = 0; i < CHARM.ProgressBar.Length; i++) {
+               charm.write(CHARM.ProgressBar.EmptyChar);
+            }
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.ProgressBar + 1);
+            for (i = 0; i < CHARM.ProgressBar.Length; i++) {
+               charm.display("bright");
+               charm.write(CHARM.ProgressBar.LineChar);
+               charm.display("reset");
+            }
+
+            // Update the status text
+            this.renderStatus();
+
+         } catch (e) {
+            this.exitWithError(e, "Error renderPageFramework()");
+         }
+      },
+
+      /**
+       * Animate the progress bar
+       *
+       * @instance
+       */
+      renderProgressBar: function() {
+
+         // Wrap all in try/catch
+         try {
+
+            // Hide the cursor
+            charm.cursor(false);
+
+            // Update the animation
+            charm.position(this.state.charm.progressBarCurrPos, CHARM.Row.ProgressBar);
+            charm.display("bright");
+            charm.write(CHARM.SpinnerChars[this.state.charm.nextSpinnerIndex++ % CHARM.SpinnerChars.length]);
+            charm.display("reset");
+
+            // Put the cursor back
+            this.resetCursor();
+
+         } catch (e) {
+            this.exitWithError(e, "Error running renderProgressBar()");
+         }
+      },
+
+      /**
+       * Update the progress text
+       *
+       * @instance
+       */
+      renderProgressText: function() {
+
+         // Wrap all in try/catch
+         try {
+
+            // Hide the cursor
+            charm.cursor(false);
+
+            // Calculate and update the text
+            var ratioComplete = this.testCounts.run / this.testCounts.total,
+               percentComplete = Math.floor(ratioComplete * 100) + "%",
+               timeTaken = Date.now() - this.startTime,
+               timeTakenMessage = this.msToHumanReadable(timeTaken),
+               timeLeftMs = timeTaken * ((1 / ratioComplete) - 1),
+               timeLeftMins = this.msToTimeLeft(timeLeftMs),
+               timeLeftMessage = this.pad(timeLeftMins, CHARM.Col.StatusName - CHARM.Col.ProgressValue, " ", true);
+            charm.position(CHARM.Col.ProgressValue, CHARM.Row.PercentComplete);
+            charm.write(percentComplete);
+            charm.position(CHARM.Col.ProgressValue, CHARM.Row.TunnelStatus);
+            charm.write(this.state.tunnel);
+            charm.position(CHARM.Col.ProgressValue, CHARM.Row.TimeTaken);
+            charm.write(timeTakenMessage);
+            charm.position(CHARM.Col.ProgressValue, CHARM.Row.TimeRemaining);
+            if (ratioComplete > 0.1 || (timeTaken > 60000 && ratioComplete > 0.05)) {
+               charm.write(timeLeftMessage);
+            } else {
+               charm.write("Calculating...");
+            }
+
+            // Update the progress bar
+            var progressBarPartsComplete = Math.floor(ratioComplete * CHARM.ProgressBar.Length);
+            charm.position(CHARM.Col.ProgressName, CHARM.Row.ProgressBar);
+            for (var i = 0; i < progressBarPartsComplete; i++) {
+               charm.write(CHARM.ProgressBar.CompleteChar);
+            }
+            this.state.charm.progressBarCurrPos = CHARM.Col.ProgressName + progressBarPartsComplete;
+
+            // Put the cursor back
+            this.resetCursor();
+
+         } catch (e) {
+            this.exitWithError(e, "Error running renderProgressText()");
+         }
+      },
+
+      /**
+       * Do a redraw of the latest information
+       *
+       * @instance
+       */
+      renderStatus: function() {
+         /*jshint maxstatements:false,maxcomplexity:false*/
+
+         // Catch all errors
+         try {
+
+            // Setup variables
+            var environmentNames = Object.keys(this.environments),
+               messagesRow = CHARM.Row.MessagesLine;
+
+            // Hide cursor
+            charm.cursor(false);
+
+            // Create environments message
+            var environmentsMessage = "Updating...",
+               spaceToDisplayEnvironments = this.terminalInfo.cols - CHARM.Col.StatusValue - CHARM.ScreenMargin;
+            if (environmentNames.length) {
+               environmentsMessage = environmentNames.length + " (" + environmentNames.join(", ") + ")";
+               if (environmentsMessage.length > spaceToDisplayEnvironments - 4) {
+                  environmentsMessage = environmentsMessage.substr(0, spaceToDisplayEnvironments - 4) + "...)";
+               }
+            }
+
+            // Create passed/failed/skipped messages
+            var total = this.testCounts.total,
+               passed = this.testCounts.passed,
+               failed = this.testCounts.failed,
+               skipped = this.testCounts.skipped;
+            if (passed && passed !== total && (failed || skipped)) {
+               passed += " (" + (passed / total * 100).toFixed(1) + "%)"
+            }
+            if (failed && failed !== total && (passed || skipped)) {
+               failed += " (" + (failed / total * 100).toFixed(1) + "%)"
+            }
+            if (skipped && skipped !== total && (passed || failed)) {
+               skipped += " (" + (skipped / total * 100).toFixed(1) + "%)"
+            }
+
+            // Position, write, repeat (status info)
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Environments);
+            charm.write(environmentsMessage);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Total);
+            charm.write(total);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Passed);
+            charm.write(passed);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Failed);
+            charm.write(failed);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Skipped);
+            charm.write(skipped);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Errors);
+            charm.write(this.testCounts.errors);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Warnings);
+            charm.write(this.testCounts.warnings);
+            charm.position(CHARM.Col.StatusValue, CHARM.Row.Deprecations);
+            charm.write(this.testCounts.deprecations);
+
+            // Prepare object to contain messages
+            var messages = {
+               deprecations: [],
+               errors: [],
+               failed: [],
+               warnings: []
+            };
+
+            // Generate failure messages
+            var failedTests = this.results.failed;
+            if (!Object.keys(failedTests).length) {
+               failedTests = {
+                  "N/A": {}
+               };
+            }
+            Object.keys(failedTests).forEach(function(suiteName) {
+               messages.failed.push(suiteName);
+               var failingTests = failedTests[suiteName];
+               Object.keys(failingTests).forEach(function(testName) {
+                  var testFailingEnvironments = failingTests[testName],
+                     environments = Object.keys(testFailingEnvironments).join(", "),
+                     failureMessage = CHARM.ProblemPrefix + testName;
+                  failureMessage += ANSI_CODES.Bright + " [" + environments + "]" + ANSI_CODES.Reset;
+                  messages.failed.push(failureMessage);
+               });
+            });
+
+            // Generate problem messages
+            Object.keys(this.problems).forEach(function(problemType) {
+
+               // Get the problem collection and construct artificially if empty
+               var problems = this.problems[problemType];
+               if (!Object.keys(problems).length) {
+                  problems = {
+                     "N/A": {}
+                  };
+               }
+
+               // Log the groups and their counts
+               Object.keys(problems).forEach(function(groupName) {
+                  messages[problemType].push(groupName);
+                  var groupProblems = problems[groupName];
+                  Object.keys(groupProblems).forEach(function(problemMessage) {
+                     var messageCount = groupProblems[problemMessage].count,
+                        messageOutput = CHARM.ProblemPrefix + problemMessage;
+                     if (messageCount && messageCount > 1) {
+                        messageOutput += " (x" + messageCount + ")";
+                     }
+                     messages[problemType].push(messageOutput);
+                  });
+               });
+            }, this);
+
+            // Calculate how many rows of messages to show
+            var availableRowsForMessages = this.totalMessageRows - 7, // Four titles, three blank rows between
+               failureLines = messages.failed.length,
+               errorLines = messages.errors.length,
+               warningLines = messages.warnings.length,
+               deprecationLines = messages.deprecations.length;
+            if ((failureLines + errorLines + warningLines + warningLines) > availableRowsForMessages) {
+
+               // Work out the ostensible max height of each message group if all are full
+               var maxLines = Math.floor(availableRowsForMessages / 4),
+                  newFailureLines = Math.min(failureLines, maxLines),
+                  newErrorLines = Math.min(errorLines, maxLines),
+                  newWarningLines = Math.min(warningLines, maxLines),
+                  newDeprecationLines = Math.min(deprecationLines, maxLines),
+                  linesPool = (availableRowsForMessages - newFailureLines - newErrorLines - newWarningLines - newDeprecationLines);
+
+               // Add more lines to each message group (note priority order)
+               while (linesPool) {
+                  (newFailureLines < failureLines) && linesPool-- && newFailureLines++;
+                  (newErrorLines < errorLines) && linesPool-- && newErrorLines++;
+                  (newWarningLines < warningLines) && linesPool-- && newWarningLines++;
+                  (newDeprecationLines < deprecationLines) && linesPool-- && newDeprecationLines++;
+               }
+
+               // Update the collections
+               messages.failed = messages.failed.reverse().slice(0, newFailureLines).reverse();
+               messages.errors = messages.errors.reverse().slice(0, newErrorLines).reverse();
+               messages.warnings = messages.warnings.reverse().slice(0, newWarningLines).reverse();
+               messages.deprecations = messages.deprecations.reverse().slice(0, newDeprecationLines).reverse();
+
+               // Indicate on first line if previous lines hidden
+               if (newFailureLines < failureLines) {
+                  messages.failed[0] = ANSI_CODES.Dim + CHARM.ProblemsCroppedMessage + ANSI_CODES.Reset;
+               }
+               if (newErrorLines < errorLines) {
+                  messages.errors[0] = ANSI_CODES.Dim + CHARM.ProblemsCroppedMessage + ANSI_CODES.Reset;
+               }
+               if (newWarningLines < warningLines) {
+                  messages.warnings[0] = ANSI_CODES.Dim + CHARM.ProblemsCroppedMessage + ANSI_CODES.Reset;
+               }
+               if (newDeprecationLines < deprecationLines) {
+                  messages.deprecations[0] = ANSI_CODES.Dim + CHARM.ProblemsCroppedMessage + ANSI_CODES.Reset;
+               }
+            }
+
+            // Remove previous messages
+            charm.position(0, messagesRow);
+            charm.erase("down");
+
+            // Output the messages (array literal determines output order)
+            var messageGroups = ["failed", "errors", "warnings", "deprecations"];
+            messageGroups.forEach(function(groupName) {
+
+               // Display the title (broken to avoid weird grunt formatting)
+               charm.position(CHARM.Col.MessageTitle, messagesRow);
+               charm.display("bright");
+               charm.write(groupName.toUpperCase().substr(0, 1));
+               charm.position(CHARM.Col.MessageTitle + 1, messagesRow++);
+               charm.write(groupName.toUpperCase().substr(1));
+               charm.display("reset");
+
+               // Display the messages
+               var messageLines = messages[groupName];
+               messageLines.forEach(function(nextLine) {
+                  charm.position(CHARM.Col.MessageTitle, messagesRow++);
+                  var maxLineLength = this.terminalInfo.cols - 7; // 7 = ellipsis length (3) + side-margins (2x2)
+                  if (nextLine.length > maxLineLength) {
+                     nextLine = nextLine.slice(0, maxLineLength) + "...";
+                  }
+                  charm.write(nextLine + ANSI_CODES.Reset);
+               }, this);
+
+               // Line-break before next set of messages
+               messagesRow++;
+            }, this);
+
+            // Update last-row state-variable
+            this.state.charm.finalRow = messagesRow;
+
+            // Reset cursor
+            this.resetCursor();
+
+         } catch (e) {
+            this.exitWithError(e, "Error running renderStatus()");
+         }
+      },
+
+      /**
+       * Reset the cursor
+       *
+       * @instance
+       */
+      resetCursor: function() {
+         charm.position(0, this.state.charm.finalRow);
+         charm.cursor(true);
+      }
+   };
+
+   /**
+    * The reporter class.
+    *
+    * @class
+    * @constructor
+    * @param {Object} config Config object from Intern
+    */
+   function Reporter( /*jshint unused:false*/ config) {
+      // NOOP
+   }
+
+   /**
+    * Augment the reporter (JSDoc for each function comes from Intern website)
+    *
+    * @type {Object}
+    * @lends AikauConcurrentReporter/Reporter.prototype
+    */
+   Reporter.prototype = {
+
+      /**
+       * This method is called when code coverage data has been retrieved from an environment.
+       * This will occur once per remote environment when all unit tests have completed, and
+       * again any time a new page is loaded.
+       * 
+       * @instance
+       * @param {string} sessionId Corresponds to a single remote environment. Will be null
+       *                           for a local environment (e.g. in the Node.js client)
+       * @param {Object} data The coverage data
+       */
+      coverage: function() {
+         // Not currently used
+      },
+
+      /**
+       * This method is called when a deprecated function is called.
+       *
+       * @instance
+       * @param {string} name Name of the deprecated function
+       * @param {string} [replacement] The replacement, if available
+       * @param {string} [extra] Any extra information
+       */
+      deprecated: function(name, replacement, extra) {
+         var msg = name + " has been deprecated and replaced by " + replacement;
+         if (extra) {
+            msg += " (" + extra + ")";
+         }
+         helper.logProblem(PROBLEM_TYPE.Deprecation, "General", msg);
+      },
+
+      /**
+       * This method is called when an error occurs within the test system that is non-recoverable (e.g. a bug within Intern).
+       *
+       * @instance
+       * @param {Error} error The error
+       */
+      fatalError: function(error) {
+         helper.logProblem(PROBLEM_TYPE.Error, "Fatal", error);
+      },
+
+      /**
+       * This method is called when a new test suite is created.
+       *
+       * @instance
+       * @param {Object} suite The new suite
+       */
+      newSuite: function( /*jshint unused:false*/ suite) {
+         helper.augmentSuite(suite);
+      },
+
+      /**
+       * This method is called when a new test is created.
+       *
+       * @instance
+       * @param {Object} test The new test
+       */
+      newTest: function( /*jshint unused:false*/ test) {
+         helper.incrementCounter("total");
+      },
+
+      /**
+       * This method is called once the built-in HTTP server has finished shutting down.
+       *
+       * @instance
+       * @param {Object} config The proxy config
+       */
+      proxyEnd: function( /*jshint unused:false*/ config) {
+         // Not currently used
+      },
+
+      /**
+       * This method is called once the built-in HTTP server has finished starting up.
+       *
+       * @instance
+       * @param {Object} config The proxy config
+       */
+      proxyStart: function( /*jshint unused:false*/ config) {
+         // Not currently used
+      },
+
+      /**
+       * This method is called when a reporter throws an error during execution of a command. If a reporter throws an error in response to a reporterError call, it will not be called again to avoid infinite recursion.
+       *
+       * @instance
+       * @param {Object} reporter The reporter
+       * @param {Error} error The error
+       */
+      reporterError: function( /*jshint unused:false*/ reporter, error) {
+         helper.logProblem(PROBLEM_TYPE.Error, "Reporter", error);
+      },
+
+      /**
+       * This method is called after all test suites have finished running and the test system is preparing to shut down.
+       *
+       * @instance
+       * @param {Object} executor The test executor
+       */
+      runEnd: function( /*jshint unused:false*/ executor) {
+         helper.finishUpdating();
+         helper.outputFinalResults();
+      },
+
+      /**
+       * This method is called after all tests have been registered and the test system is about to begin running tests.
+       *
+       * @instance
+       * @param {Object} executor The test executor
+       */
+      runStart: function( /*jshint unused:false*/ executor) {
+         if (helper.state.tunnel !== "N/A") {
+            helper.state.tunnel = "Active";
+         }
+         var terminalInfo = executor.config.terminalInfo;
+         helper.terminalInfo = {
+            cols: terminalInfo.cols || 150,
+            rows: terminalInfo.rows || 35
+         };
+         helper.startTime = Date.now();
+         helper.initCharm();
+      },
+
+      /**
+       * This method is called when a test suite has finished running.
+       *
+       * @instance
+       * @param {Object} suite The ended suite
+       */
+      suiteEnd: function( /*jshint unused:false*/ suite) {
+         // Not currently used
+      },
+
+      /**
+       * This method is called when an error occurs within one of the suite's lifecycle
+       * methods (setup, beforeEach, afterEach, or teardown), or when an error occurs
+       * when a suite attempts to run a child test.
+       *
+       * @instance
+       * @param {Object} suite The suite
+       * @param {Error} error The error
+       */
+      suiteError: function(suite, error) {
+         if (suite.name) {
+            var envName = helper.getEnv(suite);
+            helper.logProblem(PROBLEM_TYPE.Error, suite.name + " (" + envName + ")", error);
+         }
+      },
+
+      /**
+       * This method is called when a test suite starts running.
+       *
+       * @instance
+       * @param {Object} suite The suite
+       */
+      suiteStart: function( /*jshint unused:false*/ suite) {
+         // Not currently used
+      },
+
+      /**
+       * This method is called when a test has finished running.
+       *
+       * @instance
+       * @param {Object} test The test
+       */
+      testEnd: function( /*jshint unused:false*/ test) {
+         helper.incrementCounter("run");
+      },
+
+      /**
+       * This method is called when a test has failed.
+       *
+       * @instance
+       * @param {Object} test The test
+       */
+      testFail: function(test) {
+         helper.logResult(RESULT_TYPE.Failed, test);
+      },
+
+      /**
+       * This method is called when a test has passed.
+       *
+       * @instance
+       * @param {Object} test The test
+       */
+      testPass: function( /*jshint unused:false*/ test) {
+         helper.incrementCounter("passed");
+      },
+
+      /**
+       * This method is called when a test has been skipped.
+       *
+       * @instance
+       * @param {Object} test The test
+       */
+      testSkip: function( /*jshint unused:false*/ test) {
+         helper.logResult(RESULT_TYPE.Skipped, test);
+      },
+
+      /**
+       * This method is called when a test starts running.
+       *
+       * @instance
+       * @param {Object} test The test
+       */
+      testStart: function( /*jshint unused:false*/ test) {
+         // Not currently used
+      },
+
+      /**
+       * This method is called every time a tunnel download has progressed.
+       *
+       * @instance
+       * @param {Object} tunnel The tunnel
+       * @param {Object} progress The progress information
+       * @param {number} progress.loaded Number of bytes received
+       * @param {number} progress.total Number of bytes to download
+       */
+      tunnelDownloadProgress: function( /*jshint unused:false*/ tunnel, progress) {
+         if (progress.type === "data") {
+            var percentComplete = (progress.loaded / progress.total * 100).toFixed(1);
+            helper.state.tunnel = "Downloading (" + percentComplete + "%)";
+         }
+      },
+
+      /**
+       * This method is called after the WebDriver server tunnel has shut down.
+       *
+       * @instance
+       * @param {Object} tunnel The tunnel
+       */
+      tunnelEnd: function( /*jshint unused:false*/ tunnel) {
+         helper.state.tunnel = "Closing";
+      },
+
+      /**
+       * This method is called immediately before the WebDriver server tunnel is started.
+       *
+       * @instance
+       * @param {Object} tunnel The tunnel
+       */
+      tunnelStart: function( /*jshint unused:false*/ tunnel) {
+         helper.state.tunnel = "Starting";
+      },
+
+      /**
+       * This method is called whenever the WebDriver server tunnel reports a status change.
+       *
+       * @instance
+       * @param {Object} tunnel The tunnel
+       * @param {string} status The status update
+       */
+      tunnelStatus: function( /*jshint unused:false*/ tunnel, /*jshint unused:false*/ status) {
+         helper.state.tunnel = status;
+      }
+   };
+
+   // Pass back the reporter object
+   return Reporter;
+});

--- a/aikau/src/test/resources/reporters/AikauConcurrentReporter.js
+++ b/aikau/src/test/resources/reporters/AikauConcurrentReporter.js
@@ -270,7 +270,8 @@ define([
             emptyLine: null,
             finalRow: 0,
             nextSpinnerIndex: 0,
-            progressBarCurrPos: CHARM.Col.ProgressBar
+            progressBarCurrPos: CHARM.Col.ProgressBar,
+            progressBarActive: false
          },
          screenData: "",
          tunnel: "N/A"
@@ -458,8 +459,7 @@ define([
             // Setup rendering intervals
             this.intervals = [
                setInterval(this.hitch(this, this.updateVirtualScreen), CONFIG.ScreenRenderInterval),
-               setInterval(this.hitch(this, this.renderToScreen), CONFIG.ScreenRenderInterval),
-               setInterval(this.hitch(this, this.renderProgressBar), CONFIG.ProgressBarRenderInterval)
+               setInterval(this.hitch(this, this.renderToScreen), CONFIG.ScreenRenderInterval)
             ];
 
             // // Do initial page draw
@@ -802,9 +802,16 @@ define([
          // Catch all errors
          try {
 
+            // Render the screen
             charm.position(0, 1);
             charm.write(this.state.screenData.join("\n"));
             this.resetCursor();
+
+            // Start the progress bar spinner if it's not already going
+            if (!this.state.charm.progressBarActive) {
+               this.intervals.push(setInterval(this.hitch(this, this.renderProgressBar), CONFIG.ProgressBarRenderInterval));
+               this.state.charm.progressBarActive = true;
+            }
 
          } catch (e) {
             this.exitWithError(e, "Error running renderToScreen()");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/AlfDetailedView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/AlfDetailedView.get.js
@@ -1,5 +1,6 @@
 model.jsonModel = {
-   services: [{
+   services: [
+      {
          name: "alfresco/services/LoggingService",
          config: {
             loggingPreferences: {
@@ -14,21 +15,27 @@ model.jsonModel = {
       "alfresco/services/DocumentService",
       "alfresco/services/ErrorReporter"
    ],
-   widgets: [{
-      id: "DOCLIST",
-      name: "alfresco/documentlibrary/AlfDocumentList",
-      widthPx: 600,
-      config: {
-         waitForPageWidgets: false,
-         useHash: true,
-         widgets: [{
-            id: "DETAILED_VIEW",
-            name: "alfresco/documentlibrary/views/AlfDetailedView"
-         }]
+   widgets: [
+      {
+         id: "DOCLIST",
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         widthPx: 600,
+         config: {
+            waitForPageWidgets: false,
+            useHash: true,
+            widgets: [
+               {
+                  id: "DETAILED_VIEW",
+                  name: "alfresco/documentlibrary/views/AlfDetailedView"
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/DocumentLibraryDetailedViewMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
-   }, {
-      name: "aikauTesting/mockservices/DocumentLibraryDetailedViewMockXhr"
-   }, {
-      name: "alfresco/logging/SubscriptionLog"
-   }]
+   ]
 };


### PR DESCRIPTION
This addresses issue [AKU-585](https://issues.alfresco.com/jira/browse/AKU-585) which is about re-integrating the spike-branch for investigating BrowserStack integration. As part of that work a new, concurrent-capable reporter was created for Intern, and there are benefits in pulling that back into the project.

Points worth noting are ...

__The layout of unit tests has changed__

Instead of ...

```javascript
var browser;
registerSuite({

  // Tests

});
```

... tests should now be laid out in the following format ...

```javascript
registerSuite(function(){
  var browser;
  return {

    // Tests

  };
});
```

... which has been done to avoid sharing the browser variable across environments (this is a BadThing&trade;).

__New things in TestCommon__

There are two new methods in `TestCommon`: `tabToElement()` and `skipIf()`.

___NOTE: Worth having `w=1` in the request params of the change-diff page, to hide any spurious whitespace changes!___