### PR TITLE
AKU-600: Support dynamic visibility in FixedHeaderFooter

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/DynamicVisibilityResizingMixin.js
+++ b/aikau/src/main/resources/alfresco/layout/DynamicVisibilityResizingMixin.js
@@ -73,13 +73,13 @@ define(["dojo/_base/declare",
        * and creates a subscription for each one bound to the supplied function.
        * 
        * @instance
-       * @param {function} f The function to bind each subscription to.
+       * @param {function} func The function to bind each subscription to.
        */
-      subscribeToVisibilityRuleTopics: function alfresco_layout_DynamicVisibilityResizingMixin__subscribeToVisibilityRuleTopics(f) {
+      subscribeToVisibilityRuleTopics: function alfresco_layout_DynamicVisibilityResizingMixin__subscribeToVisibilityRuleTopics(func) {
          if (this.visibilityRuleTopics)
          {
             array.forEach(this.visibilityRuleTopics, function(topic) {
-               this.alfSubscribe(topic, lang.hitch(this, f));
+               this.alfSubscribe(topic, lang.hitch(this, func));
             }, this);
          }
       }

--- a/aikau/src/main/resources/alfresco/layout/DynamicVisibilityResizingMixin.js
+++ b/aikau/src/main/resources/alfresco/layout/DynamicVisibilityResizingMixin.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This module has been created to be mixed into layout modules that need to resize themselves as their child
+ * widgets are dynamically displayed or hidden. The [getVisibilityRuleTopics]{@link module:alfresco/layout/DynamicVisibilityResizingMixin#getVisibilityRuleTopics}
+ * function should be called before widgets are created (i.e. before any call to [processWidgets]{@link module:alfresco/core/CoreWidgetProcessing#processWidgets})
+ * and the [subscribeToVisibilityRuleTopics]{@link module:alfresco/layout/DynamicVisibilityResizingMixin#subscribeToVisibilityRuleTopics}
+ * function should be called after widget processing has been completed (i.e. in an extension to 
+ * [allWidgetsProcessed]{@link module:alfresco/core/CoreWidgetProcessing#allWidgetsProcessed}).
+ * 
+ * @module alfresco/layout/DynamicVisibilityResizingMixin
+ * @author Dave Draper
+ * @since 1.0.38
+ */
+define(["dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/_base/array"], 
+        function(declare, lang, array) {
+   
+   return declare([], {
+      
+      /**
+       * This array is setup when the [getVisibilityRuleTopics]{@link module:alfresco/layout/DynamicVisibilityResizingMixin#getVisibilityRuleTopics}
+       * is called and each topic is then subscribed to in order to trigger resize events when widgets are displayed or hidden.
+       *
+       * @instance
+       * @type {string[]}
+       * @default
+       */
+      visibilityRuleTopics: null,
+
+      /**
+       * This function can be called to check all the supplied widgets for dynamic visibility configuration so that 
+       * subscriptions can be created on the same rules to trigger resizing as widgets are displayed or hidden.
+       * 
+       * @instance
+       * @param {object[]} widgets The widgets to check for visibility/invisibility configuration
+       * @return {string[]} An array of the topics that are using in dynamic visibility/invisibility configuration
+       */
+      getVisibilityRuleTopics: function alfresco_layout_DynamicVisibilityResizingMixin__getVisibilityRuleTopics(widgets) {
+         var topicNames = {};
+         array.forEach(widgets, function(widget) {
+            var visibilityRules = lang.getObject("config.visibilityConfig.rules", false, widget) || [];
+            var invisibilityRules = lang.getObject("config.invisibilityConfig.rules", false, widget) || [];
+            array.forEach(visibilityRules.concat(invisibilityRules), function(rule) {
+               if (rule.topic) {
+                  topicNames[rule.topic] = true;
+               }
+            });
+         });
+         return Object.keys(topicNames);
+      },
+
+      /**
+       * Iterates over the [visibilityRuleTopics]{@link module:alfresco/layout/DynamicVisibilityResizingMixin#visibilityRuleTopics}
+       * and creates a subscription for each one bound to the supplied function.
+       * 
+       * @instance
+       * @param {function} f The function to bind each subscription to.
+       */
+      subscribeToVisibilityRuleTopics: function alfresco_layout_DynamicVisibilityResizingMixin__subscribeToVisibilityRuleTopics(f) {
+         if (this.visibilityRuleTopics)
+         {
+            array.forEach(this.visibilityRuleTopics, function(topic) {
+               this.alfSubscribe(topic, lang.hitch(this, f));
+            }, this);
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -252,8 +252,8 @@ define(["alfresco/core/ProcessWidgets",
        * @since 1.0.38
        */
       allWidgetsProcessed: function alfresco_layout_HorizontalWidgets__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
-         this._allWidgetsProcessedCount++;
-         if (this._allWidgetsProcessedCount === 3)
+         this._allWidgetsProcessedCount--;
+         if (this._allWidgetsProcessedCount === 0)
          {
             this.subscribeToVisibilityRuleTopics(this.onResize);
          }
@@ -266,7 +266,7 @@ define(["alfresco/core/ProcessWidgets",
        * @param {object[]} widgetInfos The widget information as objects with 'widgets' and 'node' properties
        */
       _doProcessWidgets: function alfresco_layout_FixedHeaderFooter___doProcessWidgets(widgetInfos) {
-         this._allWidgetsProcessedCount = 0;
+         this._allWidgetsProcessedCount = widgetInfos.length;
          array.forEach(widgetInfos, function(widgetInfo) {
             var widgets = widgetInfo.widgets,
                node = widgetInfo.node;

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -28,70 +28,126 @@ define(["intern!object",
        function(registerSuite, assert, TestCommon) {
 
    /* global document*/
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "FixedHeaderFooter tests",
+      return {
+         name: "FixedHeaderFooter tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/FixedHeaderFooter#currentItem=10", "FixedHeaderFooter Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/FixedHeaderFooter#currentItem=10", "FixedHeaderFooter Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Total height is correct": function() {
-         return browser.findById("HEADER_FOOTER")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.height, 300, "Height not as per widget config");
-            });
-      },
+         "Total height is correct": function() {
+            return browser.findById("HEADER_FOOTER")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 300, "Height not as per widget config");
+               });
+         },
 
-      "Only content is scrollable": function() {
-         function nodeOverflows(selector) {
-            var node = document.querySelector(selector);
-            return node.scrollHeight > node.offsetHeight;
+         "Header initially has no height": function() {
+            return browser.findByCssSelector(".alfresco-layout-FixedHeaderFooter__header")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 0, "Header should not have had any height");
+               });
+         },
+
+         "Footer initially has no height": function() {
+            return browser.findByCssSelector(".alfresco-layout-FixedHeaderFooter__footer")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.height, 0, "Footer should not have had any height");
+               });
+         },
+
+         "Content offset should be zero": function() {
+            return browser.findByCssSelector(".alfresco-layout-FixedHeaderFooter__content")
+               .getPosition()
+               .then(function(position) {
+                  // NOTE: "top" takes margin of 10 into consideration...
+                  assert.equal(position.y, 10, "Content should be at top of page");
+               });
+         },
+
+         "Reveal header": function() {
+            return browser.findById("SHOW_HEADER_label")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-layout-FixedHeaderFooter__header")
+               .getSize()
+               .then(function(size) {
+                  assert.notEqual(size.height, 0, "Header should now have height");
+               });
+         },
+
+         "Reveal footer": function() {
+            return browser.findById("SHOW_FOOTER_label")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-layout-FixedHeaderFooter__footer")
+               .getSize()
+               .then(function(size) {
+                  assert.notEqual(size.height, 0, "Footer should now have height");
+               });
+         },
+
+         "Content offset should be increased": function() {
+            return browser.findByCssSelector(".alfresco-layout-FixedHeaderFooter__content")
+               .getPosition()
+               .then(function(position) {
+                  // NOTE: "top" takes margin of 10 into consideration...
+                  assert.notEqual(position.y, 10, "Content should no longer be at top of page");
+               });
+         },
+
+         "Only content is scrollable": function() {
+            function nodeOverflows(selector) {
+               var node = document.querySelector(selector);
+               return node.scrollHeight > node.offsetHeight;
+            }
+
+            return browser.execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__header"])
+               .then(function(overflows) {
+                  assert.isFalse(overflows, "Header is not same height as its content");
+               })
+
+            .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
+               .then(function(overflows) {
+                  assert.isTrue(overflows, "Content is not overflowing");
+               })
+
+            .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__footer"])
+               .then(function(overflows) {
+                  assert.isFalse(overflows, "Footer is not same height as its content");
+               });
+         },
+
+         "List has automatically scrolled to correct location": function() {
+            // See AKU-330
+            // The FixedHeaderFooter widget provides the best way of testing scrolling that is NOT on the
+            // main document...
+            function getScrollTop(selector) {
+               var node = document.querySelector(selector);
+               return node.scrollTop;
+            }
+            return browser.execute(getScrollTop, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
+               .then(function(scrollTop) {
+                  assert.notEqual(scrollTop, 0, "List did not scroll");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
          }
-
-         return browser.execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__header"])
-            .then(function(overflows) {
-               assert.isFalse(overflows, "Header is not same height as its content");
-            })
-
-         .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
-            .then(function(overflows) {
-               assert.isTrue(overflows, "Content is not overflowing");
-            })
-
-         .execute(nodeOverflows, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__footer"])
-            .then(function(overflows) {
-               assert.isFalse(overflows, "Footer is not same height as its content");
-            });
-      },
-
-      "List has automatically scrolled to correct location": function() {
-         // See AKU-330
-         // The FixedHeaderFooter widget provides the best way of testing scrolling that is NOT on the
-         // main document...
-         function getScrollTop(selector) {
-            var node = document.querySelector(selector);
-            return node.scrollTop;
-         }
-         return browser.execute(getScrollTop, ["#HEADER_FOOTER .alfresco-layout-FixedHeaderFooter__content"])
-            .then(function(scrollTop) {
-               assert.notEqual(scrollTop, 0, "List did not scroll");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-});
+      };
+   });
 
    registerSuite(function(){
       var browser;

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -43,7 +43,17 @@ model.jsonModel = {
                                  {
                                     label: "Heaven"
                                  }
-                              ]
+                              ],
+                              visibilityConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       topic: "HEADER_VISIBILITY",
+                                       attribute: "value",
+                                       isNot: ["HIDE"]
+                                    }
+                                 ]
+                              }
                            }
                         }
                      ],
@@ -93,13 +103,67 @@ model.jsonModel = {
                            config: {
                               useHash: false,
                               documentsPerPage: 10,
-                              pageSizes: [5,10,20]
+                              pageSizes: [5,10,20],
+                              visibilityConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       topic: "FOOTER_VISIBILITY",
+                                       attribute: "value",
+                                       isNot: ["HIDE"]
+                                    }
+                                 ]
+                              }
                            }
                         }
                      ]
                   }
                }
             ]
+         }
+      },
+      {
+         id: "HIDE_HEADER",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide header",
+            publishTopic: "HEADER_VISIBILITY",
+            publishPayload: {
+               value: "HIDE"
+            }
+         }
+      },
+      {
+         id: "SHOW_HEADER",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show header",
+            publishTopic: "HEADER_VISIBILITY",
+            publishPayload: {
+               value: "SHOW"
+            }
+         }
+      },
+      {
+         id: "HIDE_FOOTER",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Hide footer",
+            publishTopic: "FOOTER_VISIBILITY",
+            publishPayload: {
+               value: "HIDE"
+            }
+         }
+      },
+      {
+         id: "SHOW_FOOTER",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show footer",
+            publishTopic: "FOOTER_VISIBILITY",
+            publishPayload: {
+               value: "SHOW"
+            }
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-600 to ensure that the alfresco/layout/FixedHeaderFooter respects dynamic visibility. This abstracts the solution previously applied to the alfresco/layout/HorizontalWidgets module to a new mixin that is then applied to both modules. The unit test has been updated to verify the correct behaviour.