### PR TITLE
AKU-587: Further dialog sizing refinement

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -236,26 +236,7 @@ define(["dojo/_base/declare",
          {
             simplePanelHeight = (parseInt(this.contentHeight, 10) - paddingAdjustment) + "px";
          }
-         else
-         {
-            // When there is no fixed content height, make sure that the max-height adapts to the displayed content...
-            var containerHeight = $(this.containerNode).height();
-            if (containerHeight)
-            {
-               if (this.widgetsButtons)
-               {
-                  // We need to deduct 40 pixels from the container height to accomodate the buttons bar
-                  // if it is present...
-                  containerHeight -= 40;
-               }
-               
-               if (containerHeight < maxHeight)
-               {
-                  maxHeight = containerHeight;
-               }
-            }
-         }
-
+         
          calculatedHeights.documentHeight = docHeight;
          calculatedHeights.clientHeight = clientHeight;
          calculatedHeights.maxBodyHeight = maxHeight;


### PR DESCRIPTION
Following on from the changes that were made for https://issues.alfresco.com/jira/browse/AKU-587, it was observed that dialogs were getting cropped in some circumstances. Reviewing the code I've found that an if block was now surplus to requirements. I've verified that this does not re-introduce the originally reported issue.

In particular this was noticed on the http://localhost:8089/aikau/page/tp/ws/Select unit test page when displaying a dialog containing RadioButtons (on the first use of the dialog only)