### PR TITLE
AKU-595: Ensure that right ordering in LeftAndRight is correct

### DIFF
--- a/aikau/src/main/resources/alfresco/core/DynamicWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/DynamicWidgetProcessing.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -37,7 +37,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_core_DynamicWidgetProcessing__postCreate() {
-         this.alfSubscribe(this.dynamicallyAddWidgetTopic, lang.hitch(this, "processDynamicUpdates"))
+         this.alfSubscribe(this.dynamicallyAddWidgetTopic, lang.hitch(this, this.processDynamicUpdates));
          this.inherited(arguments);
       },
       
@@ -61,10 +61,10 @@ define(["dojo/_base/declare",
          {
             this.alfLog("warn", "A request made to add widgets dynamically but a 'widgets' attribute was not provided", payload);
          }
-         else if (payload.targetId == this.id)
+         else if (payload.targetId === this.id)
          {
             var targetPosition = (typeof payload.targetPosition === "number") ? payload.targetPosition : null;
-            array.forEach(payload.widgets, lang.hitch(this, "addWidgetDynamically", payload.targetId, targetPosition));
+            array.forEach(payload.widgets, lang.hitch(this, this.addWidgetDynamically, payload.targetId, targetPosition));
          }
       },
       
@@ -77,7 +77,7 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget to add
        * @param {integer} index The index of the widget
        */
-      addWidgetDynamically: function alfresco_core_DynamicWidgetProcessing__addWidgetDynamically(targetId, targetPosition, widget, index) {
+      addWidgetDynamically: function alfresco_core_DynamicWidgetProcessing__addWidgetDynamically(targetId, targetPosition, widget, /*jshint unused:false*/index) {
          if (typeof widget.placeAt !== "function")
          {
             this.alfLog("error", "Widget has no 'placeAt' function so cannot be dynamically added", widget);

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfToolbar.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfToolbar.js
@@ -44,7 +44,7 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/AlfToolbar.css"}],
       
       /**
-       * Adds the "alf-documentlist-toolbar" CSS class to the DOM node.
+       * Adds the "alfresco-documentlibrary-AlfToolbar" CSS class to the DOM node.
        * @instance
        */
       postCreate: function alfresco_documentlibrary_AlfToolbar__postCreate() {
@@ -59,9 +59,8 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget to add
        * @param {number} insertIndex The index at which to add the widget.
        */
-      addChild: function(widget, insertIndex) {
-         var refNode = domConstruct.create("div", { className: "horizontal-widget"}, this.rightWidgets, insertIndex);
-         domConstruct.place(widget.domNode, refNode, insertIndex);
+      addChild: function alfresco_documentlibrary_AlfToolbar__addChild(widget, /*jshint unused:false*/ insertIndex) {
+         domConstruct.place(widget.domNode, this.rightWidgets, "last");
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
+++ b/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
@@ -120,6 +120,9 @@ define(["dojo/_base/declare",
                return widget.align !== "right";
             });
          }
+         // We need to reverse the order of RIGHT widgets so that the last widget is defined is furthest
+         // to the RIGHT
+         this.widgetsRight = this.widgetsRight.reverse();
          this.processWidgets(this.widgetsRight, this.rightWidgets, "RIGHT");
          this.processWidgets(this.widgetsLeft, this.leftWidgets, "LEFT");
 

--- a/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
+++ b/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
@@ -122,7 +122,7 @@ define(["dojo/_base/declare",
          }
          // We need to reverse the order of RIGHT widgets so that the last widget is defined is furthest
          // to the RIGHT
-         this.widgetsRight = this.widgetsRight.reverse();
+         this.widgetsRight.reverse();
          this.processWidgets(this.widgetsRight, this.rightWidgets, "RIGHT");
          this.processWidgets(this.widgetsLeft, this.leftWidgets, "LEFT");
 

--- a/aikau/src/test/resources/alfresco/layout/BasicLayoutTest.js
+++ b/aikau/src/test/resources/alfresco/layout/BasicLayoutTest.js
@@ -27,204 +27,232 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, require, TestCommon) {
 
-registerSuite(function(){
-   var testableDimensions = {}, 
-      browser;
+   registerSuite(function(){
+      var testableDimensions = {}, 
+          browser;
 
-   return {
-      name: "Basic Layout Tests",
+      return {
+         name: "Basic Layout Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/BasicLayouts", "Basic Layout Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/BasicLayouts", "Basic Layout Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Test top margin is set correctly on a vertical widget": function () {
-         return browser.findByCssSelector("#SURF_LOGO1")
-            .getAttribute("style")
-            .then(function(style) {
-               assert.equal(style, "margin-top: 10px;", "The style was not set correctly on a vertical widget with top margin: " + style);
-            });
-      },
+         "Test top margin is set correctly on a vertical widget": function () {
+            return browser.findByCssSelector("#SURF_LOGO1")
+               .getAttribute("style")
+               .then(function(style) {
+                  assert.equal(style, "margin-top: 10px;", "The style was not set correctly on a vertical widget with top margin: " + style);
+               });
+         },
 
-      "Test bottom margin is set correctly on a vertical widget": function() {
-         return browser.findByCssSelector("#SURF_LOGO2")
-            .getAttribute("style")
-            .then(function(style) {
-               assert.equal(style, "margin-bottom: 20px;", "The style was not set correctly on a vertical widget with bottom margin: " + style);
-            });
-      },
+         "Test bottom margin is set correctly on a vertical widget": function() {
+            return browser.findByCssSelector("#SURF_LOGO2")
+               .getAttribute("style")
+               .then(function(style) {
+                  assert.equal(style, "margin-bottom: 20px;", "The style was not set correctly on a vertical widget with bottom margin: " + style);
+               });
+         },
 
-      "Test both top and bottom margins are set correctly on a vertical widget": function() {
-         return browser.findByCssSelector("#SURF_LOGO3")
-            .getAttribute("style")
-            .then(function(style) {
-               assert.equal(style, "margin-top: 30px; margin-bottom: 40px;", "The style was not set correctly on a vertical widget with top and bottom margins: " + style);
-            });
-      },
+         "Test both top and bottom margins are set correctly on a vertical widget": function() {
+            return browser.findByCssSelector("#SURF_LOGO3")
+               .getAttribute("style")
+               .then(function(style) {
+                  assert.equal(style, "margin-top: 30px; margin-bottom: 40px;", "The style was not set correctly on a vertical widget with top and bottom margins: " + style);
+               });
+         },
 
-      "Test that empty horizontal widgets are rendered": function() {
-         return browser.findByCssSelector("#EMPTY_HORIZONTAL")
-            .then(null, function() {
-               assert(false, "Empty horizontal widgets was not rendered");
-            });
-      },
+         "Test that empty horizontal widgets are rendered": function() {
+            return browser.findByCssSelector("#EMPTY_HORIZONTAL")
+               .then(null, function() {
+                  assert(false, "Empty horizontal widgets was not rendered");
+               });
+         },
 
-      "Test that empty vertical widgets are rendered": function() {
-         return browser.findByCssSelector("#EMPTY_VERTICAL")
-            .then(null, function() {
-               assert(false, "Empty vertical widgets was not rendered");
-            });
-      },
+         "Test that empty vertical widgets are rendered": function() {
+            return browser.findByCssSelector("#EMPTY_VERTICAL")
+               .then(null, function() {
+                  assert(false, "Empty vertical widgets was not rendered");
+               });
+         },
 
-      "Test that empty left and right widgets are rendered": function() {
-         return browser.findByCssSelector("#EMPTY_LEFT_AND_RIGHT")
-            .then(null, function() {
-               assert(false, "TEmpty left and right widgets was not rendered");
-            });
-      },
+         "Test that empty left and right widgets are rendered": function() {
+            return browser.findByCssSelector("#EMPTY_LEFT_AND_RIGHT")
+               .then(null, function() {
+                  assert(false, "Empty left and right widgets was not rendered");
+               });
+         },
 
-      "Test that empty centered widgets are rendered": function() {
-         return browser.findByCssSelector("#EMPTY_CENTERED_WIDGETS")
-            .then(null, function() {
-               assert(false, "Empty centered widgets was not rendered");
-            });
-      },
+         "Test that RIGHT left and right layout widgets are ordered correctly": function() {
+            return browser.findByCssSelector("#ALFRESCO_LOGO2 + #ALFRESCO_LOGO1")
+               .then(null, function() {
+                  assert(false, "Right layout widgets in the wrong order");
+               });
+         },
 
-      "Test left alignment": function() {
-         return browser.findByCssSelector(".alfresco-layout-LeftAndRight__left #SURF_LOGO4")
-            .then(null, function() {
-               assert(false, "Widget was not left aligned");
-            });
-      },
+         "Test that LEFT left and right layout widgets are ordered correctly": function() {
+            return browser.findByCssSelector(".additional-test-class+.additional-test-class-2")
+               .then(null, function() {
+                  assert(false, "Left layout widgets in the wrong order");
+               });
+         },
 
-      "Test right alignment": function() {
-         return browser.findByCssSelector(".alfresco-layout-LeftAndRight__right #ALFRESCO_LOGO1")
-            .then(null, function() {
-               assert(false, "logo was not right aligned");
-            });
-      },
+         "Test that RIGHT left and right layout widgets are ordered correctly (LEGACY)": function() {
+            return browser.findByCssSelector("#ALFRESCO_LOGO4 + #ALFRESCO_LOGO3")
+               .then(null, function() {
+                  assert(false, "Right layout widgets in the wrong order");
+               });
+         },
 
-      "Test left margin of horizontal widget": function() {
-         return browser.findByCssSelector("#LEVEL2_HORIZONTAL2")
-            .getComputedStyle("width")
-            .then(function(width) {
-               testableDimensions.horiz2 = width.substring(0, width.lastIndexOf("px"));
-            })
-         .end()
-         .findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(3)")
-            .getComputedStyle("margin-left")
-            .then(function(x) {
-               assert.equal(x, "10px", "The left margin was not set correctly on a horizontal widget");
-            });
-      },
+         "Test that LEFT left and right layout widgets are ordered correctly (LEGACY)": function() {
+            return browser.findByCssSelector(".additional-test-class-3+.additional-test-class-4")
+               .then(null, function() {
+                  assert(false, "Left layout widgets in the wrong order");
+               });
+         },
 
-      "Test right margin of horizontal widget": function() {
-         return browser.findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(3)")
-            .getComputedStyle("margin-right")
-            .then(function(x) {
-               assert.equal(x, "20px", "The right margin was not set correctly on a horizontal widget");
-            });
-      },
+         "Test that empty centered widgets are rendered": function() {
+            return browser.findByCssSelector("#EMPTY_CENTERED_WIDGETS")
+               .then(null, function() {
+                  assert(false, "Empty centered widgets was not rendered");
+               });
+         },
 
-      "Test width of horizontal element by remaining percentage": function() {
-         return browser.findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(3)")
-            .getComputedStyle("width")
-            .then(function(width) {
-               // Calculate what the width should be...
-               // 75% of the the width of the REMAINDER of the horizontal widget parent minus all the margins and the pixel width widget
-               var x = width.substring(0, width.lastIndexOf("px"));
-               var shouldBe = (testableDimensions.horiz2 - 90 - 300 - 3 - 30) * 0.75;
-               assert.equal(shouldBe, x, "The width was not set correctly by remaining percentage: " + x + " (should be: " + shouldBe + ")");
-            });
-      },
+         "Test left alignment": function() {
+            return browser.findByCssSelector(".alfresco-layout-LeftAndRight__left #SURF_LOGO4")
+               .then(null, function() {
+                  assert(false, "Widget was not left aligned");
+               });
+         },
 
-      "Test width is set correctly": function() {
-         return browser.findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(2)")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert.equal(width, "300px", "The width was not set correctly by pixels");
-            });
-      },
+         "Test right alignment": function() {
+            return browser.findByCssSelector(".alfresco-layout-LeftAndRight__right #ALFRESCO_LOGO1")
+               .then(null, function() {
+                  assert(false, "logo was not right aligned");
+               });
+         },
 
-      "Test space is evenly divided (1)": function() {
-         return browser.findByCssSelector("#LEVEL2_HORIZONTAL3")
-            .getComputedStyle("width")
-            .then(function(width) {
-               testableDimensions.horiz3 = width.substring(0, width.lastIndexOf("px"));
-            })
-         .end()
-         .findByCssSelector("#LEVEL2_HORIZONTAL3 > div > div:nth-child(1)")
-            .getComputedStyle("width")
-            .then(function(width) {
-               var x = width.substring(0, width.lastIndexOf("px"));
-               var shouldBe = (testableDimensions.horiz3 - 2 - 30) * 0.5;
-               assert.equal(shouldBe, x, "The width was not set correctly by evenly dividing space, was: " + x + ", should be: " + shouldBe);
-            });
-      },
+         "Test left margin of horizontal widget": function() {
+            return browser.findByCssSelector("#LEVEL2_HORIZONTAL2")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  testableDimensions.horiz2 = width.substring(0, width.lastIndexOf("px"));
+               })
+            .end()
+            .findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(3)")
+               .getComputedStyle("margin-left")
+               .then(function(x) {
+                  assert.equal(x, "10px", "The left margin was not set correctly on a horizontal widget");
+               });
+         },
 
-      "Test space is evenly divided (2)": function() {
-         return browser.findByCssSelector("#LEVEL2_HORIZONTAL3 > div > div:nth-child(2)")
-            .getComputedStyle("width")
-            .then(function(width) {
-               var x = width.substring(0, width.lastIndexOf("px"));
-               var shouldBe = (testableDimensions.horiz3 - 2 - 30) * 0.5;
-               assert.equal(shouldBe, x, "The width was not set correctly by evenly dividing space");
-            });
-      },
+         "Test right margin of horizontal widget": function() {
+            return browser.findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(3)")
+               .getComputedStyle("margin-right")
+               .then(function(x) {
+                  assert.equal(x, "20px", "The right margin was not set correctly on a horizontal widget");
+               });
+         },
 
-      "Test that first excess pixel widget is rendered": function() {
-         return browser.findByCssSelector("#LOGO6")
-            .then(null, function() {
-               assert(false, "first widget with excess pixels was not rendered");
-            });
-      },
+         "Test width of horizontal element by remaining percentage": function() {
+            return browser.findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(3)")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  // Calculate what the width should be...
+                  // 75% of the the width of the REMAINDER of the horizontal widget parent minus all the margins and the pixel width widget
+                  var x = width.substring(0, width.lastIndexOf("px"));
+                  var shouldBe = (testableDimensions.horiz2 - 90 - 300 - 3 - 30) * 0.75;
+                  assert.equal(shouldBe, x, "The width was not set correctly by remaining percentage: " + x + " (should be: " + shouldBe + ")");
+               });
+         },
 
-      "Test that second excess pixel widget is rendered": function() {
-         return browser.findByCssSelector("#LOGO7")
-            .then(null, function() {
-               assert(false, "second widget with excess pixels was not rendered");
-            });
-      },
+         "Test width is set correctly": function() {
+            return browser.findByCssSelector("#LEVEL2_HORIZONTAL2 > div > div:nth-child(2)")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  assert.equal(width, "300px", "The width was not set correctly by pixels");
+               });
+         },
 
-      "Test that third excess pixel widget is rendered": function() {
-         return browser.findByCssSelector("#LOGO8")
-            .then(null, function() {
-               assert(false, "widget1 with excess pixels was not rendered");
-            });
-      },
+         "Test space is evenly divided (1)": function() {
+            return browser.findByCssSelector("#LEVEL2_HORIZONTAL3")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  testableDimensions.horiz3 = width.substring(0, width.lastIndexOf("px"));
+               })
+            .end()
+            .findByCssSelector("#LEVEL2_HORIZONTAL3 > div > div:nth-child(1)")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  var x = width.substring(0, width.lastIndexOf("px"));
+                  var shouldBe = (testableDimensions.horiz3 - 2 - 30) * 0.5;
+                  assert.equal(shouldBe, x, "The width was not set correctly by evenly dividing space, was: " + x + ", should be: " + shouldBe);
+               });
+         },
 
-      "Find center-container class": function() {
-         return browser.findByCssSelector(".center-container")
-            .then(null, function() {
-               assert(false, "center-container not found");
-            });
-      },
+         "Test space is evenly divided (2)": function() {
+            return browser.findByCssSelector("#LEVEL2_HORIZONTAL3 > div > div:nth-child(2)")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  var x = width.substring(0, width.lastIndexOf("px"));
+                  var shouldBe = (testableDimensions.horiz3 - 2 - 30) * 0.5;
+                  assert.equal(shouldBe, x, "The width was not set correctly by evenly dividing space");
+               });
+         },
 
