### PR TITLE
Update "cancel message"

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
@@ -70,7 +70,7 @@ define(["dojo/_base/declare",
       templateString: template,
 
       /**
-       * The title text to be displayed when hovering over the cancel "button"
+       * Optional override for the title text to be displayed when hovering over the cancel "button"
        *
        * @instance
        * @type {String}
@@ -118,16 +118,6 @@ define(["dojo/_base/declare",
        * @since 1.0.35
        */
       disablementProperty: null,
-
-      /**
-       * This is run after the instance properties have been mixed in
-       *
-       * @instance
-       */
-      postMixInProperties: function alfresco_renderers_PublishingDropDownMenu__postMixInProperties() {
-         this.inherited(arguments);
-         this.cancelPublishLabel = this.message("alf.renderers.PublishingDropDownMenu.cancelPublish");
-      },
 
       /**
        *
@@ -204,6 +194,9 @@ define(["dojo/_base/declare",
             this._updateCancelHandle = this.alfSubscribe(responseTopic + "_CANCEL", lang.hitch(this, this.onChangeCancel));
 
             updatePayload.responseTopic = responseTopic;
+
+            // Update the title text of the cancel button
+            this.processingNode.title = this.cancelPublishLabel || this.message("alf.renderers.PublishingDropDownMenu.cancelUpdate", this.value);
 
             // Request to make the update...
             this._reponsePending = true;

--- a/aikau/src/main/resources/alfresco/renderers/i18n/PublishingDropDownMenu.properties
+++ b/aikau/src/main/resources/alfresco/renderers/i18n/PublishingDropDownMenu.properties
@@ -1,1 +1,1 @@
-alf.renderers.PublishingDropDownMenu.cancelPublish=Cancel publish
+alf.renderers.PublishingDropDownMenu.cancelUpdate=Cancel update and reset to "{0}"


### PR DESCRIPTION
Update the default text used for the cancel button title attribute, as recently added in pull request #540, as it was using inappropriate language.