### PR TITLE
AKU-591: Delete action should reload document list

### DIFF
--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Delete.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Delete.get.js
@@ -71,6 +71,7 @@ model.jsonModel = {
          id: "LIST",
          name: "alfresco/lists/views/AlfListView",
          config: {
+            pubSubScope: "SCOPED_",
             currentData: {
                items: [
                   {
@@ -240,7 +241,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "aikauTesting/mockservices/DownloadArchiveMockXhr"
+         name: "aikauTesting/mockservices/GenericMockXhr"
       },
       {
          name: "alfresco/logging/DebugLog"

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/GenericMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/GenericMockXhr.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Generic mock XHR that returns 200 OK for everything.
+ * 
+ * @module aikauTesting/mockservices/GenericMockXhr
+ * @author Martin Doyle
+ */
+define([
+      "aikauTesting/MockXhr",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(MockXhr, declare, lang) {
+
+      return declare([MockXhr], {
+
+         /**
+          * Set up the fake server
+          *
+          * @instance
+          */
+         setupServer: function aikauTesting_mockservices_GenericMockXhr__setupServer() {
+            try {
+               this.server.respondWith([200, {
+                  "Content-Type": "application/json;charset=UTF-8"
+               }, "OK"]);
+               this.alfPublish("ALF_MOCK_XHR_SERVICE_READY");
+            } catch (e) {
+               this.alfLog("error", "The following error occurred setting up the mock server", e);
+            }
+         }
+      });
+   });


### PR DESCRIPTION
As part of the work for [AKU-591](https://issues.alfresco.com/jira/browse/AKU-591), I fixed the test page for the Delete action, as the mock XHR service it was using failed on attempting the Delete, and so didn't fire the reload event. The actual bug is apparently no longer an issue, after other fixes, so this is just to tidy up the test page and makes no changes to the actual code.