### PR TITLE
AKU-586: alfresco/documentlibrary/AlfTagFilters does not work in a scoped environment

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -115,6 +115,7 @@ define(["dojo/_base/declare",
        * @property {function} [progressCallback] - overrides the default progress callback
        * @property {function} [callbackScope=_this] - the scope to pass to the overridden callback function
        * @property {string} [alfTopic] - The topic to by published by the default request callbacks.
+       * @property {string} [alfResponseScope=""] - The scope to use when publishing in the default request callbacks.
        * Appended with "_PROGRESS", "_FAILURE" or "_SUCCESS" depending on response status code.
        *
        *
@@ -312,7 +313,7 @@ define(["dojo/_base/declare",
             this.alfPublish(requestConfig.alfTopic + "_SUCCESS", {
                requestConfig: requestConfig,
                response: response
-            });
+            }, false, false, requestConfig.alfResponseScope || this.pubSubScope);
          }
          else
          {
@@ -334,7 +335,7 @@ define(["dojo/_base/declare",
             this.alfPublish(requestConfig.alfTopic + "_FAILURE", {
                requestConfig: requestConfig,
                response: response
-            });
+            }, false, false, requestConfig.alfResponseScope || this.pubSubScope);
          }
          if (typeof this.displayMessage === "function" && response.response.text)
          {
@@ -377,7 +378,7 @@ define(["dojo/_base/declare",
             this.alfPublish(requestConfig.alfTopic + "_PROGRESS", {
                requestConfig: requestConfig,
                response: response
-            });
+            }, false, false, requestConfig.alfResponseScope || this.pubSubScope);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -58,7 +58,7 @@ define([],function() {
        * @default
        * @since 1.0.36
        *
-       * @event module:alfresco/core/topics~ASSIGN_WORKFLOW
+       * @event
        * @property {object[]} nodes - The array of Nodes to start the workflow on
        * @property {object} currentTarget - The current Node in which the nodes reside
        */

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -127,6 +127,20 @@ define([],function() {
       CREATE_FORM_DIALOG: "ALF_CREATE_FORM_DIALOG_REQUEST",
 
       /**
+       * Create a new tag
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.37
+       *
+       * @event
+       * @property {string} tagName The name of the tag to create
+       * @property {string} alfResponseTopic The topic on which to respond
+       */
+      CREATE_TAG: "ALF_CREATE_TAG",
+
+      /**
        * Delete the archive created for downloading.
        *
        * @instance
@@ -204,6 +218,32 @@ define([],function() {
        * @property {object[]} [selectedItems=null] A specific set of items to be selected
        */
       DOCUMENT_SELECTION_UPDATE: "ALF_DOCLIST_FILE_SELECTION",
+
+      /**
+       * Fired when a "document" has been tagged
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.37
+       *
+       * @event
+       */
+      DOCUMENT_TAGGED: "ALF_DOCUMENT_TAGGED",
+
+      /**
+       * Fired when a tag has been chosen to filter a document list.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.37
+       *
+       * @event
+       * @property {string} description A textual description of this tag
+       * @property {string} value The name of the tag on which to filter
+       */
+      DOCUMENTLIST_TAG_CHANGED: "ALF_DOCUMENTLIST_TAG_CHANGED",
       
       /**
        * This topic is published to request either the download of a single document or folder (or a selection
@@ -442,6 +482,20 @@ define([],function() {
       REQUEST_FINISHED_TOPIC: "ALF_DOCLIST_REQUEST_FINISHED",
 
       /**
+       * Retrieve the currently available tags
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.37
+       *
+       * @event
+       * @property {string} alfResponseTopic The topic on which to publish the results
+       * @property {object} [query] An optional query to pass through with the tags request
+       */
+      RETRIEVE_CURRENT_TAGS: "ALF_RETRIEVE_CURRENT_TAGS",
+
+      /**
        * <p>This topic is used to indicate that a navigable collection has been scrolled to
        * "near" its bottom. Since its creation, this topic's meaning has extended to go beyond
        * just scrolling (sometimes it's clicking arrows) and to not necessarily being the
@@ -482,6 +536,23 @@ define([],function() {
        * @since 1.0.34
        */
       SET_PREFERENCE: "ALF_PREFERENCE_SET",
+
+      /**
+       * This topic is used to request tags for a node and its descendants. The payload must container either siteId and containerId, or rootNode.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.37
+       * @event
+       * @property {function} callback The function to be called after the query has successfully executed
+       * @property {object} callbackScope The scope within which to run the callback function
+       * @property {int} [maxTags=100] The maxinum number of tags to retrieve
+       * @property {string} [siteId] The site ID
+       * @property {string} [containerId] The container ID within the site
+       * @property {string} [rootNode] The root node
+       */
+      TAG_QUERY: "ALF_TAG_QUERY",
 
       /**
        * This topic can be used to publish a request to change the title of a page. It is subscribed to by the

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -251,7 +251,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe(this.showPathTopic, lang.hitch(this, this.onShowBreadcrumb));
          this.alfSubscribe(this.filterSelectionTopic, lang.hitch(this, this.onFilterSelection));
          this.alfSubscribe("ALF_DOCUMENTLIST_CATEGORY_CHANGED", lang.hitch(this, this.onFilterSelection));
-         this.alfSubscribe("ALF_DOCUMENTLIST_TAG_CHANGED", lang.hitch(this, this.onFilterSelection));
+         this.alfSubscribe(this.docListTagChangedTopic, lang.hitch(this, this.onFilterSelection));
 
          if (this.breadcrumbs)
          {

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -141,7 +141,7 @@ define(["dojo/_base/declare",
        * @instance
        * @listens ALF_DOCUMENTLIST_PATH_CHANGED
        * @listens ALF_DOCUMENTLIST_CATEGORY_CHANGED
-       * @listens ALF_DOCUMENTLIST_TAG_CHANGED
+       * @listens module:alfresco/core/topics#DOCUMENTLIST_TAG_CHANGED
        * @listens filterSelectionTopic
        * @listens documentSelectionTopic
        * @listens parentNavTopic
@@ -150,7 +150,7 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          this.alfSubscribe(topics.PATH_CHANGED, lang.hitch(this, this.onPathChanged));
          this.alfSubscribe("ALF_DOCUMENTLIST_CATEGORY_CHANGED", lang.hitch(this, this.onCategoryChanged));
-         this.alfSubscribe("ALF_DOCUMENTLIST_TAG_CHANGED", lang.hitch(this, this.onTagChanged));
+         this.alfSubscribe(this.docListTagChangedTopic, lang.hitch(this, this.onTagChanged));
          this.alfSubscribe(this.filterSelectionTopic, lang.hitch(this, this.onFilterChanged));
          this.alfSubscribe(this.documentSelectionTopic, lang.hitch(this, this.onDocumentSelection));
          this.alfSubscribe(this.showFoldersTopic, lang.hitch(this, this.onShowFolders));

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -27,16 +27,17 @@
 define(["dojo/_base/declare",
         "alfresco/documentlibrary/AlfDocumentFilters", 
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "alfresco/services/_TagServiceTopics",
         "alfresco/documentlibrary/AlfDocumentFilter",
         "alfresco/core/ObjectTypeUtils",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/on",
         "dijit/registry"], 
-        function(declare, AlfDocumentFilters, _AlfDocumentListTopicMixin, _TagServiceTopics, AlfDocumentFilter, ObjectTypeUtils, lang, array, domConstruct, domClass, on, registry) {
+        function(declare, AlfDocumentFilters, _AlfDocumentListTopicMixin, AlfDocumentFilter,
+               ObjectTypeUtils, topics, lang, array, domConstruct, domClass, on, registry) {
 
    return declare([AlfDocumentFilters, _AlfDocumentListTopicMixin], {
       
@@ -100,25 +101,38 @@ define(["dojo/_base/declare",
       rootNode: null,
 
       /**
-       * Overrides the mixed-in constant so that a tag specific topic is published on
+       * Overrides the mixed-in value so that a tag specific topic is published
        *
        * @instance
        * @type {string}
        * @default
        */
-      filterSelectionTopic: "ALF_DOCUMENTLIST_TAG_CHANGED",
+      filterSelectionTopic: topics.DOCUMENTLIST_TAG_CHANGED,
 
       /**
+       * This topic is used to request that a node should be rated (the details should be supplied
+       * as the publication payload).
+       * 
        * @instance
+       * @type {string}
+       * @default
+       */
+      tagQueryTopic: topics.TAG_QUERY,
+
+      /**
+       * Called immediately after instantiation and before any processing
+       * 
+       * @instance
+       * @fires module:alfresco/core/topics~TAG_QUERY
        */
       postMixInProperties: function alfresco_documentlibrary_AlfTagFilters__postMixInProperties() {
          this.inherited(arguments);
          
          // Subscribe to publications about documents being tagged/untagged...
-         this.alfSubscribe(this.documentTaggedTopic, lang.hitch(this, "onDocumentTagged"));
+         this.alfSubscribe(this.documentTaggedTopic, lang.hitch(this, this.onDocumentTagged));
          
          // Make a request to get the initial set of tags for the current location...
-         this.alfPublish(_TagServiceTopics.tagQueryTopic, {
+         this.alfServicePublish(this.tagQueryTopic, {
             callback: this.onTagQueryResults,
             callbackScope: this,
             siteId: this.siteId,
@@ -159,6 +173,7 @@ define(["dojo/_base/declare",
             widget.destroy();
          }
       },
+      
       /**
        * Creates a new [filter widget]{@link module:alfresco/documentlibrary/AlfDocumentFilter} and then calls the
        * [addFilter function]{@link module:alfresco/documentlibrary/AlfDocumentFilters#addFilter} to add it.

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -122,7 +122,7 @@ define(["dojo/_base/declare",
        * Called immediately after instantiation and before any processing
        * 
        * @instance
-       * @fires module:alfresco/core/topics~TAG_QUERY
+       * @fires module:alfresco/core/topics#TAG_QUERY
        */
       postMixInProperties: function alfresco_documentlibrary_AlfTagFilters__postMixInProperties() {
          this.inherited(arguments);

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -27,7 +27,6 @@
 define(["dojo/_base/declare",
         "alfresco/documentlibrary/AlfDocumentFilters", 
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "alfresco/documentlibrary/AlfDocumentFilter",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/core/topics",
         "dojo/_base/lang",
@@ -35,9 +34,9 @@ define(["dojo/_base/declare",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/on",
-        "dijit/registry"], 
-        function(declare, AlfDocumentFilters, _AlfDocumentListTopicMixin, AlfDocumentFilter,
-               ObjectTypeUtils, topics, lang, array, domConstruct, domClass, on, registry) {
+        "dijit/registry",
+        "alfresco/documentlibrary/AlfDocumentFilter"], // Referenced in this.createWidget call, so must be explicitly included here
+        function(declare, AlfDocumentFilters, _AlfDocumentListTopicMixin, ObjectTypeUtils, topics, lang, array, domConstruct, domClass, on, registry) {
 
    return declare([AlfDocumentFilters, _AlfDocumentListTopicMixin], {
       
@@ -112,7 +111,7 @@ define(["dojo/_base/declare",
       /**
        * This topic is used to request that a node should be rated (the details should be supplied
        * as the publication payload).
-       * 
+       *
        * @instance
        * @type {string}
        * @default
@@ -173,7 +172,7 @@ define(["dojo/_base/declare",
             widget.destroy();
          }
       },
-      
+
       /**
        * Creates a new [filter widget]{@link module:alfresco/documentlibrary/AlfDocumentFilter} and then calls the
        * [addFilter function]{@link module:alfresco/documentlibrary/AlfDocumentFilters#addFilter} to add it.
@@ -186,11 +185,14 @@ define(["dojo/_base/declare",
              tagData.name &&
              tagData.count)
          {
-            var tagFilter = new AlfDocumentFilter({
-               filterSelectionTopic: this.filterSelectionTopic,
-               label: this.message("filter.tag.label", {"0": tagData.name, "1": tagData.count}),
-               filter: tagData.name,
-               description: this.message("filter.tagged.label", {"0":tagData.name})
+            var tagFilter = this.createWidget({
+               name: "alfresco/documentlibrary/AlfDocumentFilter",
+               config: {
+                  filterSelectionTopic: this.filterSelectionTopic,
+                  label: this.message("filter.tag.label", {"0": tagData.name, "1": tagData.count}),
+                  filter: tagData.name,
+                  description: this.message("filter.tagged.label", {"0": tagData.name})
+               }
             });
             this.addFilter(tagFilter);
          }
@@ -199,7 +201,7 @@ define(["dojo/_base/declare",
             this.alfLog("warn", "It is not possible to create a filter tag without 'name' and 'count' attributes", tagData);
          }
       },
-      
+
       /**
        * Used to keep track of the current set of filter tags.
        * 

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -72,6 +72,15 @@ define(["dojo/_base/declare",
        * @default
        */
       filterSelectionTopic: "ALF_DOCLIST_FILTER_SELECTION",
+
+      /**
+       * This is fired when a tag is chosen for a document list.
+       *
+       * @instance
+       * @type {string}
+       * @default [topics.DOCUMENTLIST_TAG_CHANGED]{@link module:alfresco/core/topics#DOCUMENTLIST_TAG_CHANGED}
+       */
+      docListTagChangedTopic: topics.DOCUMENTLIST_TAG_CHANGED,
       
       /**
        * This topic is used to publish changes for the users access rights to the current location, e.g. if they 
@@ -257,12 +266,11 @@ define(["dojo/_base/declare",
       /**
        * Used to indicate that a document has been tagged.
        *
-       * @event documentTaggedTopic
        * @instance
        * @type {string}
-       * @default
+       * @default [topics.DOCUMENT_TAGGED]{@link module:alfresco/core/topics#DOCUMENT_TAGGED}
        */
-      documentTaggedTopic: "ALF_DOCUMENT_TAGGED",
+      documentTaggedTopic: topics.DOCUMENT_TAGGED,
          
       /**
        * @event syncLocationTopic

--- a/aikau/src/main/resources/alfresco/renderers/Tags.js
+++ b/aikau/src/main/resources/alfresco/renderers/Tags.js
@@ -189,7 +189,7 @@ define(["dojo/_base/declare",
                additionalCssClasses: "hiddenlabel",
                optionsConfig: {
                   queryAttribute: "name",
-                  publishTopic: topics.ALF_RETRIEVE_CURRENT_TAGS,
+                  publishTopic: topics.RETRIEVE_CURRENT_TAGS,
                   publishPayload: {
                      resultsProperty: "response.data.items"
                   }

--- a/aikau/src/main/resources/alfresco/renderers/Tags.js
+++ b/aikau/src/main/resources/alfresco/renderers/Tags.js
@@ -30,6 +30,7 @@
 define(["dojo/_base/declare",
         "alfresco/renderers/InlineEditProperty", 
         "alfresco/core/ObjectTypeUtils",
+        "alfresco/core/topics",
         "dojo/_base/array",
         "dojo/_base/lang",
         "alfresco/forms/controls/ComboBox",
@@ -41,8 +42,8 @@ define(["dojo/_base/declare",
         "dojo/on",
         "dojo/keys",
         "dojo/_base/event"], 
-        function(declare, InlineEditProperty, ObjectTypeUtils, array, lang, ComboBox, ReadOnlyTag, EditTag, domConstruct, 
-                 domClass, registry, on, keys, event) {
+        function(declare, InlineEditProperty, ObjectTypeUtils, topics, array, lang, ComboBox, ReadOnlyTag,
+            EditTag, domConstruct, domClass, registry, on, keys, event) {
 
    return declare([InlineEditProperty], {
       
@@ -188,7 +189,7 @@ define(["dojo/_base/declare",
                additionalCssClasses: "hiddenlabel",
                optionsConfig: {
                   queryAttribute: "name",
-                  publishTopic: "ALF_RETRIEVE_CURRENT_TAGS",
+                  publishTopic: topics.ALF_RETRIEVE_CURRENT_TAGS,
                   publishPayload: {
                      resultsProperty: "response.data.items"
                   }
@@ -318,7 +319,7 @@ define(["dojo/_base/declare",
                alfResponseTopic: responseTopic
             };
             this._createTagHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onTagCreated), true);
-            this.alfPublish("ALF_CREATE_TAG", payload, true);
+            this.alfPublish(topics.CREATE_TAG, payload, true);
          }
       },
       

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -902,6 +902,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload The payload from the original request
+       * @fires module:alfresco/core/topics#ASSIGN_WORKFLOW
        */
       onActionAssignWorkflow: function alfresco_services_ActionService__onActionAssignWorkflow(payload) {
          this.alfPublish(topics.ASSIGN_WORKFLOW, {

--- a/aikau/src/main/resources/alfresco/services/_TagServiceTopics.js
+++ b/aikau/src/main/resources/alfresco/services/_TagServiceTopics.js
@@ -18,7 +18,11 @@
  */
 
 /**
+ * This mixin used to be used to contain the topics used by the tag service, however it has now been superseded by the global topics module.
+ * 
  * @module alfresco/services/_TagServiceTopics
+ * @deprecated Since 1.0.37 - Use [global topics module]{@link module:alfresco/core/topics} instead.
+ * @deprecated [description]
  * @author Dave Draper
  */
 define([], 
@@ -31,6 +35,7 @@ define([],
        * as the publication payload).
        * 
        * @instance
+       * @deprecated Since 1.0.37 - Use [topics.TAG_QUERY]{@link module:alfresco/core/topics#TAG_QUERY} instead.
        * @type {string}
        * @default
        */

--- a/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
@@ -108,7 +108,7 @@ define(["dojo/_base/declare",
        * @instance
        * @since 1.0.32
        *
-       * @listens module:alfresco/core/topics~event:ASSIGN_WORKFLOW
+       * @listens module:alfresco/core/topics#ASSIGN_WORKFLOW
        */
       registerSubscriptions: function alfresco_services_actions_WorkflowService__registerSubscriptions() {
          this.alfSubscribe("ALF_APPROVE_SIMPLE_WORKFLOW", lang.hitch(this, this.onApproveSimpleWorkflow));

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -209,11 +209,14 @@ define(["intern/dojo/node!fs",
                   urlDisplay.style.fontFamily = "Open Sans Bold, sans-serif";
                   urlDisplay.style.fontSize = "12px";
                   urlDisplay.style.lineHeight = "18px";
+                  urlDisplay.style.maxWidth = "400px";
                   urlDisplay.style.opacity = ".85";
                   urlDisplay.style.padding = "10px";
                   urlDisplay.style.position = "fixed";
                   urlDisplay.style.right = "0";
                   urlDisplay.style.bottom = "10px";
+                  urlDisplay.appendChild(document.createTextNode("User Agent: " + navigator.userAgent));
+                  urlDisplay.appendChild(document.createElement("BR"));
                   urlDisplay.appendChild(document.createTextNode("Time: " + (new Date()).toISOString()));
                   urlDisplay.appendChild(document.createElement("BR"));
                   urlDisplay.appendChild(document.createTextNode("URL: " + location.href));

--- a/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["alfresco/TestCommon",
+      "intern!object",
+      "intern/chai!assert"
+   ],
+   function(TestCommon, registerSuite, assert) {
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "TagFilters Tests",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/TagFilters", "TagFilters Tests");
+            },
+
+            "Can retrieve tags in unscoped context": function() {
+               return browser.findAllByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 9);
+                  });
+            },
+
+            "Can retrieve tags in scoped context": function() {
+               return browser.findAllByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 9);
+                  });
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+   });

--- a/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
@@ -51,6 +51,20 @@ define(["alfresco/TestCommon",
                   });
             },
 
+            "Clicked tags publish change notification (unscoped)": function(){
+               return browser.findByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
+                  .clearLog()
+                  .click()
+                  .getLastPublish("ALF_DOCUMENTLIST_TAG_CHANGED", true);
+            },
+
+            "Clicked tags publish change notification (scoped)": function(){
+               return browser.findByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
+                  .clearLog()
+                  .click()
+                  .getLastPublish("SCOPED_ALF_DOCUMENTLIST_TAG_CHANGED", true);
+            },
+
             beforeEach: function() {
                browser.end();
             },

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,8 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/renderers/actions/CopyToActionTest"
+      "src/test/resources/alfresco/documentlibrary/TagFiltersTest",
+      "src/test/resources/alfresco/renderers/TagsTest"
    ],
 
    /**
@@ -85,6 +86,7 @@ define({
       "src/test/resources/alfresco/documentlibrary/SearchListTest",
       "src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest",
       "src/test/resources/alfresco/documentlibrary/SitesListTest",
+      "src/test/resources/alfresco/documentlibrary/TagFiltersTest",
       "src/test/resources/alfresco/documentlibrary/ViewPreferencesGroupTest",
       "src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest",
       "src/test/resources/alfresco/documentlibrary/views/AlfDocumentListWithHeaderTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfTagFilters Test</shortname>
+  <description>This WebScript define the page for testing the alfresco/documentlibrary/AlfTagFilters widget</description>
+  <family>aikau-unit-tests</family>
+  <url>/TagFilters</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.js
@@ -1,0 +1,50 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/TagService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/AlfTagFilters",
+                  id: "TAG_FILTERS",
+                  config: {
+                     label: "Tags (unscoped)",
+                     siteId: "eng",
+                     containerId: "documentLibrary"
+                  }
+               },
+               {
+                  name: "alfresco/documentlibrary/AlfTagFilters",
+                  id: "SCOPED_TAG_FILTERS",
+                  config: {
+                     label: "Tags (scoped)",
+                     siteId: "eng",
+                     containerId: "documentLibrary",
+                     pubSubScope: "SCOPED_"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/TagsMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/TagsMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/TagsMockXhr.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Generic mock XHR that can be configured to support multiple
+ * tests' requirements for mock data.
+ * 
+ * @module aikauTesting/mockservices/TagsMockXhr
+ * @author Martin Doyle
+ */
+define([
+      "aikauTesting/MockXhr",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(MockXhr, declare, lang) {
+
+      return declare([MockXhr], {
+
+         /**
+          * Mock data to return to a tags request
+          *
+          * @instance
+          * @type {Object[]}
+          */
+         _mockTags: [{
+            "name": "Somewhere over",
+            "count": 27
+         }, {
+            "name": "the rainbow",
+            "count": 14
+         }, {
+            "name": "skies are blue",
+            "count": 9
+         }, {
+            "name": "and the",
+            "count": 5
+         }, {
+            "name": "dreams",
+            "count": 2
+         }, {
+            "name": "that you dare",
+            "count": 2
+         }, {
+            "name": "to dream",
+            "count": 1
+         }, {
+            "name": "really do",
+            "count": 1
+         }, {
+            "name": "come true",
+            "count": 1
+         }],
+
+         /**
+          * Set up the fake server
+          *
+          * @instance
+          */
+         setupServer: function aikauTesting_mockservices_TagsMockXhr__setupServer() {
+            try {
+               this.server.respondWith(
+                  /.*\/aikau\/proxy\/alfresco\/api\/tagscopes\/site\/eng\/documentLibrary\/tags.*/,
+                  lang.hitch(this, this.respondToTagsRequest)
+               );
+               this.alfPublish("ALF_MOCK_XHR_SERVICE_READY");
+            } catch (e) {
+               this.alfLog("error", "The following error occurred setting up the mock server", e);
+            }
+         },
+
+         /**
+          * Respond to the supplied request
+          *
+          * @instance
+          * @param {Object} request The request object
+          */
+         respondToTagsRequest: function aikauTesting_mockservices_TagsMockXhr__respondToTagsRequest(request) {
+
+            // Setup response
+            var responseData = {
+                  tags: this._mockTags
+               },
+               jsonResponse = JSON.stringify(responseData);
+
+            // Send it
+            request.respond(200, {
+               "Content-Type": "application/json;charset=UTF-8"
+            }, jsonResponse);
+         }
+      });
+   });


### PR DESCRIPTION
This addresses [AKU-586](https://issues.alfresco.com/jira/browse/AKU-586), and deals with the issues with using alfresco/documentlibrary/AlfTagFilters in a scoped environment. It has been tested in Share locally, and new tests have been created and a full test run completed succcesfully. CoreXhr has also been updated to support scoped responses. Additionally, various topics constants have been updated, some small improvements to TestCommon helper methods have been made and the test reporter has had its environment detection/reporting improved.