### PR TITLE
AKU-464: Set DateTextBox to today

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -18,7 +18,7 @@
  */
 
 /**
- * Creates a date-field input box
+ * Creates a date-field input box. Can be preset to today's date by passing a value of "TODAY".
  *
  * @example <caption>Sample usage:</caption>
  * {
@@ -62,7 +62,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function(){
-         if(!this.value || (typeof this.value === "string" && lang.trim(this.value).length === 0)) {
+         if (this.value === "TODAY") { // Special case
+            this.value = (new Date()).toISOString();
+         } else if (!this.value || (typeof this.value === "string" && lang.trim(this.value).length === 0)) {
             this.value = null; // Falsy values and empty strings should be treated as nulls, i.e. no value (see AKU-430)
          }
          this.inherited(arguments); // Must 'clean' the empty strings before calling this

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -49,8 +49,10 @@ registerSuite(function(){
             .click()
             .getLastPublish("VALID_DATES_FORM_SUBMIT")
             .then(function(payload) {
-               assert.propertyVal(payload, "validDate1", "2012-12-12", "Incorrect date value retrieved from control");
-               assert.propertyVal(payload, "validDate2", "2015-07-07", "Incorrect date value retrieved from control");
+               var todaysDate = (new Date()).toISOString().substr(0, 10);
+               assert.propertyVal(payload, "validDate1", "2012-12-25", "Incorrect date value retrieved from control");
+               assert.propertyVal(payload, "validDate2", "2015-10-31", "Incorrect date value retrieved from control");
+               assert.propertyVal(payload, "todaysDate", todaysDate, "Today's date was not set correctly");
             });
       },
 
@@ -101,8 +103,8 @@ registerSuite(function(){
             .click()
             .getLastPublish("VALID_DATES_FORM_SUBMIT")
             .then(function(payload) {
-               assert.propertyVal(payload, "validDate1", "2012-12-12", "Incorrect date value retrieved from control after other control updated");
-               assert.propertyVal(payload, "validDate2", "2015-07-14", "Incorrect date value retrieved from control after this control updated");
+               assert.propertyVal(payload, "validDate1", "2012-12-25", "Incorrect date value retrieved from control after other control updated");
+               assert.propertyVal(payload, "validDate2", "2015-10-13", "Incorrect date value retrieved from control after this control updated");
             });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,17 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/lists/AlfHashListTest",
-      "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
-      "src/test/resources/alfresco/lists/FilteredListTest",
-      "src/test/resources/alfresco/lists/FilteredListUseCaseTest",
-      "src/test/resources/alfresco/lists/InfiniteScrollTest",
-      "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
-      "src/test/resources/alfresco/lists/PaginatorVisibilityTest",
-      "src/test/resources/alfresco/lists/views/AlfListViewTest",
-      "src/test/resources/alfresco/lists/views/HtmlListViewTest",
-      "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
-      "src/test/resources/alfresco/lists/views/layouts/RowTest"
+      "src/test/resources/alfresco/forms/controls/DateTextBoxTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -27,9 +27,9 @@ model.jsonModel = {
                            id: "VALID_DATE_VALUE_1",
                            config: {
                               name: "validDate1",
-                              value: "2012-12-12",
+                              value: "2012-12-25",
                               label: "Valid date",
-                              description: "Preset with the value \"2012-12-12\""
+                              description: "Preset with the value \"2012-12-25\""
                            }
                         },
                         {
@@ -37,43 +37,22 @@ model.jsonModel = {
                            id: "VALID_DATE_VALUE_2",
                            config: {
                               name: "validDate2",
-                              value: "2015-07-07",
+                              value: "2015-10-31",
                               label: "Valid date (mandatory)",
-                              description: "Preset with the value \"2015-07-07\"",
+                              description: "Preset with the value \"2015-10-31\"",
                               requirementConfig: {
                                  initialValue: true
                               }
                            }
                         },
                         {
-                           id: "RULES_CHECKER",
                            name: "alfresco/forms/controls/DateTextBox",
+                           id: "TODAYS_DATE",
                            config: {
-                              fieldId: "RULES_CHECKER",
-                              name: "date3",
-                              value: null,
-                              label: "Any Date",
-                              description: "Enter a data via the keyboard to ensure that the TextBox below becomes required."
-                           }
-                        },
-                        {
-                           id: "RULES_SUBSCRIBER",
-                           name: "alfresco/forms/controls/TextBox",
-                           config: {
-                              fieldId: "RULES_SUBSCRIBER",
-                              label: "Test",
-                              name: "test",
-                              description: "This should become required when a date is entered into the previous DataTextBox",
-                              value: "",
-                              requirementConfig: {
-                                 initialValue: false,
-                                 rules: [
-                                    {
-                                       targetId: "RULES_CHECKER",
-                                       isNot: ["",null]
-                                    }
-                                 ]
-                              }
+                              name: "todaysDate",
+                              value: "TODAY",
+                              label: "Today's date",
+                              description: "Preset with today's date"
                            }
                         }
                      ]
@@ -126,6 +105,37 @@ model.jsonModel = {
                               value: undefined,
                               label: "Undefined date",
                               description: "Preset with the value undefined"
+                           }
+                        },
+                        {
+                           id: "RULES_CHECKER",
+                           name: "alfresco/forms/controls/DateTextBox",
+                           config: {
+                              fieldId: "RULES_CHECKER",
+                              name: "date3",
+                              value: null,
+                              label: "Any Date",
+                              description: "Enter a data via the keyboard to ensure that the TextBox below becomes required."
+                           }
+                        },
+                        {
+                           id: "RULES_SUBSCRIBER",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "RULES_SUBSCRIBER",
+                              label: "Test",
+                              name: "test",
+                              description: "This should become required when a date is entered into the previous DataTextBox",
+                              value: "",
+                              requirementConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       targetId: "RULES_CHECKER",
+                                       isNot: ["",null]
+                                    }
+                                 ]
+                              }
                            }
                         }
                      ]


### PR DESCRIPTION
This addresses [AKU-464](https://issues.alfresco.com/jira/browse/AKU-464) by allowing a special value of "TODAY" to set the initial value to today's date.