### PR TITLE
AKU-593: Take buttons bar into consideration when calculating dialog sizes

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -224,8 +224,13 @@ define(["dojo/_base/declare",
             var containerHeight = $(this.containerNode).height();
             if (containerHeight)
             {
-               // We need to deduct 40 pixels from the container height to accomodate the buttons bar...
-               containerHeight -= 40;
+               if (this.widgetsButtons)
+               {
+                  // We need to deduct 40 pixels from the container height to accomodate the buttons bar
+                  // if it is present...
+                  containerHeight -= 40;
+               }
+               
                if (containerHeight < maxHeight)
                {
                   maxHeight = containerHeight;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-593. In the updates made for 1.0.36 I neglected to take the buttons bar into consideration when calculating resizing the dialog. This PR will be reviewed and merged into develop and then cherry-picked into a 1.0.36.1 hotfix release.