### PR TITLE
AKU-603: Defensively code against duplicate IDs

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -627,7 +627,7 @@ define(["dojo/_base/declare",
                {
                   if (registry.byId(initArgs.id))
                   {
-                     initArgs.id = widget.name + "___" + _this.generateUuid();
+                     initArgs.id = widget.name.replace(/\//g, "_") + "___" + _this.generateUuid();
                   }
 
                   // Instantiate the new widget

--- a/aikau/src/main/resources/alfresco/forms/TabbedControls.js
+++ b/aikau/src/main/resources/alfresco/forms/TabbedControls.js
@@ -83,9 +83,9 @@ define(["alfresco/layout/AlfTabContainer",
         "dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array"], 
-        function(HorizontalWidgets, LayoutMixin, declare, lang, array) {
+        function(AlfTabContainer, LayoutMixin, declare, lang, array) {
    
-   return declare([HorizontalWidgets, LayoutMixin], {
+   return declare([AlfTabContainer, LayoutMixin], {
       
       /**
        * Overrides the [default]{@link module:alfresco/layout/AlfTabContainer#delayProcessingDefault} 

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -378,7 +378,13 @@ define(["dojo/_base/declare",
        * @param {integer} index The index of the required tab position
        */
       addWidget: function alfresco_layout_AlfTabContainer__addWidget(widget, /*jshint unused:false*/ index) {
-         var indexOfDuplicateTab = this.indexOfTabId(widget.id);
+         var targetTabId = null;
+         if (widget.id)
+         {
+            targetTabId = this.id + "_" + widget.id;
+         }
+
+         var indexOfDuplicateTab = this.indexOfTabId(targetTabId);
          if (indexOfDuplicateTab !== -1)
          {
             // A tab with the requested ID has already been added, so just select it...
@@ -391,7 +397,7 @@ define(["dojo/_base/declare",
             //       of the tab (e.g. for an AlfSideBarContainer to calculate it's height appropriately)...
             var domNode = domConstruct.create("div", {});
             var cp = new ContentPane({
-               id: widget.id || null
+               id: targetTabId
             });
             domClass.add(cp.domNode, "alfresco-layout-AlfTabContainer__OuterTab");
             this.tabContainerWidget.addChild(cp, widget.tabIndex);
@@ -537,9 +543,10 @@ define(["dojo/_base/declare",
          }
          else if(payload && (typeof payload.id === "string" || typeof payload.title === "string"))
          {
+            var targetTabId = this.id + "_" + payload.id;
             for(var i = 0; i < tabs.length; i++) // tabs does not support forEach
             {
-               if((payload.id && tabs[i].id === payload.id) || (payload.title && tabs[i].title === payload.title))
+               if((payload.id && tabs[i].id === targetTabId) || (payload.title && tabs[i].title === payload.title))
                {
                   tc.selectChild(tabs[i]);
                   break;
@@ -569,7 +576,8 @@ define(["dojo/_base/declare",
          {
             for(var i = 0; i < tabs.length; i++) // tabs does not support forEach
             {
-               if((payload.id && tabs[i].id === payload.id) || (payload.title && tabs[i].title === payload.title))
+               var targetTabId = this.id + "_" + payload.id;
+               if((payload.id && tabs[i].id === targetTabId) || (payload.title && tabs[i].title === payload.title))
                {
                   tabs[i].set("disabled", payload.value);
                   break;
@@ -632,7 +640,8 @@ define(["dojo/_base/declare",
          {
             for(var i = 0; i < tabs.length; i++) // tabs does not support forEach
             {
-               if((payload.id && tabs[i].id === payload.id) || (payload.title && tabs[i].title === payload.title))
+               var targetTabId = this.id + "_" + payload.id;
+               if((payload.id && tabs[i].id === targetTabId) || (payload.title && tabs[i].title === payload.title))
                {
                   tc.removeChild(tabs[i]);
                   break;

--- a/aikau/src/test/resources/alfresco/core/WidgetCreationTest.js
+++ b/aikau/src/test/resources/alfresco/core/WidgetCreationTest.js
@@ -21,60 +21,89 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Widget Creation Tests",
+      return {
+         name: "Widget Creation Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/WidgetCreation", "Widget Creation Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/WidgetCreation", "Widget Creation Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
-     "Count the number of Logo widgets": function () {
-         // This isn't the optimal way of testing this - ideally we want to get each widget and then
-         // check the IDs - however, it's not easily understood how to do this with mulitple selection and 
-         // chaining of promises - this test should be sufficient but it would be nice to update at some
-         // point in the future!
+         "Count the number of Logo widgets": function () {
+            // This isn't the optimal way of testing this - ideally we want to get each widget and then
+            // check the IDs - however, it's not easily understood how to do this with mulitple selection and 
+            // chaining of promises - this test should be sufficient but it would be nice to update at some
+            // point in the future!
 
-         return browser.findAllByCssSelector(".alfresco-logo-Logo")
-            .then(function (els) {
-               assert.lengthOf(els, 3, "An unexpected number of logo widgets found");
-            });
-      },
+            return browser.findAllByCssSelector(".alfresco-logo-Logo")
+               .then(function (els) {
+                  assert.lengthOf(els, 3, "An unexpected number of logo widgets found");
+               });
+         },
 
-      "Check for the Logo with the specific ID": function() {
-         return browser.findAllByCssSelector("#SPECIFIC_DOM_ID")
-            .then(function (els) {
-               assert.lengthOf(els, 1, "Couldn't find Logo with specific DOM id");
-            });
-      },
+         "Check for the Logo with the specific ID": function() {
+            return browser.findAllByCssSelector("#SPECIFIC_DOM_ID")
+               .then(function (els) {
+                  assert.lengthOf(els, 1, "Couldn't find Logo with specific DOM id");
+               });
+         },
 
-      "Check for the Logo with the overridden ID": function() {
-         return browser.findAllByCssSelector("#SPECIFIC_DOM_ID")
-            .then(function (els) {
-               assert.lengthOf(els, 1, "Couldn't find Logo with overridden DOM id");
-            });
-      },
+         "Check for the Logo with the overridden ID": function() {
+            return browser.findAllByCssSelector("#SPECIFIC_DOM_ID")
+               .then(function (els) {
+                  assert.lengthOf(els, 1, "Couldn't find Logo with overridden DOM id");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Open dialog for first item": function() {
+            // Open the dialog for the first item in the list...
+            return browser.findByCssSelector("#PROPERTY_LINK_ITEM_0 .value")
+               .click()
+            .end()
+
+            // Wait for the dialog to open...
+            .findByCssSelector("#one_DIALOG.dialogDisplayed")
+            .end()
+
+            // Close it...
+            .findById("one_DIALOG_OK_label")
+               .click()
+            .end()
+
+            // Wait for it to close...
+            .findByCssSelector("#one_DIALOG.dialogHidden")
+            .end()
+
+            // Open the dialog for the second item in the list...
+            .findByCssSelector("#PROPERTY_LINK_ITEM_1 .value")
+               .click()
+            .end()
+
+            // Wait for the dialog to open...
+            .findByCssSelector("#two_DIALOG.dialogDisplayed")
+            .end()
+
+            .findByCssSelector("#two_DIALOG .alfresco-forms-controls-BaseFormControl")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The text box in the second dialog should have been displayed");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/AsyncFormControlLoadingTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/AsyncFormControlLoadingTest.js
@@ -51,7 +51,7 @@ define(["intern!object",
             .end()
 
             // Select the "DYNAMIC" tab...
-            .findById("TABS_TABCONTAINER_tablist_DYNAMIC")
+            .findById("TABS_TABCONTAINER_tablist_TABS_DYNAMIC")
                .click()
             .end()
 

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -529,7 +529,7 @@ define(["intern!object",
          },
 
          "Check that delayed processing form control is displayed correctly": function() {
-            return browser.findById("TC_TABCONTAINER_tablist_FormControl1")
+            return browser.findById("TC_TABCONTAINER_tablist_TC_FormControl1")
                .click()
             .end()
             .findByCssSelector("#FormControl1 .label")
@@ -540,7 +540,7 @@ define(["intern!object",
          },
 
           "Check that non-delayed processing form control is displayed correctly": function() {
-            return browser.findById("TC_TABCONTAINER_tablist_FormControl2")
+            return browser.findById("TC_TABCONTAINER_tablist_TC_FormControl2")
                .click()
             .end()
             .findByCssSelector("#FormControl2 .label")
@@ -672,7 +672,7 @@ define(["intern!object",
 
          "Attempt to create the same tab": function() {
             // Switch back to the 2nd tab...
-            return browser.findById("TC1_TABCONTAINER_tablist_SEARCH_LIST")
+            return browser.findById("TC1_TABCONTAINER_tablist_TC1_SEARCH_LIST")
                .click()
             .end()
 
@@ -696,7 +696,7 @@ define(["intern!object",
 
          "Create a tab with a follow-on publication": function() {
             // Switch back to the 2nd tab...
-            return browser.findById("TC1_TABCONTAINER_tablist_SEARCH_LIST")
+            return browser.findById("TC1_TABCONTAINER_tablist_TC1_SEARCH_LIST")
                .click()
             .end()
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/WidgetCreation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/WidgetCreation.get.js
@@ -11,7 +11,7 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/DialogService"
    ],
    widgets: [
       {
@@ -36,10 +36,87 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "LIST",
+         name: "alfresco/lists/AlfList",
+         config: {
+            currentData: {
+               items: [
+                  { value: "one"},
+                  { value: "two"}
+               ]
+            },
+            widgets: [
+               {
+                  id: "LIST_VIEW",
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "PROPERTY_LINK",
+                                             name: "alfresco/renderers/PropertyLink",
+                                             config: {
+                                                propertyToRender: "value",
+                                                useCurrentItemAsPayload: false,
+                                                publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+                                                publishPayloadType: "PROCESS",
+                                                publishPayloadModifiers: ["processCurrentItemTokens"],
+                                                publishPayload: {
+                                                   dialogId: "{value}_DIALOG",
+                                                   dialogTitle: "Dialog",
+                                                   formSubmissionTopic: "POST_DIALOG_2",
+                                                   widgets: [
+                                                      {
+                                                         id: "TABBED_CONTROLS",
+                                                         name: "alfresco/forms/TabbedControls",
+                                                         config: {
+                                                            widgets: [
+                                                               {
+                                                                  id: "TABBED_CONTROL_COLUMN",
+                                                                  name: "alfresco/forms/ControlColumn",
+                                                                  title: "Tab 1",
+                                                                  config: {
+                                                                     widgets: [
+                                                                        {
+                                                                           id: "TEXTBOX",
+                                                                           name: "alfresco/forms/controls/TextBox",
+                                                                           config: {
+                                                                              fieldId: "TB",
+                                                                              name: "tab1tb",
+                                                                              label: "Tab 1 TextBox"
+                                                                           }
+                                                                        }
+                                                                     ]
+                                                                  }
+                                                               }
+                                                            ]
+                                                         }
+                                                      }
+                                                   ]
+                                                }
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-603 to defensively code against duplicate IDs causing failure to process models. This problem was found when creating dialogs (with different IDs) that render form controls that share IDs. Because the dialogIds are different the first dialog is not destroyed so the form controls attempt to use an already registered id. This was particularly problematic with the TabbedControl layout. This has been fixed and the unit tests updated to prevent regressions.