### PR TITLE
Update references to "ALF_DISPLAY_NOTIFICATION"

### DIFF
--- a/aikau/src/main/resources/alfresco/core/NotificationUtils.js
+++ b/aikau/src/main/resources/alfresco/core/NotificationUtils.js
@@ -25,8 +25,9 @@
  * @deprecated Since 1.0.17 - use the [NotificationService]{@link module:alfresco/services/NotificationService} instead.
  */
 define(["dojo/_base/declare",
+        "alfresco/core/topics",
         "alfresco/core/Core"],
-        function(declare, AlfCore) {
+        function(declare, topics, AlfCore) {
 
    return declare([AlfCore], {
 
@@ -35,9 +36,10 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param msg {String} The message to be displayed.
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       displayMessage: function alfresco_core_Core__displayMessage(msg) {
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: msg
          });
       },

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -273,6 +273,13 @@ define([],function() {
        * @instance
        * @type {string}
        * @default
+       *
+       * @event
+       * @property {string} message The message to be displayed
+       * @property {string} [publishTopic] A topic to be published after the notification has closed
+       * @property {object} [publishPayload] The payload to be published after the notification has closed
+       * @property {boolean} [publishGlobal] Whether to publish the topic globally
+       * @property {boolean} [publishToParent] Whether to publish the topic on the parent scope
        */
       DISPLAY_NOTIFICATION: "ALF_DISPLAY_NOTIFICATION",
 

--- a/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
+++ b/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
@@ -87,6 +87,7 @@ define(["dojo/_base/declare",
       "alfresco/core/Core",
       "alfresco/core/CoreWidgetProcessing",
       "alfresco/core/ResizeMixin",
+      "alfresco/core/topics",
       "alfresco/services/_DashletServiceTopicMixin",
       "dojo/_base/lang",
       "dojo/_base/array",
@@ -97,7 +98,7 @@ define(["dojo/_base/declare",
       "jqueryui"
    ],
    function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing,
-      ResizeMixin, _DashletServiceTopicMixin, lang, array, domConstruct, domClass, domStyle, $) {
+      ResizeMixin, topics, _DashletServiceTopicMixin, lang, array, domConstruct, domClass, domStyle, $) {
 
       return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, ResizeMixin, _DashletServiceTopicMixin], {
 
@@ -300,9 +301,10 @@ define(["dojo/_base/declare",
           *
           * @instance
           * @param {Object} payload The payload from the publishing of the failure topic
+          * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
           */
          onHeightStorageError: function(payload) {
-            this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+            this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
                message: "Error occurred while storing dashlet height"
             }, true);
             this.alfLog("error", "Error storing dashlet height:\n\"" + payload.response.message + "\"");

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/PDFFindController.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/PDFFindController.js
@@ -32,8 +32,9 @@
  * @author Kevin Roast
  */
 define(["dojo/_base/declare",
+        "alfresco/core/topics",
         "alfresco/core/Core"], 
-        function(declare, AlfCore) {
+        function(declare, topics, AlfCore) {
    
    return declare([AlfCore], {
 
@@ -514,6 +515,7 @@ define(["dojo/_base/declare",
        *
        *
        * @instance
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       updateUIState: function alfresco_preview_PdfJs_PDFFindController__updateUIState(state, previous) {
          var findMsg = "";
@@ -554,7 +556,7 @@ define(["dojo/_base/declare",
          }
          
          // This will require that the alfresco/service/NotificationService is on the page
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: findMsg
          }, true);
       }

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/PDFFindController.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/PDFFindController.js
@@ -246,6 +246,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       extractText: function alfresco_preview_PdfJs_PDFFindController__extractText() {
+         /*jshint loopfunc:true*/
          if (this.startedTextExtraction) {
             return;
          }
@@ -337,6 +338,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       nextMatch: function alfresco_preview_PdfJs_PDFFindController__nextMatch() {
+         /*jshint loopfunc:true,maxstatements:false*/
          var previous = this.state.findPrevious;
          // ALFRESCO - changed .page to pageNum
          var currentPageIndex = this.pdfPageSource.pageNum - 1;

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/PdfJs.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/PdfJs.js
@@ -45,6 +45,7 @@ define(["dojo/_base/declare",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/core/ObjectProcessingMixin",
         "alfresco/core/Core",
+        "alfresco/core/topics",
         "service/constants/Default",
         "alfresco/preview/PdfJs/PdfJsConstants",
         "alfresco/preview/PdfJs/DocumentView",
@@ -62,7 +63,7 @@ define(["dojo/_base/declare",
         "dojo/window",
         "dojo/on",
         "jquery"], 
-        function(declare, AlfDocumentPreviewPlugin, FileSizeMixin, CoreWidgetProcessing, ObjectProcessingMixin, AlfCore, AlfConstants, 
+        function(declare, AlfDocumentPreviewPlugin, FileSizeMixin, CoreWidgetProcessing, ObjectProcessingMixin, AlfCore, topics, AlfConstants, 
                  PdfJsConstants, DocumentView, PDFFindController, WidgetsCreator, AlfTabContainer, lang, domGeom, 
                  domConstruct, domClass, domStyle, html, has, ioQuery, win, on, $) {
    
@@ -732,6 +733,7 @@ define(["dojo/_base/declare",
        * Error encountered retrieving PDF document
        * 
        * @instance
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       _onGetDocumentFailure: function alfresco_preview_PdfJs_PdfJs___onGetDocumentFailure(exception) {
 
@@ -800,7 +802,7 @@ define(["dojo/_base/declare",
                });
 
                // Display an error using the notification service
-               this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+               this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
                   message: loadingErrorMessage
                });
             }
@@ -1260,13 +1262,14 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload The payload containing the details of the page to skip to.
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onSetPageConfirmation: function alfresco_preview_PdfJs_PdfJs__onSetPageConfirmation(payload) {
          var pn = lang.getObject("pageNumber", false, payload);
          if (!pn || pn < 1 || pn > this.numPages)
          {
             // This will require that the alfresco/service/NotificationService is on the page
-            this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+            this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
                message: this.previewManager.message("error.badpage")
             }, true);
          }

--- a/aikau/src/main/resources/alfresco/renderers/AvatarThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/AvatarThumbnail.js
@@ -44,7 +44,7 @@
  *       currentItem: {
  *          userName: "guest"
  *       },
- *       publishTopic: "ALF_DISPLAY_NOTIFICATION",
+ *       publishTopic: topics.DISPLAY_NOTIFICATION,
  *       publishPayload: {
  *          message: "You clicked on the guest thumbnail"
  *       },

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -275,6 +275,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onActionDeleteSuccess: function alfresco_services_ContentService__onActionDeleteSuccess(payload) {
          var subscriptionHandle = lang.getObject("requestConfig.subscriptionHandle", false, payload);
@@ -282,7 +283,7 @@ define(["dojo/_base/declare",
          {
             this.alfUnsubscribe(subscriptionHandle);
          }
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message("contentService.delete.success.message")
          });
          this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, payload.requestConfig.responseScope);

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -30,12 +30,13 @@
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
         "alfresco/core/CoreXhr",
+        "alfresco/core/topics",
         "service/constants/Default",
         "alfresco/dialogs/AlfDialog",
         "dojo/_base/lang",
         "dojo/_base/array",
         "alfresco/util/urlUtils"],
-        function(declare, BaseService, CoreXhr, AlfConstants, AlfDialog, lang, array, urlUtils) {
+        function(declare, BaseService, CoreXhr, topics, AlfConstants, AlfDialog, lang, array, urlUtils) {
 
    return declare([BaseService, CoreXhr], {
 
@@ -68,6 +69,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response The response from the original XHR request.
        * @param {object} originalRequestConfig The configuration passed to the original XHR request.
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       refreshRequest: function alfresco_services_CrudService__refreshRequest(response, originalRequestConfig) {
          var responseTopic = lang.getObject("alfTopic", false, originalRequestConfig);
@@ -82,7 +84,7 @@ define(["dojo/_base/declare",
             message = "crudservice.generic.success.message";
          }
 
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message(message)
          });
 

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -55,6 +55,8 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default [topics.DISPLAY_NOTIFICATION]{@link module:alfresco/core/topics#DISPLAY_NOTIFICATION}
+       * @listens module:alfresco/core/topics#DISPLAY_NOTIFICATION
+       * @event
        */
       displayNotificationTopic: topics.DISPLAY_NOTIFICATION,
 
@@ -72,6 +74,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @since 1.0.32
+       * @listens module:alfresco/services/NotificationService#displayNotificationTopic
        */
       registerSubscriptions: function alfresco_services_NotificationService__registerSubscriptions() {
          this.alfSubscribe(this.displayNotificationTopic, lang.hitch(this, this.onDisplayNotification));

--- a/aikau/src/main/resources/alfresco/services/QuaddsService.js
+++ b/aikau/src/main/resources/alfresco/services/QuaddsService.js
@@ -34,6 +34,10 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/json"],
         function(declare, BaseService, CoreXhr, topics, AlfConstants, lang, array, dojoJson) {
+
+   function isRealString(testStr) {
+      return testStr && lang.trim(testStr);
+   }
    
    return declare([BaseService, CoreXhr], {
       
@@ -57,12 +61,12 @@ define(["dojo/_base/declare",
        */
       processQuaddItemData: function alfresco_services_QuaddsService__processQuaddItemData(response, originalRequestConfig) {
          var responseTopic = lang.getObject("alfTopic", false, originalRequestConfig);
-         if (responseTopic != null)
+         if (responseTopic)
          {
 
             this.alfLog("log", "Processing QuADDS data", response, originalRequestConfig, this);
 
-            array.forEach(response.items, function(item, index) {
+            array.forEach(response.items, function(item) {
                try
                {
                   item.data = dojoJson.parse(item.data, true);
@@ -88,7 +92,7 @@ define(["dojo/_base/declare",
        */
       refreshRequest: function alfresco_services_QuaddsService__refreshRequest(response, originalRequestConfig) {
          var responseTopic = lang.getObject("alfTopic", false, originalRequestConfig);
-         if (responseTopic != null)
+         if (responseTopic)
          {
             this.alfPublish(responseTopic + "_SUCCESS", response);
          }
@@ -110,7 +114,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload 
        */
-      onGetAllQuadds: function alfresco_services_QuaddsService__onGetAllQuadds(payload) {
+      onGetAllQuadds: function alfresco_services_QuaddsService__onGetAllQuadds(/*jshint unused:false*/payload) {
          var url = AlfConstants.PROXY_URI + "aikau/quadds";
          this.serviceXhr({url : url,
                           method: "GET"});
@@ -124,7 +128,7 @@ define(["dojo/_base/declare",
        */
       onGetQuaddsItems: function alfresco_services_QuaddsService__onGetQuaddsItems(payload) {
          var quadds = lang.getObject("quadds", false, payload);
-         if (quadds == null || lang.trim(quadds) === "")
+         if (!isRealString(quadds))
          {
             this.alfLog("warn", "A request was made to retrieve the data items from a QuADDS but no QuADDS was provided", payload, this);
          }
@@ -132,7 +136,7 @@ define(["dojo/_base/declare",
          {
             var url = AlfConstants.PROXY_URI + "aikau/quadds/" + lang.trim(quadds);
             this.serviceXhr({url : url,
-                             alfTopic: payload.alfResponseTopic != null ? payload.alfResponseTopic : payload.alfTopic,
+                             alfTopic: payload.alfResponseTopic || payload.alfTopic,
                              method: "GET",
                              successCallback: this.processQuaddItemData,
                              callbackScope: this});
@@ -148,11 +152,11 @@ define(["dojo/_base/declare",
       onGetQuaddsItem: function alfresco_services_QuaddsService__onGetQuaddsItem(payload) {
          var quadds = lang.getObject("quadds", false, payload);
          var name = lang.getObject("name", false, payload);
-         if (quadds == null || quadds === "")
+         if (!isRealString(quadds))
          {
             this.alfLog("warn", "A request was made to retrieve a data item from a QuADDS but no QuADDS was provided", payload, this);
          }
-         else if (name == null || lang.trim(name) === "")
+         else if (!isRealString(name))
          {
             this.alfLog("warn", "A request was made to retrieve a data item from a QuADDS but no item name was provided", payload, this);
          }
@@ -160,7 +164,7 @@ define(["dojo/_base/declare",
          {
             var url = AlfConstants.PROXY_URI + "aikau/quadds/" + lang.trim(quadds) + "/item/" + lang.trim(name);
             this.serviceXhr({url : url,
-                             alfTopic: payload.alfResponseTopic != null ? payload.alfResponseTopic : payload.alfTopic,
+                             alfTopic: payload.alfResponseTopic || payload.alfTopic,
                              method: "GET",
                              successCallback: this.processQuaddItemData,
                              callbackScope: this});
@@ -177,15 +181,15 @@ define(["dojo/_base/declare",
          var quadds = lang.getObject("quadds", false, payload);
          var name = lang.getObject("name", false, payload);
          var data = lang.getObject("data", false, payload);
-         if (quadds == null || lang.trim(quadds) === "")
+         if (!isRealString(quadds))
          {
             this.alfLog("warn", "A request was made to create a data item in a QuADDS but no QuADDS was provided", payload, this);
          }
-         else if (name == null || lang.trim(name) === "")
+         else if (!isRealString(name))
          {
             this.alfLog("warn", "A request was made to create a data item in a QuADDS but no item name was provided", payload, this);
          }
-         else if (data == null)
+         else if (!data)
          {
             this.alfLog("warn", "A request was made to create a data item in a QuADDS but no data was provided", payload, this);
          }
@@ -199,7 +203,7 @@ define(["dojo/_base/declare",
             this.serviceXhr({url : url,
                              data: config,
                              method: "POST",
-                             alfTopic: payload.alfResponseTopic != null ? payload.alfResponseTopic : payload.alfTopic,
+                             alfTopic: payload.alfResponseTopic || payload.alfTopic,
                              successCallback: this.refreshRequest,
                              callbackScope: this});
          }
@@ -214,15 +218,15 @@ define(["dojo/_base/declare",
          var quadds = lang.getObject("quadds", false, payload);
          var name = lang.getObject("name", false, payload);
          var data = lang.getObject("data", false, payload);
-         if (quadds == null || lang.trim(quadds) === "")
+         if (!isRealString(quadds))
          {
             this.alfLog("warn", "A request was made to update a data item in a QuADDS but no QuADDS was provided", payload, this);
          }
-         else if (name == null || lang.trim(name) === "")
+         else if (!isRealString(name))
          {
             this.alfLog("warn", "A request was made to update a data item in a QuADDS but no item name was provided", payload, this);
          }
-         else if (data == null)
+         else if (!data)
          {
             this.alfLog("warn", "A request was made to update a data item in a QuADDS but no data was provided", payload, this);
          }
@@ -236,7 +240,7 @@ define(["dojo/_base/declare",
             this.serviceXhr({url : url,
                              data: config,
                              method: "PUT",
-                             alfTopic: payload.alfResponseTopic != null ? payload.alfResponseTopic : payload.alfTopic,
+                             alfTopic: payload.alfResponseTopic || payload.alfTopic,
                              successCallback: this.refreshRequest,
                              callbackScope: this});
          }
@@ -250,11 +254,11 @@ define(["dojo/_base/declare",
       onDeleteQuaddsItem: function alfresco_services_QuaddsService__onDeleteQuaddsItem(payload) {
          var quadds = lang.getObject("quadds", false, payload);
          var name = lang.getObject("name", false, payload);
-         if (quadds == null || lang.trim(quadds) === "")
+         if (!isRealString(quadds))
          {
             this.alfLog("warn", "A request was made to delete a data item from a QuADDS but no QuADDS was provided", payload, this);
          }
-         else if (name == null || lang.trim(name) === "")
+         else if (!isRealString(name))
          {
             this.alfLog("warn", "A request was made to delete a data item from a QuADDS but no item name was provided", payload, this);
          }
@@ -263,7 +267,7 @@ define(["dojo/_base/declare",
             var url = AlfConstants.PROXY_URI + "aikau/quadds/" + lang.trim(quadds) + "/item/" + lang.trim(name);
             this.serviceXhr({url : url,
                              method: "DELETE",
-                             alfTopic: payload.alfResponseTopic != null ? payload.alfResponseTopic : payload.alfTopic,
+                             alfTopic: payload.alfResponseTopic || payload.alfTopic,
                              successCallback: this.refreshRequest,
                              callbackScope: this});
          }

--- a/aikau/src/main/resources/alfresco/services/QuaddsService.js
+++ b/aikau/src/main/resources/alfresco/services/QuaddsService.js
@@ -28,11 +28,12 @@
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
         "alfresco/core/CoreXhr",
+        "alfresco/core/topics",
         "service/constants/Default",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/json"],
-        function(declare, BaseService, CoreXhr, AlfConstants, lang, array, dojoJson) {
+        function(declare, BaseService, CoreXhr, topics, AlfConstants, lang, array, dojoJson) {
    
    return declare([BaseService, CoreXhr], {
       
@@ -83,6 +84,7 @@ define(["dojo/_base/declare",
       /**
        * Parses the data JSON string back into an object.
        * @instance
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       refreshRequest: function alfresco_services_QuaddsService__refreshRequest(response, originalRequestConfig) {
          var responseTopic = lang.getObject("alfTopic", false, originalRequestConfig);
@@ -95,7 +97,7 @@ define(["dojo/_base/declare",
             this.alfLog("warn", "It was not possible to publish requested QuADDS data because the 'responseTopic' attribute was not set on the original request", response, originalRequestConfig);
          }
          // TODO: Need a context sensitive, localized message...
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: "Operation Completed Successfully"
          });
          this.alfPublish("ALF_DOCLIST_RELOAD_DATA");

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -555,10 +555,11 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response The response from the XHR request to join the site.
        * @param {object} originalRequestConfig The original configuration passed when the request was made.
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       siteJoined: function alfresco_services_SiteService__siteJoined(response, originalRequestConfig) {
          this.alfLog("log", "User has successfully joined a site", response, originalRequestConfig);
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message("message.joining", {
                "0": originalRequestConfig.user,
                "1": originalRequestConfig.site

--- a/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
@@ -239,6 +239,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onActionSuccess: function alfresco_services_ActionService__onActionSuccess(payload) {
          // jshint unused:false
@@ -249,7 +250,7 @@ define(["dojo/_base/declare",
          }
          if (payload.response.overallSuccess === true)
          {
-            this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+            this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
                message: payload.requestConfig.copy ? this.message("copyMoveService.copy.completeSuccess") : this.message("copyMoveService.move.completeSuccess")
             });
          }
@@ -282,6 +283,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onActionFailure: function alfresco_services_ActionService__onActionFailure(payload) {
          // jshint unused:false
@@ -291,7 +293,7 @@ define(["dojo/_base/declare",
          {
             this.alfUnsubscribeSaveHandles(subscriptionHandles);
          }
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: payload.requestConfig.copy ? this.message("copyMoveService.copy.failure") : this.message("copyMoveService.move.failure")
          });
       }

--- a/aikau/src/main/resources/alfresco/services/actions/CreateTemplateContentService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CreateTemplateContentService.js
@@ -31,9 +31,10 @@
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
         "alfresco/core/CoreXhr",
+        "alfresco/core/topics",
         "service/constants/Default",
         "dojo/_base/lang"],
-        function(declare, BaseService, AlfCoreXhr, AlfConstants, lang) {
+        function(declare, BaseService, AlfCoreXhr, topics, AlfConstants, lang) {
 
    return declare([BaseService, AlfCoreXhr], {
 
@@ -206,9 +207,10 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response The response from the request
        * @param {object} originalRequestConfig The configuration passed on the original request
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       templateContentCreateSuccess: function alfresco_services_ActionService__templateContentCreateSuccess(response, originalRequestConfig) {
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message("create.template.content.success", {
                0: response.name
             })

--- a/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
@@ -30,11 +30,12 @@
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
         "alfresco/core/CoreXhr",
+        "alfresco/core/topics",
         "service/constants/Default",
         "dojo/_base/lang",
         "dojo/_base/array",
         "alfresco/core/ObjectTypeUtils"],
-        function(declare, BaseService, AlfCoreXhr, AlfConstants, lang, array, ObjectTypeUtils) {
+        function(declare, BaseService, AlfCoreXhr, topics, AlfConstants, lang, array, ObjectTypeUtils) {
 
    return declare([BaseService, AlfCoreXhr], {
 
@@ -375,7 +376,7 @@ define(["dojo/_base/declare",
        */
       onUpdateSuccess: function  alfresco_services_actions_ManageAspectsService__onUpdateSuccess(response, originalRequestConfig) {
          this.alfLog("info", "Aspects updated successfully", response, originalRequestConfig, this);
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message("services.actionservice.ManageAspects.aspectUpdateSuccess", {
                "0": originalRequestConfig.item.displayName
             })

--- a/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/WorkflowService.js
@@ -197,10 +197,11 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response
        * @param {object} originalRequestConfig The configuration used for the XHR request
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onApproveSuccess: function alfresco_services_actions_WorkflowService__onApproveSuccess(response, originalRequestConfig) {
          var message = lang.getObject("requestConfig.action.successMessage", false, response);
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message(message || this.approveSuccessMessage)
          });
          this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, originalRequestConfig.responseScope);
@@ -211,10 +212,11 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param {object} response
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onApproveFailure: function alfresco_services_actions_WorkflowService__onApproveFailure(response) {
          var message = lang.getObject("requestConfig.action.failureMessage", false, response);
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message(message || this.approveFailureMessage)
          });
       },
@@ -225,10 +227,11 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response
        * @param {object} originalRequestConfig The configuration used for the XHR request
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onRejectSuccess: function alfresco_services_actions_WorkflowService__onRejectSuccess(response, originalRequestConfig) {
          var message = lang.getObject("requestConfig.action.successMessage", false, response);
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message(message || this.rejectSuccessMessage)
          });
          this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, originalRequestConfig.responseScope);
@@ -239,10 +242,11 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param {object} response
+       * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
       onRejectFailure: function alfresco_services_actions_WorkflowService__onRejectFailure(response) {
          var message = lang.getObject("requestConfig.action.failureMessage", false, response);
-         this.alfPublish("ALF_DISPLAY_NOTIFICATION", {
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message(message || this.rejectFailureMessage)
          });
       }


### PR DESCRIPTION
Update references to "ALF_DISPLAY_NOTIFICATION". Also fix JSHint errors in two files: `alfresco/preview/PdfJs/PDFFindController` and `alfresco/services/QuaddsService`. Full test suite has been run on FF/Chrome, and JSDoc confirmed working.