### PR TITLE
AKU-617: Return to user dashboard after joining site / AKU-623: SiteService siteLanding page variable incorrect

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -45,14 +45,14 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/SiteService.properties"}],
 
       /**
-       * The standard landing page for a site
+       * The standard home page for a user
        *
        * @instance
        * @type {string}
        * @default
-       * @since 1.0.38
+       * @since 1.0.39
        */
-      siteLandingPage: "/dashboard",
+      userHomePage: "/dashboard",
 
       /**
        * Sets up the subscriptions for the SiteService
@@ -505,9 +505,9 @@ define(["dojo/_base/declare",
        */
       siteMembershipRequestComplete: function alfresco_services_SiteService__siteMembershipRequestComplete(response, originalRequestConfig) {
          this.alfLog("log", "User has successfully requested to join a moderated site", response, originalRequestConfig);
-         this.displayPrompt({
-            title: this.message("message.request-join-success-title"),
-            message: this.message("message.request-join-success", { "0": originalRequestConfig.user, "1": originalRequestConfig.site}),
+         this.alfServicePublish(topics.CREATE_DIALOG, {
+            dialogTitle: this.message("message.request-join-success-title"),
+            textContent: this.message("message.request-join-success", {"0": originalRequestConfig.user, "1": originalRequestConfig.site}),
             widgetsButtons: [
                {
                   name: "alfresco/buttons/AlfButton",
@@ -515,7 +515,7 @@ define(["dojo/_base/declare",
                      label: this.message("button.leave-site.confirm-label"),
                      publishTopic: "ALF_NAVIGATE_TO_PAGE",
                      publishPayload: {
-                        url: "user/" + originalRequestConfig.user + this.siteLandingPage.replace(/^\/*/, "/"),
+                        url: "user/" + originalRequestConfig.user + this.userHomePage.replace(/^\/*/, "/"),
                         type: "PAGE_RELATIVE",
                         target: "CURRENT"
                      },
@@ -761,8 +761,8 @@ define(["dojo/_base/declare",
        * @instance
        */
       leaveSiteSuccess: function alfresco_services_SiteService__leaveSiteSuccess(response, requestConfig) {
-         this.alfPublish("ALF_NAVIGATE_TO_PAGE", {
-            url: "user/" + requestConfig.user + this.siteLandingPage.replace(/^\/*/, "/"),
+         this.alfServicePublish("ALF_NAVIGATE_TO_PAGE", {
+            url: "user/" + requestConfig.user + this.userHomePage.replace(/^\/*/, "/"),
             type: "PAGE_RELATIVE",
             target: "CURRENT"
          });

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -463,6 +463,16 @@ define(["intern/dojo/node!fs",
                .setExecuteAsyncTimeout(opts.queryTimeout + 2000)
                .executeAsync(function(entriesSelector, timeout, asyncComplete) {
 
+                  // Create helper function outside of loop
+                  var jsonify = function(data) {
+                     try {
+                        return JSON.parse(data);
+                     } catch (e) {
+                        // Ignore
+                     }
+                     return data;
+                  };
+
                   // Store the start-time and start the interval
                   var before = Date.now(),
                      intervalPointer = setInterval(function() {
@@ -479,26 +489,16 @@ define(["intern/dojo/node!fs",
                                  responseHeaders = entry.getAttribute("data-aikau-xhr-response-headers"),
                                  responseBody = entry.getAttribute("data-aikau-xhr-response-body");
 
-                              // Reformat if necessary
-                              [requestHeaders, requestBody, requestBody, responseBody].map(function(val) {
-                                 try {
-                                    return JSON.parse(val);
-                                 } catch (e) {
-                                    // Ignore
-                                 }
-                                 return val;
-                              });
-                              
                               return {
                                  request: {
                                     method: method,
                                     url: url,
-                                    headers: requestHeaders,
-                                    body: requestBody
+                                    headers: jsonify(requestHeaders),
+                                    body: jsonify(requestBody)
                                  },
                                  response: {
-                                    headers: responseHeaders,
-                                    body: responseBody
+                                    headers: jsonify(responseHeaders),
+                                    body: jsonify(responseBody)
                                  }
                               };
                            });

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -480,9 +480,15 @@ define(["intern/dojo/node!fs",
                                  responseBody = entry.getAttribute("data-aikau-xhr-response-body");
 
                               // Reformat if necessary
-                              requestHeaders = JSON.parse(requestHeaders);
-                              responseHeaders = JSON.parse(responseHeaders);
-
+                              [requestHeaders, requestBody, requestBody, responseBody].map(function(val) {
+                                 try {
+                                    return JSON.parse(val);
+                                 } catch (e) {
+                                    // Ignore
+                                 }
+                                 return val;
+                              });
+                              
                               return {
                                  request: {
                                     method: method,

--- a/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
@@ -388,15 +388,14 @@ registerSuite(function(){
          .end()
          .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogHidden")
          .end()
-         .findByCssSelector(".mx-row:nth-child(4) .mx-request-body")
-            .getVisibleText()
-            .then(function(payload) {
-               // NOTE: Checking payload elements individually because order is not guaranteed...
-               assert.include(payload, "\"parentNodeRef\":\"some://dummy/node\"", "Parent NodeRef incorrect");
-               assert.include(payload, "\"sourceNodeRef\":\"workspace://SpacesStore/c90aa137-2c57-4a36-8681-b0b207cbee91\"", "Source NodeRef incorrect");
-               assert.include(payload, "\"prop_cm_name\":\"Name\"", "Name incorrect");
-               assert.include(payload, "\"prop_cm_title\":\"Title\"", "Title incorrect");
-               assert.include(payload, "\"prop_cm_description\":\"Description\"", "Description incorrect");
+         .getXhrEntries({url: "folder-templates", method: "POST", pos: "last"})
+            .then(function(xhrEntry){
+               var requestBody = xhrEntry.request.body;
+               assert.propertyVal(requestBody, "parentNodeRef", "some://dummy/node");
+               assert.propertyVal(requestBody, "sourceNodeRef", "workspace://SpacesStore/c90aa137-2c57-4a36-8681-b0b207cbee91");
+               assert.propertyVal(requestBody, "prop_cm_name", "Name");
+               assert.propertyVal(requestBody, "prop_cm_title", "Title");
+               assert.propertyVal(requestBody, "prop_cm_description", "Description");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/CreateContentTest.js
@@ -389,13 +389,12 @@ registerSuite(function(){
          .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogHidden")
          .end()
          .getXhrEntries({url: "folder-templates", method: "POST", pos: "last"})
-            .then(function(xhrEntry){
-               var requestBody = xhrEntry.request.body;
-               assert.propertyVal(requestBody, "parentNodeRef", "some://dummy/node");
-               assert.propertyVal(requestBody, "sourceNodeRef", "workspace://SpacesStore/c90aa137-2c57-4a36-8681-b0b207cbee91");
-               assert.propertyVal(requestBody, "prop_cm_name", "Name");
-               assert.propertyVal(requestBody, "prop_cm_title", "Title");
-               assert.propertyVal(requestBody, "prop_cm_description", "Description");
+            .then(function(xhr){
+               assert.propertyVal(xhr.request.body, "parentNodeRef", "some://dummy/node");
+               assert.propertyVal(xhr.request.body, "sourceNodeRef", "workspace://SpacesStore/c90aa137-2c57-4a36-8681-b0b207cbee91");
+               assert.propertyVal(xhr.request.body, "prop_cm_name", "Name");
+               assert.propertyVal(xhr.request.body, "prop_cm_title", "Title");
+               assert.propertyVal(xhr.request.body, "prop_cm_description", "Description");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -23,9 +23,8 @@
 define(["intern!object",
         "intern/chai!expect", 
         "intern/chai!assert", 
-        "require", 
         "alfresco/TestCommon"], 
-        function(registerSuite, expect, assert, require, TestCommon) {
+        function(registerSuite, expect, assert, TestCommon) {
 
 registerSuite(function(){
    var browser;
@@ -129,16 +128,13 @@ registerSuite(function(){
       },
 
       "Test that user page size user preference is updated": function() {
-         return browser.findByCssSelector("tr.mx-row:nth-child(1) .mx-url")
-            .getVisibleText()
-            .then(function(text) {
-               assert.include(text, "aikau/proxy/alfresco/api/people/guest/preferences", "Page size preference not updated");
-            })
-         .end()
-         .findByCssSelector("tr.mx-row:nth-child(1) .mx-request-body")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "{\"org\":{\"alfresco\":{\"share\":{\"documentList\":{\"documentsPerPage\":50}}}}}", "Page size preference not with correct value");
+         return browser.findByCssSelector("body")
+            .end()
+
+         .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.deepPropertyVal(requestBody, "org.alfresco.share.documentList.documentsPerPage", 50);
             });
       },
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -133,8 +133,7 @@ registerSuite(function(){
 
          .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.deepPropertyVal(requestBody, "org.alfresco.share.documentList.documentsPerPage", 50);
+               assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.documentList.documentsPerPage", 50);
             });
       },
 

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -195,24 +195,24 @@ registerSuite(function(){
       "Check that closing a twister updates its preferences": function() {
          return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
             .click()
-         .end()
+            .end()
 
-         .findByCssSelector("tr.mx-row:nth-child(1) td.mx-request-body")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "{\"org\":{\"alfresco\":{\"share\":{\"twisters\":{\"twister1\":false}}}}}", "Preference not saved on close");
+         .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.deepPropertyVal(requestBody, "org.alfresco.share.twisters.twister1", false);
             });
       },
 
-      "Check that opending a twister updates its preferences": function() {
+      "Check that opening a twister updates its preferences": function() {
          return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
             .click()
-         .end()
+            .end()
 
-         .findByCssSelector("tr.mx-row:nth-child(2) td.mx-request-body")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "{\"org\":{\"alfresco\":{\"share\":{\"twisters\":{\"twister1\":true}}}}}", "Preference not saved on open");
+         .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.deepPropertyVal(requestBody, "org.alfresco.share.twisters.twister1", true);
             });
       },
 

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -199,8 +199,7 @@ registerSuite(function(){
 
          .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.deepPropertyVal(requestBody, "org.alfresco.share.twisters.twister1", false);
+               assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.twisters.twister1", false);
             });
       },
 
@@ -211,8 +210,7 @@ registerSuite(function(){
 
          .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.deepPropertyVal(requestBody, "org.alfresco.share.twisters.twister1", true);
+               assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.twisters.twister1", true);
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -164,11 +164,11 @@ registerSuite(function(){
       "Type a new tag name and hit enter to create it": function() {
          return browser.pressKeys("tag1")
             .pressKeys(keys.ENTER)
-            .findByCssSelector(".mx-row:last-child .mx-request-body")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "{\"name\":\"tag1\"}", "Request to create new tag not made");
-               });
+            .getLastXhr("aikau/proxy/alfresco/api/tag/workspace/SpacesStore")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.propertyVal(requestBody, "name", "tag1");
+            });
       },
 
       "New tag should be displayed": function() {
@@ -180,11 +180,11 @@ registerSuite(function(){
 
       "Hit return to save the node with the new tag": function() {
          return browser.pressKeys([keys.ENTER])
-            .findByCssSelector(".mx-row:last-child .mx-url")
-               .getVisibleText()
-               .then(function(url) {
-                  assert.include(url, "proxy/alfresco/api/node/workspace/SpacesStore/d91128af-3b99-4710-95b6-a858eb090418/formprocessor", "A request was not made to save the node");
-               });
+            .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/d91128af-3b99-4710-95b6-a858eb090418/formprocessor")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.propertyVal(requestBody, "node.properties.cm:taggable", "workspace://SpacesStore/6619a771-5e35-40be-8c08-2f4791d9a056");
+            });
       },
 
       "The updated tag should be displayed in read-only mode": function() {

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -166,8 +166,7 @@ registerSuite(function(){
             .pressKeys(keys.ENTER)
             .getLastXhr("aikau/proxy/alfresco/api/tag/workspace/SpacesStore")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.propertyVal(requestBody, "name", "tag1");
+               assert.propertyVal(xhr.request.body, "name", "tag1");
             });
       },
 
@@ -182,8 +181,7 @@ registerSuite(function(){
          return browser.pressKeys([keys.ENTER])
             .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/d91128af-3b99-4710-95b6-a858eb090418/formprocessor")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.propertyVal(requestBody, "node.properties.cm:taggable", "workspace://SpacesStore/6619a771-5e35-40be-8c08-2f4791d9a056");
+               assert.propertyVal(xhr.request.body, "node.properties.cm:taggable", "workspace://SpacesStore/6619a771-5e35-40be-8c08-2f4791d9a056");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/actions/DeleteActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/actions/DeleteActionTest.js
@@ -133,10 +133,10 @@ registerSuite(function(){
          .end()
          .findByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
          .end()
-         .findByCssSelector("tr.mx-row:nth-child(1) .mx-request-body")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "{\"nodeRefs\":[\"workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e\"]}");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/doclib/action/files?alf_method=delete")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.deepPropertyVal(requestBody, "nodeRefs[0]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4d");
             });
       },
 
@@ -151,10 +151,11 @@ registerSuite(function(){
          .end()
          .findByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
          .end()
-         .findByCssSelector("tr.mx-row:nth-child(2) .mx-request-body")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "{\"nodeRefs\":[\"workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e\",\"workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e\"]}");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/doclib/action/files?alf_method=delete")
+            .then(function(xhr){
+               var requestBody = xhr.request.body;
+               assert.deepPropertyVal(requestBody, "nodeRefs[0]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e");
+               assert.deepPropertyVal(requestBody, "nodeRefs[1]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4f");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/actions/DeleteActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/actions/DeleteActionTest.js
@@ -135,8 +135,7 @@ registerSuite(function(){
          .end()
          .getLastXhr("aikau/proxy/alfresco/slingshot/doclib/action/files?alf_method=delete")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.deepPropertyVal(requestBody, "nodeRefs[0]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4d");
+               assert.deepPropertyVal(xhr.request.body, "nodeRefs[0]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4d");
             });
       },
 
@@ -153,9 +152,8 @@ registerSuite(function(){
          .end()
          .getLastXhr("aikau/proxy/alfresco/slingshot/doclib/action/files?alf_method=delete")
             .then(function(xhr){
-               var requestBody = xhr.request.body;
-               assert.deepPropertyVal(requestBody, "nodeRefs[0]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e");
-               assert.deepPropertyVal(requestBody, "nodeRefs[1]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4f");
+               assert.deepPropertyVal(xhr.request.body, "nodeRefs[0]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e");
+               assert.deepPropertyVal(xhr.request.body, "nodeRefs[1]", "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4f");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -154,10 +154,11 @@ registerSuite(function(){
             .click()
             .end()
 
-         .findByCssSelector("tr.mx-row:nth-child(3) .mx-url")
-            .getVisibleText()
-            .then(function(text) {
-               assert.include(text, "aikau/proxy/alfresco/api/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e/formprocessor", "Update POST did not include nodeRef");
+         .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e/formprocessor")
+            .then(function(xhr){
+               assert.deepPropertyVal(xhr.request.body, "prop_cm_name", "Some Node");
+               assert.deepPropertyVal(xhr.request.body, "prop_cm_title", "With this title");
+               assert.deepPropertyVal(xhr.request.body, "prop_cm_description", "And this description");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
@@ -46,166 +46,163 @@ define(["intern!object",
          }, 5000));
    }
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "CrudService",
+      return {
+         name: "CrudService",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/CrudService", "CrudService")
-            .end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/CrudService", "CrudService")
+               .end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Valid DELETE call succeeds": function() {
-         return browser.findById("DELETE_SUCCESS_BUTTON")
-            .click()
-         .end()
+         "Valid DELETE call succeeds": function() {
+            return browser.findById("DELETE_SUCCESS_BUTTON")
+               .click()
+            .end()
 
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_SUCCESS", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Delete did not succeed");
-            });
-      },
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_SUCCESS", "publish", "any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Delete did not succeed");
+               });
+         },
 
-      "Invalid DELETE call fails": function() {
-         return browser.findById("DELETE_FAILURE_BUTTON")
-            .click()
-         .end()
+         "Invalid DELETE call fails": function() {
+            return browser.findById("DELETE_FAILURE_BUTTON")
+               .click()
+            .end()
 
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_FAILURE", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Invalid delete did not fail");
-            });
-      },
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_FAILURE", "publish", "any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Invalid delete did not fail");
+               });
+         },
 
-      "Failed DELETE displays failure message": function() {
-         return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
-            .then(function(dialogBody) {
-               return dialogBody.getVisibleText()
-                  .then(function(messageText) {
-                     var trimmed = messageText.replace(/^\s+|\s+$/g, "");
-                     assert.equal(trimmed, "Test delete-failure message", "Delete failure message not displayed");
-                  });
-            });
-      },
+         "Failed DELETE displays failure message": function() {
+            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+               .then(function(dialogBody) {
+                  return dialogBody.getVisibleText()
+                     .then(function(messageText) {
+                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                        assert.equal(trimmed, "Test delete-failure message", "Delete failure message not displayed");
+                     });
+               });
+         },
 
-      "Valid UPDATE call succeeds": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("UPDATE_SUCCESS_BUTTON")
-                  .click()
-               .end()
+         "Valid UPDATE call succeeds": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("UPDATE_SUCCESS_BUTTON")
+                     .click()
+                  .end()
 
-               .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_SUCCESS", "publish", "any"))
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 1, "Update did not succeed");
-                  });
-            });
-      },
+                  .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_SUCCESS", "publish", "any"))
+                     .then(function(elements) {
+                        assert.lengthOf(elements, 1, "Update did not succeed");
+                     });
+               });
+         },
 
-      "Invalid UPDATE call fails": function() {
-         return browser.findById("UPDATE_FAILURE_BUTTON")
-            .click()
-         .end()
+         "Invalid UPDATE call fails": function() {
+            return browser.findById("UPDATE_FAILURE_BUTTON")
+               .click()
+            .end()
 
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_FAILURE", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Invalid update did not fail");
-            });
-      },
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_FAILURE", "publish", "any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Invalid update did not fail");
+               });
+         },
 
-      "Failed UPDATE displays failure message": function() {
-         return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
-            .then(function(dialogBody) {
-               return dialogBody.getVisibleText()
-                  .then(function(messageText) {
-                     var trimmed = messageText.replace(/^\s+|\s+$/g, "");
-                     assert.equal(trimmed, "Test update-failure message", "Update failure message not displayed");
-                  });
-            });
-      },
+         "Failed UPDATE displays failure message": function() {
+            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+               .then(function(dialogBody) {
+                  return dialogBody.getVisibleText()
+                     .then(function(messageText) {
+                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                        assert.equal(trimmed, "Test update-failure message", "Update failure message not displayed");
+                     });
+               });
+         },
 
-      "Valid CREATE call succeeds": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("CREATE_SUCCESS_BUTTON")
-                  .click()
-               .end()
+         "Valid CREATE call succeeds": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("CREATE_SUCCESS_BUTTON")
+                     .click()
+                  .end()
 
-               .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_SUCCESS", "publish", "any"))
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 1, "Create did not succeed");
-                  });
-            });
-      },
+                  .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_SUCCESS", "publish", "any"))
+                     .then(function(elements) {
+                        assert.lengthOf(elements, 1, "Create did not succeed");
+                     });
+               });
+         },
 
-      "Invalid CREATE call fails": function () {
-         return browser.findById("CREATE_FAILURE_BUTTON")
-            .click()
-         .end()
+         "Invalid CREATE call fails": function () {
+            return browser.findById("CREATE_FAILURE_BUTTON")
+               .click()
+            .end()
 
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_FAILURE", "publish", "any"))
-            .then(function (elements) {
-               assert.lengthOf(elements, 1, "Invalid create did not fail");
-            });
-      },
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_FAILURE", "publish", "any"))
+               .then(function (elements) {
+                  assert.lengthOf(elements, 1, "Invalid create did not fail");
+               });
+         },
 
-      "Failed CREATE displays failure message": function () {
-         return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
-            .then(function (dialogBody) {
-               return dialogBody.getVisibleText()
-                  .then(function (messageText) {
-                     var trimmed = messageText.replace(/^\s+|\s+$/g, "");
-                     assert.equal(trimmed, "Test create-failure message", "Create failure message not displayed");
-                  });
-            });
-      },
+         "Failed CREATE displays failure message": function () {
+            return browser.findByCssSelector("#NOTIFICATION_PROMPT .dialog-body")
+               .then(function (dialogBody) {
+                  return dialogBody.getVisibleText()
+                     .then(function (messageText) {
+                        var trimmed = messageText.replace(/^\s+|\s+$/g, "");
+                        assert.equal(trimmed, "Test create-failure message", "Create failure message not displayed");
+                     });
+               });
+         },
 
-      "GET ALL success": function () {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("GET_ALL_DEFAULT_CACHE_BUTTON")
-                  .click()
-               .end()
+         "GET ALL success": function () {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("GET_ALL_DEFAULT_CACHE_BUTTON")
+                     .click()
+                  .end()
 
-               .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_DEFAULT_CACHE_SUCCESS", "publish", "any"))
-                  .then(function (elements) {
-                     assert.lengthOf(elements, 1, "GET ALL didn't succeed");
-                  });
-            });
-      },
+                  .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_DEFAULT_CACHE_SUCCESS", "publish", "any"))
+                     .then(function (elements) {
+                        assert.lengthOf(elements, 1, "GET ALL didn't succeed");
+                     });
+               });
+         },
 
-      "GET ALL with prevent cache option success": function () {
-         return browser.findById("GET_ALL_PREVENT_CACHE_BUTTON")
-            .click()
-         .end()
+         "GET ALL with prevent cache option success": function () {
+            return browser.findById("GET_ALL_PREVENT_CACHE_BUTTON")
+               .click()
+            .end()
 
-         .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_PREVENT_CACHE_SUCCESS", "publish", "any"))
-            .then(function (elements) {
-               assert.lengthOf(elements, 1, "GET ALL with preventCache flag failed");
-            });
-      },
+            .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_PREVENT_CACHE_SUCCESS", "publish", "any"))
+               .then(function (elements) {
+                  assert.lengthOf(elements, 1, "GET ALL with preventCache flag failed");
+               });
+         },
 
-      "Check URI encoding": function() {
-         return browser.findById("URL_ENCODING_REQUIRED_BUTTON")
-            .click()
-         .end()
-         .findByCssSelector("tr.mx-row:nth-child(9) .mx-url")
-            .getVisibleText()
-            .then(function(text) {
-               assert.include(text, "/aikau/proxy/alfresco/resources/nocache?filter=%25moomin", "URI was not encoded");
-            });
-      },
+         "Check URI encoding": function() {
+            return browser.findById("URL_ENCODING_REQUIRED_BUTTON")
+               .clearXhrLog()
+               .click()
+            .end()
+            .getLastXhr("aikau/proxy/alfresco/resources/nocache?filter=%25moomin");
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -62,10 +62,12 @@ registerSuite(function(){
       },
 
       "Check there are no unexpected queries": function() {
-         return browser.findByCssSelector("td.mx-url")
-            .getVisibleText()
-            .then(function(text) {
-               assert(decodeURIComponent(text).indexOf("&query={") === -1, "unexpected query found");
+         return browser.findByCssSelector("body")
+            .end()
+
+         .getXhrEntries({url: "&query={"})
+            .then(function(entries) {
+               assert.lengthOf(entries, 0);
             });
       },
 
@@ -75,13 +77,11 @@ registerSuite(function(){
                assert.propertyVal(payload, "repo", true, "Repository scope not requested");
             })
          .end()
-         .findByCssSelector("tr.mx-row:nth-child(1) td.mx-url")
-            .getVisibleText()
-            .then(function(url) {
-               assert.include(url, "repo=true", "Repository scope not used in XHR");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+            .then(function(xhr){
+               assert.include(xhr.request.url, "repo=true");
             })
-         .end()
-         .clearLog();
+            .clearLog();
       },
 
       "Switch to All Sites scope": function() {
@@ -96,13 +96,11 @@ registerSuite(function(){
             assert.propertyVal(payload, "repo", false, "Repository scope used");
             assert.propertyVal(payload, "site", "", "Site incorrect");
          })
-         .findByCssSelector("tr.mx-row:nth-child(3) td.mx-url")
-            .getVisibleText()
-            .then(function(url) {
-               assert.include(url, "repo=false", "Repository scope not used in XHR");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+            .then(function(xhr){
+               assert.include(xhr.request.url, "repo=false");
             })
-         .end()
-         .clearLog();
+            .clearLog();
       },
 
       "Switch to Site scope": function() {
@@ -117,14 +115,12 @@ registerSuite(function(){
             assert.propertyVal(payload, "repo", false, "Repository scope used");
             assert.propertyVal(payload, "site", "site", "Site incorrect");
          })
-         .findByCssSelector("tr.mx-row:nth-child(4) td.mx-url")
-            .getVisibleText()
-            .then(function(url) {
-               assert.include(url, "repo=false", "Repository scope not used in XHR");
-               assert.include(url, "site=site", "Repository scope not used in XHR");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+            .then(function(xhr){
+               assert.include(xhr.request.url, "repo=false");
+               assert.include(xhr.request.url, "site=site");
             })
-         .end()
-         .clearLog();
+            .clearLog();
       },
 
       "Switch to Repository scope": function() {
@@ -138,13 +134,11 @@ registerSuite(function(){
          .then(function(payload) {
             assert.propertyVal(payload, "repo", true, "Repository scope NOT used");
          })
-         .findByCssSelector("tr.mx-row:nth-child(5) td.mx-url")
-            .getVisibleText()
-            .then(function(url) {
-               assert.include(url, "repo=true", "Repository scope not used in XHR");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+            .then(function(xhr){
+               assert.include(xhr.request.url, "repo=true");
             })
-         .end()
-         .clearLog();
+            .clearLog();
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -42,18 +42,39 @@ define(["alfresco/TestCommon",
             browser.end();
          },
 
-         "Leave site and confirm landing page override works": function(){
-            return browser.findById("LEAVE_SITE")
+         "Request to join site navigates user to their dashboard afterwards": function(){
+            return browser.findById("REQUEST_SITE_MEMBERSHIP_label")
                .click()
                .end()
 
-            .findByCssSelector("#ALF_SITE_SERVICE_DIALOG.dialogDisplayed .dijitButton:first-child .dijitButtonNode")
+            .findByCssSelector(".dialogDisplayed .dijitButtonNode")
                .click()
+               .end()
+
+            .waitForDeletedByCssSelector(".dialogDisplayed")
                .end()
 
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload){
-                  assert.propertyVal(payload, "url", "user/admin/dashboard", "Did not generate URL with correct landing page");
+                  assert.propertyVal(payload, "url", "user/admin/home", "Did not navigate to user home page");
+               });
+         },
+
+         "Leave site and confirm user home page override works": function(){
+            return browser.findById("LEAVE_SITE_label")
+               .click()
+               .end()
+
+            .findByCssSelector(".dialogDisplayed .dijitButton:first-child .dijitButtonNode")
+               .click()
+               .end()
+
+            .waitForDeletedByCssSelector(".dialogDisplayed")
+               .end()
+
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload){
+                  assert.propertyVal(payload, "url", "user/admin/home", "Did not generate URL with correct user home page");
                });
          },
 

--- a/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
@@ -196,19 +196,16 @@ registerSuite(function(){
       },
 
       "Test the repository root override is applied": function() {
-         return browser.findByCssSelector(".mx-row:nth-child(1) .mx-url")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text.indexOf("libraryRoot=some%3A%2F%2Ffake%2Fnode") !== -1, "The configured root node was not used: ", text);
+         return browser.findByCssSelector("body")
+            .getLastXhr("aikau/proxy/alfresco/slingshot/doclib/treenode/node/alfresco/company/home")
+            .then(function(xhr){
+               assert.include(xhr.request.url, "libraryRoot=some%3A%2F%2Ffake%2Fnode");
             });
       },
 
       "Test that the custom copyAPI was used": function() {
-         return browser.findByCssSelector(".mx-row:nth-child(2) .mx-url")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text.indexOf("/aikau/proxy/alfresco/fail/some/fake/node") !== -1, "The custom copy API was not used");
-            });
+         return browser.findByCssSelector("body")
+            .getLastXhr("aikau/proxy/alfresco/fail/some/fake/node");
       },
 
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
@@ -129,10 +129,12 @@ registerSuite(function(){
          return browser.findByCssSelector("#ALF_MANAGE_ASPECTS_DIALOG .confirmationButton > span")
             .click()
          .end()
-         .findByCssSelector(".mx-row:nth-child(2) .mx-request-body")
-            .getVisibleText()
-            .then(function(payload) {
-               assert.equal(payload, "{\"added\":[\"cm:complianceable\"],\"removed\":[\"cm:generalclassifiable\"]}", "The added/removed payload wasn't generated correctly");
+         .getLastXhr("aikau/proxy/alfresco/slingshot/doclib/action/aspects/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e")
+            .then(function(xhr){
+               assert.lengthOf(xhr.request.body.added, 1, "Wrong number of aspects added");
+               assert.lengthOf(xhr.request.body.removed, 1, "Wrong number of aspects removed");
+               assert.deepPropertyVal(xhr.request.body, "added[0]", "cm:complianceable");
+               assert.deepPropertyVal(xhr.request.body, "removed[0]", "cm:generalclassifiable");
             });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/core/CoreXhrTest"
+      "src/test/resources/alfresco/services/SiteServiceTest"
 
       // THESE SITES REGULARLY FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/dnd/FormCreationTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -34,11 +34,12 @@ define({
    xbaseFunctionalSuites: [
       "src/test/resources/alfresco/services/SiteServiceTest"
 
-      // THESE SITES REGULARLY FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
+      // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/dnd/FormCreationTest",
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
       // "src/test/resources/alfresco/preview/PdfJsPreviewTest"
       // "src/test/resources/alfresco/search/SearchSuggestionsTest",
+      // "src/test/resources/alfresco/services/CloudSyncServiceTest",
    ],
 
    /**

--- a/aikau/src/test/resources/intern_bs.js
+++ b/aikau/src/test/resources/intern_bs.js
@@ -111,6 +111,10 @@ define(["./config/Suites"],
             }, {
                name: "dojo",
                location: "./node_modules/intern/node_modules/dojo"
+            }, {
+               name: "lodash",
+               location: "./src/test/resources/lib/lodash",
+               main: "lodash.compat"
             }]
          },
 

--- a/aikau/src/test/resources/intern_grid.js
+++ b/aikau/src/test/resources/intern_grid.js
@@ -63,6 +63,10 @@ define(["./config/Suites"],
             }, {
                name: "reporters",
                location: "./src/test/resources/reporters"
+            }, {
+               name: "lodash",
+               location: "./src/test/resources/lib/lodash",
+               main: "lodash.compat"
             }]
          },
 

--- a/aikau/src/test/resources/intern_local.js
+++ b/aikau/src/test/resources/intern_local.js
@@ -81,6 +81,10 @@ define(["./config/Suites"],
             }, {
                name: "dojo",
                location: "./node_modules/intern/node_modules/dojo"
+            }, {
+               name: "lodash",
+               location: "./src/test/resources/lib/lodash",
+               main: "lodash.compat"
             }]
          },
 

--- a/aikau/src/test/resources/intern_sl.js
+++ b/aikau/src/test/resources/intern_sl.js
@@ -64,7 +64,8 @@ define(["./config/Suites"],
 	      // Note: the config package is specifically for sauce labs (sl)
 	      packages: [
             { name: 'alfresco', location: './src/test/resources/alfresco' },
-            { name: 'config', location: './src/test/resources/config/sl' }
+            { name: 'config', location: './src/test/resources/config/sl' },
+            { name: "lodash", location: "./src/test/resources/lib/lodash", main: "lodash.compat" }
          ]
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -10,7 +10,10 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/services/SiteService"
+         name: "alfresco/services/SiteService",
+         config: {
+            userHomePage: "home"
+         }
       },
       {
          name: "alfresco/services/DialogService"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Delete.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Delete.get.js
@@ -35,7 +35,7 @@ model.jsonModel = {
                },
                document: {
                   node: {
-                     nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                     nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4d"
                   },
                   displayName: "Some Node Title"
                }
@@ -60,7 +60,7 @@ model.jsonModel = {
                   {
                      displayName: "Node 2",
                      node: {
-                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4f"
                      }
                   }
                ]

--- a/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
@@ -188,7 +188,7 @@ define(["dojo/_base/declare",
             "data-aikau-xhr-url": xhrRequest.url || "",
             "data-aikau-xhr-request-headers": (xhrRequest.requestHeaders && JSON.stringify(xhrRequest.requestHeaders)) || "",
             "data-aikau-xhr-request-body": xhrRequest.requestBody || "",
-         }, this.logNode);
+         }, this.logNode, "first");
          domConstruct.create("td", {
             className: "mx-method",
             innerHTML: xhrRequest.method,

--- a/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/MockXhr.js
@@ -73,6 +73,24 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Build the HTML for displaying a request/response body on the page
+       *
+       * @instance
+       * @param {object} body The body object (request or response)
+       * @returns {string} The HTML
+       */
+      buildBodyHTML: function alfresco_testing_MockXhr__buildBodyHTML(body) {
+         var bodyHTML = body;
+         try {
+            bodyHTML = JSON.parse(bodyHTML);
+            bodyHTML = JSON.stringify(bodyHTML, null, 2);
+         } catch (e) {
+            // Ignore
+         }
+         return bodyHTML;
+      },
+
+      /**
        * Build the HTML for displaying headers on the page
        *
        * @instance
@@ -173,19 +191,23 @@ define(["dojo/_base/declare",
          }, this.logNode);
          domConstruct.create("td", {
             className: "mx-method",
-            innerHTML: xhrRequest.method
+            innerHTML: xhrRequest.method,
+            title: xhrRequest.method
          }, rowNode);
          domConstruct.create("td", {
             className: "mx-url",
-            innerHTML: xhrRequest.url
+            innerHTML: xhrRequest.url,
+            title: xhrRequest.url
          }, rowNode);
          domConstruct.create("td", {
             className: "mx-request-headers",
-            innerHTML: this.buildHeadersHTML(xhrRequest.requestHeaders)
+            innerHTML: this.buildHeadersHTML(xhrRequest.requestHeaders),
+            title: this.buildHeadersHTML(xhrRequest.requestHeaders)
          }, rowNode);
          domConstruct.create("td", {
             className: "mx-request-body",
-            innerHTML: xhrRequest.requestBody || "&nbsp;"
+            innerHTML: this.buildBodyHTML(xhrRequest.requestBody) || "&nbsp;",
+            title: this.buildBodyHTML(xhrRequest.requestBody) || "&nbsp;"
          }, rowNode);
          var responseNode = domConstruct.create("td", {
             className: "mx-response",
@@ -207,7 +229,7 @@ define(["dojo/_base/declare",
             responseHtml += "<dt>Headers</dt>";
             responseHtml += "<dd>" + headersHtml + "</dd>";
             responseHtml += "<dt>Reponse body</dt>";
-            responseHtml += "<dd>" + responseBody + "</dd>";
+            responseHtml += "<dd>" + this.buildBodyHTML(responseBody) + "</dd>";
             responseHtml += "</dl>";
 
             // Add a new row to the log and update the data attribute

--- a/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/css/MockXhr.css
@@ -19,10 +19,12 @@
    }
    th, td, caption {
       border: 1px solid #808080;
-      min-width: 100px;
       padding: 4px;
       text-align: left;
       vertical-align: top;
+   }
+   th, td {
+      word-break: break-word;
    }
    th {
       font-family: @bold-font;
@@ -58,6 +60,9 @@
          top: 1px;
       }
    }
+   .mx-request-body {
+      white-space: pre-wrap;
+   }
    .mx-response {
       position: relative;
       &__info {
@@ -69,8 +74,8 @@
          padding: 10px;
          position: absolute;
          right: 105%;
-         text-align: right;
          top: 8px;
+         width: 500px;
          z-index: 1;
          dt, dd {
             display: block;
@@ -84,6 +89,9 @@
             &:first-child {
                margin-top: 0;
             }
+         }
+         dd {
+            white-space: pre-wrap;
          }
       }
       &:hover {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/GenericMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/GenericMockXhr.js
@@ -41,7 +41,9 @@ define([
             try {
                this.server.respondWith([200, {
                   "Content-Type": "application/json;charset=UTF-8"
-               }, "OK"]);
+               }, JSON.stringify({
+                  result: "OK"
+               })]);
                this.alfPublish("ALF_MOCK_XHR_SERVICE_READY");
             } catch (e) {
                this.alfLog("error", "The following error occurred setting up the mock server", e);

--- a/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/templates/MockXhr.html
@@ -7,11 +7,11 @@
       </caption>
       <thead class="mx-thead">
          <tr>
-            <th class="mx-method">Method</th>
-            <th class="mx-url">URL</th>
-            <th class="mx-request-headers">Headers</th>
-            <th class="mx-request-body">Body</th>
-            <th class="mx-response">Response</th>
+            <th width="5%" class="mx-method">Method</th>
+            <th width="30%" class="mx-url">URL</th>
+            <th width="20%" class="mx-request-headers">Headers</th>
+            <th width="30%" class="mx-request-body">Body</th>
+            <th width="15%" class="mx-response">Response</th>
          </tr>
       </thead>
       <tbody class="mx-tbody" data-dojo-attach-point="logNode">


### PR DESCRIPTION
This PR addresses issues [AKU-617](https://issues.alfresco.com/jira/browse/AKU-617) and [AKU-623](https://issues.alfresco.com/jira/browse/AKU-623), which are both updates to do with the user dashboard page usage in SiteService. Also, the MockXhr log functionality has been upgraded, and tests updated to cope with this. A full test suite has been run, and no unexpected failures occurred.