### PR TITLE
Modified URLs for default Login and Logout services.

### DIFF
--- a/aikau/src/main/resources/alfresco/services/LoginService.js
+++ b/aikau/src/main/resources/alfresco/services/LoginService.js
@@ -56,7 +56,7 @@ define(["dojo/_base/declare",
          });
 
          // Determine the URL to use if login is successful, this is included in the payload...
-         var url = AlfConstants.URL_PAGECONTEXT + "dologin?username=" + payload.username + "&password=" + payload.password;
+         var url = AlfConstants.URL_SERVICECONTEXT + "dologin?username=" + payload.username + "&password=" + payload.password;
          if (payload.successUrl == null || lang.trim(payload.successUrl) === "")
          {
             payload.successful = AlfConstants.URL_PAGECONTEXT + this.defaultLoginPage;

--- a/aikau/src/main/resources/alfresco/services/LogoutService.js
+++ b/aikau/src/main/resources/alfresco/services/LogoutService.js
@@ -51,7 +51,7 @@ define(["dojo/_base/declare",
        */
       doLogout: function alfresco_services_LogoutService__doLogout() {
          this.serviceXhr({
-            url: AlfConstants.URL_PAGECONTEXT + "dologout",
+            url: AlfConstants.URL_SERVICECONTEXT + "dologout",
             method: "POST",
             successCallback: this.reloadPage,
             callbackScope: this


### PR DESCRIPTION
Modified URLs for default Login and Logout services to use SERVICECONTEXT rather than PAGECONTEXT.

For the default installation of Aikau with example archetype the service context redirects to the page context - so it makes no difference, which is also true for Alfresco Share. However for some future apps, we may want the PAGECONTEXT to rewrite to something quite different (such as to an authenticated aikau webscript page URL) - and therefore having login/logout use the more correct SERVICECONTEXT will allow that.
