### PR TITLE
Increase timeouts to improve test consistency

### DIFF
--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -286,7 +286,7 @@ define(["intern/dojo/node!fs",
             var opts = lang.mixin({
                pos: "all",
                isGlobal: !!isGlobal,
-               queryTimeout: queryTimeout || 500
+               queryTimeout: queryTimeout || 2000
             }, filter || {});
 
             // Build the selector
@@ -310,7 +310,7 @@ define(["intern/dojo/node!fs",
                .then(function(timeout) {
                   existingTimeout = timeout;
                })
-               .setExecuteAsyncTimeout(opts.queryTimeout + 500)
+               .setExecuteAsyncTimeout(opts.queryTimeout + 2000)
                .executeAsync(function(entriesSelector, timeout, asyncComplete) {
 
                   // Store the start-time and start the interval

--- a/aikau/src/test/resources/config/vm/Config.js
+++ b/aikau/src/test/resources/config/vm/Config.js
@@ -42,10 +42,10 @@ define({
     * @type {object}
     */
    timeout: {
-      base: 2000,
-      find: 750,
-      pageLoad: 10000,
-      executeAsync: 1000
+      base: 5000,
+      find: 2000,
+      pageLoad: 30000,
+      executeAsync: 5000
    }
 
 });

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -38,11 +38,11 @@ define(["./config/Suites"],
          // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
          // capabilities options specified for an environment will be copied as-is
          environments: [{
-            browserName: "Chrome",
-            chromeOptions: {
-               excludeSwitches: ["ignore-certificate-errors"]
-            }
-         }, {
+            // browserName: "Chrome",
+            // chromeOptions: {
+            //    excludeSwitches: ["ignore-certificate-errors"]
+            // }
+         // }, {
             browserName: "Firefox"
          }],
 


### PR DESCRIPTION
I've found that by increasing the time outs that the unit tests pass more reliable when run in bulk.