### PR TITLE
AKU-467: Truncate the text for the select widget element automatically

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/Select.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/Select.css
@@ -1,38 +1,58 @@
-.alfresco-forms-controls-BaseFormControl > .control-row > .control > table{
-   -moz-border-radius: 3px;
-   -webkit-border-radius: 3px;
-   -khtml-border-radius: 3px;
-   border-radius: 3px;
-   background-color: @primary-background-color;
-}
-
-.alfresco-forms-controls-BaseFormControl > .control-row > .control > table > tr{
-   background: transparent;
-}
-
-.alfresco-forms-controls-BaseFormControl > .control-row > .control > table td{
-   border: none;
-   padding: 1px 3px;
-   background: transparent;
-}
-
-.alfresco-forms-controls-BaseFormControl > .control-row > .control > table td.dijitArrowButton{
-   border: none;
-   background: transparent;
-   padding-right: 3px;
-}
-
-.alfresco-forms-controls-BaseFormControl > .control-row > .control > table td.dijitArrowButton > input{
-   border: none;
+.alfresco-forms-controls-BaseFormControl {
+   > .control-row {
+      > .control {
+         > table {
+            background-color: @primary-background-color;
+            border-radius: 3px;
+            tr, td {
+               background: transparent;
+            }
+            td {
+               border: none;
+               padding: 1px 3px;
+               &.dijitArrowButton {
+                  padding-right: 3px;
+                  > input {
+                     border: none;
+                  }
+               }
+            }
+         }
+      }
+   }
 }
 
 .dijitMenuPopup {
    margin-top: 3px;
 }
-.claro .dijitMenuPopup .dijitMenu .dijitMenuItem td.dijitMenuItemLabel {
-   padding: 5px;
+
+.claro {
+   .dijitMenuPopup .dijitMenu .dijitMenuItem td.dijitMenuItemLabel {
+      padding: 5px;
+   }
+   .dijitMenu .dijitSelectSelectedOption * {
+      font-family: @bold-font;
+   }
 }
 
-.claro .dijitMenu .dijitSelectSelectedOption * {
-   font-family: @bold-font;
+.dijitSelectMenu {
+   tbody {
+      max-width: inherit;
+      .dijitMenuItem {
+         max-width: inherit;
+         white-space: normal;
+         .dijitMenuItemLabel {
+            max-width: inherit;
+            overflow: hidden;
+            text-overflow: ellipsis;
+         }
+      }
+   }
+   &.truncate {
+      tbody {
+         .dijitMenuItem {
+            white-space: nowrap;
+         }
+      }
+   }
 }

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
@@ -84,6 +84,7 @@ registerSuite(function(){
          return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
             .click()
          .end()
+         .getLastPublish("HAS_ITEMS_ALF_DOCLIST_SET_GALLERY_COLUMNS")
          .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
             .then(function(elements) {
                assert.lengthOf(elements, 7, "The number of items per row was not increased");
@@ -94,6 +95,7 @@ registerSuite(function(){
          return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
             .click()
          .end()
+         .getLastPublish("HAS_ITEMS_ALF_DOCLIST_SET_GALLERY_COLUMNS")
          .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
             .then(function(elements) {
                assert.lengthOf(elements, 10, "The number of items per row was not increased");
@@ -144,17 +146,13 @@ registerSuite(function(){
       },
       
       "Test selecting first item (Folder 1)": function () {
-         // 1. Focus on the first thumbnail...
-         return browser.pressKeys(keys.TAB) // Goes to first thumbnail...
-         .sleep(alfPause)
-         // 2. Tab again to select the selector...
-         .pressKeys(keys.TAB)
-         .sleep(alfPause)
-         .pressKeys(keys.SPACE)
-         .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
-            .then(function(payload) {
-               assert.deepPropertyVal(payload, "value.displayName", "Folder 1", "The wrong document was selected");
-            });
+         return browser.findByCssSelector("body")
+            .tabToElement(".alfresco-lists-views-layouts-Grid tr:first-child td:first-child .alfresco-renderers-Thumbnail .alfresco-renderers-Selector")
+            .pressKeys(keys.SPACE)
+            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "value.displayName", "Folder 1", "The wrong document was selected");
+               });
       },
 
       "Check selector click doesn't navigate": function() {

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -23,9 +23,9 @@
  */
 define(["intern!object",
         "intern/chai!assert", 
-        "require", 
-        "alfresco/TestCommon"], 
-        function(registerSuite, assert, require, TestCommon) {
+        "alfresco/TestCommon", 
+        "intern/dojo/node!leadfoot/keys"], 
+        function(registerSuite, assert, TestCommon, keys) {
 
    // Get the options labels using:
    //    #FIXED_INVALID_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel
@@ -39,254 +39,288 @@ define(["intern!object",
    // Get specific menu option:
    //    #FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function() {
+      var browser;
 
-   return {
-      name: "Select Menu Tests",
+      return {
+         name: "Select Menu Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Select", "Select Form Control Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Select", "Select Form Control Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Test Label Rendering": function() {
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .label")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Fixed Options", "The label was not rendered correctly");
+         "Test Label Rendering": function() {
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .label")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Fixed Options", "The label was not rendered correctly");
+               });
+         },
+
+         "Test initial value of fixed config": function() {
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO span[role=option]")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Two", "The initial value was not represented correctly");
+               });
+         },
+
+         "Test fixed options count": function() {
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "Incorrect number of fixed options found");
+               });
+         },
+
+         "Test fixed option label rendering": function() {
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Priv\u00e9", "Fixed label not set correctly");
+               });
+         },
+
+         "Test fixed option label set from value": function() {
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(3) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "NO LABEL", "Fixed label not set correctly from value");
+               });
+         },
+
+         "Test initial value of pub sub option": function() {
+            return browser.findByCssSelector("#FORM2 .confirmationButton .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLastPublish("UNIT_TEST_FORM2_POST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "updated1", "Value2_1");
+               });
+         },
+
+         "Test pub/sub options generated": function() {
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown .dijitMenuItemLabel")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "The wrong number of options were generated");
+               });
+         },
+
+         "Test updated label set by pub/sub": function() {
+            return browser.findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Update1_1", "Updated label not set correctly by pub/sub");
+               });
+         },
+
+         "Test options provided once": function() {
+            // The options should have been provided once (the mock service increments the options)...
+            return browser.findByCssSelector("#HAS_CHANGES_TO_CONTROL")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Update1_3", "Updated label not set correctly by pub/sub");
+               });
+         },
+
+         "Test update topics processed": function() {
+            return browser.findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#REQUEST_GLOBAL_UPDATE_label")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Update1_2", "Updated label not set correctly by external update");
+               });
+         },
+
+         "Test value of pub sub option after options update": function() {
+            return browser.findByCssSelector("#FORM2 .confirmationButton .dijitButtonNode")
+               .clearLog()
+               .click()
+               .end()
+
+            .getLastPublish("UNIT_TEST_FORM2_POST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "updated1", "Value2_1");
+               });
+         },
+
+         "Test pub/sub options generated from field change": function() {
+            // Check that pub/sub options generated from field changes are correct (should be on 3rd request based on values being set)...
+            return browser.findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "Incorrect number of options found");
+               });
+         },
+
+         "Test update topic scoping": function() {
+            // Clicking the 2nd button should have no effect (as it's the scoped topic published globally)...
+            return browser.findByCssSelector("#REQUEST_SCOPED_UPDATE_GLOBALLY_label")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Update1_2", "Updated label not unexpectedly updated");
+               });
+         },
+
+         "Test label updated  from external publication": function() {
+            // Clicking the 3rd button should perform an update...
+            return browser.findByCssSelector("#REQUEST_SCOPED_UPDATE_label")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Update1_3", "Updated label not set correctly by external update");
+               });
+         },
+
+         "Test changing field triggers update": function() {
+            // Change a field to check an update is made...
+            return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
+               .click()
+               .end()
+
+            .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Update1_4", "Updated label not set correctly by pub/sub");
+               });
+         },
+
+         "Test XSS attack fails": function() {
+            // Change a field to check an update is made...
+            return browser.then(function() {
+               var notHacked = browser.execute("!window.hackedLabel && !window.hackedValue");
+               assert(notHacked, "XSS prevention failed - script executed in label or value of option");
             });
-      },
+         },
 
