### PR TITLE
AKU-568: Updates resulting from presentation creation

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -451,6 +451,17 @@ define([],function() {
        * @default
        * @since 1.0.34
        */
-      UPLOAD_TO_UNKNOWN_LOCATION: "ALF_UPLOAD_TO_UNKNOWN_LOCATION"
+      UPLOAD_TO_UNKNOWN_LOCATION: "ALF_UPLOAD_TO_UNKNOWN_LOCATION",
+
+      /**
+       * This topic is published to indicate that widget processing has been completed. It is typically
+       * fired by widgets that dynamically render widget models.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       */
+      WIDGET_PROCESSING_COMPLETE: "ALF_WIDGET_PROCESSING_COMPLETE"
    };
 });

--- a/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
+++ b/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
@@ -146,17 +146,17 @@
    }
    /* Same-level classes */
    &.smallpad {
-      .alfresco-dashlets-Dashlet__body__widgets {
+      .alfresco-dashlets-Dashlet__body {
          padding: 4px;
       }
    }
    &.mediumpad {
-      .alfresco-dashlets-Dashlet__body__widgets {
+      .alfresco-dashlets-Dashlet__body {
          padding: 10px;
       }
    }
    &.largepad {
-      .alfresco-dashlets-Dashlet__body__widgets {
+      .alfresco-dashlets-Dashlet__body {
          padding: 16px;
       }
    }

--- a/aikau/src/main/resources/alfresco/dialogs/_AlfCreateFormDialogMixin.js
+++ b/aikau/src/main/resources/alfresco/dialogs/_AlfCreateFormDialogMixin.js
@@ -32,8 +32,9 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "dojo/_base/lang",
         "alfresco/dialogs/AlfDialog",
-        "alfresco/forms/Form"],
-        function(declare, AlfCore, lang, AlfDialog, /*jshint unused:false*/ AlfForm) {
+        "alfresco/forms/Form",
+        "dojo/when"],
+        function(declare, AlfCore, lang, AlfDialog, /*jshint unused:false*/ AlfForm, when) {
 
    return declare([AlfCore], {
 
@@ -240,16 +241,20 @@ define(["dojo/_base/declare",
        */
       onDialogConfirmation: function alfresco_dialogs__CreateFormDialogMixin__onDialogConfirmation(payload) {
          if (payload &&
-             payload.dialogContent &&
-             payload.dialogContent.length === 1 &&
-             typeof payload.dialogContent[0].getValue === "function")
+             payload.dialogContent)
          {
-            var data = payload.dialogContent[0].getValue();
-            this.alfPublish(this.formSubmissionTopic, data, this.formSubmissionGlobal, this.formSubmissionToParent);
-         }
-         else
-         {
-            this.alfLog("error", "The format of the dialog content was not as expected, the 'formSubmissionTopic' will not be published", payload, this);
+            when(payload.dialogContent, lang.hitch(this, function(dialogContent) {
+               if (dialogContent && dialogContent.length)
+               {
+                  var data = {};
+                  var formData = dialogContent[0].getValue();
+                  this.alfPublish(this.formSubmissionTopic, formData, this.formSubmissionGlobal, this.formSubmissionToParent);
+               }
+               else
+               {
+                  this.alfLog("error", "The format of the dialog content was not as expected, the 'formSubmissionTopic' will not be published", payload, this);
+               }
+            }));
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -501,7 +501,7 @@ define(["dojo/_base/declare",
             this._delayedProcessingWidgets.splice(forDeletion, 1);
          }
          this.alfPublish(topics.PAGE_WIDGETS_READY, {}, true);
-         this.alfPublish("ALF_WIDGET_PROCESSING_COMPLETE", {}, true);
+         this.alfPublish(topics.WIDGET_PROCESSING_COMPLETE, {}, true);
          this.alfPublishResizeEvent(this.domNode);
       },
 

--- a/aikau/src/main/resources/alfresco/layout/DynamicWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/DynamicWidgets.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This widget can be used to dynamically render widget models whenever the configured 
+ * [subscriptionTopic]{@link module:alfresco/layout/DynamicWidgets#subscriptionModel} is published. 
+ * The payload on the topic is expected to contain a "widgets" attribute that defines the
+ * model to be rendered.
+ * 
+ * @module alfresco/layout/DynamicWidgets
+ * @extends module:alfresco/core/ProcessWidgets
+ * @author Dave Draper
+ * @since 1.0.36
+ */
+define(["alfresco/core/ProcessWidgets",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "dojo/dom-construct"], 
+        function(ProcessWidgets, declare, lang, array, domConstruct) {
+   
+   return declare([ProcessWidgets], {
+      
+      /**
+       * The CSS class (or a space separated list of classes) to include in the DOM node.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      baseClass: "alfresco-layout-DynamicWidgets",
+
+      /**
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      subscriptionTopic: null,
+
+      /**
+       * This is an extension point for handling the completion of calls to [processWidgets]{@link module:alfresco/core/Core#processWidgets}
+       *
+       * @instance
+       * @param {Array} widgets An array of all the widgets that have been processed
+       */
+      allWidgetsProcessed: function alfresco_layout_DynamicWidgets__allWidgetsProcessed(widgets) {
+         this._previouslyCreatedWidgets = widgets;
+      },
+
+     /**
+       * 
+       * @instance postCreate
+       */
+      postCreate: function alfresco_layout_DynamicWidgets__postCreate() {
+         this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.render));
+      },
+
+      /**
+       * Makes a request for the current users upload history from their preferences and then
+       * with a callback to the [createUploadTargets]{@link module:alfresco/upload/UploadHistory#createUploadTargets}
+       * function to render the upload history.
+       * 
+       * @instance
+       * @param {object} payload A payload containing the widgets to dymaically create
+       */
+      render: function alfresco_layout_DynamicWidgets__render(payload) {
+         if (payload && payload.widgets)
+         {
+            array.forEach(this._previouslyCreatedWidgets, function(target) {
+               target.destroy();
+            });
+            domConstruct.empty(this.domNode);
+            this.processWidgets(payload.widgets, this.domNode);
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -138,8 +138,9 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        * @type {string}
        * @default
+       * @deprecated Since 1.0.36 use [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} instead
        */
-      height: "auto",
+      height: "AUTO",
 
       /**
        * If this widget is placed into a widget that has padding then this allowance can be configured which
@@ -186,7 +187,7 @@ define(["alfresco/core/ProcessWidgets",
          // HeightMixin and was expecting a "height" rather than a "heightMode" attribute.
          // It was also expecting "auto" rather than "AUTO" so for backwards compatibility
          // we convert non-numeric values to be all uppercase.
-         if (this.height && !this.heightMode)
+         if (this.height)
          {
             this.heightMode = this.height;
             if (typeof this.heightMode.toUpperCase === "function")

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -252,7 +252,7 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       onResize: function alfresco_layout_FixedHeaderFooter__onResize() {
-         if ((!this.heightMode || this.heightMode === "AUTO") && this.recalculateAutoHeightOnResize === true)
+         if (this.recalculateAutoHeightOnResize === true)
          {
             this.setHeight(this.domNode);
          }

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -152,6 +152,7 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        * @type {number}
        * @default
+       * @deprecated Since 1.0.36 use [heightAdjustment]{@link module:alfresco/layout/HeightMixin#heightAdjustment} instead
        */
       autoHeightPaddingAllowance: 0,
 
@@ -187,7 +188,7 @@ define(["alfresco/core/ProcessWidgets",
          // HeightMixin and was expecting a "height" rather than a "heightMode" attribute.
          // It was also expecting "auto" rather than "AUTO" so for backwards compatibility
          // we convert non-numeric values to be all uppercase.
-         if (this.height)
+         if (this.height !== "AUTO" && this.heightMode === "AUTO")
          {
             this.heightMode = this.height;
             if (typeof this.heightMode.toUpperCase === "function")
@@ -195,6 +196,11 @@ define(["alfresco/core/ProcessWidgets",
                this.heightMode = this.heightMode.toUpperCase();
             }
          }
+         if (this.autoHeightPaddingAllowance && !this.heightAdjustment)
+         {
+            this.heightAdjustment = this.autoHeightPaddingAllowance;
+         }
+
          this.setHeight(this.domNode);
 
          // Add in the widgets

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -93,6 +93,7 @@
  */
 define(["alfresco/core/ProcessWidgets",
         "alfresco/core/ResizeMixin",
+        "alfresco/layout/HeightMixin",
         "dojo/_base/array",
         "dojo/_base/declare",
         "dojo/_base/lang",
@@ -101,11 +102,10 @@ define(["alfresco/core/ProcessWidgets",
         "dojo/dom-construct",
         "dojo/dom-style",
         "dojo/topic",
-        "dojo/text!./templates/FixedHeaderFooter.html",
-        "jquery"],
-        function(ProcessWidgets, ResizeMixin, array, declare, lang, aspect, domClass, domConstruct, domStyle, topic, template, $) {
+        "dojo/text!./templates/FixedHeaderFooter.html"],
+        function(ProcessWidgets, ResizeMixin, HeightMixin, array, declare, lang, aspect, domClass, domConstruct, domStyle, topic, template) {
 
-   return declare([ProcessWidgets, ResizeMixin], {
+   return declare([ProcessWidgets, ResizeMixin, HeightMixin], {
 
       /**
        * The base class for the widget
@@ -181,7 +181,20 @@ define(["alfresco/core/ProcessWidgets",
       postCreate: function alfresco_layout_FixedHeaderFooter__postCreate() {
          // We need to potentially resize sometimes ... use these triggers
          this.alfSetupResizeSubscriptions(this.onResize, this);
-         this.setHeight();
+
+         // This is to fix the fact that the FixedHeaderFooter didn't originally use the 
+         // HeightMixin and was expecting a "height" rather than a "heightMode" attribute.
+         // It was also expecting "auto" rather than "AUTO" so for backwards compatibility
+         // we convert non-numeric values to be all uppercase.
+         if (this.height && !this.heightMode)
+         {
+            this.heightMode = this.height;
+            if (typeof this.heightMode.toUpperCase === "function")
+            {
+               this.heightMode = this.heightMode.toUpperCase();
+            }
+         }
+         this.setHeight(this.domNode);
 
          // Add in the widgets
          this._doProcessWidgets([
@@ -202,45 +215,6 @@ define(["alfresco/core/ProcessWidgets",
          // Do the resize
          this.onResize();
          this.alfPublishResizeEvent(this.domNode);
-      },
-
-      /**
-       * Calculates and sets the height of the widget.
-       * 
-       * @instance
-       */
-      setHeight: function alfresco_layout_FixedHeaderFooter__setHeight() {
-         // When no height is specified (the only way to do this would be to configure in 
-         // null or 0) or the height is left as the default we'll try and set a sensible
-         // height based on the available space in the client window/document.
-         if (!this.height || this.height === "auto")
-         {
-            var offset = $(this.domNode).offset();
-            var docHeight = $(document).height(),
-                clientHeight = $(window).height();
-
-            // Work with either the window or document height depending upon which is smallest...
-            var h = (docHeight < clientHeight) ? docHeight : clientHeight;
-            var height = (h - offset.top - this.autoHeightPaddingAllowance) + "px";
-
-            // Set the height of the dom node
-            domStyle.set(this.domNode, {
-               height: height
-            });
-         }
-         else
-         {
-            // See AKU-483 - if the configured height is a number, assume it to be pixels...
-            if (!isNaN(this.height))
-            {
-               this.height = this.height + "px";
-            }
-
-            // Set the height of the dom node
-            domStyle.set(this.domNode, {
-               height: this.height
-            });
-         }
       },
 
       /**
@@ -271,9 +245,9 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       onResize: function alfresco_layout_FixedHeaderFooter__onResize() {
-         if ((!this.height || this.height === "auto") && this.recalculateAutoHeightOnResize === true)
+         if ((!this.heightMode || this.heightMode === "AUTO") && this.recalculateAutoHeightOnResize === true)
          {
-            this.setHeight();
+            this.setHeight(this.domNode);
          }
 
          var widgetHeight = this.domNode.offsetHeight,

--- a/aikau/src/main/resources/alfresco/layout/HeightMixin.js
+++ b/aikau/src/main/resources/alfresco/layout/HeightMixin.js
@@ -134,7 +134,7 @@ define(["dojo/_base/declare",
             {
                calculatedHeight = this.calculateParentHeight(domNode, offset);
             }
-            else if (!heightMode || heightMode === "AUTO" || heightMode === "auto" || isNaN(heightMode))
+            else if (!heightMode || heightMode === "AUTO" || heightMode === "auto")
             {
                calculatedHeight =  availableHeight;
             }
@@ -186,7 +186,11 @@ define(["dojo/_base/declare",
          if (height || height === 0)
          {
             when(height, lang.hitch(this, function(value) {
-               domStyle.set(domNode, "height", value + "px");
+               if (!isNaN(height))
+               {
+                  height = height + "px";
+               }
+               domStyle.set(domNode, "height", value);
             }));
          }
       }

--- a/aikau/src/main/resources/alfresco/layout/HeightMixin.js
+++ b/aikau/src/main/resources/alfresco/layout/HeightMixin.js
@@ -186,9 +186,9 @@ define(["dojo/_base/declare",
          if (height || height === 0)
          {
             when(height, lang.hitch(this, function(value) {
-               if (!isNaN(height))
+               if (!isNaN(value))
                {
-                  height = height + "px";
+                  value = value + "px";
                }
                domStyle.set(domNode, "height", value);
             }));

--- a/aikau/src/main/resources/alfresco/layout/HeightMixin.js
+++ b/aikau/src/main/resources/alfresco/layout/HeightMixin.js
@@ -27,7 +27,7 @@
  * given a specific height or (if a negative value is provided) for a number of pixels to be deducted
  * from the available height.
  * 
- * @module alfresco/core/HeightMixin
+ * @module alfresco/layout/HeightMixin
  * @author Dave Draper
  * @since 1.0.34
  */
@@ -75,6 +75,38 @@ define(["dojo/_base/declare",
       heightMode: "AUTO",
 
       /**
+       * Calculates the height when [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} is "DIALOG".
+       * 
+       * @instance
+       * @param {element} domNode The DOM element to calculate the height for.
+       * @returns {number|promise} Either an actual height or a promise of the height
+       * @since 1.0.36
+       */
+      calculateDialogHeight: function alfresco_layout_HeightMixin__calculateDialogHeight(domNode) {
+         var calculatedHeight = $(domNode).parentsUntil(".alfresco-dialog-AlfDialog .dialog-body").last().innerHeight();
+         if (!calculatedHeight)
+         {
+            // When using the DIALOG mode it is necessary to return a promise of the height because it won't 
+            // be possible to know the height until the dialog is displayed.
+            var containingDialog = registry.byNode($(domNode).parents(".alfresco-dialog-AlfDialog")[0]);
+            if (containingDialog)
+            {
+               var heightAdjustment = this.heightAdjustment; // Required to compensate for lack of *this*
+               calculatedHeight = new Deferred();
+               this.own(aspect.after(containingDialog, "_onFocus", function() {
+                  var dialogHeight = $(domNode).parentsUntil(".alfresco-dialog-AlfDialog .dialog-body").first().innerHeight();
+                  calculatedHeight.resolve(dialogHeight - heightAdjustment);
+               }, true));
+            }
+         }
+         else
+         {
+            calculatedHeight -= this.heightAdjustment; // Deduct the adjustment value...
+         }
+         return calculatedHeight;
+      },
+
+      /**
        * Calculates the height of the supplied element based on the available space using the configured 
        * [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} setting.
        * 
@@ -96,28 +128,13 @@ define(["dojo/_base/declare",
             var heightMode = this.heightMode;
             if (heightMode === "DIALOG")
             {
-               calculatedHeight = $(domNode).parentsUntil(".alfresco-dialog-AlfDialog .dialog-body").last().innerHeight();
-               if (!calculatedHeight)
-               {
-                  // When using the DIALOG mode it is necessary to return a promise of the height because it won't 
-                  // be possible to know the height until the dialog is displayed.
-                  var containingDialog = registry.byNode($(domNode).parents(".alfresco-dialog-AlfDialog")[0]);
-                  if (containingDialog)
-                  {
-                     var heightAdjustment = this.heightAdjustment; // Required to compensate for lack of *this*
-                     calculatedHeight = new Deferred();
-                     this.own(aspect.after(containingDialog, "_onFocus", function() {
-                        var dialogHeight = $(domNode).parentsUntil(".alfresco-dialog-AlfDialog .dialog-body").first().innerHeight();
-                        calculatedHeight.resolve(dialogHeight - heightAdjustment);
-                     }, true));
-                  }
-               }
-               else
-               {
-                  calculatedHeight -= this.heightAdjustment; // Deduct the adjustment value...
-               }
+               calculatedHeight = this.calculateDialogHeight(domNode);
             }
-            else if (!heightMode || heightMode === "AUTO" || isNaN(heightMode))
+            else if (heightMode === "PARENT")
+            {
+               calculatedHeight = this.calculateParentHeight(domNode, offset);
+            }
+            else if (!heightMode || heightMode === "AUTO" || heightMode === "auto" || isNaN(heightMode))
             {
                calculatedHeight =  availableHeight;
             }
@@ -131,6 +148,29 @@ define(["dojo/_base/declare",
                calculatedHeight = heightMode;
             }
          }
+         return calculatedHeight;
+      },
+
+      /**
+       * Calculates the height when [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} is "PARENT".
+       * 
+       * @instance
+       * @param {element} domNode The DOM element to calculate the height for.
+       * @returns {number|promise} Either an actual height or a promise of the height
+       * @since 1.0.36
+       */
+      calculateParentHeight: function alfresco_layout_HeightMixin__calculateParentHeight(domNode, offset) {
+         var calculatedHeight;
+         var _this = this;
+         $(domNode).parents().each(function() {
+            var style = $(this).attr("style");
+            if (style && style.indexOf("height:") !== -1)
+            {
+               var parentOffset = offset - $(this).offset().top;
+               calculatedHeight = $(this).height() - parentOffset - _this.heightAdjustment;
+               return false;
+            }
+         });
          return calculatedHeight;
       },
 

--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreviewPlugin.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreviewPlugin.js
@@ -111,6 +111,7 @@ define(["dojo/_base/declare",
       _setPreviewerElementHeight: function alfresco_preview_AlfDocumentPreviewPlugin___setPreviewerElementHeight() {
          var pE = this.previewManager.getPreviewerElement();
          this.heightMode = this.previewManager.heightMode;
+         this.heightAdjustment = this.previewManager.heightAdjustment || 0;
          this.setHeight(pE);
       }
    });

--- a/aikau/src/main/resources/alfresco/search/css/AlfSearchResult.css
+++ b/aikau/src/main/resources/alfresco/search/css/AlfSearchResult.css
@@ -3,6 +3,10 @@
    border-spacing: 0;
 }
 
+.alfresco-search-AlfSearchResult .selectorCell {
+   width: 20px;
+}
+
 .alfresco-search-AlfSearchResult .thumbnailCell {
    width: 100px;
 }

--- a/aikau/src/main/resources/alfresco/upload/UploadHistory.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadHistory.js
@@ -103,6 +103,7 @@ define(["dojo/_base/declare",
        */
       allWidgetsProcessed: function alfresco_upload_UploadHistory__allWidgetsProcessed(widgets) {
          this.currentHistoryTargets = widgets;
+         this.alfPublish(topics.WIDGET_PROCESSING_COMPLETE);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest.js
+++ b/aikau/src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest.js
@@ -21,65 +21,61 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
-        "require",
+        "intern/chai!assert",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "SemanticWrapperMixin Test",
+      return {
+         name: "SemanticWrapperMixin Test",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/SemanticWrapperMixin", "SemanticWrapperMixin Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/SemanticWrapperMixin", "SemanticWrapperMixin Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
 
-      "Test NO_WRAPPER is correct": function () {
-         return browser.findByCssSelector("#NO_WRAPPER > span.copyright > span.licenseHolder")
-            .getVisibleText()
-            .then(function (text) {
-               expect(text).to.equal("Licensed To: NO_WRAPPER licenseLabel", "The NO_WRAPPER dom must be incorrect");
-            });
-      },
+         "Test NO_WRAPPER is correct": function () {
+            return browser.findByCssSelector("#NO_WRAPPER > span.copyright > span.licenseHolder")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text, "Licensed To: NO_WRAPPER licenseLabel", "The NO_WRAPPER dom must be incorrect");
+               });
+         },
 
-      "Test GOOD_WRAPPER is correct": function() {
-         return browser.findByCssSelector("#GOOD_WRAPPER > footer > span.copyright > span.licenseHolder")
-            .getVisibleText()
-            .then(function (text) {
-               expect(text).to.equal("Licensed To: GOOD_WRAPPER licenseLabel", "The GOOD_WRAPPER dom must be incorrect");
-            });
-      },
+         "Test GOOD_WRAPPER is correct": function() {
+            return browser.findByCssSelector("#GOOD_WRAPPER > footer > span.copyright > span.licenseHolder")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text, "Licensed To: GOOD_WRAPPER licenseLabel", "The GOOD_WRAPPER dom must be incorrect");
+               });
+         },
 
-      "Test BAD_WRAPPER is correct": function() {
-         return browser.findByCssSelector("#BAD_WRAPPER > span.copyright > span.licenseHolder")
-            .getVisibleText()
-            .then(function (text) {
-               expect(text).to.equal("Licensed To: BAD_WRAPPER licenseLabel", "The BAD_WRAPPER dom must be incorrect");
-            });
-      },
+         "Test BAD_WRAPPER is correct": function() {
+            return browser.findByCssSelector("#BAD_WRAPPER > span.copyright > span.licenseHolder")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text, "Licensed To: BAD_WRAPPER licenseLabel", "The BAD_WRAPPER dom must be incorrect");
+               });
+         },
 
-      "Test LEFT_AND_RIGHT_WRAPPER is correct": function() {
-         return browser.findByCssSelector("#LEFT_AND_RIGHT_WRAPPER > header > div > div.left-widgets")
-            .getVisibleText()
-            .then(function (text) {
-               expect(text).to.equal("This is a title with a semantic wrapper", "The LEFT_AND_RIGHT_WRAPPER dom must be incorrect");
-            });
-      },
+         "Test LEFT_AND_RIGHT_WRAPPER is correct": function() {
+            return browser.findByCssSelector("#LEFT_AND_RIGHT_WRAPPER > header > div > div.alfresco-layout-LeftAndRight__left")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text, "This is a title with a semantic wrapper", "The LEFT_AND_RIGHT_WRAPPER dom must be incorrect");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
@@ -115,7 +115,7 @@ registerSuite(function(){
 
             .getLastPublish("VALID_ID_ALF_STORE_DASHLET_HEIGHT_SUCCESS")
                .then(function(payload) {
-                  assert.deepPropertyVal(payload, "requestConfig.data.height", 250, "Did not publish new height");
+                  assert.deepPropertyVal(payload, "requestConfig.data.height", 270, "Did not publish new height");
                });
          },
 

--- a/aikau/src/test/resources/alfresco/layout/BasicLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/BasicLayoutTest.js
@@ -1,3 +1,4 @@
+
 /**
  * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
@@ -95,14 +96,14 @@ registerSuite(function(){
       },
 
       "Test left alignment": function() {
-         return browser.findByCssSelector(".left-widgets #SURF_LOGO4")
+         return browser.findByCssSelector(".alfresco-layout-LeftAndRight__left #SURF_LOGO4")
             .then(null, function() {
                assert(false, "Widget was not left aligned");
             });
       },
 
       "Test right alignment": function() {
-         return browser.findByCssSelector(".right-widgets #ALFRESCO_LOGO1")
+         return browser.findByCssSelector(".alfresco-layout-LeftAndRight__right #ALFRESCO_LOGO1")
             .then(null, function() {
                assert(false, "logo was not right aligned");
             });

--- a/aikau/src/test/resources/alfresco/layout/DynamicWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/layout/DynamicWidgetsTest.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+       function(registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Dynamic Widgets Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/DynamicWidgets", "Dynamic Widgets Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Ensure logo and label not rendered on load": function() {
+            return browser.findAllByCssSelector(".alfresco-logo-Logo")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Logo should not have been rendered on load");
+               })
+            .end()
+            .findAllByCssSelector(".alfresco-html-Label")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Label should not have been rendered on load");
+               });
+         },
+
+         "Render the logo": function() {
+            return browser.findById("BUTTON1_label")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-layout-ClassicWindow .alfresco-logo-Logo");
+         },
+
+         "Render the label": function() {
+            return browser.findById("BUTTON2_label")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-layout-ClassicWindow .alfresco-html-Label")
+            .end()
+            .findAllByCssSelector(".alfresco-logo-Logo")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Logo should not have been rendered on load");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
+++ b/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
@@ -27,141 +27,178 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function(registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var windowHeight;
-   var browser;
+   registerSuite(function(){
+      var windowHeight;
+      var browser;
 
-   return {
-      name: "HeightMixin tests",
+      return {
+         name: "HeightMixin tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/HeightMixin", "HeightMixin Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/HeightMixin", "HeightMixin Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.findByCssSelector("body")
-            .getSize()
-            .then(function(size) {
-               windowHeight = size.height - 20; // PLEASE NOTE: 20 pixels deducted for test page padding
-            })
-         .end();
-      },
+         beforeEach: function() {
+            browser.findByCssSelector("body")
+               .getSize()
+               .then(function(size) {
+                  windowHeight = size.height - 20; // PLEASE NOTE: 20 pixels deducted for test page padding
+               })
+            .end();
+         },
 
-      "Check AUTO height": function() {
-         return browser.findById("AUTO")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.height, windowHeight, "Height not calculated correctly");
-            });
-      },
+         "Check AUTO height": function() {
+            return browser.findById("AUTO")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, windowHeight, "Height not calculated correctly");
+               });
+         },
 
-      "Check AUTO height (with adjustment)": function() {
-         return browser.findById("AUTO_WITH_ADJUSTMENT")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.height, windowHeight - 50, "Height not calculated correctly");
-            });
-      },
+         "Check AUTO height (with adjustment)": function() {
+            return browser.findById("AUTO_WITH_ADJUSTMENT")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, windowHeight - 50, "Height not calculated correctly");
+               });
+         },
 
-      "Check FIXED height": function() {
-         return browser.findById("FIXED")
-            .getSize()
-            .then(function(size) {
-               // NOTE: Extra 2 pixels for border compensation
-               assert.equal(size.height, 202, "Height not calculated correctly");
-            });
-      },
+         "Check FIXED height": function() {
+            return browser.findById("FIXED")
+               .getSize()
+               .then(function(size) {
+                  // NOTE: Extra 2 pixels for border compensation
+                  assert.equal(size.height, 202, "Height not calculated correctly");
+               });
+         },
 
-      "Check MINUS height": function() {
-         return browser.findById("MINUS")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.height, windowHeight - 100, "Height not calculated correctly");
-            });
-      },
+         "Check MINUS height": function() {
+            return browser.findById("MINUS")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, windowHeight - 100, "Height not calculated correctly");
+               });
+         },
 
-      "Show dialog with no padding and fixed height": function() {
-         return browser.findById("LAUNCH_DIALOG_1_label")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_1.dialogDisplayed")
-         .end()
-         .findById("DIALOG_1_TEST")
-            .getSize()
-            .then(function(size) {
-               // Height is the dialog content height minus 2px adjustment to show border
-               assert.equal(size.height, 300, "Height not calculated correctly");
-            })
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_1 .dijitDialogCloseIcon")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_1.dialogHidden")
-         .end();
-      },
+         "Show dialog with no padding and fixed height": function() {
+            return browser.findById("LAUNCH_DIALOG_1_label")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_1.dialogDisplayed")
+            .end()
+            .findById("DIALOG_1_TEST")
+               .getSize()
+               .then(function(size) {
+                  // Height is the dialog content height minus 2px adjustment to show border
+                  assert.equal(size.height, 300, "Height not calculated correctly");
+               })
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_1 .dijitDialogCloseIcon")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_1.dialogHidden")
+            .end();
+         },
 
-      "Show dialog with padding and fixed height": function() {
-         return browser.findById("LAUNCH_DIALOG_2_label")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_2.dialogDisplayed")
-         .end()
-         .findById("DIALOG_2_TEST")
-            .getSize()
-            .then(function(size) {
-               // Height is minus the standard border adjustment of 24 pixels
-               assert.equal(size.height, 76, "Height not calculated correctly");
-            })
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_2 .dijitDialogCloseIcon")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_2.dialogHidden")
-         .end();
-      },
+         "Show dialog with padding and fixed height": function() {
+            return browser.findById("LAUNCH_DIALOG_2_label")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_2.dialogDisplayed")
+            .end()
+            .findById("DIALOG_2_TEST")
+               .getSize()
+               .then(function(size) {
+                  // Height is minus the standard border adjustment of 24 pixels
+                  assert.equal(size.height, 76, "Height not calculated correctly");
+               })
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_2 .dijitDialogCloseIcon")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_2.dialogHidden")
+            .end();
+         },
 
-      "Show dialog with defaults": function() {
-         return browser.findById("LAUNCH_DIALOG_3_label")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_3.dialogDisplayed")
-         .end()
-         .findById("DIALOG_3_TEST")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.height, 18, "Height not calculated correctly");
-            })
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_3 .dijitDialogCloseIcon")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_3.dialogHidden")
-         .end();
-      },
+         "Show dialog with defaults": function() {
+            return browser.findById("LAUNCH_DIALOG_3_label")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_3.dialogDisplayed")
+            .end()
+            .findById("DIALOG_3_TEST")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 18, "Height not calculated correctly");
+               })
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_3 .dijitDialogCloseIcon")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_3.dialogHidden")
+            .end();
+         },
 
-      "Show dialog with buttons": function() {
-         return browser.findById("LAUNCH_DIALOG_4_label")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_4.dialogDisplayed")
-         .end()
-         .findById("DIALOG_4_TEST")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.height, 18, "Height not calculated correctly");
-            })
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_4 .dijitDialogCloseIcon")
-            .click()
-         .end()
-         .findByCssSelector("#HEIGHT_DIALOG_4.dialogHidden")
-         .end();
-      },
+         "Show dialog with buttons": function() {
+            return browser.findById("LAUNCH_DIALOG_4_label")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_4.dialogDisplayed")
+            .end()
+            .findById("DIALOG_4_TEST")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 18, "Height not calculated correctly");
+               })
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_4 .dijitDialogCloseIcon")
+               .click()
+            .end()
+            .findByCssSelector("#HEIGHT_DIALOG_4.dialogHidden")
+            .end();
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "HeightMixin tests (parent height)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ParentHeight", "HeightMixin Tests (parent height)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check FixedHeaderFooter height": function() {
+            return browser.findById("FIXED_HEADER_FOOTER_1")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 600, "The FixedHeaderFooter widget did not take the parent height");
+               });
+         },
+
+         "Check PDF.js previewer height": function() {
+            return browser.findByCssSelector("#PDF_PREVIEW .alfresco-preview-PdfJs")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.height, 558, 5, "The PDF.js previewer did not take the parent height");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -141,6 +141,7 @@ define({
       "src/test/resources/alfresco/layout/AlfTabContainerTest",
       "src/test/resources/alfresco/layout/BasicLayoutTest",
       "src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest",
+      "src/test/resources/alfresco/layout/DynamicWidgetsTest",
       "src/test/resources/alfresco/layout/FixedHeaderFooterTest",
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
       "src/test/resources/alfresco/layout/HeightMixinTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicWidgets.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicWidgets.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Dynamic Widget Processing</shortname>
+  <description>Demonstrates the alfresco/layout/DynamicWidgets layout container that renders a widget model defined in a published payload.</description>
+  <family>aikau-unit-tests</family>
+  <url>/DynamicWidgets</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicWidgets.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicWidgets.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/DynamicWidgets.get.js
@@ -1,0 +1,76 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/VerticalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "BUTTON1",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Create logo",
+                     publishTopic: "SHOW_WIDGET_MODEL",
+                     publishPayload: {
+                        widgets: [
+                           {
+                              id: "LOGO1",
+                              name: "alfresco/logo/Logo"
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  id: "BUTTON2",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Create label",
+                     publishTopic: "SHOW_WIDGET_MODEL",
+                     publishPayload: {
+                        widgets: [
+                           {
+                              id: "LABEL1",
+                              name: "alfresco/html/Label",
+                              config: {
+                                 label: "A label"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  id: "CW1",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Widget Models Will Be Rendered Here...",
+                     widgets: [
+                        {
+                           id: "DW1",
+                           name: "alfresco/layout/DynamicWidgets",
+                           config: {
+                              subscriptionTopic: "SHOW_WIDGET_MODEL"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ParentHeight.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ParentHeight.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Parent Height</shortname>
+  <description>Shows various layout widgets that set their height based on that of the first parent with an element height</description>
+  <family>aikau-unit-tests</family>
+  <url>/ParentHeight</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ParentHeight.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ParentHeight.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ParentHeight.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ParentHeight.get.js
@@ -1,0 +1,84 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService",
+      "alfresco/services/ErrorReporter",
+      "alfresco/services/DialogService",
+      "alfresco/services/NotificationService"
+   ],
+   widgets: [
+      {
+         id: "SIMPLE_PANEL_1",
+         name: "alfresco/layout/SimplePanel",
+         config: {
+            height: "600px",
+            widgets: [
+               {
+                  id: "HORIZ_1",
+                  name: "alfresco/layout/HorizontalWidgets",
+                  config: {
+                     widgets: [
+                        {
+                           id: "FIXED_HEADER_FOOTER_1",
+                           name: "alfresco/layout/FixedHeaderFooter",
+                           config: {
+                              heightMode: "PARENT",
+                              widgetsForHeader: [
+                                 {
+                                    name: "alfresco/html/Label",
+                                    config: {
+                                       label: "Header"
+                                    }
+                                 }
+                              ],
+                              widgets: [
+                                 {
+                                    id: "PDF_DOCUMENT",
+                                    name: "alfresco/documentlibrary/AlfDocument",
+                                    config: {
+                                       nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
+                                       widgets: [
+                                          {
+                                             id: "PDF_PREVIEW",
+                                             name: "alfresco/preview/AlfDocumentPreview",
+                                             config: {
+                                                heightMode: "PARENT",
+                                                heightAdjustment: 4
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ],
+                              widgetsForFooter: [
+                                 {
+                                    name: "alfresco/html/Label",
+                                    config: {
+                                       label: "Footer"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PdfJsMockXhr",
+         config: {
+            
+         }
+      }
+   ]
+};


### PR DESCRIPTION
This PR has resulted from the work done for an internal presentation (work done under https://issues.alfresco.com/jira/browse/AKU-568). It adds a new alfresco/layout/DynamicWidgets layout container that was needed for a demo, as well as adding a new heightMode of "PARENT" for the alfresco/layout/HeightMixin (and updates the alfresco/layout/FixedHeaderFooter widget to use that mixin). There are a couple of other minor tweaks as well.