### PR TITLE
Fixes bug introduced in PR 589

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -23,8 +23,9 @@
  * actively monitors the state of selected items so that any 
  * [menu items]{@link modulealfresco/documentlibrary/AlfDocumentActionMenuItem} contained in the pop-up menu that
  * are used will have the selected nodes "attached" to their payload by the 
- * [onSelectedDocumentsAction]{@link module:alfresco/menus/AlfMenuBarPopup#onSelectedDocumentsAction} function. This
- * function will also process the action payload and swap out any "{nodes}" tokens with the array of selected
+ * [onSelectedDocumentsAction]{@link module:alfresco/menus/AlfMenuBarPopup#onSelectedDocumentsAction} function. If
+ * [processActionPayloads]{@link module:alfresco/menus/AlfMenuBarPopup#processActionPayloads} is configured to be true then 
+ * this function will also process the action payload and swap out any "{nodes}" tokens with the array of selected
  * nodes.
  * 
  * @module alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup
@@ -93,6 +94,17 @@ define(["dojo/_base/declare",
        * @default
        */
       itemKeyProperty: "node.nodeRef",
+
+      /**
+       * This can be configured so that action payloads are processed for the existence of a "{nodes}" token. If
+       * one is found then it will be swapped out with the array of selected nodes.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.38
+       */
+      processActionPayloads: false,
 
       /**
        * Extends the [superclass function]{@link module:alfresco/menus/AlfMenuBarPopup#postCreate} to subscribe to
@@ -250,15 +262,22 @@ define(["dojo/_base/declare",
          }
          payload.documents = selectedItems;
 
-         // There are circumstances where the requested action might need access to the selected nodes *within*
-         // the payload. This can be achieved by referencing the {nodes} token with the payload and using the standard
-         // object processing mixin.
-         this.currentItem = {
-            nodes: selectedItems
-         };
-         var clonedPayload = lang.clone(payload);
-         this.processObject(["processCurrentItemTokens"], clonedPayload);
-         this.alfServicePublish(topics.MULTIPLE_ITEM_ACTION_REQUEST, clonedPayload);
+         if (this.processActionPayloads)
+         {
+            // There are circumstances where the requested action might need access to the selected nodes *within*
+            // the payload. This can be achieved by referencing the {nodes} token with the payload and using the standard
+            // object processing mixin.
+            this.currentItem = {
+               nodes: selectedItems
+            };
+            var clonedPayload = lang.clone(payload);
+            this.processObject(["processCurrentItemTokens"], clonedPayload);
+            this.alfServicePublish(topics.MULTIPLE_ITEM_ACTION_REQUEST, clonedPayload);
+         }
+         else
+         {
+            this.alfServicePublish(topics.MULTIPLE_ITEM_ACTION_REQUEST, payload);
+         }
       }
    });
 });


### PR DESCRIPTION
This updates the previous changes in #589 to make the processing of action payloads and opt-in behaviour rather than the default. This is needed because an infinite recursion loop can occur when this is used with selected nodes in the Document Library (this was originally written with respect to the search page which uses a different API).