-      "Test logo is center aligned": function() {
-         return browser.findByCssSelector(".center-container #LOGO9")
-            .then(null, function() {
-               assert(false, "logo was not center aligned");
-            });
-      },
+         "Test that first excess pixel widget is rendered": function() {
+            return browser.findByCssSelector("#LOGO6")
+               .then(null, function() {
+                  assert(false, "first widget with excess pixels was not rendered");
+               });
+         },
 
-      "": function() {
-         return browser.findByCssSelector(".center-container")
-            .getComputedStyle("width")
-            .then(function(width) {
-               var x = width.substring(0, width.lastIndexOf("px"));
-               var shouldBe = 368;
-               assert.equal(shouldBe, x, "The width was not set correctly");
-            });
-      },
+         "Test that second excess pixel widget is rendered": function() {
+            return browser.findByCssSelector("#LOGO7")
+               .then(null, function() {
+                  assert(false, "second widget with excess pixels was not rendered");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Test that third excess pixel widget is rendered": function() {
+            return browser.findByCssSelector("#LOGO8")
+               .then(null, function() {
+                  assert(false, "widget1 with excess pixels was not rendered");
+               });
+         },
+
+         "Find center-container class": function() {
+            return browser.findByCssSelector(".center-container")
+               .then(null, function() {
+                  assert(false, "center-container not found");
+               });
+         },
+
+         "Test logo is center aligned": function() {
+            return browser.findByCssSelector(".center-container #LOGO9")
+               .then(null, function() {
+                  assert(false, "logo was not center aligned");
+               });
+         },
+
+         "": function() {
+            return browser.findByCssSelector(".center-container")
+               .getComputedStyle("width")
+               .then(function(width) {
+                  var x = width.substring(0, width.lastIndexOf("px"));
+                  var shouldBe = 368;
+                  assert.equal(shouldBe, x, "The width was not set correctly");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,8 +31,8 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/actions/CopyToActionTest"
+   baseFunctionalSuites: [
+      "src/test/resources/alfresco/layout/BasicLayoutTest"
    ],
 
    /**
@@ -41,7 +41,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   baseFunctionalSuites: [
+   xbaseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,8 +31,8 @@ define({
     * @type {string[]}
     */
    // Uncomment and add specific tests as necessary during development!
-   baseFunctionalSuites: [
-      "src/test/resources/alfresco/layout/BasicLayoutTest"
+   xbaseFunctionalSuites: [
+      "src/test/resources/alfresco/renderers/actions/CopyToActionTest"
    ],
 
    /**
@@ -41,7 +41,7 @@ define({
     * @instance
     * @type {string[]}
     */
-   xbaseFunctionalSuites: [
+   baseFunctionalSuites: [
       "src/test/resources/alfresco/accessibility/AccessibilityMenuTest",
       "src/test/resources/alfresco/accessibility/SemanticWrapperMixinTest",
 

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -42,8 +42,8 @@ define(["./config/Suites"],
             chromeOptions: {
                excludeSwitches: ["ignore-certificate-errors"]
             }
-         // }, {
-         //    browserName: "Firefox"
+         }, {
+            browserName: "Firefox"
          }],
 
          // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/BasicLayouts.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/BasicLayouts.get.js
@@ -66,25 +66,82 @@ model.jsonModel = {
                   }
                },
                {
+                  id: "LEVEL2_LEFTANDRIGHT",
                   name: "alfresco/layout/LeftAndRight",
                   config: {
-                     id: "LEVEL2_LEFTANDRIGHT",
                      widgetsLeft: [
                         {
+                           id: "SURF_LOGO4",
                            name: "alfresco/logo/Logo",
                            className: "additional-test-class",
                            config: {
-                              id: "SURF_LOGO4",
+                              logoClasses: "surf-logo-small"
+                           }
+                        },
+                        {
+                           id: "SURF_LOGO5",
+                           name: "alfresco/logo/Logo",
+                           className: "additional-test-class-2",
+                           config: {
                               logoClasses: "surf-logo-small"
                            }
                         }
                      ],
                      widgetsRight: [
                         {
+                           id: "ALFRESCO_LOGO1",
                            name: "alfresco/logo/Logo",
                            config: {
-                              id: "ALFRESCO_LOGO1",
                               logoClasses: "alfresco-logo-only"
+                           }
+                        },
+                        {
+                           id: "ALFRESCO_LOGO2",
+                           name: "alfresco/logo/Logo",
+                           config: {
+                              logoClasses: "surf-logo-large"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "LEVEL3_LEFTANDRIGHT",
+                  name: "alfresco/layout/LeftAndRight",
+                  config: {
+                     widgets: [
+                        {
+                           id: "SURF_LOGO6",
+                           name: "alfresco/logo/Logo",
+                           className: "additional-test-class-3",
+                           align: "left",
+                           config: {
+                              logoClasses: "surf-logo-small"
+                           }
+                        },
+                        {
+                           id: "SURF_LOGO7",
+                           name: "alfresco/logo/Logo",
+                           className: "additional-test-class-4",
+                           align: "left",
+                           config: {
+                              logoClasses: "surf-logo-small"
+                           }
+                        },
+                        {
+                           id: "ALFRESCO_LOGO3",
+                           name: "alfresco/logo/Logo",
+                           align: "right",
+                           config: {
+                              logoClasses: "alfresco-logo-only"
+                           }
+                        },
+                        {
+                           id: "ALFRESCO_LOGO4",
+                           name: "alfresco/logo/Logo",
+                           align: "right",
+                           config: {
+                              logoClasses: "surf-logo-large"
                            }
                         }
                      ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-595 to ensure that the right aligned widgets in the LeftAndRight module are ordered correctly. The unit tests have been updated to verify the behaviour.