### PR TITLE
Bean override config

### DIFF
--- a/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/surf-config.xml
+++ b/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/surf-config.xml
@@ -16,6 +16,9 @@
    
    <!-- Import Surf Framework -->
    <import resource="classpath*:org/springframework/extensions/surf/*-context.xml" />
+
+   <!-- Custom bean override support -->
+   <import resource="classpath*:alfresco/web-extension/custom-web-framework-application-context.xml" />
    
     <!-- Set up to auto-resolve to url based views -->    
     <bean id="handlerMappings" parent="webframeworkHandlerMappings">

--- a/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/web-application-config.xml
+++ b/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/web-application-config.xml
@@ -138,14 +138,4 @@
       </property>
    </bean>
    
-   <!-- Override DependencyAggregator to set compression exclusions -->
-   <bean id="dependency.aggregator" parent="dependency.aggregator.abstract" class="org.springframework.extensions.surf.DependencyAggregator">
-      <property name="compressionExclusions">
-         <list>
-            <!-- required for Aikau 1.0.36 to avoid LESS errors util Surf dependencies can be updated -->
-            <value>*.css</value>
-         </list>
-      </property>
-   </bean>
-   
 </beans>

--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -162,6 +162,13 @@
          </resource>
 
          <resource>
+            <!-- Spring Bean overrides -->
+            <targetPath>./alfresco/web-extension/</targetPath>
+            <filtering>false</filtering>
+            <directory>${basedir}/src/main/resources/spring-context-config</directory>
+         </resource>
+
+         <resource>
             <!-- WebScript library files go straight into a package -->
             <targetPath>./alfresco/site-webscripts/org/alfresco/aikau/webscript/libs</targetPath>
             <filtering>false</filtering>

--- a/aikau/src/main/resources/spring-context-config/custom-web-framework-application-context.xml
+++ b/aikau/src/main/resources/spring-context-config/custom-web-framework-application-context.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                http://www.hazelcast.com/schema/spring
+                http://www.hazelcast.com/schema/spring/hazelcast-spring-2.4.xsd">
+
+   <!-- Override DependencyAggregator to set compression exclusions 
+        NOTE: This is temporary until Surf is updated to remove YUI compression stage prior to LESS engine processing -->
+   <bean id="dependency.aggregator" parent="dependency.aggregator.abstract" class="org.springframework.extensions.surf.DependencyAggregator">
+      <property name="compressionExclusions">
+         <list>
+            <!-- required for Aikau 1.0.36 to avoid LESS errors util Surf dependencies can be updated -->
+            <value>*.css</value>
+         </list>
+      </property>
+   </bean>
+</beans>

--- a/aikau/src/main/resources/spring-context-config/custom-web-framework-application-context.xml
+++ b/aikau/src/main/resources/spring-context-config/custom-web-framework-application-context.xml
@@ -12,6 +12,10 @@
    <bean id="dependency.aggregator" parent="dependency.aggregator.abstract" class="org.springframework.extensions.surf.DependencyAggregator">
       <property name="compressionExclusions">
          <list>
+            <!-- Duplicates the default in Alfresco Share -->
+            <value>*-min.js"</value>
+            <value>*/lib/code-mirror/*.js</value>
+
             <!-- required for Aikau 1.0.36 to avoid LESS errors util Surf dependencies can be updated -->
             <value>*.css</value>
          </list>


### PR DESCRIPTION
This is a follow up to https://github.com/Alfresco/Aikau/pull/539 to remove the requirement for 3rd party modules to add in the bean override. This will need to be removed once we have Alfresco releases containing AKU-589.