### PR TITLE
AKU-602: Update search failure message

### DIFF
--- a/aikau/src/main/resources/alfresco/search/i18n/AlfSearchList.properties
+++ b/aikau/src/main/resources/alfresco/search/i18n/AlfSearchList.properties
@@ -2,6 +2,6 @@ searchlist.loading.data.message=Searching...
 searchlist.no.view.message=Select a view
 searchlist.no.data.message=No results found
 searchlist.rendering.data.message=Waiting for search results...
-searchlist.data.failure.message=There was an error loading search results
+searchlist.data.failure.message=We hit a problem getting your search results. Try searching again
 
 search.results.count.label={0} - results found

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -47,7 +47,7 @@ registerSuite(function(){
          return browser.findById("FCTSRCH_SEARCH_RESULTS_LIST")
             .getVisibleText()
             .then(function (text){
-               assert.equal(text, "There was an error loading search results", "There should not be any results found yet");
+               assert.equal(text, "We hit a problem getting your search results. Try searching again", "There should not be any results found yet");
             })
          .end()
          .clearLog();


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-602 to update the search failure message.