### PR TITLE
AKU-587: Dialog resizing

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -78,7 +78,7 @@ define(["alfresco/core/_EventsMixin",
          }
          else
          {
-            var scope = (resizeHandlerCallScope != null) ? resizeHandlerCallScope : this,
+            var scope = resizeHandlerCallScope || this,
                resizeListener = on(window, "resize", lang.hitch(scope, resizeHandler));
             if(typeof this.own === "function") { // If we're in a widget, use it to handle cleaning up the listener
                this.own(resizeListener);

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -198,8 +198,15 @@ define(["dojo/_base/declare",
          var docHeight = $(document).height(),
              clientHeight = $(window).height();
          var h = (docHeight < clientHeight) ? docHeight : clientHeight;
+
+         // We want to ensure that the dialog always fits within the viewport, so take the available
+         // height and remove 200 pixels to accomodate both the title and buttons bars and still leave
+         // some padding...
          var maxHeight = h - 200;
 
+         // By default there is padding around the dialog body (12px above and below the body)... 
+         // We need to take this into consideration when calculating the simple panel height to ensure
+         // that it fits perfectly within the available space...
          var paddingAdjustment = 24;
          if (this.additionalCssClasses && this.additionalCssClasses.indexOf("no-padding") !== -1)
          {
@@ -211,14 +218,18 @@ define(["dojo/_base/declare",
          {
             simplePanelHeight = (parseInt(this.contentHeight, 10) - paddingAdjustment) + "px";
          }
-
-         var containerHeight = $(this.containerNode).height();
-         if (containerHeight)
+         else
          {
-            containerHeight -= 40;
-            if (containerHeight < maxHeight)
+            // When there is no fixed content height, make sure that the max-height adapts to the displayed content...
+            var containerHeight = $(this.containerNode).height();
+            if (containerHeight)
             {
-               maxHeight = containerHeight;
+               // We need to deduct 40 pixels from the container height to accomodate the buttons bar...
+               containerHeight -= 40;
+               if (containerHeight < maxHeight)
+               {
+                  maxHeight = containerHeight;
+               }
             }
          }
 
@@ -379,9 +390,13 @@ define(["dojo/_base/declare",
        */
       onWindowResize: function alfresco_dialogs_AlfDialog__onWindowResize() {
          var calculatedHeights = this.calculateHeights();
-         domStyle.set(this.bodyNode, {
-            "max-height": calculatedHeights.maxBodyHeight + "px"
-         });
+         if (calculatedHeights.maxBodyHeight)
+         {
+            // Don't set a max-height when it's 0...
+            domStyle.set(this.bodyNode, {
+               "max-height": calculatedHeights.maxBodyHeight + "px"
+            });
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -181,6 +181,56 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Calculates various heights that are used to set dimensions of the dialog when it is created
+       * as well as on resize events (such as resizing the window).
+       * 
+       * @instance
+       * @returns {object} heights The calculated heights
+       * @returns {number} heights.clientHeight The height of the viewport
+       * @returns {number} heights.documentHeight The height of the document
+       * @returns {number} heights.maxBodyHeight The maximum height allowed for the body of the dialog
+       * @returns {number} heights.paddingAdjustment The pixels to allow for padding in the dialog body
+       * @returns {number} heights.simplePanelHeight The height of the [SimplePanel]{@link module:alfresco/layout/SimplePanel} containing the dialog content
+       * @since 1.0.36
+       */
+      calculateHeights: function alfresco_dialogs_AlfDialog__calculateHeights() {
+         var calculatedHeights = {};
+         var docHeight = $(document).height(),
+             clientHeight = $(window).height();
+         var h = (docHeight < clientHeight) ? docHeight : clientHeight;
+         var maxHeight = h - 200;
+
+         var paddingAdjustment = 24;
+         if (this.additionalCssClasses && this.additionalCssClasses.indexOf("no-padding") !== -1)
+         {
+            paddingAdjustment = 0;
+         }
+
+         var simplePanelHeight = null;
+         if (this.contentHeight)
+         {
+            simplePanelHeight = (parseInt(this.contentHeight, 10) - paddingAdjustment) + "px";
+         }
+
+         var containerHeight = $(this.containerNode).height();
+         if (containerHeight)
+         {
+            containerHeight -= 40;
+            if (containerHeight < maxHeight)
+            {
+               maxHeight = containerHeight;
+            }
+         }
+
+         calculatedHeights.documentHeight = docHeight;
+         calculatedHeights.clientHeight = clientHeight;
+         calculatedHeights.maxBodyHeight = maxHeight;
+         calculatedHeights.paddingAdjustment = paddingAdjustment;
+         calculatedHeights.simplePanelHeight = simplePanelHeight;
+         return calculatedHeights;
+      },
+
+      /**
        * Extends the superclass implementation to set the dialog as not closeable (by clicking an "X"
        * in the corner).
        * 
@@ -206,7 +256,7 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
 
          // Listen for requests to resize the dialog...
-         this.alfSubscribe("ALF_RESIZE_DIALOG", lang.hitch(this, "onResizeRequest"));
+         this.alfSubscribe("ALF_RESIZE_DIALOG", lang.hitch(this, this.onResizeRequest));
 
          domClass.add(this.domNode, "alfresco-dialog-AlfDialog");
 
@@ -224,17 +274,16 @@ define(["dojo/_base/declare",
             });
          }
 
+         // Calculate the heights required for the dialog...
+         var calculatedHeights = this.calculateHeights();
+
          domConstruct.empty(this.containerNode);
          this.bodyNode = domConstruct.create("div", {
-            "class" : "dialog-body"
+            "class" : "dialog-body",
+            style: "max-height:" + calculatedHeights.maxBodyHeight + "px"
          }, this.containerNode, "last");
 
          // Workout a maximum height for the dialog as it should always fit in the window...
-         var docHeight = $(document).height(),
-             clientHeight = $(window).height();
-         var h = (docHeight < clientHeight) ? docHeight : clientHeight;
-         var maxHeight = h - 200;
-
          // Set the dimensions of the body if required...
          domStyle.set(this.bodyNode, {
             width: this.contentWidth ? this.contentWidth: null,
@@ -265,36 +314,16 @@ define(["dojo/_base/declare",
 
          if (this.widgetsContent)
          {
-            // This is a slightly unpleasant convergence of CSS and JS, but will suffice for the time being...
-            // There is a "no-padding" CSS class that can be applied which will remove the default padding applied
-            // to the dialog body, if we detect this setting then we should not compensate the content height 
-            // for this padding.
-            var paddingAdjustment = 24;
-            if (this.additionalCssClasses && this.additionalCssClasses.indexOf("no-padding") !== -1)
-            {
-               paddingAdjustment = 0;
-            }
-            
-            var simplePanelHeight = null;
-            if (this.contentHeight)
-            {
-               simplePanelHeight = (parseInt(this.contentHeight, 10) - paddingAdjustment) + "px";
-            }
-            
-            // Add widget content to the container node...
-            var widgetsNode = domConstruct.create("div", {
-               style: "max-height:" + maxHeight + "px"
-            }, this.bodyNode, "last");
             var bodyModel = [{
                name: "alfresco/layout/SimplePanel",
                assignTo: "_dialogPanel",
                config: {
                   handleOverflow: this.handleOverflow,
-                  height: simplePanelHeight,
+                  height: calculatedHeights.simplePanelHeight,
                   widgets: this.widgetsContent
                }
             }];
-            this.processWidgets(bodyModel, widgetsNode, "BODY");
+            this.processWidgets(bodyModel, this.bodyNode, "BODY");
          }
          else if (this.content)
          {
@@ -302,6 +331,8 @@ define(["dojo/_base/declare",
             // setting basic text content in an confirmation dialog...
             html.set(this.bodyNode, this.encodeHTML(this.content));
          }
+
+         this.alfSetupResizeSubscriptions(this.onWindowResize, this);
       },
       
       /**
@@ -337,6 +368,20 @@ define(["dojo/_base/declare",
          domStyle.set(document.documentElement, "overflow", "");
          domClass.remove(this.domNode, "dialogDisplayed");
          domClass.add(this.domNode, "dialogHidden");
+      },
+
+      /**
+       * This is called whenever the window is resized. It ensures that the dialog body is the correct height
+       * when taking into account the new size of the view port.
+       *
+       * @instance
+       * @since 1.0.36
+       */
+      onWindowResize: function alfresco_dialogs_AlfDialog__onWindowResize() {
+         var calculatedHeights = this.calculateHeights();
+         domStyle.set(this.bodyNode, {
+            "max-height": calculatedHeights.maxBodyHeight + "px"
+         });
       },
 
       /**
@@ -409,6 +454,7 @@ define(["dojo/_base/declare",
          if (this.domNode)
          {
             this.resize();
+            this.onWindowResize();
          }
       },
 

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -47,7 +47,6 @@
 .alfresco-dialog-AlfDialog .dialog-body {
    padding: 12px;
    overflow: auto;
-   height: ~"calc(100% - 40px)";
    margin-bottom: 40px;
    min-width: 560px;
 }

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -45,9 +45,9 @@
 }
 
 .alfresco-dialog-AlfDialog .dialog-body {
-   padding: 12px;
+   padding: 12px; /* NOTE: If this is changed, the associated paddingAdjustment in the JS needs updating */
    overflow: auto;
-   margin-bottom: 40px;
+   margin-bottom: 40px; /* NOTE: If this is changed, the associated margin adjustment in the JS needs updating */
    min-width: 560px;
 }
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-587 to ensure that the dialog body is correctly sized and removes the dependency on LESS escaped calculations.