### PR TITLE
AKU-578: Update logging service to suppress user prefs

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -269,6 +269,11 @@ define([],function() {
        * @type {string}
        * @default
        * @since 1.0.34
+       *
+       * @event module:alfresco/core/topics~GET_PREFERENCE
+       * @property {string} preference Dot-notation property indicating the user preference to retrieve
+       * @property {function} callback The function to call when the preference has been retrieved
+       * @property {object} callbackScope The scope with which to execute the callback
        */
       GET_PREFERENCE: "ALF_PREFERENCE_GET",
 

--- a/aikau/src/main/resources/alfresco/services/LoggingService.js
+++ b/aikau/src/main/resources/alfresco/services/LoggingService.js
@@ -63,6 +63,17 @@ define(["dojo/_base/declare",
       logSubscriptionHandle: null,
 
       /**
+       * Indicates whether or not the user preferences for logging should be suppressed. If this is set to true then
+       * a request will not be made to retrieve the user preferences for logging.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.36
+       */
+      suppressUserPreferences: false,
+
+      /**
        * Sets up the subscriptions for the LoggingService
        *
        * @instance
@@ -72,7 +83,7 @@ define(["dojo/_base/declare",
        * @listens ALF_SHOW_DATA_MODEL
        * @listens ALF_TOGGLE_DEVELOPER_MODE
        *
-       * @fires getPreferenceTopic
+       * @fires module:alfresco/core/topics~event:GET_PREFERENCE
        * @since 1.0.32
        */
       registerSubscriptions: function alfresco_services_LoggingService__registerSubscriptions() {
@@ -89,13 +100,21 @@ define(["dojo/_base/declare",
             this.handleSubscription();
          }
 
-         this.alfPublish(this.getPreferenceTopic, {
-            preference: this.loggingPreferencesId,
-            callback: this.setLoggingStatus,
-            callbackScope: this
-         });
+         if (!this.suppressUserPreferences)
+         {
+            this.alfPublish(this.getPreferenceTopic, {
+               preference: this.loggingPreferencesId,
+               callback: this.setLoggingStatus,
+               callbackScope: this
+            });
+         }
       },
 
+      /**
+       * Switches into the developer mode that gives an exploded view of the widgets on the page.
+       * 
+       * @instance
+       */
       toggleDeveloperMode: function alfresco_services_LoggingService__toggleDeveloperMode() {
          domClass.toggle(win.body(), "alfresco-developer-mode-Enabled");
       },

--- a/aikau/src/test/resources/alfresco/services/LoggingServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/LoggingServiceTest.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Logging Service Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/LoggingService", "Logging Service Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "There should be no preference request for SCOPE1_": function() {
+            return browser.findByCssSelector("body").end()
+               .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "SCOPE1_ALF_PREFERENCE_GET",
+                  pos: "all"
+               }, true)
+               .then(function(subscriptions) {
+                  assert.lengthOf(subscriptions, 0, "User preference request should have been suppressed");
+               });
+         },
+
+         "There should be a preference request for SCOPE2_": function() {
+            return browser.findByCssSelector("body").end()
+               .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "SCOPE2_ALF_PREFERENCE_GET",
+                  pos: "all"
+               }, true)
+               .then(function(subscriptions) {
+                  assert.lengthOf(subscriptions, 1, "User preference request not published");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -231,6 +231,7 @@ define({
       "src/test/resources/alfresco/services/DeleteSiteTest",
       "src/test/resources/alfresco/services/DialogServiceTest",
       "src/test/resources/alfresco/services/FullScreenDialogTest",
+      "src/test/resources/alfresco/services/LoggingServiceTest",
       "src/test/resources/alfresco/services/NavigationServiceTest",
       "src/test/resources/alfresco/services/NotificationServiceTest",
       "src/test/resources/alfresco/services/SearchServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/LoggingService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/LoggingService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>LoggingService</shortname>
+  <description>This page is used to test the configuration options of the alfresco/services/LoggingService</description>
+  <family>aikau-unit-tests</family>
+  <url>/LoggingService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/LoggingService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/LoggingService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/LoggingService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/LoggingService.get.js
@@ -1,0 +1,40 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            pubSubScope: "SCOPE1_",
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            },
+            suppressUserPreferences: true
+         }
+      },
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            pubSubScope: "SCOPE2_",
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/html/Label",
+         config: {
+            label: "This page is used for testing the LoggingService configuration"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-578 (and issue #530) to provide support for suppressing user preferences for the LoggingService.