### PR TITLE
AKU-596: Prevent bad thumbnail renditions corrupting search view

### DIFF
--- a/aikau/src/main/resources/alfresco/search/css/SearchThumbnail.css
+++ b/aikau/src/main/resources/alfresco/search/css/SearchThumbnail.css
@@ -3,4 +3,5 @@
    float: right;
    box-shadow: 0.33px 1px 3px rgba(0,0,0,0.3);
    border: none;
+   max-width: 100px;
 }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-596. This is a defensive CSS update required for future deployment of Share in the Cloud.