-      "Test initial value of fixed config": function() {
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO span[role=option]")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Two", "The initial value was not represented correctly");
-            });
-      },
+         "Test pub/sub options in dialog": function() {
+            // See https://issues.alfresco.com/jira/browse/AKU-131
+            // Create the form dialog...
+            return browser.findByCssSelector("#CREATE_FORM_DIALOG_label")
+               .click()
+               .end()
 
-      "Test fixed options count": function() {
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
-            .click()
-            .end()
+            // Open the opens...
+            .findByCssSelector("#SELECT_IN_DIALOG .dijitArrowButtonInner")
+               .click()
+               .end()
 
-         .findAllByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "Incorrect number of fixed options found");
-            });
-      },
+            // Count that there are some...
+            .findAllByCssSelector("#SELECT_IN_DIALOG_CONTROL_dropdown .dijitMenuItemLabel")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "No pub sub options provided for select in a dialog");
+               })
+               .pressKeys(keys.ESCAPE)
+               .end();
+         },
 
-      "Test fixed option label rendering": function() {
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Priv\u00e9", "Fixed label not set correctly");
-            });
-      },
+         "Test pub/sub options value": function() {
+            return browser.findByCssSelector("#DIALOG_WITH_SELECT .confirmationButton > span")
+               .click()
+               .end()
 
-      "Test fixed option label set from value": function() {
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(3) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "NO LABEL", "Fixed label not set correctly from value");
-            });
-      },
+            .findByCssSelector("#DIALOG_WITH_SELECT.dialogHidden")
 
