### PR TITLE
AKU-559: Ensure that filterTopic subscriptions are set up when filters have been created

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -118,11 +118,15 @@ define(["dojo/_base/declare",
 
             // Setup the filtering topics based on the filter widgets configured...
             array.forEach(this.widgetsForFilters, this.setupFilteringTopics, this);
+
+            // Create the subscriptions for the filters once created...
+            this.createFilterSubscriptions();
          }
          else
          {
             // Only perform the inherited function (e.g. to processViews) when not processing filters
-            this.inherited(arguments);
+            this.registerViews(widgets);
+            this.completeListSetup();
          }
       },
 


### PR DESCRIPTION
This is another PR as part of the fall out of changes made for https://issues.alfresco.com/jira/browse/AKU-559. This change ensures that the filterTopic subscriptions are only setup once all the filter widgets have successfully been created.