### PR TITLE
AKU-608: XhrActions updates

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -100,6 +100,17 @@ define(["dojo/_base/declare",
       additionalOtherNodeActions: null,
 
       /**
+       * The [customActions]{@link module:alfresco/renderers/_ActionsMixin#customActions} to apply to the
+       * configuration of the enclosed [XhrActions]{@link module:alfresco/renderers/XhrActions} widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.38
+       */
+      customActions: null,
+
+      /**
        * This can be configured to override the default filter for the actions that are applicable to 
        * folder and document nodes. Actions need to be filtered as Aikau does not currently support all
        * of the actions that can be configured in Alfresco Share. However, if custom actions are provided
@@ -119,6 +130,19 @@ define(["dojo/_base/declare",
        * @default
        */
       enableContextMenu: false,
+
+      /**
+       * Indicates whether or not the standard actions (e.g. those derived from Document Library XML configuration)
+       * should be merged with any [customActions]{@link module:alfresco/renderers/_ActionsMixin#customActions} and
+       * [widgetsForActions]{@link module:alfresco/renderers/_ActionsMixin#widgetsForActions}. This is applied to 
+       * the configuration of the enclosed [XhrActions]{@link module:alfresco/renderers/XhrActions} widget.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.38
+       */
+      mergeActions: false,
 
       /**
        * This can be configured to override the default filter for the actions that are applicable to 
@@ -174,6 +198,17 @@ define(["dojo/_base/declare",
       widgetsBelow: null,
 
       /**
+       * The [customActions]{@link module:alfresco/renderers/_ActionsMixin#widgetsForActions} to apply to the
+       * configuration of the enclosed [XhrActions]{@link module:alfresco/renderers/XhrActions} widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.38
+       */
+      widgetsForActions: null,
+
+      /**
        * Creates the renderers to display for a search result and adds them into the template. Renderers
        * will only be created if there is data for them. This is done to further improve the performance
        * of the search rendering.
@@ -207,11 +242,15 @@ define(["dojo/_base/declare",
       createActionsRenderer: function alfresco_search_AlfSearchResult__createActionsRenderer() {
          // jshint nonew:false
          new XhrActions({
+            id: this.id + "_ACTIONS",
             onlyShowOnHover: true,
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
+            customActions: this.customActions,
             filterActions: true,
-            allowedActions: (this.currentItem.type === "document" || this.currentItem.type === "folder") ? this.documentAndFolderActions : this.otherNodeActions
+            mergeActions: this.mergeActions,
+            allowedActions: (this.currentItem.type === "document" || this.currentItem.type === "folder") ? this.documentAndFolderActions : this.otherNodeActions,
+            widgetsForActions: this.widgetsForActions
          }, this.actionsNode);
       },
 
@@ -260,6 +299,7 @@ define(["dojo/_base/declare",
          {
             // jshint nonew:false
             new Property({
+               id: this.id + "_DESCRIPTION",
                currentItem: this.currentItem,
                pubSubScope: this.pubSubScope,
                propertyToRender: "description",
@@ -278,6 +318,7 @@ define(["dojo/_base/declare",
       createDateRenderer: function alfresco_search_AlfSearchResult__createDateRenderer() {
          // jshint nonew:false
          new DateLink({
+            id: this.id + "_DATE",
             renderedValueClass: "alfresco-renderers-Property pointer",
             renderSize: "small",
             deemphasized: true,
@@ -307,6 +348,7 @@ define(["dojo/_base/declare",
       createDisplayNameRenderer: function alfresco_search_AlfSearchResult__createDisplayNameRenderer() {
          // jshint nonew:false
          new SearchResultPropertyLink({
+            id: this.id + "_DISPLAY_NAME",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
             propertyToRender: "displayName",
@@ -327,6 +369,7 @@ define(["dojo/_base/declare",
          if (this.showMoreInfo === true)
          {
             var moreInfoConfig = {
+               id: this.id + "_MORE_INFO",
                currentItem: this.currentItem,
                pubSubScope: this.pubSubScope,
                xhrRequired: true,
@@ -369,6 +412,7 @@ define(["dojo/_base/declare",
 
             // jshint nonew:false
             new PropertyLink({
+               id: this.id + "_PATH",
                renderedValueClass: "alfresco-renderers-Property pointer",
                pubSubScope : this.pubSubScope,
                currentItem : this.currentItem,
@@ -405,6 +449,7 @@ define(["dojo/_base/declare",
          {
             // jshint nonew:false
             new Selector({
+               id: this.id + "_SELECTOR",
                currentItem : this.currentItem,
                pubSubScope : this.pubSubScope
             }, this.selectorNode);
@@ -430,6 +475,7 @@ define(["dojo/_base/declare",
          {
             // jshint nonew:false
             new PropertyLink({
+               id: this.id + "_SITE",
                renderedValueClass: "alfresco-renderers-Property pointer",
                renderSize: "small",
                pubSubScope: this.pubSubScope,
@@ -464,6 +510,7 @@ define(["dojo/_base/declare",
          {
             // jshint nonew:false
             new Size({
+               id: this.id + "_SIZE",
                currentItem : this.currentItem,
                pubSubScope : this.pubSubScope,
                label : this.message("faceted-search.doc-lib.value-prefix.size"),
@@ -482,6 +529,7 @@ define(["dojo/_base/declare",
       createThumbnailRenderer: function alfresco_search_AlfSearchResult__createThumbnailRenderer() {
          // jshint nonew:false
          new SearchThumbnail({
+            id: this.id + "_THUMBNAIL",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
             showDocumentPreview: true
@@ -538,6 +586,7 @@ define(["dojo/_base/declare",
          else
          {
             new Property({
+               id: this.id + "_TITLE",
                currentItem: this.currentItem,
                pubSubScope: this.pubSubScope,
                propertyToRender: "title",

--- a/aikau/src/test/resources/alfresco/renderers/XhrActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/XhrActionsTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -21,51 +21,81 @@
  * @author David Webster
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"],
-       function (registerSuite, expect, assert, require, TestCommon) {
+       function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "XHR Actions Renderer Tests",
+      return {
+         name: "XHR Actions Renderer Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/XhrActions", "XHR Actions Renderer Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/XhrActions", "XHR Actions Renderer Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-     "Check Actions menu was rendered": function () {
-         // Test spec:
-         // 1: Check dropdown element exists
-         return browser.findByCssSelector(".alfresco-menus-AlfMenuBar span:first-child")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert(resultText === "Actions", "Actions should be rendered as a menu: " + resultText);
-            });
-      },
+        "Check Actions menu was rendered": function () {
+            // Test spec:
+            // 1: Check dropdown element exists
+            return browser.findById("XHR_ACTIONS_ITEM_0_MENU_text")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Actions", "Actions should be rendered as a menu");
+               });
+         },
 
-      "Check that document request event was triggered": function() {
-         // 2: Click on it. Check event triggered: ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST
-         return browser.findByCssSelector(".alfresco-menus-AlfMenuBar span:first-child")
-            .click()
+         "Check that document request event was triggered": function() {
+            // 2: Click on it. Check event triggered: ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST
+            return browser.findById("XHR_ACTIONS_ITEM_0_MENU_text")
+               .click()
             .end()
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST", "publish", "any"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Retrieve single doc request not triggered");
-            });
-      },
+            .getLastPublish("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST", "Retrieve single doc request not triggered");
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Check default behaviour to render 'legacy' document actions": function() {
+            return browser.findById("XHR_ACTIONS_ITEM_0_document-download")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-view-content")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-edit-properties")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-upload-new-version")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-edit-offline")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-copy-to")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-move-to")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-delete")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-assign-workflow")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-assign-workflow")
+               .end()
+               .findById("XHR_ACTIONS_ITEM_0_document-manage-granular-permissions");
+         },
+
+         "Check merged and filtered actions": function() {
+            return browser.findById("MERGED_XHR_ACTIONS_ITEM_0_MENU_text")
+               .click()
+            .end()
+            .findById("MERGED_XHR_ACTIONS_ITEM_0_document-delete")
+            .end()
+            .findById("MERGED_XHR_ACTIONS_ITEM_0_CUSTOM3")
+            .end()
+            .findById("MERGED_XHR_ACTIONS_ITEM_0_MANAGE_ASPECTS");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -20,18 +20,17 @@
 /**
  * This test generates some variations on AlfSearchResult to test the various if statements in the rendering widgets involved
  *
- * @author Richard Smith
+ * @author Dave Draper
  */
 define(["intern!object",
-      "intern/chai!assert",
-      "alfresco/TestCommon"
-   ],
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
    function(registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
+      return {
          name: "AlfSearchResult Tests",
 
          setup: function() {
@@ -54,13 +53,13 @@ registerSuite(function(){
             var activeElementId;
             return browser.findByCssSelector(".alfresco-search-AlfSearchResult:last-child")
                .click()
-               .end()
+            .end()
 
             .getActiveElement()
                .then(function(element) {
                   activeElementId = element.elementId;
                })
-               .end()
+            .end()
 
             .findByCssSelector(".alfresco-search-AlfSearchResult:last-child")
 
@@ -102,9 +101,18 @@ registerSuite(function(){
                });
          },
 
+         "Check merged actions": function() {
+            return browser.findById("SR_ACTIONS_MENU_text")
+               .click()
+            .end()
+            .findById("SR_ACTIONS_CUSTOM3")
+            .end()
+            .findById("SR_ACTIONS_MANAGE_ASPECTS");
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
       };
-      });
    });
+});

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/XhrActions.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/XhrActions.get.js
@@ -9,7 +9,7 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/DocumentService"
    ],
    widgets:[
       {
@@ -18,7 +18,7 @@ model.jsonModel = {
             subscribeToDocRequests: true,
             currentData: {
                items: [
-                  {col1:"Test1", nodeRef:"12345"},
+                  {col1:"Test1", nodeRef:"workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339"},
                   {col1:"Test2", nodeRef:"23456"},
                   {col1:"Test3", nodeRef:"34567"}
                ]
@@ -47,7 +47,42 @@ model.jsonModel = {
                            config: {
                               widgets: [
                                  {
+                                    id: "XHR_ACTIONS",
                                     name: "alfresco/renderers/XhrActions"
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "MERGED_XHR_ACTIONS",
+                                    name: "alfresco/renderers/XhrActions",
+                                    config: {
+                                       filterActions: true,
+                                       mergeActions: true,
+                                       allowedActions: [
+                                          "document-delete",
+                                          "CUSTOM3"
+                                       ],
+                                       customActions: [
+                                          {
+                                             id: "CUSTOM3",
+                                             label: "Custom Action 3",
+                                             icon: "document-delete",
+                                             index: "10",
+                                             publishTopic: "DELETE_ACTION_TOPIC",
+                                             type: "javascript"
+                                          }
+                                       ],
+                                       widgetsForActions: [
+                                          {
+                                             name: "alfresco/renderers/actions/ManageAspects"
+                                          }
+                                       ]
+                                    }
                                  }
                               ]
                            }
@@ -59,10 +94,13 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "aikauTesting/mockservices/PdfJsMockXhr",
+         config: {
+            
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -9,7 +9,7 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/DocumentService"
    ],
    widgets:[
       {
@@ -19,7 +19,7 @@ model.jsonModel = {
             currentData: {
                items: [
                   {
-                     nodeRef: "dummy://nodeRef/1",
+                     nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
                      type: "folder",
                      name: "test1 & test2",
                      displayName: "Normal result",
@@ -232,12 +232,38 @@ model.jsonModel = {
             ],
             widgets:[
                {
+                  id: "SR",
                   name: "alfresco/search/AlfSearchResult",
                   config: {
-                     pubSubScope: "AlfSearchResultScope"
+                     pubSubScope: "AlfSearchResultScope",
+                     mergeActions: true,
+                     additionalDocumentAndFolderActions: [
+                        "CUSTOM3"
+                     ],
+                     customActions: [
+                        {
+                           id: "CUSTOM3",
+                           label: "Custom Action 3",
+                           icon: "document-delete",
+                           index: "10",
+                           publishTopic: "DELETE_ACTION_TOPIC",
+                           type: "javascript"
+                        }
+                     ],
+                     widgetsForActions: [
+                        {
+                           name: "alfresco/renderers/actions/ManageAspects"
+                        }
+                     ]
                   }
                }
             ]
+            
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PdfJsMockXhr",
+         config: {
             
          }
       },


### PR DESCRIPTION
This PR addresses both https://issues.alfresco.com/jira/browse/AKU-607 and https://issues.alfresco.com/jira/browse/AKU-608 to make it possible that XhrActions supports customActions and widgetsForActions attributes. It also exposes those configuration attributes on the AlfSearchResult module so that they can be used in search.