-      "Test initial value of pub sub option": function() {
-         return browser.findByCssSelector(".confirmationButton > span")
-            .click()
-            .end()
+            .getLastPublish("DIALOG_POST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "selected", "DO2");
+               });
+         },
 
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("UNIT_TEST_FORM_POST", "updated1", "Value2_1"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "The value was not re-selected in the second set of options");
-            });
-      },
+         "Force-width option narrower than normal width": function() {
+            var normalWidth,
+               forcedWidth;
 
-      "Test pub/sub options generated": function() {
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
-            .click()
-            .end()
+            return browser.findById("LONG_OPTIONS_NORMAL_CONTROL")
+               .click()
+               .end()
 
-         .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
-            .click()
-            .end()
+            .findById("LONG_OPTIONS_NORMAL_CONTROL_menu")
+               .getSize()
+               .then(function(size) {
+                  normalWidth = size.width;
+               })
+               .pressKeys(keys.ESCAPE)
+               .end()
 
-         .findAllByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown .dijitMenuItemLabel")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "The wrong number of options were generated");
-            });
-      },
+            .findById("LONG_OPTIONS_FORCEWIDTH_CONTROL")
+               .click()
+               .end()
 
-      "Test updated label set by pub/sub": function() {
-         return browser.findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Update1_1", "Updated label not set correctly by pub/sub");
-            });
-      },
+            .findById("LONG_OPTIONS_FORCEWIDTH_CONTROL_menu")
+               .getSize()
+               .then(function(size) {
+                  forcedWidth = size.width;
+                  assert.isBelow(forcedWidth, normalWidth);
+               })
+               .pressKeys(keys.ESCAPE);
+         },
 
