### PR TITLE
AKU-598: "ALF_DOCUMENT_TAGGED" is neither fired nor properly handled

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -169,13 +169,27 @@ define(["dojo/_base/declare",
             rootNode: this.rootNode
          });
       },
+
+      /**
+       * Destroys the supplied tag widget.
+       *
+       * @instance
+       * @param {object} widget The widget to destroy
+       * @param {number} index The index of the widget
+       * @deprecated Since 1.0.38 - use [clearAllTags]{@link module:alfresco/documentlibrary/AlfTagFilters#clearAllTags} instead.
+       */
+      clearTags: function alfresco_documentlibrary_AlfTagFilters__clearTags(widget, /*jshint unused:false*/ index) {
+         if (typeof widget.destroy === "function") {
+            widget.destroy();
+         }
+      },
       
       /**
        * Clears the current tags
        * 
        * @instance
        */
-      clearTags: function alfresco_documentlibrary_AlfTagFilters__clearTags() {
+      clearAllTags: function alfresco_documentlibrary_AlfTagFilters__clearAllTags() {
          var oldTags = registry.findWidgets(this.contentNode);
          array.forEach(oldTags, function(tagWidget) {
             tagWidget.destroy();

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -122,22 +122,16 @@ define(["dojo/_base/declare",
        * Called immediately after instantiation and before any processing
        * 
        * @instance
-       * @fires module:alfresco/core/topics#TAG_QUERY
+       * @listens module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentTaggedTopic
        */
       postMixInProperties: function alfresco_documentlibrary_AlfTagFilters__postMixInProperties() {
          this.inherited(arguments);
          
          // Subscribe to publications about documents being tagged/untagged...
          this.alfSubscribe(this.documentTaggedTopic, lang.hitch(this, this.onDocumentTagged));
-         
+
          // Make a request to get the initial set of tags for the current location...
-         this.alfServicePublish(this.tagQueryTopic, {
-            callback: this.onTagQueryResults,
-            callbackScope: this,
-            siteId: this.siteId,
-            containerId: this.containerId,
-            rootNode: this.rootNode
-         });
+         this.requestTags();
       },
       
       /**
@@ -149,28 +143,41 @@ define(["dojo/_base/declare",
          // Create the tags...
          if (response && ObjectTypeUtils.isArray(response.tags))
          {
-            var oldTags = registry.findWidgets(this.contentNode);
-            array.forEach(oldTags, lang.hitch(this, "clearTags"));
-            array.forEach(response.tags, lang.hitch(this, "createTagFilter"));
+            this.clearTags();
+            array.forEach(response.tags, this.createTagFilter, this);
          }
          else
          {
             this.alfLog("warn", "A request was made to generate filter tag links, but no 'tags' array attribute was provided", response, originalRequestConfig);
          }
       },
+
+      /**
+       * Request the tags for this tags list
+       *
+       * @instance
+       * @fires module:alfresco/core/topics#TAG_QUERY
+       */
+      requestTags: function alfresco_documentlibrary_AlfTagFilters__requestTags(){
+         this.alfServicePublish(this.tagQueryTopic, {
+            callback: this.onTagQueryResults,
+            callbackScope: this,
+            siteId: this.siteId,
+            containerId: this.containerId,
+            rootNode: this.rootNode
+         });
+      },
       
       /**
-       * Destroys the supplied tag widget.
+       * Clears the current tags
        * 
        * @instance
-       * @param {object} widget The widget to destroy
-       * @param {number} index The index of the widget
        */
-      clearTags: function alfresco_documentlibrary_AlfTagFilters__clearTags(widget, /*jshint unused:false*/ index) {
-         if (typeof widget.destroy === "function")
-         {
-            widget.destroy();
-         }
+      clearTags: function alfresco_documentlibrary_AlfTagFilters__clearTags() {
+         var oldTags = registry.findWidgets(this.contentNode);
+         array.forEach(oldTags, function(tagWidget) {
+            tagWidget.destroy();
+         });
       },
 
       /**
@@ -212,12 +219,14 @@ define(["dojo/_base/declare",
       currentTagFilters: null,
       
       /**
-       * Handles documents being tagged and creates a filter for the tag.
+       * Handles documents being tagged and recreates the tags list
        * 
        * @instance
-       * @param {object} payload
+       * @param {object} payload The publish payload
        */
       onDocumentTagged: function alfresco_documentlibrary_AlfTagFilters__onDocumentTagged(/*jshint unused:false*/ payload) {
+         this.clearTags();
+         this.requestTags();
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -145,7 +145,7 @@ define(["dojo/_base/declare",
          // Create the tags...
          if (response && ObjectTypeUtils.isArray(response.tags))
          {
-            this.clearTags();
+            this.clearAllTags();
             array.forEach(response.tags, this.createTagFilter, this);
          }
          else
@@ -241,7 +241,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The publish payload
        */
       onDocumentTagged: function alfresco_documentlibrary_AlfTagFilters__onDocumentTagged(/*jshint unused:false*/ payload) {
-         this.clearTags();
+         this.clearAllTags();
          this.requestTags();
       },
       

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfTagFilters.js
@@ -115,6 +115,8 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @listens module:alfresco/core/topics#TAG_QUERY
+       * @event
        */
       tagQueryTopic: topics.TAG_QUERY,
 
@@ -156,7 +158,7 @@ define(["dojo/_base/declare",
        * Request the tags for this tags list
        *
        * @instance
-       * @fires module:alfresco/core/topics#TAG_QUERY
+       * @fires module:alfresco/documentlibrary/AlfTagFilters#tagQueryTopic
        */
       requestTags: function alfresco_documentlibrary_AlfTagFilters__requestTags(){
          this.alfServicePublish(this.tagQueryTopic, {

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -269,6 +269,8 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default [topics.DOCUMENT_TAGGED]{@link module:alfresco/core/topics#DOCUMENT_TAGGED}
+       * @listens module:alfresco/core/topics#DOCUMENT_TAGGED
+       * @event
        */
       documentTaggedTopic: topics.DOCUMENT_TAGGED,
          

--- a/aikau/src/main/resources/alfresco/renderers/Tags.js
+++ b/aikau/src/main/resources/alfresco/renderers/Tags.js
@@ -387,6 +387,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload The success payload
+       * @fires module:alfresco/core/topics#DOCUMENT_TAGGED
        */
       onSaveSuccess: function alfresco_renderers_Tags__onSaveSuccess(/*jshint unused:false*/ payload) {
          this.alfUnsubscribeSaveHandles([this._saveSuccessHandle, this._saveFailureHandle]);
@@ -411,6 +412,9 @@ define(["dojo/_base/declare",
          domClass.remove(this.renderedValueNode, "hidden faded");
          domClass.add(this.editNode, "hidden");
          this.renderedValueNode.focus();
+
+         // Fire document tagged event
+         this.alfPublish(topics.DOCUMENT_TAGGED);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
@@ -51,18 +51,28 @@ define(["alfresco/TestCommon",
                   });
             },
 
-            "Clicked tags publish change notification (unscoped)": function(){
+            "Clicked tags publish change notification (unscoped)": function() {
                return browser.findByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
                   .clearLog()
                   .click()
                   .getLastPublish("ALF_DOCUMENTLIST_TAG_CHANGED", true);
             },
 
-            "Clicked tags publish change notification (scoped)": function(){
+            "Clicked tags publish change notification (scoped)": function() {
                return browser.findByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
                   .clearLog()
                   .click()
                   .getLastPublish("SCOPED_ALF_DOCUMENTLIST_TAG_CHANGED", true);
+            },
+
+            "Document tagged event forces reload of scoped list": function() {
+               return browser.findById("PUBLISH_TAGGED_BUTTON_label")
+                  .click()
+                  .getLastPublish("SCOPED_ALF_DOCUMENT_TAGGED", true)
+                  .getLastPublish("ALF_TAG_QUERY", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "alfResponseScope", "SCOPED_");
+                  });
             },
 
             beforeEach: function() {

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -145,7 +145,8 @@ registerSuite(function(){
          return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-ReadOnlyTag")
             .then(function(elements) {
                assert.lengthOf(elements, 0, "There should be no tags initially");
-            });
+            })
+            .clearLog();
       },
 
       "Navigate to a node with no tags and edit it": function() {
@@ -191,6 +192,11 @@ registerSuite(function(){
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Should be displaying the tag just created");
             });
+      },
+
+      "The document-tagged event should have fired": function() {
+         return browser.findByCssSelector("body")
+            .getLastPublish("ALF_DOCUMENT_TAGGED");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,10 +32,8 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/documentlibrary/SearchListScrollTest",
-      "src/test/resources/alfresco/lists/AlfHashListTest",
-      "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",
-      "src/test/resources/alfresco/search/SearchSuggestionsTest"
+      "src/test/resources/alfresco/documentlibrary/TagFiltersTest",
+      "src/test/resources/alfresco/renderers/TagsTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.js
@@ -15,6 +15,15 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "PUBLISH_TAGGED_BUTTON",
+         config: {
+            label: "Publish document-tagged event",
+            publishTopic: "ALF_DOCUMENT_TAGGED",
+            pubSubScope: "SCOPED_"
+         }
+      },
+      {
          name: "alfresco/layout/HorizontalWidgets",
          config: {
             widgets: [

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/TaggingMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/TaggingMockXhr.js
@@ -49,6 +49,9 @@ define(["dojo/_base/declare",
             this.server.respondWith("GET",
                                     /\/proxy\/alfresco\/api\/forms\/picker\/category\/workspace\/SpacesStore\/tag:tag-root\/(.*)/,
                                     lang.hitch(this, this.getTags));
+            this.server.respondWith("POST",
+                                    /.*\/aikau\/proxy\/alfresco\/api\/node\/.*\/formprocessor/,
+                                    "OK");
          }
          catch(e)
          {


### PR DESCRIPTION
This addresses [AKU-598](https://issues.alfresco.com/jira/browse/AKU-598) and adds support for the ALF_DOCUMENT_TAGGED event.