### PR TITLE
AKU-588: Ensure resize events published on dynamic width resizing

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -30,24 +30,24 @@
  * @module alfresco/core/ResizeMixin
  * @author Dave Draper
  */
-define(["alfresco/core/_EventsMixin",
-        "dojo/_base/declare",
+define(["dojo/_base/declare",
+        "alfresco/core/_EventsMixin",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/on",
         "dojo/dom"], 
-        function(_EventsMixin, declare, lang, on, dom) {
+        function( declare, _EventsMixin, topics, lang, on, dom) {
    
    return declare([_EventsMixin], {
       
       /**
        * The topic to use for publishing and subscribing to node resize events
        *
-       * @event
        * @instance
        * @type {string}
-       * @default
+       * @default [NODE_RESIZED]{@link module:alfresco/core/topics#NODE_RESIZED}
        */
-      alfResizeNodeTopic: "ALF_NODE_RESIZED",
+      alfResizeNodeTopic: topics.NODE_RESIZED,
 
       /**
        * Publishes on a topic that indicates that the supplied node has been resized.

--- a/aikau/src/main/resources/alfresco/core/_EventsMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_EventsMixin.js
@@ -41,11 +41,12 @@
  * @author Martin Doyle
  */
 define(["alfresco/core/Core",
+        "alfresco/core/topics",
         "alfresco/util/functionUtils", 
         "dojo/_base/declare", 
         "dojo/_base/lang", 
         "dojo/on"], 
-        function(AlfCore, funcUtils, declare, lang, on) {
+        function(AlfCore, topics, funcUtils, declare, lang, on) {
 
    return declare([AlfCore], {
 
@@ -146,7 +147,7 @@ define(["alfresco/core/Core",
             resizeListener = on(window, "resize", resizeAction);
             this.own && this.own(resizeListener);
          } else {
-            resizeSubscription = this.alfSubscribe("ALF_NODE_RESIZED", lang.hitch(this, function(payload) {
+            resizeSubscription = this.alfSubscribe(topics.NODE_RESIZED, lang.hitch(this, function(payload) {
                var resizedNode = payload.node,
                   resizedNodeIsAncestor = false,
                   testNode = nodeToMonitor;

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -311,6 +311,23 @@ define([],function() {
       NAVIGATE_TO_PAGE: "ALF_NAVIGATE_TO_PAGE",
 
       /**
+       * This topic is published from the [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent} function.
+       * To publish this this topic a widget should mixin the [ResizeMixin]{@link module:alfresco/core/ResizeMixin} and call that function
+       * and to subscribe to it, a module should mixin the [ResizeMixin]{@link module:alfresco/core/ResizeMixin} and call the
+       * [alfSetupResizeSubscriptions]{@link module:alfresco/core/ResizeMixin#alfSetupResizeSubscriptions} to set up callback handlers 
+       * for resizing.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.36.1
+       *
+       * @event
+       * @property {element} node The DOM node that has been resized
+       */
+      NODE_RESIZED: "ALF_NODE_RESIZED",
+
+      /**
        * This topic is fired automatically whenever a notification is destroyed.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/HorizontalWidgets.js
@@ -357,9 +357,14 @@ define(["alfresco/core/ProcessWidgets",
             array.forEach(processedWidgets, function(widget) {
                if (widget && widget.domNode && widget.widthCalc)
                {
+                  var currentWidth = domGeom.getMarginBox(widget.domNode.parentNode).w;
                   domStyle.set(widget.domNode.parentNode, "width", widget.widthCalc + "px");
+                  if (currentWidth !== widget.widthCalc)
+                  {
+                     this.alfPublishResizeEvent(widget.domNode.parentNode);
+                  }
                }
-            });
+            }, this);
          }));
       },
 

--- a/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
@@ -285,12 +285,11 @@ define(["intern!object",
          },
 
          "Check that when a widget is revealed that a resize event is published": function() {
-            return browser.findByCssSelector("body").end()
+            return browser.findById("HIDE_WIDGET_2_BUTTON_label")
                .clearLog()
-               .findById("HIDE_WIDGET_2_BUTTON_label")
-                  .click()
-               .end()
-               .getLastPublish("ALF_NODE_RESIZED", "A resize publication should have been made");
+               .click()
+            .end()
+            .getLastPublish("ALF_NODE_RESIZED", "A resize publication should have been made");
          },
          
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/DynamicHorizontalLayoutTest.js
@@ -283,6 +283,15 @@ define(["intern!object",
                   assert.closeTo(size.width, expectedWidth, 10, "Widget 5 was not the correct size");
                });
          },
+
+         "Check that when a widget is revealed that a resize event is published": function() {
+            return browser.findByCssSelector("body").end()
+               .clearLog()
+               .findById("HIDE_WIDGET_2_BUTTON_label")
+                  .click()
+               .end()
+               .getLastPublish("ALF_NODE_RESIZED", "A resize publication should have been made");
+         },
          
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-588. It ensures that resize publications are made from the alfresco/layout/HorizontalWidgets module when widths are dynamically updated. This will be merged to develop and then cherry picked for a 1.0.36.1 hotfix release.