### PR TITLE
Some updates to the full screen mode for dialogs

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -407,9 +407,9 @@ define(["dojo/_base/declare",
        */
       onWindowResize: function alfresco_dialogs_AlfDialog__onWindowResize() {
          var calculatedHeights = this.calculateHeights();
-         if (calculatedHeights.maxBodyHeight)
+         if (calculatedHeights.maxBodyHeight && !this.fullScreenMode)
          {
-            // Don't set a max-height when it's 0...
+            // Don't set a max-height when it's 0 or when in full screen mode...
             domStyle.set(this.bodyNode, {
                "max-height": calculatedHeights.maxBodyHeight + "px"
             });
@@ -468,6 +468,23 @@ define(["dojo/_base/declare",
                w: $(window).width() - dimensionAdjustment,
                h: $(window).height() - dimensionAdjustment
             }]);
+
+            // When in full screen mode it is also necessary to take care of the inner dimensions
+            // of the dialog...
+            var calculatedHeights = this.calculateHeights();
+            var containerHeight = $(this.containerNode).height();
+            var bodyHeight = containerHeight;
+            if (this.widgetsButtons)
+            {
+               // Dedebug height for the widgets buttons if present
+               bodyHeight = bodyHeight - 44;
+            }
+            $(this.bodyNode).height(bodyHeight);
+            $(this.bodyNode).css("max-height", bodyHeight); // NOTE: This is necessary to override the default max-height
+            if (this._dialogPanel)
+            {
+               $(this._dialogPanel.domNode).height(bodyHeight - calculatedHeights.paddingAdjustment);
+            }
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
+++ b/aikau/src/test/resources/alfresco/layout/HeightMixinTest.js
@@ -159,6 +159,48 @@ define(["intern!object",
             .end();
          },
 
+         "Show full screen dialog with no buttons": function() {
+            return browser.findById("FULL_SCREEN_DIALOG_NO_BUTTON_label")
+               .click()
+            .end()
+            .findByCssSelector("#FSDNB.dialogDisplayed")
+            .end()
+            .findByCssSelector("#FSDNB .alfresco-layout-FixedHeaderFooter")
+               .getSize()
+               .then(function(size) {
+                  // NOTE: target height is client height minus dialog "margin", padding and title
+                  var target = windowHeight - 80 - 24 - 39; 
+                  assert.closeTo(size.height, target, 10, "Height not calculated correctly");
+               })
+            .end()
+            .findByCssSelector("#FSDNB .dijitDialogCloseIcon")
+               .click()
+            .end()
+            .findByCssSelector("#FSDNB.dialogHidden")
+            .end();
+         },
+
+         "Show full screen dialog with buttons bar": function() {
+            return browser.findById("FULL_SCREEN_DIALOG_label")
+               .click()
+            .end()
+            .findByCssSelector("#FSD.dialogDisplayed")
+            .end()
+            .findByCssSelector("#FSD .alfresco-layout-FixedHeaderFooter")
+               .getSize()
+               .then(function(size) {
+                  // NOTE: target height is client height minus dialog "margin", padding, title and button bars
+                  var target = windowHeight - 80 - 24 - 39 - 44; 
+                  assert.closeTo(size.height, target, 10, "Height not calculated correctly");
+               })
+            .end()
+            .findByCssSelector("#FSD .dijitDialogCloseIcon")
+               .click()
+            .end()
+            .findByCssSelector("#FSD.dialogHidden")
+            .end();
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/HeightMixin.get.js
@@ -54,6 +54,7 @@ model.jsonModel = {
                {
                   id: "DIALOG_LAUNCH_PANEL",
                   name: "alfresco/layout/ClassicWindow",
+                  widthPx: 500,
                   config: {
                      title: "Dialog launch panel",
                      widgets: [
@@ -162,11 +163,114 @@ model.jsonModel = {
                                  ]
                               }
                            }
+                        },
+                        {
+                           id: "FULL_SCREEN_DIALOG_NO_BUTTON",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Launch full screen dialog",
+                              publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                              publishPayload: {
+                                 dialogId: "FSDNB",
+                                 dialogTitle: "Full Screen Dialog",
+                                 fullScreenMode: true,
+                                 fullScreenPadding: 40,
+                                 widgetsContent: [
+                                    {
+                                       name: "alfresco/layout/FixedHeaderFooter",
+                                       widthPc: 50,
+                                       config: {
+                                          heightMode: "DIALOG",
+                                          widgetsForHeader: [
+                                             {
+                                                name: "alfresco/html/Label",
+                                                config: {
+                                                   label: "Header"
+                                                }
+                                             }
+                                          ],
+                                          widgets: [
+                                             {
+                                                name: "alfresco/html/Label",
+                                                config: {
+                                                   label: "Content"
+                                                }
+                                             }
+                                          ],
+                                          widgetsForFooter: [
+                                             {
+                                                name: "alfresco/html/Label",
+                                                config: {
+                                                   label: "Footer"
+                                                }
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        },
+                        {
+                           id: "FULL_SCREEN_DIALOG",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Full Screen With HeightMixin Content",
+                              publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                              publishPayload: {
+                                 dialogId: "FSD",
+                                 dialogTitle: "Full Screen Dialog",
+                                 fullScreenMode: true,
+                                 fullScreenPadding: 40,
+                                 widgetsContent: [
+                                    {
+                                       name: "alfresco/layout/FixedHeaderFooter",
+                                       widthPc: 50,
+                                       config: {
+                                          heightMode: "DIALOG",
+                                          widgetsForHeader: [
+                                             {
+                                                name: "alfresco/html/Label",
+                                                config: {
+                                                   label: "Header"
+                                                }
+                                             }
+                                          ],
+                                          widgets: [
+                                             {
+                                                name: "alfresco/html/Label",
+                                                config: {
+                                                   label: "Content"
+                                                }
+                                             }
+                                          ],
+                                          widgetsForFooter: [
+                                             {
+                                                name: "alfresco/html/Label",
+                                                config: {
+                                                   label: "Footer"
+                                                }
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 ],
+                                 widgetsButtons: [
+                                    {
+                                       name: "alfresco/buttons/AlfButton",
+                                       config: {
+                                          label: "OK",
+                                          additionalCssClasses: "cancellationButton",
+                                          publishTopic: "ALF_ITEMS_SELECTED"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
                         }
                      ]
                   }
                }
-               
             ]
          }
       }


### PR DESCRIPTION
I was evaluating some customer use cases and realised that the full screen dialog mode was not working correctly with the HeightMixin functionality. This PR fixes the issues - I've added unit tests to verify behaviour and to prevent regressions.