### PR TITLE
AKU-465: placeHolder config option for DateTextBox and TextArea is missing

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -78,9 +78,11 @@ define(["dojo/_base/declare",
        */
       getWidgetConfig: function alfresco_forms_controls_DateTextBox__getWidgetConfig() {
          this.configureValidation();
+         var placeHolder = this.message(this.placeHolder || "");
          return {
-            id : this.id + "_CONTROL",
+            id: this.id + "_CONTROL",
             name: this.name,
+            placeHolder: placeHolder,
             options: (this.options !== null) ? this.options : []
          };
       },

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -56,6 +56,14 @@ registerSuite(function(){
             });
       },
 
+      "Ensure placeHolder attribute is used": function() {
+         return browser.findByCssSelector("#DATE_WITH_PLACEHOLDER .dijitPlaceHolder")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "This is a placeholder");
+            });
+      },
+
       "Test initial invalid values": function() {
          return browser.findById("LETTERS_DATE_VALUE_CONTROL")
             .getProperty("value")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -60,6 +60,56 @@ model.jsonModel = {
                },
                {
                   name: "alfresco/forms/Form",
+                  id: "OTHER_DATES_FORM",
+                  config: {
+                     okButtonPublishTopic: "OTHER_DATES_FORM_SUBMIT",
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/DateTextBox",
+                           id: "DATE_WITH_PLACEHOLDER",
+                           config: {
+                              name: "dateWithPlaceholder",
+                              label: "Date with placeholder",
+                              description: "No preset value, but placeholder text",
+                              placeHolder: "This is a placeholder"
+                           }
+                        },
+                        {
+                           id: "RULES_CHECKER",
+                           name: "alfresco/forms/controls/DateTextBox",
+                           config: {
+                              fieldId: "RULES_CHECKER",
+                              name: "date3",
+                              value: null,
+                              label: "Any Date",
+                              description: "Enter a data via the keyboard to ensure that the TextBox below becomes required."
+                           }
+                        },
+                        {
+                           id: "RULES_SUBSCRIBER",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "RULES_SUBSCRIBER",
+                              label: "Test",
+                              name: "test",
+                              description: "This should become required when a date is entered into the previous DataTextBox",
+                              value: "",
+                              requirementConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       targetId: "RULES_CHECKER",
+                                       isNot: ["",null]
+                                    }
+                                 ]
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/Form",
                   id: "INVALID_DATES_FORM",
                   config: {
                      okButtonPublishTopic: "INVALID_DATES_FORM_SUBMIT",
@@ -105,37 +155,6 @@ model.jsonModel = {
                               value: undefined,
                               label: "Undefined date",
                               description: "Preset with the value undefined"
-                           }
-                        },
-                        {
-                           id: "RULES_CHECKER",
-                           name: "alfresco/forms/controls/DateTextBox",
-                           config: {
-                              fieldId: "RULES_CHECKER",
-                              name: "date3",
-                              value: null,
-                              label: "Any Date",
-                              description: "Enter a data via the keyboard to ensure that the TextBox below becomes required."
-                           }
-                        },
-                        {
-                           id: "RULES_SUBSCRIBER",
-                           name: "alfresco/forms/controls/TextBox",
-                           config: {
-                              fieldId: "RULES_SUBSCRIBER",
-                              label: "Test",
-                              name: "test",
-                              description: "This should become required when a date is entered into the previous DataTextBox",
-                              value: "",
-                              requirementConfig: {
-                                 initialValue: false,
-                                 rules: [
-                                    {
-                                       targetId: "RULES_CHECKER",
-                                       isNot: ["",null]
-                                    }
-                                 ]
-                              }
                            }
                         }
                      ]


### PR DESCRIPTION
This addresses [AKU-465](https://issues.alfresco.com/jira/browse/AKU-465) which requests placeHolder attribute support for the DateTextBox and TextArea controls. Unfortunately, there's [a bug in the underlying Dojo control](https://bugs.dojotoolkit.org/ticket/11145) for the TextArea that means we can't add support there, but it's been added to the DateTextBox control, and the tests updated.