### PR TITLE
AKU-609: Support for bulk favouriting

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -365,7 +365,7 @@ define([],function() {
        * @since 1.0.38
        *
        * @event
-       * @property {string} id The ID of the action (this should map to a function in the [ActionService]{@link module:alfresco/services/ActionService})
+       * @property {string} action The action to perform (this should map to a function in the [ActionService]{@link module:alfresco/services/ActionService})
        * @property {string} actionTopic A topic to forward the action request on to. 
        */
       MULTIPLE_ITEM_ACTION_REQUEST: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -356,6 +356,21 @@ define([],function() {
       GET_PREFERENCE: "ALF_PREFERENCE_GET",
 
       /**
+       * This can be published to request that an action be performed on multiple selected items. The 
+       * selected items are tracked by either the [ActionService]{@link module:alfresco/services/ActionService}
+       * or preferrably a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
+       * 
+       * @instance
+       * @type {string}
+       * @since 1.0.38
+       *
+       * @event
+       * @property {string} id The ID of the action (this should map to a function in the [ActionService]{@link module:alfresco/services/ActionService})
+       * @property {string} actionTopic A topic to forward the action request on to. 
+       */
+      MULTIPLE_ITEM_ACTION_REQUEST: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+
+      /**
        * This topic can be published to request navigation to another URL.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -31,6 +31,19 @@ define([],function() {
    return {
 
       /**
+       * This can be published to request to add a node or nodes as a favourite.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       * @since 1.0.38
+       * @event
+       * @property {object} node - The node to add as a favourite
+       * @property {object[]} nodes - An array of nodes to add as a favourites
+       */
+      ADD_FAVOURITE_NODE: "ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE",
+
+      /**
        * Triggered when the progress request has failed
        *
        * @instance
@@ -443,6 +456,20 @@ define([],function() {
        * @event module:alfresco/core/topics~RELOAD_PAGE
        */
       RELOAD_PAGE: "ALF_RELOAD_PAGE",
+
+      /**
+       * This can be published to request to add a node or nodes as a favourite.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       * @since 1.0.38
+       * 
+       * @event
+       * @property {object} node - The node to remove from favourites
+       * @property {object[]} nodes - An array of nodes to remove from favourites
+       */
+      REMOVE_FAVOURITE_NODE: "ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE",
 
       /**
        * Called to start off the archiving process.

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -240,7 +240,7 @@ define(["dojo/_base/declare",
             }
          }
          payload.documents = selectedItems;
-         this.alfServicePublish("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", payload);
+         this.alfServicePublish(topics.MULTIPLE_ITEM_ACTION_REQUEST, payload);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -229,6 +229,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload The payload containing the details of the action being requested
+       * @fires alfresco/core/topics#MULTIPLE_ITEM_ACTION_REQUEST
        */
       onSelectedDocumentsAction: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onSelectedDocumentsAction(payload) {
          var selectedItems = [];

--- a/aikau/src/main/resources/alfresco/renderers/Favourite.js
+++ b/aikau/src/main/resources/alfresco/renderers/Favourite.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -95,13 +95,8 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_Like__postMixInProperties() {
-         this.toggleOnTopic = (this.toggleOnTopic != null) ? this.toggleOnTopic : this.addFavouriteDocumentTopic;
-         this.toggleOnSuccessTopic = (this.toggleOnSuccessTopic != null) ? this.toggleOnSuccessTopic : this.addFavouriteDocumentSuccessTopic;
-         this.toggleOnFailureTopic = (this.toggleOnFailureTopic != null) ? this.toggleOnFailureTopic : this.addFavouriteDocumentFailureTopic;
-         this.toggleOffTopic = (this.toggleOffTopic != null) ? this.toggleOffTopic : this.removeFavouriteDocumentTopic;
-         this.toggleOffSuccessTopic = (this.toggleOffSuccessTopic != null) ? this.toggleOffSuccessTopic : this.removeFavouriteDocumentSuccessTopic;
-         this.toggleOffFailureTopic = (this.toggleOffFailureTopic != null) ? this.toggleOffFailureTopic : this.removeFavouriteDocumentFailureTopic;
-         
+         this.toggleOnTopic = this.toggleOnTopic || this.addFavouriteDocumentTopic;
+         this.toggleOffTopic = this.toggleOffTopic || this.removeFavouriteDocumentTopic;
          this.inherited(arguments);
       },
       

--- a/aikau/src/main/resources/alfresco/renderers/Favourite.js
+++ b/aikau/src/main/resources/alfresco/renderers/Favourite.js
@@ -25,8 +25,9 @@
  */
 define(["dojo/_base/declare",
         "alfresco/renderers/Toggle",
-        "alfresco/services/_PreferenceServiceTopicMixin"], 
-        function(declare, Toggle, _PreferenceServiceTopicMixin) {
+        "alfresco/services/_PreferenceServiceTopicMixin",
+        "dojo/_base/lang"], 
+        function(declare, Toggle, _PreferenceServiceTopicMixin, lang) {
 
    return declare([Toggle, _PreferenceServiceTopicMixin], {
       
@@ -94,10 +95,53 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      postMixInProperties: function alfresco_renderers_Like__postMixInProperties() {
+      postMixInProperties: function alfresco_renderers_Favourite__postMixInProperties() {
          this.toggleOnTopic = this.toggleOnTopic || this.addFavouriteDocumentTopic;
          this.toggleOffTopic = this.toggleOffTopic || this.removeFavouriteDocumentTopic;
          this.inherited(arguments);
+      },
+
+      /**
+       * Extends the [inherted function]{@link module:alfresco/renderers/Toggle#postCreate} to
+       * create additional subscriptions to the [toggleOnSuccessTopic]{@link module:alfresco/renderers/Toggle#toggleOnSuccessTopic}
+       * and [toggleOffSuccessTopic]{@link module::alfresco/renderers/Toggle#toggleOffSuccessTopic} in order
+       * to track bulk adding and removing of favourites.
+       * 
+       * @instance
+       * @since 1.0.38
+       */
+      postCreate: function alfresco_renderers_Favourite__postCreate() {
+         this.inherited(arguments);
+         this.alfSubscribe(this.toggleOnSuccessTopic, lang.hitch(this, this.onBulkUpdate, true), true);
+         this.alfSubscribe(this.toggleOffSuccessTopic, lang.hitch(this, this.onBulkUpdate, false), true);
+      },
+
+      /**
+       * This function evaluates whether or not a bulk add or remove favourite operation effects the 
+       * Node rendered by the current instance and if so, calls the appropriate functions to update
+       * the rendering accordingly.
+       * 
+       * @param {boolean} add Indicates whether or not the bulk change was to add favourites
+       * @param {object}  payload The payload from the bulk update publication.
+       * @since 1.0.38
+       */
+      onBulkUpdate: function alfresco_renderers_Favourite__onBulkUpdate(add, payload) {
+         this.alfLog("log", "Favourites added", payload);
+         var updatedNodes = lang.getObject("requestConfig.updatedValue", false, payload);
+         var currentNodeRef = lang.getObject("node.nodeRef", false, this.currentItem);
+         if (updatedNodes && currentNodeRef && updatedNodes.indexOf(currentNodeRef) !== -1)
+         {
+            if (add)
+            {
+               this.renderToggledOn();
+               this.onToggleOnSuccess();
+            }
+            else
+            {
+               this.renderToggledOff();
+               this.onToggleOffSuccess();
+            }
+         }
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/renderers/Favourite.js
+++ b/aikau/src/main/resources/alfresco/renderers/Favourite.js
@@ -109,6 +109,8 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @since 1.0.38
+       * @listens alfresco/renderers/Toggle#toggleOnSuccessTopic
+       * @listens alfresco/renderers/Toggle#toggleOffSuccessTopic
        */
       postCreate: function alfresco_renderers_Favourite__postCreate() {
          this.inherited(arguments);

--- a/aikau/src/main/resources/alfresco/renderers/Toggle.js
+++ b/aikau/src/main/resources/alfresco/renderers/Toggle.js
@@ -118,6 +118,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
        */
       toggleOnSuccessTopic: null,
       
@@ -126,6 +127,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
        */
       toggleOnFailureTopic: null,
       
@@ -134,6 +136,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
        */
       toggleOffTopic: null,
       
@@ -142,6 +145,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
        */
       toggleOffSuccessTopic: null,
       
@@ -150,6 +154,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
        */
       toggleOffFailureTopic: null,
       

--- a/aikau/src/main/resources/alfresco/renderers/Toggle.js
+++ b/aikau/src/main/resources/alfresco/renderers/Toggle.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -170,24 +170,24 @@ define(["dojo/_base/declare",
           * as this matches the pattern provided by the generic handlers of "alfresco/core/CoreXhr".
           * (obviously if they have been set then leave them as they are).
           */
-         if (this.toggleOnTopic != null)
+         if (this.toggleOnTopic)
          {
-            if (this.toggleOnSuccessTopic == null)
+            if (!this.toggleOnSuccessTopic)
             {
                this.toggleOnSuccessTopic = this.toggleOnTopic + "_SUCCESS";
             }
-            if (this.toggleOnFailureTopic == null)
+            if (!this.toggleOnFailureTopic)
             {
                this.toggleOnFailureTopic = this.toggleOnTopic + "_FAILURE";
             }
          }
-         if (this.toggleOffTopic != null)
+         if (this.toggleOffTopic)
          {
-            if (this.toggleOffSuccessTopic == null)
+            if (!this.toggleOffSuccessTopic)
             {
                this.toggleOffSuccessTopic = this.toggleOffTopic + "_SUCCESS";
             }
-            if (this.toggleOffFailureTopic == null)
+            if (!this.toggleOffFailureTopic)
             {
                this.toggleOffFailureTopic = this.toggleOffTopic + "_FAILURE";
             }
@@ -216,9 +216,9 @@ define(["dojo/_base/declare",
        * @returns {boolean} Indicating the initial state of the toggle.
        */
       getInitialState: function alfresco_renderers_Toggle__getInitialState() {
-         if (this.propertyToRender != null)
+         if (this.propertyToRender)
          {
-            return (lang.getObject(this.propertyToRender, false, this.currentItem) == true);
+            return (lang.getObject(this.propertyToRender, false, this.currentItem) === true);
          }
          else
          {
@@ -320,11 +320,11 @@ define(["dojo/_base/declare",
        * @instance
        */
       removeSubscriptionHandles: function alfresco_renderers_Toggle__removeSubscriptionHandles() {
-         if (this._successHandle != null)
+         if (this._successHandle)
          {
             this.alfUnsubscribe(this._successHandle);
          }
-         if (this._failureHandle != null)
+         if (this._failureHandle)
          {
             this.alfUnsubscribe(this._failureHandle);
          }
@@ -334,7 +334,7 @@ define(["dojo/_base/declare",
        * Called whenever the "toggleOnSuccessTopic" attribute is published on
        * @instance
        */
-      onToggleOnSuccess: function alfresco_renderers_Toggle__onToggleOnSuccess(payload) {
+      onToggleOnSuccess: function alfresco_renderers_Toggle__onToggleOnSuccess(/*jshint unused:false*/ payload) {
          this.removeSubscriptionHandles();
          this.isToggleOn = true;
          domClass.add(this.processingNode, "hidden");
@@ -345,7 +345,7 @@ define(["dojo/_base/declare",
        * Called whenever the "toggleOnFailureTopic" attribute is published on
        * @instance
        */
-      onToggleOnFailure: function alfresco_renderers_Toggle__onToggleOnFailure(payload) {
+      onToggleOnFailure: function alfresco_renderers_Toggle__onToggleOnFailure(/*jshint unused:false*/ payload) {
          this.removeSubscriptionHandles();
          this.isToggleOn = false;
          domClass.add(this.processingNode, "hidden");
@@ -357,7 +357,7 @@ define(["dojo/_base/declare",
        * Called whenever the "toggleOffSuccessTopic" attribute is published on
        * @instance
        */
-      onToggleOffSuccess: function alfresco_renderers_Toggle__onToggleOffSuccess(payload) {
+      onToggleOffSuccess: function alfresco_renderers_Toggle__onToggleOffSuccess(/*jshint unused:false*/ payload) {
          this.removeSubscriptionHandles();
          this.isToggleOn = false;
          domClass.add(this.processingNode, "hidden");
@@ -368,7 +368,7 @@ define(["dojo/_base/declare",
        * Called whenever the "toggleOffFailureTopic" attribute is published on
        * @instance
        */
-      onToggleOffFailure: function alfresco_renderers_Toggle__onToggleOffFailure(payload) {
+      onToggleOffFailure: function alfresco_renderers_Toggle__onToggleOffFailure(/*jshint unused:false*/ payload) {
          this.removeSubscriptionHandles();
          this.isToggleOn = true;
          domClass.add(this.processingNode, "hidden");

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -978,6 +978,36 @@ define(["dojo/_base/declare",
          this.alfPublish("ALF_LOCATE_DOCUMENT", {
             node: payload.document
          });
+      },
+
+      /**
+       * This function provides support for adding multiple folders and documents as user
+       * favourites via [AlfDocumentActionMenuItem]{@link module:alfresco/documentlibrary/AlfDocumentActionMenuItem}
+       * within a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
+       * 
+       * @instance
+       * @param  {object} payload The payload from the original request
+       * @since 1.0.38
+       */
+      onAddFavourite: function alfresco_services_ActionService__onAddFavourite(payload) {
+         this.alfPublish(topics.ADD_FAVOURITE_NODE, {
+            nodes: payload.documents || [payload.document]
+         });
+      },
+
+      /**
+       * This function provides support for adding multiple folders and documents as user
+       * favourites via [AlfDocumentActionMenuItem]{@link module:alfresco/documentlibrary/AlfDocumentActionMenuItem}
+       * within a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
+       * 
+       * @instance
+       * @param  {object} payload The payload from the original request
+       * @since 1.0.38
+       */
+      onRemoveFavourite: function alfresco_services_ActionService__onAddFavourite(payload) {
+         this.alfPublish(topics.REMOVE_FAVOURITE_NODE, {
+            nodes: payload.documents || [payload.document]
+         });
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -115,6 +115,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @since 1.0.32
+       *
+       * @listens module:alfresco/core/topics#MULTIPLE_ITEM_ACTION_REQUEST
        */
       registerSubscriptions: function alfresco_services_ActionService__registerSubscriptions() {
          // Normal processing...
@@ -127,7 +129,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe(this.syncLocationTopic, lang.hitch(this, this.onSyncLocation));
          this.alfSubscribe(this.unsyncLocationTopic, lang.hitch(this, this.onUnsyncLocation));
 
-         this.alfSubscribe("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", lang.hitch(this, this.handleMultiDocLegacyAction));
+         this.alfSubscribe(topics.MULTIPLE_ITEM_ACTION_REQUEST, lang.hitch(this, this.handleMultiDocLegacyAction));
          this.alfSubscribe("ALF_CREATE_CONTENT", lang.hitch(this, this.processActionObject));
 
          // Non-legacy action handlers...
@@ -232,28 +234,56 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * This function is called when handling actions for the currently selected items. If the
+       * payload provided does not include a "documents" attribute then one will be created and
+       * populated with the selected items that have been tracked by this service. Ideally this 
+       * will not be necessary as the payload should include the items populated by the
+       * [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
+       * 
+       * @instance
+       * @param {object} payload The data passed in the request to perform the action.
+       * @since 1.0.38
+       */
+      addSelectedItems: function alfresco_services_ActionService__addSelectedItems(payload) {
+         if (!payload.documents)
+         {
+            payload.documents = [];
+            for (var nodeRef in this.currentlySelectedDocuments)
+            {
+               if (this.currentlySelectedDocuments.hasOwnProperty(nodeRef))
+               {
+                  payload.documents.push(this.currentlySelectedDocuments[nodeRef]);
+               }
+            }
+         }
+         // NOTE: We also want to add the selected items to a "nodes" attribute as that is the attribute
+         //       that some of the services will be expecting. This is regrettable but until the next major
+         //       release we won't be able to remove these inconsistencies. By including the selected items
+         //       as "nodes" it allows us to forward to "actionTopics" without the need to create individual
+         //       actions to alias all the capabilities provided by other services.
+         payload.nodes = payload.documents;
+      },
+
+      /**
        *
        * @instance
        * @param {object} payload The data passed in the request to perform the action.
        */
-      handleMultiDocLegacyAction: function alfresco_services_ActionService__handleLegacyAction(payload) {
+      handleMultiDocLegacyAction: function alfresco_services_ActionService__handleMultiDocLegacyAction(payload) {
          this.alfLog("log", "Multiple document action request:", payload);
+
          if (typeof this[payload.action] === "function")
          {
-            // NOTE: We want to avoid relying on the service to track currently selected documents, this
-            //       is now handled AlfSelectedItemsMenuBarPopup...
-            if (!payload.documents)
-            {
-               payload.documents = [];
-               for (var nodeRef in this.currentlySelectedDocuments)
-               {
-                  if (this.currentlySelectedDocuments.hasOwnProperty(nodeRef))
-                  {
-                     payload.documents.push(this.currentlySelectedDocuments[nodeRef]);
-                  }
-               }
-            }
+            this.addSelectedItems(payload);
             this[payload.action].call(this, payload);
+         }
+         else if (payload.actionTopic)
+         {
+            // If an "actionTopic" attribute has been defined then it will be used to "forward" on the
+            // provided payload to the topic defined. This was added in 1.0.38 as a way in which to make
+            // it easier to process custom menu items added to a AlfSelectedItemsMenuBarPopup. 
+            this.addSelectedItems(payload);
+            this.alfServicePublish(payload.actionTopic, payload);
          }
       },
 
@@ -592,7 +622,6 @@ define(["dojo/_base/declare",
          if (typeof f === "function")
          {
             f.call(this, payload);
-            // f.call(this, payload.action, [payload.document]);
          }
          else
          {
@@ -977,36 +1006,6 @@ define(["dojo/_base/declare",
       onActionLocate: function alfresco_services_ActionService__onActionLocate(payload) {
          this.alfPublish("ALF_LOCATE_DOCUMENT", {
             node: payload.document
-         });
-      },
-
-      /**
-       * This function provides support for adding multiple folders and documents as user
-       * favourites via [AlfDocumentActionMenuItem]{@link module:alfresco/documentlibrary/AlfDocumentActionMenuItem}
-       * within a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
-       * 
-       * @instance
-       * @param  {object} payload The payload from the original request
-       * @since 1.0.38
-       */
-      onAddFavourite: function alfresco_services_ActionService__onAddFavourite(payload) {
-         this.alfPublish(topics.ADD_FAVOURITE_NODE, {
-            nodes: payload.documents || [payload.document]
-         });
-      },
-
-      /**
-       * This function provides support for adding multiple folders and documents as user
-       * favourites via [AlfDocumentActionMenuItem]{@link module:alfresco/documentlibrary/AlfDocumentActionMenuItem}
-       * within a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
-       * 
-       * @instance
-       * @param  {object} payload The payload from the original request
-       * @since 1.0.38
-       */
-      onRemoveFavourite: function alfresco_services_ActionService__onAddFavourite(payload) {
-         this.alfPublish(topics.REMOVE_FAVOURITE_NODE, {
-            nodes: payload.documents || [payload.document]
          });
       }
    });

--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -174,6 +174,9 @@ define(["dojo/_base/declare",
             }
             this.serviceXhr({url : url,
                              alfTopic: responseTopic,
+                             preference: payload.preference,
+                             updatedValue: payload.updatedValue,
+                             value: payload.value,
                              data: preferenceObj,
                              method: "POST"});
 
@@ -219,9 +222,12 @@ define(["dojo/_base/declare",
                }
                
                // Save preference with the new value
+               // We include the updatedValue so that subscribers can identify the requested changes
+               // because the stored value will not included data that has been removed...
                this.setPreference({
                   alfTopic: requestConfig.data.alfTopic,
-                  preference: name, 
+                  preference: name,
+                  updatedValue: value, 
                   value: arrValues.join(",")
                });
             }
@@ -402,7 +408,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onAddFavouriteDocument: function alfresco_services_PreferenceService__onAddFavouriteDocument(payload) {
-         var alfTopic = payload.alfResponseTopic || this.onAddFavouriteDocument;
+         var alfTopic = payload.alfResponseTopic || topics.ADD_FAVOURITE_NODE;
          this.processFavourites(payload, alfTopic, true);
       },
       
@@ -413,7 +419,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onRemoveFavouriteDocument: function alfresco_services_PreferenceService__onRemoveFavouriteDocument(payload) {
-         var alfTopic = payload.alfResponseTopic || this.onRemoveFavouriteDocument;
+         var alfTopic = payload.alfResponseTopic || topics.REMOVE_FAVOURITE_NODE;
          this.processFavourites(payload, alfTopic, false);
       }
    });

--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -36,13 +36,14 @@ define(["dojo/_base/declare",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/core/topics",
         "dojo/_base/lang",
+        "dojo/_base/array",
         "service/constants/Default",
         "alfresco/core/ArrayUtils",
         "dojo/Deferred",
         "dojo/when",
         "jquery"],
         function(declare, BaseService, CoreXhr, _PreferenceServiceTopicMixin, _AlfDocumentListTopicMixin, topics, lang, 
-                 AlfConstants, ArrayUtils, Deferred, when, $) {
+                 array, AlfConstants, ArrayUtils, Deferred, when, $) {
    
    return declare([BaseService, CoreXhr, _PreferenceServiceTopicMixin, _AlfDocumentListTopicMixin], {
       
@@ -69,6 +70,10 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @since 1.0.32
+       * @listens module:alfresco/core/topics#GET_PREFERENCE
+       * @listens module:alfresco/core/topics#SET_PREFERENCE
+       * @listens module:alfresco/core/topics#ADD_FAVOURITE_NODE
+       * @listens module:alfresco/core/topics#REMOVE_FAVOURITE_NODE
        */
       registerSubscriptions: function alfresco_services_PreferenceService__registerSubscriptions() {
          this.alfSubscribe(topics.GET_PREFERENCE, lang.hitch(this, this.getPreference));
@@ -76,8 +81,8 @@ define(["dojo/_base/declare",
          this.alfSubscribe(this.showFoldersTopic, lang.hitch(this, this.onShowFolders));
          this.alfSubscribe(this.showPathTopic, lang.hitch(this, this.onShowPath));
          this.alfSubscribe(this.viewSelectionTopic, lang.hitch(this, this.onViewSelection));
-         this.alfSubscribe(this.addFavouriteDocumentTopic, lang.hitch(this, this.onAddFavouriteDocument));
-         this.alfSubscribe(this.removeFavouriteDocumentTopic, lang.hitch(this, this.onRemoveFavouriteDocument));
+         this.alfSubscribe(topics.ADD_FAVOURITE_NODE, lang.hitch(this, this.onAddFavouriteDocument));
+         this.alfSubscribe(topics.REMOVE_FAVOURITE_NODE, lang.hitch(this, this.onRemoveFavouriteDocument));
 
          // Load the user preferences...
          this._preferencesLoaded = new Deferred();
@@ -209,7 +214,8 @@ define(["dojo/_base/declare",
                }
                else
                {
-                  ArrayUtils.arrayRemove(arrValues, value);
+                  var valueArr = value.split(",");
+                  array.forEach(valueArr, lang.hitch(ArrayUtils, ArrayUtils.arrayRemove, arrValues));
                }
                
                // Save preference with the new value
@@ -319,43 +325,96 @@ define(["dojo/_base/declare",
       },
       
       /**
-       * Makes the supplied node a favourite of the requesting user
+       * Iterates over the supplied array of Nodes and puts the NodeRefs from them into the supplied
+       * arrays of folders and documents based on whether or not the Node has an "isContainer" attribute
+       * set to true.
+       * 
+       * @instance
+       * @param {object[]} nodes     An array of nodes to iterate over
+       * @param {string[]} folders   A string array to populate with folder NodeRefs
+       * @param {string[]} documents A string array to populate with document NodeRefs
+       * @since 1.0.38
+       */
+      separateFoldersAndDocuments: function alfresco_services_PreferenceService__separateFoldersAndDocuments(nodes, folders, documents) {
+         array.forEach(nodes, function(item) {
+            if (item.node)
+            {
+               if (item.node.isContainer)
+               {
+                  item.node.nodeRef && folders.push(item.node.nodeRef);
+               }
+               else
+               {
+                  item.node.nodeRef && documents.push(item.node.nodeRef);
+               }
+            } 
+         });
+      },
+
+      /**
+       * Adds nodes to or removes nodes from the documents and folders favourites in the current user preferences.
+       *
+       * @instance
+       * @param  {object} payload  The original payload for the add or remove favourites request.
+       * @param  {string} alfTopic The topic to publish on the callback
+       * @param  {boolean} add     Indicates whether or not this is an add request
+       * @since 1.0.38
+       */
+      processFavourites: function alfresco_services_PreferenceService__processFavourites(payload, alfTopic, add) {
+         // Default to favouriting documents since that's more likely...
+         if (payload.nodes && payload.nodes.length)
+         {
+            var folders = [];
+            var documents = [];
+            this.separateFoldersAndDocuments(payload.nodes, folders, documents);
+            if (folders.length)
+            {
+               this.update({
+                  name: this.FAVOURITE_FOLDERS,
+                  value: folders.join(","),
+                  alfTopic: alfTopic
+               }, add);
+            }
+            if (documents.length)
+            {
+               this.update({
+                  name: this.FAVOURITE_DOCUMENTS,
+                  value: documents.join(","),
+                  alfTopic: alfTopic
+               }, add);
+            }
+         }
+         else if (payload.node && payload.node.node && payload.node.node.nodeRef)
+         {
+            var prefKey = payload.node.node.isContainer ? this.FAVOURITE_FOLDERS : this.FAVOURITE_DOCUMENTS;
+            this.update({
+               name: prefKey,
+               value: payload.node.node.nodeRef,
+               alfTopic: alfTopic
+            }, add);
+         }
+      },
+
+      /**
+       * Makes the supplied node or nodes favourites of the current user
        * 
        * @instance
        * @param {object} payload
        */
       onAddFavouriteDocument: function alfresco_services_PreferenceService__onAddFavouriteDocument(payload) {
          var alfTopic = payload.alfResponseTopic || this.onAddFavouriteDocument;
-         var jsNode = lang.getObject("node.jsNode", false, payload);
-         if (jsNode)
-         {
-            var prefKey = jsNode.isContainer ? this.FAVOURITE_FOLDERS : this.FAVOURITE_DOCUMENTS;
-            this.update({
-               name: prefKey,
-               value: jsNode.nodeRef.nodeRef,
-               alfTopic: alfTopic
-            }, true);
-         }
+         this.processFavourites(payload, alfTopic, true);
       },
       
       /**
-       * Removes the supplied node from being a favourite.
+       * Removes the supplied node or nodes from being a favourite.
        * 
        * @instance
        * @param {object} payload
        */
       onRemoveFavouriteDocument: function alfresco_services_PreferenceService__onRemoveFavouriteDocument(payload) {
          var alfTopic = payload.alfResponseTopic || this.onRemoveFavouriteDocument;
-         var jsNode = lang.getObject("node.jsNode", false, payload);
-         if (jsNode)
-         {
-            var prefKey = jsNode.isContainer ? this.FAVOURITE_FOLDERS : this.FAVOURITE_DOCUMENTS;
-            this.update({
-               name: prefKey,
-               value: jsNode.nodeRef.nodeRef,
-               alfTopic: alfTopic
-            }, false);
-         }
+         this.processFavourites(payload, alfTopic, false);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/_PreferenceServiceTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_PreferenceServiceTopicMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -20,6 +20,7 @@
 /**
  * @module alfresco/services/_PreferenceServiceTopicMixin
  * @author Dave Draper
+ * @deprecated Since 1.0.38 - Use [topics]{@link module:alfresco/core/topics} instead.
  */
 define(["dojo/_base/declare",
         "alfresco/core/topics"], 
@@ -48,7 +49,7 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      addFavouriteDocumentTopic: "ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE",
+      addFavouriteDocumentTopic: topics.ADD_FAVOURITE_NODE,
       
       /**
        * This topic is used to request that a node should be made a favourite.
@@ -57,7 +58,7 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      removeFavouriteDocumentTopic: "ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE",
+      removeFavouriteDocumentTopic: topics.REMOVE_FAVOURITE_NODE,
       
       /**
        * This topic is used to indicate that a node was successfully made a favourite.
@@ -65,6 +66,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @deprecated Since 1.0.38 - no longer required within main Aikau codebase.
        */
       addFavouriteDocumentSuccessTopic: "ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE_SUCCESS",
       
@@ -74,6 +76,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @deprecated Since 1.0.38 - no longer required within main Aikau codebase.
        */
       removeFavouriteDocumentSuccessTopic: "ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE_SUCCESS",
       
@@ -83,6 +86,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @deprecated Since 1.0.38 - no longer required within main Aikau codebase.
        */
       addFavouriteDocumentFailureTopic: "ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE_FAILURE",
       
@@ -92,6 +96,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @deprecated Since 1.0.38 - no longer required within main Aikau codebase.
        */
       removeFavouriteDocumentFailureTopic: "ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE_FAILURE"
    });

--- a/aikau/src/main/resources/alfresco/services/_PreferenceServiceTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_PreferenceServiceTopicMixin.js
@@ -32,6 +32,10 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @event
+       * @property {string} preference A dot-notation property of the preference to retrieve
+       * @property {function} callback The function to call when the preference has been retrieved
+       * @property {object} callbackScope The scope with which to call the callback function
        */
       getPreferenceTopic: topics.GET_PREFERENCE,
       
@@ -39,6 +43,10 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string}
        * @default
+       * @event
+       * @property {string} preference A dot-notation property of the preference to set
+       * @property {object} value The value to set as the preference
+       * @property {object} updatedValue The value that has been changed (e.g. this might be an item removed that)
        */
       setPreferenceTopic: topics.SET_PREFERENCE,
       

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -787,6 +787,7 @@ function getSelectedItemsActions(selectedItemsActions) {
                notAspect: (action.notAspect || "").toString(),
                publishTopic: "ALF_SELECTED_DOCUMENTS_ACTION_REQUEST",
                publishPayload: {
+                  actionTopic: (action.actionTopic || "").toString(),
                   action: (action.id || "").toString()
                }
             }

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -816,7 +816,7 @@ function getDocLibSelectedItemActions(options) {
                id: (options.idPrefix || "") + "DOCLIB_SELECTED_ITEMS_MENU_GROUP1",
                name: "alfresco/menus/AlfMenuGroup",
                config: {
-                  widgets: getSelectedItemsActions()
+                  widgets: getSelectedItemsActions(options.selectedItemsActions)
                }
             }
          ]

--- a/aikau/src/test/resources/alfresco/renderers/MultiFavouriteTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/MultiFavouriteTest.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Multiple Favouriting Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/MultiFavourite", "Multiple Favouriting Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check that nothing is shown as a favourite on page load": function() {
+            return browser.findAllByCssSelector(".alfresco-renderers-Toggle .favourite.on.hidden")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 6, "Unexpected number of unfavorited items");
+               });
+         },
+
+         "Add favourites in bulk": function() {
+            return browser.findById("ADD_MULTIPLE_FAVOURITES_label")
+               .click()
+            .end()
+            .getLastPublish("ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE_SUCCESS", "Bulk favourite success topic not published");
+         },
+
+         "Folder 1 should be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_0 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Folder 1 should be shown as a favourite");
+               });
+         },
+
+         "Folder 2 should be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_1 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Folder 2 should be shown as a favourite");
+               });
+         },
+
+         "Folder 3 should NOT be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_2 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Folder 3 should NOT be shown as a favourite");
+               });
+         },
+
+         "Document 1 should be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_3 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Document 1 should be shown as a favourite");
+               });
+         },
+
+         "Document 2 should be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_4 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Document 2 should be shown as a favourite");
+               });
+         },
+
+         "Document 3 should NOT be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_5 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Document 3 should NOT be shown as a favourite");
+               });
+         },
+
+         "Remove favourites in bulk": function() {
+            return browser.findById("REMOVE_MULTIPLE_FAVOURITES_label")
+               .click()
+            .end()
+            .getLastPublish("ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE_SUCCESS", "Bulk favourite removal success topic not published");
+         },
+
+         "Folder 1 should NOT be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_0 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Folder 1 should NOT be shown as a favourite");
+               });
+         },
+
+         "Folder 2 should STILL be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_1 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Folder 2 should STILL be shown as a favourite");
+               });
+         },
+
+         "Folder 3 should STILL not be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_2 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Folder 3 should STILL NOT be shown as a favourite");
+               });
+         },
+
+         "Document 1 should STILL be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_3 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Document 1 should STILL be shown as a favourite");
+               });
+         },
+
+         "Document 2 should NOT be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_4 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Document 2 should NOT be shown as a favourite");
+               });
+         },
+
+         "Document 3 should STILL not be favourited": function() {
+            return browser.findByCssSelector("#FAVOURITE_ITEM_5 .favourite.enabled")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Document 3 should STILL NOT be shown as a favourite");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -206,6 +206,7 @@ define({
       "src/test/resources/alfresco/renderers/IndicatorsTest",
       "src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest",
       "src/test/resources/alfresco/renderers/InlineEditPropertyTest",
+      "src/test/resources/alfresco/renderers/MultiFavouriteTest",
       "src/test/resources/alfresco/renderers/ProgressTest",
       "src/test/resources/alfresco/renderers/PropertyLinkTest",
       "src/test/resources/alfresco/renderers/PropertyTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/MultiFavourite.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/MultiFavourite.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Multiple Favouriting</shortname>
+  <description>Shows an example of being able to publish a request to add or remove multiple nodes from the user favourites. Demonstrates the alfresco/renderers/Favourite widget automatically updates on bulk changes.</description>
+  <family>aikau-unit-tests</family>
+  <url>/MultiFavourite</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/MultiFavourite.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/MultiFavourite.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/MultiFavourite.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/MultiFavourite.get.js
@@ -1,0 +1,188 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/ActionService"
+   ],
+   widgets:[
+      {
+         id: "ADD_MULTIPLE_FAVOURITES",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Add multiple favourites",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE",
+               documents: [
+                  {
+                     node: {
+                        isContainer: true,
+                        nodeRef: "some://folder/1"
+                     }
+                  },
+                  {
+                     node: {
+                        isContainer: true,
+                        nodeRef: "some://folder/2"
+                     }
+                  },
+                  {
+                     node: {
+                        isContainer: false,
+                        nodeRef: "some://document/1"
+                     }
+                  },
+                  {
+                     node: {
+                        isContainer: false,
+                        nodeRef: "some://document/2"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "REMOVE_MULTIPLE_FAVOURITES",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Remove multiple favourites",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE",
+               documents: [
+                  {
+                     node: {
+                        isContainer: true,
+                        nodeRef: "some://folder/1"
+                     }
+                  },
+                  {
+                     node: {
+                        isContainer: false,
+                        nodeRef: "some://document/2"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "LIST",
+         name: "alfresco/lists/AlfList",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     node: {
+                        nodeRef: "some://folder/1",
+                        isContainer: true,
+                        properties: {
+                           "cm:name": "Folder 1"
+                        }
+                     },
+                     isFavourite: false
+                  },
+                  {
+                     node: {
+                        nodeRef: "some://folder/2",
+                        isContainer: true,
+                        properties: {
+                           "cm:name": "Folder 2"
+                        }
+                     },
+                     isFavourite: false
+                  },
+                  {
+                     node: {
+                        nodeRef: "some://folder/3",
+                        isContainer: true,
+                        properties: {
+                           "cm:name": "Folder 3"
+                        }
+                     },
+                     isFavourite: false
+                  },
+                  {
+                     node: {
+                        nodeRef: "some://document/1",
+                        isContainer: false,
+                        properties: {
+                           "cm:name": "Document 1"
+                        }
+                     },
+                     isFavourite: false
+                  },
+                  {
+                     node: {
+                        nodeRef: "some://document/2",
+                        isContainer: false,
+                        properties: {
+                           "cm:name": "Document 2"
+                        }
+                     },
+                     isFavourite: false
+                  },
+                  {
+                     node: {
+                        nodeRef: "some://document/3",
+                        isContainer: false,
+                        properties: {
+                           "cm:name": "Document 3"
+                        }
+                     },
+                     isFavourite: false
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "NAME",
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "node.properties.cm:name"
+                                             }
+                                          },
+                                          {
+                                             id: "FAVOURITE",
+                                             name: "alfresco/renderers/Favourite"
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This issue addresses https://issues.alfresco.com/jira/browse/AKU-609 to add support for bulk adding and removing of folders and nodes as user favourites.