-      "Test options provided once": function() {
-         // The options should have been provided once (the mock service increments the options)...
-         return browser.findByCssSelector("#HAS_CHANGES_TO_CONTROL")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Update1_3", "Updated label not set correctly by pub/sub");
-            });
-      },
-
-      "Test update topics processed": function() {
-         return browser.findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#REQUEST_GLOBAL_UPDATE_label")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Update1_2", "Updated label not set correctly by external update");
-            });
-      },
-
-      "Test value of pub sub option after options update": function() {
-         return browser.findByCssSelector(".confirmationButton > span")
-            .click()
-            .end()
-
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("UNIT_TEST_FORM_POST", "updated1", "Value2_1"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "The value was not re-selected in the second set of options");
-            });
-      },
-
-      "Test pub/sub options generated from field change": function() {
-         // Check that pub/sub options generated from field changes are correct (should be on 3rd request based on values being set)...
-         return browser.findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "Incorrect number of options found");
-            });
-      },
-
-      "Test update topic scoping": function() {
-         // Clicking the 2nd button should have no effect (as it's the scoped topic published globally)...
-         return browser.findByCssSelector("#REQUEST_SCOPED_UPDATE_GLOBALLY_label")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Update1_2", "Updated label not unexpectedly updated");
-            });
-      },
-
-      "Test label updated  from external publication": function() {
-         // Clicking the 3rd button should perform an update...
-         return browser.findByCssSelector("#REQUEST_SCOPED_UPDATE_label")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_UPDATE_TOPICS .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_UPDATE_TOPICS_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Update1_3", "Updated label not set correctly by external update");
-            });
-      },
-
-      "Test changing field triggers update": function() {
-         // Change a field to check an update is made...
-         return browser.findByCssSelector("#FIXED_INVALID_CHANGES_TO .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_CHANGES_TO .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Update1_4", "Updated label not set correctly by pub/sub");
-            });
-      },
-
-      "Test XSS attack fails": function() {
-         // Change a field to check an update is made...
-         return browser.then(function() {
-            var notHacked = browser.execute("!window.hackedLabel && !window.hackedValue");
-            assert(notHacked, "XSS prevention failed - script executed in label or value of option");
-         });
-      },
-
-      "Test pub/sub options in dialog": function() {
-         // See https://issues.alfresco.com/jira/browse/AKU-131
-         // Create the form dialog...
-         return browser.findByCssSelector("#CREATE_FORM_DIALOG_label")
-            .click()
-            .end()
-
-         // Open the opens...
-         .findByCssSelector("#SELECT_IN_DIALOG .dijitArrowButtonInner")
-            .click()
-            .end()
-
-         // Count that there are some...
-         .findAllByCssSelector("#SELECT_IN_DIALOG_CONTROL_dropdown .dijitMenuItemLabel")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "No pub sub options provided for select in a dialog");
-            });
-      },
-
-      "Test pub/sub options value": function() {
-         return browser.findByCssSelector("#DIALOG_WITH_SELECT .confirmationButton > span")
-            .click()
-            .end()
-
-         .findAllByCssSelector(TestCommon.pubDataCssSelector("DIALOG_POST", "selected", "DO2"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Options value was not initialized correctly");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -38,12 +38,12 @@ define(["./config/Suites"],
          // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
          // capabilities options specified for an environment will be copied as-is
          environments: [{
-            browserName: "Chrome",
+            browserName: "chrome",
             chromeOptions: {
                excludeSwitches: ["ignore-certificate-errors"]
             }
          }, {
-            browserName: "Firefox"
+            browserName: "firefox"
          }],
 
          // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service

--- a/aikau/src/test/resources/intern_local.js
+++ b/aikau/src/test/resources/intern_local.js
@@ -3,6 +3,19 @@
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
 define(["./config/Suites"],
    function(Suites) {
+
+      // Extract the rows and columns from the command-line arguments
+      var rowsColsRegex = /rowsCols=(\d+)\|(\d+)/,
+         rows,
+         cols;
+      process.argv.forEach(function(arg) {
+         var match = rowsColsRegex.exec(arg);
+         if (match) {
+            rows = parseInt(match[1], 10);
+            cols = parseInt(match[2], 10);
+         }
+      });
+
       return {
 
          // The port on which the instrumenting proxy will listen
@@ -31,12 +44,16 @@ define(["./config/Suites"],
             }
          }, {
             browserName: "firefox"
-         // }, {
-         //    browserName: "ie"
          }],
 
          // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
          maxConcurrency: 1,
+
+         // Terminal information
+         terminalInfo: {
+            rows: rows,
+            cols: cols
+         },
 
          // Dig Dug tunnel handler
          tunnel: "NullTunnel",
@@ -61,6 +78,9 @@ define(["./config/Suites"],
             }, {
                name: "reporters",
                location: "./src/test/resources/reporters"
+            }, {
+               name: "dojo",
+               location: "./node_modules/intern/node_modules/dojo"
             }]
          },
 
@@ -77,6 +97,7 @@ define(["./config/Suites"],
          reporters: [
             // "Console",
             // "Runner",
+            // "reporters/AikauConcurrentReporter"
             "reporters/AikauReporter"
          ]
 

--- a/aikau/src/test/resources/reporters/AikauConcurrentReporter.js
+++ b/aikau/src/test/resources/reporters/AikauConcurrentReporter.js
@@ -471,7 +471,7 @@ define([
             envName = parentTest.name;
          }
          while ((parentTest = parentTest.parent));
-         return envName;
+         return this.capitalise(envName);
       },
 
       /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
@@ -14,140 +14,6 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         name: "alfresco/forms/Form",
-         config: {
-            id: "FORM",
-            pubSubScope: "UNIT_TEST_",
-            okButtonPublishTopic: "FORM_POST",
-            widgets: [
-               {
-                  id: "NO_CONFIG",
-                  name: "alfresco/forms/controls/Select",
-                  config: null
-               },
-               {
-                  id: "INVALID_CONFIG",
-                  name: "alfresco/forms/controls/Select",
-                  config: {
-                     label: "Invalid options config",
-                     description: "This select field has incorrectly configured options configuration. No options are expected to be displayed",
-                     optionsConfig: {
-                        fixed: 1
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/Select",
-                  config: {
-                     id: "FIXED_INVALID_CHANGES_TO",
-                     fieldId: "Select1",
-                     name: "fixed1",
-                     label: "Fixed Options",
-                     description: "This select field is configured with a mixture of valid and invalid static options. Only the valid options will be displayed",
-                     value: "2",
-                     optionsConfig: {
-                        changesTo: "INVALID_DATA",
-                        updateTopics: "INVALID_DATA",
-                        fixed: [
-                           {label:"select.test.fixed.option.one",value:"1"},
-                           {label:"select.test.fixed.option.two",value:"2"},
-                           {label:"No value",value:""},
-                           {value:"NO LABEL"},
-                           {INVALID:"DATA"}
-                        ]
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/Select",
-                  config: {
-                     id: "HAS_UPDATE_TOPICS",
-                     fieldId: "Select2",
-                     name: "updated1",
-                     label: "Update Topics",
-                     description: "This field is configured with a topic to publish requesting options, along with a number of topics that will trigger the options to be refreshed. The update topics can be triggered by clicking the button at below the form.",
-                     value: "Value2_1", 
-                     optionsConfig: {
-                        updateTopics: [
-                           {
-                              topic: "GLOBAL_UPDATE_TOPIC",
-                              global: true
-                           },
-                           {
-                              topic: "SCOPED_UPDATE_TOPIC",
-                              global: false
-                           },
-                           {
-                              topic: "UNSCOPED_UPDATE_TOPIC"
-                           },
-                           {
-                              INVALID: "DATA"
-                           }
-                        ],
-                        publishTopic: "GET_OPTIONS_FOR_SELECT_2"
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/Select",
-                  config: {
-                     id:"BASIC_FIXED_OPTIONS",
-                     fieldId: "Select3",
-                     name: "fixed2",
-                     label: "Fixed Options Trigger",
-                     description: "This is another example of a select field with fixed options. This particular field can be used to trigger the refreshing of options in the 'ChangesTo' field.",
-                     optionsConfig: {
-                        fixed: [
-                           {label:"Three",value:"3"},
-                           {label:"Four",value:"4"}
-                        ]
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/Select",
-                  config: {
-                     id: "HAS_CHANGES_TO",
-                     fieldId: "Select4",
-                     name: "updated2",
-                     label: "ChangesTo",
-                     description: "This select field is configured to dynamically request options each time the value of 'Fixed Options Trigger' is changed",
-                     optionsConfig: {
-                        changesTo: [
-                           {
-                              targetId:"Select1"
-                           },
-                           {
-                              targetId:"Select3",
-                              global: false
-                           },
-                           {
-                              INVALID: "DATA"
-                           }
-                        ],
-                        publishTopic: "GET_OPTIONS_FOR_SELECT_4"
-                     }
-                  }
-               },
-               {
-                  id:"XSS_OPTIONS",
-                  name: "alfresco/forms/controls/Select",
-                  config: {
-                     fieldId: "XSS_OPTIONS",
-                     name: "xss",
-                     label: "Check XSS Options",
-                     description: "This field is configured with a single option that attempts to inject JavaScript into the page, it is included to validate that this is not possible",
-                     optionsConfig: {
-                        fixed: [
-                           {label:'<img src="1" onerror="window.hackedLabel=true">',value:'<img src="1" onerror="window.hackedValue=true">'}
-                        ]
-                     }
-                  }
-               }
-            ]
-         }
-      },
-      {
          name: "alfresco/buttons/AlfButton",
          config: {
             id: "REQUEST_GLOBAL_UPDATE",
@@ -215,7 +81,281 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/forms/Form",
+                  id: "FORM1",
+                  config: {
+                     pubSubScope: "UNIT_TEST_",
+                     okButtonPublishTopic: "FORM1_POST",
+                     widgets: [
+                        {
+                           id: "NO_CONFIG",
+                           name: "alfresco/forms/controls/Select",
+                           config: null
+                        },
+                        {
+                           id: "INVALID_CONFIG",
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              label: "Invalid options config",
+                              description: "This select field has incorrectly configured options configuration. No options are expected to be displayed",
+                              optionsConfig: {
+                                 fixed: 1
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              id: "FIXED_INVALID_CHANGES_TO",
+                              fieldId: "Select1",
+                              name: "fixed1",
+                              label: "Fixed Options",
+                              description: "This select field is configured with a mixture of valid and invalid static options. Only the valid options will be displayed",
+                              value: "2",
+                              optionsConfig: {
+                                 changesTo: "INVALID_DATA",
+                                 updateTopics: "INVALID_DATA",
+                                 fixed: [
+                                    {label:"select.test.fixed.option.one",value:"1"},
+                                    {label:"select.test.fixed.option.two",value:"2"},
+                                    {label:"No value",value:""},
+                                    {value:"NO LABEL"},
+                                    {INVALID:"DATA"}
+                                 ]
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/Form",
+                  id: "FORM2",
+                  config: {
+                     pubSubScope: "UNIT_TEST_",
+                     okButtonPublishTopic: "FORM2_POST",
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              id: "HAS_UPDATE_TOPICS",
+                              fieldId: "Select2",
+                              name: "updated1",
+                              label: "Update Topics",
+                              description: "This field is configured with a topic to publish requesting options, along with a number of topics that will trigger the options to be refreshed. The update topics can be triggered by clicking the button at below the form.",
+                              value: "Value2_1", 
+                              optionsConfig: {
+                                 updateTopics: [
+                                    {
+                                       topic: "GLOBAL_UPDATE_TOPIC",
+                                       global: true
+                                    },
+                                    {
+                                       topic: "SCOPED_UPDATE_TOPIC",
+                                       global: false
+                                    },
+                                    {
+                                       topic: "UNSCOPED_UPDATE_TOPIC"
+                                    },
+                                    {
+                                       INVALID: "DATA"
+                                    }
+                                 ],
+                                 publishTopic: "GET_OPTIONS_FOR_SELECT_2"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              id:"BASIC_FIXED_OPTIONS",
+                              fieldId: "Select3",
+                              name: "fixed2",
+                              label: "Fixed Options Trigger",
+                              description: "This is another example of a select field with fixed options. This particular field can be used to trigger the refreshing of options in the 'ChangesTo' field.",
+                              optionsConfig: {
+                                 fixed: [
+                                    {label:"Three",value:"3"},
+                                    {label:"Four",value:"4"}
+                                 ]
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              id: "HAS_CHANGES_TO",
+                              fieldId: "Select4",
+                              name: "updated2",
+                              label: "ChangesTo",
+                              description: "This select field is configured to dynamically request options each time the value of 'Fixed Options Trigger' is changed",
+                              optionsConfig: {
+                                 changesTo: [
+                                    {
+                                       targetId:"Select1"
+                                    },
+                                    {
+                                       targetId:"Select3",
+                                       global: false
+                                    },
+                                    {
+                                       INVALID: "DATA"
+                                    }
+                                 ],
+                                 publishTopic: "GET_OPTIONS_FOR_SELECT_4"
+                              }
+                           }
+                        },
+                        {
+                           id:"XSS_OPTIONS",
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              fieldId: "XSS_OPTIONS",
+                              name: "xss",
+                              label: "Check XSS Options",
+                              description: "This field is configured with a single option that attempts to inject JavaScript into the page, it is included to validate that this is not possible",
+                              optionsConfig: {
+                                 fixed: [
+                                    {label:'<img src="1" onerror="window.hackedLabel=true">',value:'<img src="1" onerror="window.hackedValue=true">'}
+                                 ]
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/forms/Form",
+         id: "FORM3",
+         config: {
+            pubSubScope: "UNIT_TEST_",
+            okButtonPublishTopic: "FORM3_POST",
+            widgets: [
+               {
+                  name: "alfresco/layout/HorizontalWidgets",
+                  config: {
+                     widgetMarginRight: "20px",
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           id: "LONG_OPTIONS_NORMAL",
+                           config: {
+                              name: "longOptionsNormal",
+                              label: "Long options (normal)",
+                              description: "This select field is has some long options values without any width constraints",
+                              optionsConfig: {
+                                 fixed: [{
+                                    label: "Krill sardonically clung outside and",
+                                    value: "1"
+                                 }, {
+                                    label: "Forgot folded owing gosh matter-of-factly so hello less bleak gosh contrary precise",
+                                    value: "2"
+                                 }, {
+                                    label: "Through chose ate convulsive dear insufferably in ingenuously",
+                                    value: "3"
+                                 }, {
+                                    label: "Firefly and thus oh connected or much this tacky preparatory hence grievously notwithstanding wombat",
+                                    value: "4"
+                                 }, {
+                                    label: "Clung some as much some since lightly",
+                                    value: "5"
+                                 }, {
+                                    label: "Alas together ape dazedly less fleetly",
+                                    value: "6"
+                                 }]
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           id: "LONG_OPTIONS_FORCEWIDTH",
+                           config: {
+                              name: "longOptionsForceWidth",
+                              forceWidth: true,
+                              label: "Long options (forceWidth)",
+                              description: "This select field is has some long options values in it and has been set to constrain its with",
+                              optionsConfig: {
+                                 fixed: [{
+                                    label: "Krill sardonically clung outside and",
+                                    value: "1"
+                                 }, {
+                                    label: "Forgot folded owing gosh matter-of-factly so hello less bleak gosh contrary precise",
+                                    value: "2"
+                                 }, {
+                                    label: "Through chose ate convulsive dear insufferably in ingenuously",
+                                    value: "3"
+                                 }, {
+                                    label: "Firefly and thus oh connected or much this tacky preparatory hence grievously notwithstanding wombat",
+                                    value: "4"
+                                 }, {
+                                    label: "Clung some as much some since lightly",
+                                    value: "5"
+                                 }, {
+                                    label: "Alas together ape dazedly less fleetly",
+                                    value: "6"
+                                 }]
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/Select",
+                           id: "LONG_OPTIONS_FORCEWIDTH_TRUNCATE",
+                           config: {
+                              name: "longOptionsForceWidthTruncate",
+                              forceWidth: true,
+                              truncate: true,
+                              label: "Long options (forceWidth,truncate)",
+                              description: "This select field is has some long options values in it and has been set to constrain its with and additionally to use an ellipsis to hide anything that overflows a single line",
+                              optionsConfig: {
+                                 fixed: [{
+                                    label: "Krill sardonically clung outside and",
+                                    value: "1"
+                                 }, {
+                                    label: "Forgot folded owing gosh matter-of-factly so hello less bleak gosh contrary precise",
+                                    value: "2"
+                                 }, {
+                                    label: "Through chose ate convulsive dear insufferably in ingenuously",
+                                    value: "3"
+                                 }, {
+                                    label: "Firefly and thus oh connected or much this tacky preparatory hence grievously notwithstanding wombat",
+                                    value: "4"
+                                 }, {
+                                    label: "Clung some as much some since lightly",
+                                    value: "5"
+                                 }, {
+                                    label: "Alas together ape dazedly less fleetly",
+                                    value: "6"
+                                 }]
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -15,9 +15,6 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
-      },
-      {
          name: "aikauTesting/WaitForMockXhrService",
          config: {
             widgets: [
@@ -132,6 +129,9 @@ model.jsonModel = {
                }
             ]
          }
+      },
+      {
+         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
       },
       {
          name: "alfresco/logging/DebugLog"


### PR DESCRIPTION
This addresses issue [AKU-467](https://issues.alfresco.com/jira/browse/AKU-467) and permits restricting the width of a Select dropdown to the size of the base control. Also, update intern_local configuration to permit using the new test reporter (but without turning it on yet), and fix a bug with running multiple environments. Finally, update a couple of occasionally-failing tests to make them run more reliably (GalleryView keyboard test and Twister test).