### PR TITLE
AKU-615: Rretain selection on grid resize

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -673,6 +673,10 @@ define([],function() {
       SELECTED_DOCUMENTS_CHANGED: "ALF_SELECTED_FILES_CHANGED",
 
       /**
+       * This topic should be published by [menu items]{@link module:alfresco/menus/AlfMenuItem} contained within
+       * a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup} to
+       * be forwarded onto the [ActionService]{@link module:alfresco/services/ActionService} in order to request
+       * that the configured action be performed on the currently selected items.
        * 
        * @instance
        * @type {string}
@@ -680,7 +684,8 @@ define([],function() {
        * @since 1.0.39
        *
        * @event
-       * 
+       * @param {string} [action] The action to perform
+       * @param {string} [actionTopic] The topic to re-publish the action request on
        */
       SELECTED_DOCUMENTS_ACTION: "ALF_SELECTED_DOCUMENTS_ACTION_REQUEST",
 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -660,19 +660,6 @@ define([],function() {
       SCROLL_NEAR_BOTTOM: "ALF_SCROLL_NEAR_BOTTOM",
 
       /**
-       * Used to indicate the list of currently selected documents has changed and provides the details of those items.
-       * 
-       * @instance
-       * @type {string} 
-       * @default
-       * @since 1.0.35
-       * 
-       * @event module:alfresco/core/topics~SELECTED_DOCUMENTS_CHANGED
-       * @property {object[]} selectedItems - The items that are selected
-       */
-      SELECTED_DOCUMENTS_CHANGED: "ALF_SELECTED_FILES_CHANGED",
-
-      /**
        * This topic should be published by [menu items]{@link module:alfresco/menus/AlfMenuItem} contained within
        * a [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup} to
        * be forwarded onto the [ActionService]{@link module:alfresco/services/ActionService} in order to request
@@ -684,10 +671,23 @@ define([],function() {
        * @since 1.0.39
        *
        * @event
-       * @param {string} [action] The action to perform
-       * @param {string} [actionTopic] The topic to re-publish the action request on
+       * @property {string} [action] The action to perform
+       * @property {string} [actionTopic] The topic to re-publish the action request on
        */
       SELECTED_DOCUMENTS_ACTION: "ALF_SELECTED_DOCUMENTS_ACTION_REQUEST",
+
+      /**
+       * Used to indicate the list of currently selected documents has changed and provides the details of those items.
+       * 
+       * @instance
+       * @type {string} 
+       * @default
+       * @since 1.0.35
+       * 
+       * @event module:alfresco/core/topics~SELECTED_DOCUMENTS_CHANGED
+       * @property {object[]} selectedItems - The items that are selected
+       */
+      SELECTED_DOCUMENTS_CHANGED: "ALF_SELECTED_FILES_CHANGED",
 
       /**
        * This topic can be published to set a user preference. It is typically handled by 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -673,6 +673,18 @@ define([],function() {
       SELECTED_DOCUMENTS_CHANGED: "ALF_SELECTED_FILES_CHANGED",
 
       /**
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.39
+       *
+       * @event
+       * 
+       */
+      SELECTED_DOCUMENTS_ACTION: "ALF_SELECTED_DOCUMENTS_ACTION_REQUEST",
+
+      /**
        * This topic can be published to set a user preference. It is typically handled by 
        * the [PreferenceService]{@link module:alfresco/services/PreferenceService}.
        *

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentActionMenuItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentActionMenuItem.js
@@ -72,7 +72,7 @@ define(["dojo/_base/declare",
       /**
        * This implements the filter function extension point to check the current menu items configuration
        * against the user permissions and aspects as provided in the publication payload. This code is based
-       * on the second half of the "onSelectedFilesChanged" function from the "toolbar.js" file. It should 
+       * on the second half of the "onselectedItemsChanged" function from the "toolbar.js" file. It should 
        * be kept in-sync with any updates made to that file. 
        * 
        * @instance

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
@@ -118,7 +118,7 @@ define(["dojo/_base/declare",
             this.documentsSelected = this.documentsAvailable;
          }
          this.determineSelection({
-            selectedFiles: {
+            selectedItems: {
                length: this.documentsSelected
             }
          });
@@ -137,7 +137,7 @@ define(["dojo/_base/declare",
             this.documentsSelected = 0;
          }
          this.determineSelection({
-            selectedFiles: {
+            selectedItems: {
                length: this.documentsSelected
             }
          });
@@ -165,18 +165,18 @@ define(["dojo/_base/declare",
        * @param {object} payload The publication of the selected item change.
        */
       determineSelection: function alfresco_menus_AlfMenuBarSelectItems__determineSelection(payload) {
-         if (payload.selectedFiles && (payload.selectedFiles.length || payload.selectedFiles.length === 0))
+         if (payload.selectedItems && (payload.selectedItems.length || payload.selectedItems.length === 0))
          {
-            if (this.documentsAvailable === 0 || payload.selectedFiles.length === 0)
+            if (this.documentsAvailable === 0 || payload.selectedItems.length === 0)
             {
                this.renderNoneSelected();
                this.documentsSelected = 0;
             }
-            else if (this.documentsAvailable > payload.selectedFiles.length)
+            else if (this.documentsAvailable > payload.selectedItems.length)
             {
                this.renderSomeSelected();
             }
-            else if (this.documentsAvailable === payload.selectedFiles.length)
+            else if (this.documentsAvailable === payload.selectedItems.length)
             {
                this.renderAllSelected();
                this.documentsSelected = this.documentsAvailable;

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup.js
@@ -30,19 +30,21 @@
  * 
  * @module alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup
  * @extends module:alfresco/menus/AlfMenuBarPopup
+ * @mixes module:alfresco/lists/SelectedItemStateMixin
  * @mixes module:alfresco/core/ObjectProcessingMixin
  * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarPopup",
+        "alfresco/lists/SelectedItemStateMixin",
         "alfresco/core/ObjectProcessingMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/core/topics",
         "dojo/_base/lang"], 
-        function(declare, AlfMenuBarPopup, ObjectProcessingMixin, _AlfDocumentListTopicMixin, topics, lang) {
+        function(declare, AlfMenuBarPopup, SelectedItemStateMixin, ObjectProcessingMixin, _AlfDocumentListTopicMixin, topics, lang) {
    
-   return declare([AlfMenuBarPopup, ObjectProcessingMixin, _AlfDocumentListTopicMixin], {
+   return declare([AlfMenuBarPopup, SelectedItemStateMixin, ObjectProcessingMixin, _AlfDocumentListTopicMixin], {
       
       /**
        * Controls whether or not this widget actively tracks the selected items or passively subscribes
@@ -52,7 +54,7 @@ define(["dojo/_base/declare",
        * @type {boolean}
        * @default
        */
-      passive: false,
+      passive: true,
 
       /**
        * Overrides the default to initialise as disabled.
@@ -62,39 +64,18 @@ define(["dojo/_base/declare",
        * @default
        */
       disabled: true,
+
+      /**
+       * Overrides the [inherited default]{@link module:alfresco/lists/SelectedItemStateMixin#disableWhenNothingSelected}
+       * to ensure that the popup is disabled when no items are selected.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      disableWhenNothingSelected: true,
       
-      /**
-       * This is used to keep track of the documents that are currently selected. It is initialised to an empty
-       * array in the constructor, the onItemSelected function adds elements and the onItemDeselected
-       * function removes them.
-       *
-       * @instance
-       * @type {object}
-       * @default
-       */
-      currentlySelectedItems: null,
-
-      /**
-       * This is used to keep a reference to a timeout that is started on the publication of a selected document
-       * topic. It is important that multiple selection events can be captured so that only one publication of
-       * selected items occurs.
-       *
-       * @instance
-       * @type {timeout}
-       * @default
-       */
-      selectionTimeout: null,
-
-      /**
-       * This is the dot-notation addressed property within the selection/de-selection publication payload that
-       * uniquely identifies the item.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      itemKeyProperty: "node.nodeRef",
-
       /**
        * This can be configured so that action payloads are processed for the existence of a "{nodes}" token. If
        * one is found then it will be swapped out with the array of selected nodes.
@@ -112,7 +93,9 @@ define(["dojo/_base/declare",
        * topic which is handled by [onFilesSelected]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#onFilesSelected}.
        * However, when [passive]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#passive} is configured as false
        * then it subscribes to the topics to track item selection and deselection
+       * 
        * @instance
+       * @listens module:alfresco/core/topics#SELECTED_DOCUMENTS_ACTION
        */
       postCreate: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__postCreate() {
          if (this.passive === true)
@@ -121,115 +104,11 @@ define(["dojo/_base/declare",
          }
          else
          {
-            this.currentlySelectedItems = {};
-            this.alfSubscribe(this.documentSelectedTopic, lang.hitch(this, this.onItemSelected));
-            this.alfSubscribe(this.documentDeselectedTopic, lang.hitch(this, this.onItemDeselected));
-            this.alfSubscribe(topics.CLEAR_SELECTED_ITEMS, lang.hitch(this, this.onItemSelectionCleared));
-            this.alfSubscribe("ALF_SELECTED_DOCUMENTS_ACTION_REQUEST", lang.hitch(this, this.onSelectedDocumentsAction));
+            this.createSelectedItemSubscriptions();
          }
+
+         this.alfSubscribe(topics.SELECTED_DOCUMENTS_ACTION, lang.hitch(this, this.onSelectedDocumentsAction));
          this.inherited(arguments);
-      },
-
-      /**
-       * Updates the aray of documents that are currently selected.
-       * @instance
-       * @param {object} payload The details of the document selected
-       */
-      onItemSelected: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onItemSelected(payload) {
-         if (payload && payload.value)
-         {
-            var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
-            if (itemKey)
-            {
-               this.currentlySelectedItems[itemKey] = payload.value;
-               if (this.selectionTimeout)
-               {
-                  clearTimeout(this.selectionTimeout);
-               }
-               this.selectionTimeout = setTimeout(lang.hitch(this, this.deferredSelectionHandler), 50);
-            }
-            else
-            {
-               this.alfLog("warn", "Could not find item key property: '" + this.itemKeyProperty + "' in selected item value", payload, this);
-            }
-         }
-      },
-
-      /**
-       * This is called from [onItemSelected]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#onItemSelected}
-       * when the [selectionTimeout]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#selectionTimeout} times out. It
-       * rests the [selectionTimeout]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#selectionTimeout} to null and
-       * calls [onSelectedFilesChanged]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#deselectionTimeout}
-       *
-       * @instance
-       */
-      deferredSelectionHandler: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__deferredSelectionHandler() {
-         var selectedItems = [];
-         for (var key in this.currentlySelectedItems)
-         {
-            if (this.currentlySelectedItems.hasOwnProperty(key)) {
-               selectedItems.push(this.currentlySelectedItems[key]);
-            }
-         }
-         this.set("disabled", (selectedItems.length === 0));
-         this.publishSelectedItems(selectedItems);
-         this.selectionTimeout = null;
-      },
-
-      /**
-       * This is called from the [deferredSelectionHandler]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup#deferredSelectionHandler}
-       * function and publishes on the [selectedDocumentsChangeTopic]
-       * {@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#selectedDocumentsChangeTopic}.
-       *
-       * @instance
-       */
-      publishSelectedItems: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__publishSelectedItems(selectedItems) {
-         this.alfPublish(this.selectedDocumentsChangeTopic, {
-            selectedItems: selectedItems
-         });
-      },
-
-      /**
-       * Updates the array of documents that are currently selected.
-       *
-       * @instance
-       * @param {object} payload The details of the document selected
-       */
-      onItemDeselected: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onItemDeselected(payload) {
-         if (payload && payload.value)
-         {
-            var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
-            if (itemKey)
-            {
-               delete this.currentlySelectedItems[itemKey];
-               if (this.selectionTimeout)
-               {
-                  clearTimeout(this.selectionTimeout);
-               }
-               this.selectionTimeout = setTimeout(lang.hitch(this, this.deferredSelectionHandler), 50);
-            }
-            else
-            {
-               this.alfLog("warn", "Could not find item key property: '" + this.itemKeyProperty + "' in deselected item value", payload, this);
-            }
-         }
-      },
-
-      /**
-       * This clears the currently selected items. It it bound to the 
-       * [CLEAR_SELECTED_ITEMS topic]{@link module:alfresco/core/topics#CLEAR_SELECTED_ITEMS} that is published
-       * by the [AlfSelectedItemsMenuItem]{@link module:alfresco/menus/AlfSelectedItemsMenuItem} when clicked.
-       *
-       * @instance
-       * @param {object} payload This is not expected to contain any usable data.
-       */
-      onItemSelectionCleared: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onItemSelectionCleared(/*jshint unused:false*/ payload) {
-         this.currentlySelectedItems = {};
-         if (this.selectionTimeout)
-         {
-            clearTimeout(this.selectionTimeout);
-         }
-         this.selectionTimeout = setTimeout(lang.hitch(this, this.deferredSelectionHandler), 50);
       },
       
       /**
@@ -240,7 +119,8 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the selected files.
        */
       onFilesSelected: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onFilesSelected(payload) {
-         this.set("disabled", (payload && payload.selectedFiles && payload.selectedFiles.length === 0));
+         this.set("disabled", (payload && payload.selectedItems && payload.selectedItems.length === 0));
+         this.selectedItems = payload.selectedItems;
       },
 
       /**
@@ -252,23 +132,14 @@ define(["dojo/_base/declare",
        * @fires alfresco/core/topics#MULTIPLE_ITEM_ACTION_REQUEST
        */
       onSelectedDocumentsAction: function alfresco_documentlibrary_AlfSelectedItemsMenuBarPopup__onSelectedDocumentsAction(payload) {
-         var selectedItems = [];
-         for (var nodeRef in this.currentlySelectedItems)
-         {
-            if (this.currentlySelectedItems.hasOwnProperty(nodeRef))
-            {
-               selectedItems.push(this.currentlySelectedItems[nodeRef]);
-            }
-         }
-         payload.documents = selectedItems;
-
+         payload.documents = this.selectedItems;
          if (this.processActionPayloads)
          {
             // There are circumstances where the requested action might need access to the selected nodes *within*
             // the payload. This can be achieved by referencing the {nodes} token with the payload and using the standard
             // object processing mixin.
             this.currentItem = {
-               nodes: selectedItems
+               nodes: this.selectedItems
             };
             var clonedPayload = lang.clone(payload);
             this.processObject(["processCurrentItemTokens"], clonedPayload);

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -23,19 +23,20 @@
  * 
  * @module alfresco/documentlibrary/views/AlfGalleryView
  * @extends module:alfresco/lists/views/AlfListView
- * @mixes module:alfresco/lists/views/layouts/Grid
+ * @mixes module:alfresco/lists/SelectedItemStateMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
         "alfresco/lists/views/AlfListView",
+        "alfresco/lists/SelectedItemStateMixin",
         "dojo/text!./templates/AlfGalleryView.html",
         "alfresco/lists/views/layouts/Grid",
         "alfresco/documentlibrary/AlfGalleryViewSlider",
         "dojo/_base/lang",
         "alfresco/core/topics"], 
-        function(declare, AlfDocumentListView, template, Grid, AlfGalleryViewSlider, lang, topics) {
+        function(declare, AlfListView, SelectedItemStateMixin, template, Grid, AlfGalleryViewSlider, lang, topics) {
    
-   return declare([AlfDocumentListView], {
+   return declare([AlfListView, SelectedItemStateMixin], {
       
       /**
        * The HTML template to use for the widget.
@@ -43,6 +44,20 @@ define(["dojo/_base/declare",
        * @type {String}
        */
       templateString: template,
+
+      /**
+       * This enables the mixed in [SelectedItemStateMixin]{@link module:alfresco/lists/SelectedItemStateMixin}
+       * capabilities to track items as they are selected and deselected. This should only be changed from the
+       * default when the view is not used within a [list]{@link module:alfresco/lists/AlfList} (as lists will
+       * track selected items). This also ensures that when used outside of a list that the selected item 
+       * state will be maintained when the thumbnails are resized.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      manageSelectedItemState: false,
 
       /**
        * Returns the name of the view that is used when saving user view preferences.
@@ -76,6 +91,11 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_documentlibrary_views_AlfGalleryView__postCreate() {
          this.inherited(arguments);
          this.alfSubscribe("ALF_DOCLIST_SET_GALLERY_COLUMNS", lang.hitch(this, this.updateColumns));
+
+         if (this.manageSelectedItemState)
+         {
+            this.createSelectedItemSubscriptions();
+         }
       },
 
       /**
@@ -166,6 +186,10 @@ define(["dojo/_base/declare",
             if (this.docListRenderer)
             {
                this.docListRenderer.resizeCells();
+            }
+            if (this.manageSelectedItemState)
+            {
+               this.publishSelectedItems();
             }
             this._renderingView = false;
 

--- a/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
+++ b/aikau/src/main/resources/alfresco/layout/LeftAndRight.js
@@ -122,7 +122,7 @@ define(["dojo/_base/declare",
          }
          // We need to reverse the order of RIGHT widgets so that the last widget is defined is furthest
          // to the RIGHT
-         this.widgetsRight.reverse();
+         this.widgetsRight && this.widgetsRight.reverse();
          this.processWidgets(this.widgetsRight, this.rightWidgets, "RIGHT");
          this.processWidgets(this.widgetsLeft, this.leftWidgets, "LEFT");
 

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -25,7 +25,7 @@
  * @mixes external:dijit/_TemplatedMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/core/CoreWidgetProcessing
- * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
+ * @mixes module:alfresco/lists/SelectedItemStateMixin
  * @mixes module:alfresco/core/DynamicWidgetProcessingTopics
  * @author Dave Draper
  */
@@ -36,19 +36,21 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/core/topics",
-        "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
+        "alfresco/lists/SelectedItemStateMixin",
         "alfresco/core/DynamicWidgetProcessingTopics",
         "alfresco/lists/views/AlfListView",
         "alfresco/menus/AlfCheckableMenuItem",
+        "dojo/aspect",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/io-query"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, topics, _AlfDocumentListTopicMixin,
-                 DynamicWidgetProcessingTopics, AlfDocumentListView, AlfCheckableMenuItem, array, lang, domConstruct, domClass, ioQuery) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, topics, SelectedItemStateMixin,
+                 DynamicWidgetProcessingTopics, AlfDocumentListView, AlfCheckableMenuItem, aspect, array, lang, domConstruct, 
+                 domClass, ioQuery) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, _AlfDocumentListTopicMixin, DynamicWidgetProcessingTopics], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, SelectedItemStateMixin, DynamicWidgetProcessingTopics], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -181,7 +183,7 @@ define(["dojo/_base/declare",
          {
             this.alfSubscribe(this.scrollNearBottom, lang.hitch(this, this.onScrollNearBottom));
          }
-         this.alfSubscribe(this.selectedDocumentsChangeTopic, lang.hitch(this, this.onSelectedItemsChange));
+         this.createSelectedItemSubscriptions();
       },
 
       /**
@@ -612,6 +614,13 @@ define(["dojo/_base/declare",
          // Attempt to get a localized version of the label...
          viewSelectionConfig.label = this.message(viewSelectionConfig.label);
 
+         // After a view has been rendered publish the selected items to ensure
+         // that selection consistency has been maintained. This approach also ensures
+         // that where views re-render themselves (e.g. resizing a gallery view)
+         // that selection will be maintained even if the underlying renderer is destroyed
+         // and recreated...
+         aspect.after(view, "renderView", lang.hitch(this, this.publishSelectedItems));
+
          // Publish the additional controls...
          this.publishAdditionalControls(viewName, view);
 
@@ -729,36 +738,6 @@ define(["dojo/_base/declare",
       currentData: null,
 
       /**
-       * Used to keep track of the items that are currently selected in order to ensure that those items are selected on 
-       * the next view displayed when switching views.
-       * 
-       * @instance
-       * @type {object[]}
-       * @default
-       * @since 1.0.35
-       */
-      selectedItems: null,
-
-      /**
-       * Tracks the currently selected items and stores them as the [selectedItems]{@link module:alfresco/lists/AlfList#selectedItems}
-       * variable.
-       * 
-       * @instance
-       * @param  {object} payload A payload expected to contain a "selectedItems" attribute
-       * @since 1.0.35
-       */
-      onSelectedItemsChange: function alfresco_lists_AlfList__onSelectedItemsChange(payload) {
-         if (payload.selectedItems)
-         {
-            this.selectedItems = payload.selectedItems;
-         }
-         else
-         {
-            this.alfLog("warn", "A publication was made indicating an item selection update, but no 'selectedItems' attribute was provided in the payload", payload, this);
-         }
-      },
-
-      /**
        * Handles requests to switch views. This is called whenever the [viewSelectionTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#viewSelectionTopic}
        * topic is published on and expects a payload containing an attribute "value" which should map to a registered
        * [view]{@link module:alfresco/lists/views/AlfListView}. The views are mapped against the index they were configured
@@ -801,12 +780,6 @@ define(["dojo/_base/declare",
                newView.currentData.previousItemCount = 0;
                newView.renderView(false);
                this.showView(newView);
-
-               // Publish the selected items when the view changes in order that item selection is maintained 
-               // between views...
-               this.alfPublish(topics.DOCUMENT_SELECTION_UPDATE, {
-                  selectedItems: this.selectedItems
-               });
             }
             else
             {

--- a/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
@@ -101,7 +101,7 @@ define(["dojo/_base/declare",
        * selected items occurs.
        *
        * @instance
-       * @type {timeout}
+       * @type {number}
        * @default
        */
       selectionTimeout: null,
@@ -121,7 +121,7 @@ define(["dojo/_base/declare",
        * This is called from [onItemSelected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemSelected}
        * when the [selectionTimeout]{@link module:alfresco/lists/SelectedItemStateMixin#selectionTimeout} times out. It
        * resets the [selectionTimeout]{@link module:alfresco/lists/SelectedItemStateMixin#selectionTimeout} to null and
-       * calls [onselectedItemsChanged]{@link module:alfresco/lists/SelectedItemStateMixin#deselectionTimeout}
+       * calls [onSelectedItemsChanged]{@link module:alfresco/lists/SelectedItemStateMixin#deselectionTimeout}
        *
        * @instance
        */

--- a/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
@@ -42,10 +42,11 @@ define(["dojo/_base/declare",
    return declare([Core, _AlfDocumentListTopicMixin], {
       
       /**
-       * This is used to keep track of the documents that are currently selected. It is initialised to an empty
-       * array in the constructor, [onItemSelected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemSelected} 
-       * adds elements and the [onItemDeselected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemDeselected} 
-       * removes them.
+       * This is used to keep track of the items that are currently selected. 
+       * [onItemSelected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemSelected} 
+       * adds items and the [onItemDeselected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemDeselected} 
+       * removes them. The [itemKeyProperty]{@link module:alfresco/lists/SelectedItemStateMixin#itemKeyProperty} 
+       * is used as the key and the entire item is the value.
        *
        * @instance
        * @type {object}
@@ -84,13 +85,10 @@ define(["dojo/_base/declare",
       itemKeyProperty: "node.nodeRef",
 
       /**
-       * An array of the [itemKeyProperty]{@link module:alfresco/lists/SelectedItemStateMixin#itemKeyProperty}
-       * attributes taken from each entry in the 
-       * [currentlySelectedItems]{@link module:alfresco/lists/SelectedItemStateMixin#currentlySelectedItems}
-       * map.
+       * An array of the currently selected items.
        * 
        * @instance
-       * @type {string[]}
+       * @type {object[]}
        * @default
        */
       selectedItems: null,

--- a/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
@@ -1,0 +1,261 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>This module can be mixed into widgets that need to maintain the state of any selected items. Item
+ * selection is typically actioned by either individual [Selector]{@link module:alfresco/renderers/Selector}
+ * widgets in a [list]{@link module:alfresco/lists/AlfList} or by a menu action such as the ones provided by
+ * the [AlfSelectDocumentListItems]{@link module:alfresco/documentlibrary/AlfSelectDocumentListItems}.</P>
+ * <p>Mixing modules should call the 
+ * [createSelectedItemSubscriptions]{@link module:alfresco/lists/SelectedItemStateMixin#createSelectedItemSubscriptions}
+ * on creation to keep track of selected items. The can also call the 
+ * [publishSelectedItems]{@link module:alfresco/lists/SelectedItemStateMixin#publishSelectedItems} function
+ * to broadcast the details of changes to item selection.</p>
+ * 
+ * @module alfresco/lists/SelectedItemStateMixin
+ * @author Dave Draper
+ * @since 1.0.39
+ */
+define(["dojo/_base/declare",
+        "alfresco/core/Core",
+        "alfresco/core/topics",
+        "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
+        "dojo/_base/lang"], 
+        function( declare, Core, topics, _AlfDocumentListTopicMixin, lang) {
+   
+   return declare([Core, _AlfDocumentListTopicMixin], {
+      
+      /**
+       * This is used to keep track of the documents that are currently selected. It is initialised to an empty
+       * array in the constructor, [onItemSelected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemSelected} 
+       * adds elements and the [onItemDeselected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemDeselected} 
+       * removes them.
+       *
+       * @instance
+       * @type {object}
+       * @default
+       */
+      currentlySelectedItems: null,
+
+      /**
+       * The number of milliseconds to wait after a selection event before publishing the latest selected item
+       * data.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      debounceTime: 50,
+
+      /**
+       * Indicates whether or not the the [disable]{@link module:alfresco/lists/SelectedItemStateMixin#disable}
+       * function should be called when no items are selected.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      disableWhenNothingSelected: false,
+
+      /**
+       * This is the dot-notation addressed property within the selection/de-selection publication payload that
+       * uniquely identifies the item.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      itemKeyProperty: "node.nodeRef",
+
+      /**
+       * An array of the [itemKeyProperty]{@link module:alfresco/lists/SelectedItemStateMixin#itemKeyProperty}
+       * attributes taken from each entry in the 
+       * [currentlySelectedItems]{@link module:alfresco/lists/SelectedItemStateMixin#currentlySelectedItems}
+       * map.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       */
+      selectedItems: null,
+
+      /**
+       * This is used to keep a reference to a timeout that is started on the publication of a selected document
+       * topic. It is important that multiple selection events can be captured so that only one publication of
+       * selected items occurs.
+       *
+       * @instance
+       * @type {timeout}
+       * @default
+       */
+      selectionTimeout: null,
+
+      /**
+       * 
+       * @instance
+       */
+      createSelectedItemSubscriptions: function alfresco_lists_SelectedItemStateMixin__createSelectedItemSubscriptions() {
+         this.currentlySelectedItems = {};
+         this.alfSubscribe(this.documentSelectedTopic, lang.hitch(this, this.onItemSelected));
+         this.alfSubscribe(this.documentDeselectedTopic, lang.hitch(this, this.onItemDeselected));
+         this.alfSubscribe(topics.CLEAR_SELECTED_ITEMS, lang.hitch(this, this.onItemSelectionCleared));
+      },
+
+      /**
+       * This is called from [onItemSelected]{@link module:alfresco/lists/SelectedItemStateMixin#onItemSelected}
+       * when the [selectionTimeout]{@link module:alfresco/lists/SelectedItemStateMixin#selectionTimeout} times out. It
+       * resets the [selectionTimeout]{@link module:alfresco/lists/SelectedItemStateMixin#selectionTimeout} to null and
+       * calls [onselectedItemsChanged]{@link module:alfresco/lists/SelectedItemStateMixin#deselectionTimeout}
+       *
+       * @instance
+       */
+      deferredSelectionHandler: function alfresco_lists_SelectedItemStateMixin__deferredSelectionHandler() {
+         this.selectedItems = [];
+         for (var key in this.currentlySelectedItems)
+         {
+            if (this.currentlySelectedItems.hasOwnProperty(key)) {
+               this.selectedItems.push(this.currentlySelectedItems[key]);
+            }
+         }
+         if (this.disableWhenNothingSelected)
+         {
+            this.disable(this.selectedItems.length === 0);
+         }
+         
+         this.publishSelectedItems(this.selectedItems);
+         this.selectionTimeout = null;
+      },
+
+      /**
+       * This function is called if 
+       * [disableWhenNothingSelected]{@link module:alfresco/lists/SelectedItemStateMixin#disableWhenNothingSelected}
+       * is configured to be true and a selection update occurs that results in no items being selected. By
+       * default it will attempt to toggle the disable state of the widget.
+       *
+       * @instance
+       * @param {boolean} disable Indicates whether to disable or enable the widget
+       * @overridable
+       */
+      disable: function alfresco_lists_SelectedItemStateMixin__disable(disable) {
+         this.set("disabled", disable);
+      },
+
+      /**
+       * Updates the array of documents that are currently selected.
+       *
+       * @instance
+       * @param {object} payload The details of the item selected
+       */
+      onItemDeselected: function alfresco_lists_SelectedItemStateMixin__onItemDeselected(payload) {
+         if (payload && payload.value)
+         {
+            var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
+            if (itemKey)
+            {
+               delete this.currentlySelectedItems[itemKey];
+               if (this.selectionTimeout)
+               {
+                  clearTimeout(this.selectionTimeout);
+               }
+               this.selectionTimeout = setTimeout(lang.hitch(this, this.deferredSelectionHandler), this.debounceTime);
+            }
+            else
+            {
+               this.alfLog("warn", "Could not find item key property: '" + this.itemKeyProperty + "' in deselected item value", payload, this);
+            }
+         }
+      },
+
+      /**
+       * Updates the aray of documents that are currently selected.
+       * @instance
+       * @param {object} payload The details of the document selected
+       */
+      onItemSelected: function alfresco_lists_SelectedItemStateMixin__onItemSelected(payload) {
+         if (payload && payload.value)
+         {
+            var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
+            if (itemKey)
+            {
+               this.currentlySelectedItems[itemKey] = payload.value;
+               if (this.selectionTimeout)
+               {
+                  clearTimeout(this.selectionTimeout);
+               }
+               this.selectionTimeout = setTimeout(lang.hitch(this, this.deferredSelectionHandler), 50);
+            }
+            else
+            {
+               this.alfLog("warn", "Could not find item key property: '" + this.itemKeyProperty + "' in selected item value", payload, this);
+            }
+         }
+      },
+
+      /**
+       * This clears the currently selected items. It it bound to the 
+       * [CLEAR_SELECTED_ITEMS topic]{@link module:alfresco/core/topics#CLEAR_SELECTED_ITEMS} that is published
+       * by the [AlfSelectedItemsMenuItem]{@link module:alfresco/menus/AlfSelectedItemsMenuItem} when clicked.
+       *
+       * @instance
+       * @param {object} payload This is not expected to contain any usable data.
+       */
+      onItemSelectionCleared: function alfresco_lists_SelectedItemStateMixin__onItemSelectionCleared(/*jshint unused:false*/ payload) {
+         this.currentlySelectedItems = {};
+         if (this.selectionTimeout)
+         {
+            clearTimeout(this.selectionTimeout);
+         }
+         this.selectionTimeout = setTimeout(lang.hitch(this, this.deferredSelectionHandler), 50);
+      },
+
+      /**
+       * Tracks the currently selected items and stores them as the 
+       * [selectedItems]{@link module:alfresco/lists/SelectedItemStateMixin#selectedItems} variable.
+       * 
+       * @instance
+       * @param  {object} payload A payload expected to contain a "selectedItems" attribute
+       */
+      onSelectedItemsChange: function alfresco_lists_SelectedItemStateMixin__onSelectedItemsChange(payload) {
+         if (payload.selectedItems)
+         {
+            this.selectedItems = payload.selectedItems;
+         }
+         else
+         {
+            this.alfLog("warn", "A publication was made indicating an item selection update, but no 'selectedItems' attribute was provided in the payload", payload, this);
+         }
+      },
+
+      /**
+       * This is called from the [deferredSelectionHandler]{@link module:alfresco/lists/SelectedItemStateMixin#deferredSelectionHandler}
+       * function and publishes on the [selectedDocumentsChangeTopic]
+       * {@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#selectedDocumentsChangeTopic}.
+       *
+       * @instance
+       */
+      publishSelectedItems: function alfresco_lists_SelectedItemStateMixin__publishSelectedItems() {
+         this.alfPublish(this.selectedDocumentsChangeTopic, {
+            selectedItems: this.selectedItems
+         });
+         this.alfPublish(this.documentSelectionTopic, {
+            selectedItems: this.selectedItems
+         });
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
@@ -135,7 +135,7 @@ define(["dojo/_base/declare",
          }
          if (this.disableWhenNothingSelected)
          {
-            this.disable(this.selectedItems.length === 0);
+            this.setDisabled(this.selectedItems.length === 0);
          }
          
          this.publishSelectedItems(this.selectedItems);
@@ -152,7 +152,7 @@ define(["dojo/_base/declare",
        * @param {boolean} disable Indicates whether to disable or enable the widget
        * @overridable
        */
-      disable: function alfresco_lists_SelectedItemStateMixin__disable(disable) {
+      setDisabled: function alfresco_lists_SelectedItemStateMixin__setDisabled(disable) {
          this.set("disabled", disable);
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/Selector.js
+++ b/aikau/src/main/resources/alfresco/renderers/Selector.js
@@ -144,7 +144,8 @@ define(["dojo/_base/declare",
                   var b = lang.getObject(this.itemKey, false, this.currentItem);
                   var match = ((a || a === 0) && a === b);
                   if (match) {
-                     this.select();
+                     domClass.add(this.selectorNode, "checked");
+                     domClass.remove(this.selectorNode, "unchecked");
                   }
                   return match;
                }, this);

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -173,7 +173,7 @@ define(["dojo/_base/declare",
       onDocumentsLoaded: function alfresco_services_ActionService__onDocumentsLoaded(payload) {
          this.alfLog("log", "New Documents Loaded", payload);
          this.currentlySelectedDocuments = {};
-         this.onSelectedFilesChanged();
+         this.onselectedItemsChanged();
       },
 
       /**
@@ -332,12 +332,12 @@ define(["dojo/_base/declare",
        * This is called from [onDocumentSelected]{@link module:alfresco/services/ActionService#onDocumentSelected}
        * when the [selectionTimeout]{@link module:alfresco/services/ActionService#selectionTimeout} times out. It
        * rests the [selectionTimeout]{@link module:alfresco/services/ActionService#selectionTimeout} to null and
-       * calls [onSelectedFilesChanged]{@link module:alfresco/services/ActionService#deselectionTimeout}
+       * calls [onselectedItemsChanged]{@link module:alfresco/services/ActionService#deselectionTimeout}
        *
        * @instance
        */
       deferredSelectionHandler: function alfresco_services_ActionService__deferredSelectionHandler() {
-         this.onSelectedFilesChanged();
+         this.onselectedItemsChanged();
          this.selectionTimeout = null;
       },
 
@@ -385,7 +385,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      onSelectedFilesChanged: function alfresco_services_ActionService__onSelectedFilesChanged() {
+      onselectedItemsChanged: function alfresco_services_ActionService__onselectedItemsChanged() {
          /*jshint maxcomplexity:false*/
          var files = this.getSelectedDocumentArray(), fileTypes = [], file,
              fileType, userAccess = {}, fileAccess, index,
@@ -449,7 +449,7 @@ define(["dojo/_base/declare",
 
          // Publish the information about the actions so that menu items can be filtered...
          this.alfPublish(this.selectedDocumentsChangeTopic, {
-            selectedFiles: files,
+            selectedItems: files,
             userAccess: userAccess,
             commonAspects: commonAspects,
             allAspects: allAspects

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -173,7 +173,7 @@ define(["dojo/_base/declare",
       onDocumentsLoaded: function alfresco_services_ActionService__onDocumentsLoaded(payload) {
          this.alfLog("log", "New Documents Loaded", payload);
          this.currentlySelectedDocuments = {};
-         this.onselectedItemsChanged();
+         this.onSelectedItemsChanged();
       },
 
       /**
@@ -332,12 +332,12 @@ define(["dojo/_base/declare",
        * This is called from [onDocumentSelected]{@link module:alfresco/services/ActionService#onDocumentSelected}
        * when the [selectionTimeout]{@link module:alfresco/services/ActionService#selectionTimeout} times out. It
        * rests the [selectionTimeout]{@link module:alfresco/services/ActionService#selectionTimeout} to null and
-       * calls [onselectedItemsChanged]{@link module:alfresco/services/ActionService#deselectionTimeout}
+       * calls [onSelectedItemsChanged]{@link module:alfresco/services/ActionService#deselectionTimeout}
        *
        * @instance
        */
       deferredSelectionHandler: function alfresco_services_ActionService__deferredSelectionHandler() {
-         this.onselectedItemsChanged();
+         this.onSelectedItemsChanged();
          this.selectionTimeout = null;
       },
 
@@ -385,7 +385,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      onselectedItemsChanged: function alfresco_services_ActionService__onselectedItemsChanged() {
+      onSelectedItemsChanged: function alfresco_services_ActionService__onSelectedItemsChanged() {
          /*jshint maxcomplexity:false*/
          var files = this.getSelectedDocumentArray(), fileTypes = [], file,
              fileType, userAccess = {}, fileAccess, index,

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -26,7 +26,7 @@ function getSyncMode() {
 function getUserDocLibPreferences() {
 
    // Initialise some default preferences...
-   var docLibPrefrences = {
+   var docLibPreferences = {
       viewRendererName: "detailed",
       sortField: "cm:name",
       sortAscending: true,
@@ -60,32 +60,32 @@ function getUserDocLibPreferences() {
           prefs.org.alfresco.share.documentList)
       {
          var dlp = prefs.org.alfresco.share.documentList;
-         docLibPrefrences.viewRendererName = dlp.viewRendererName || "detailed";
-         docLibPrefrences.sortField = dlp.sortField || "cm:name";
-         docLibPrefrences.sortAscending = dlp.sortAscending !== false;
-         docLibPrefrences.showFolders = dlp.showFolders !== false;
-         docLibPrefrences.hideBreadcrumbTrail = dlp.hideNavBar === true;
-         docLibPrefrences.showSidebar = dlp.showSidebar !== false;
-         docLibPrefrences.galleryColumns = dlp.galleryColumns || 4;
-         docLibPrefrences.sideBarWidth = prefs.org.alfresco.sideBarWidth || 350;
+         docLibPreferences.viewRendererName = dlp.viewRendererName || "detailed";
+         docLibPreferences.sortField = dlp.sortField || "cm:name";
+         docLibPreferences.sortAscending = dlp.sortAscending !== false;
+         docLibPreferences.showFolders = dlp.showFolders !== false;
+         docLibPreferences.hideBreadcrumbTrail = dlp.hideNavBar === true;
+         docLibPreferences.showSidebar = dlp.showSidebar !== false;
+         docLibPreferences.galleryColumns = dlp.galleryColumns || 4;
+         docLibPreferences.sideBarWidth = prefs.org.alfresco.sideBarWidth || 350;
       }
    }
-   return docLibPrefrences;
+   return docLibPreferences;
 }
 
 function setupDocLibPreferences(options) {
-   if (options.docLibPrefrences)
+   if (options.docLibPreferences)
    {
       // Preferences have already been setup - no action required.
    }
    else if (options.getUserPreferences !== false)
    {
-      options.docLibPrefrences = getUserDocLibPreferences();
+      options.docLibPreferences = getUserDocLibPreferences();
    }
    else
    {
       // ...otherwise just define some sensible defaults
-      options.docLibPrefrences = {
+      options.docLibPreferences = {
          viewRendererName: "detailed",
          sortField: "cm:name",
          sortAscending: true,
@@ -919,7 +919,7 @@ function getDocLibSortOptions(options, sortingConfigItems) {
                value: valueTokens[0],
                group: "DOCUMENT_LIBRARY_SORT_FIELD",
                publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
-               checked: options.docLibPrefrences.sortField === valueTokens[0],
+               checked: options.docLibPreferences.sortField === valueTokens[0],
                publishPayload: {
                   label: msg.get(sortLabel),
                   direction: valueTokens[1] || null
@@ -994,7 +994,7 @@ function getDocLibConfigMenu(options) {
                         config: {
                            label: msg.get("show-folders.label"),
                            iconClass: "alf-showfolders-icon",
-                           checked: options.docLibPrefrences.showFolders,
+                           checked: options.docLibPreferences.showFolders,
                            publishTopic: "ALF_DOCLIST_SHOW_FOLDERS"
                         }
                      },
@@ -1003,7 +1003,7 @@ function getDocLibConfigMenu(options) {
                         name: "alfresco/menus/AlfCheckableMenuItem",
                         config: {
                            label: msg.get("show-path.label"),
-                           checked: !options.docLibPrefrences.hideBreadcrumbTrail,
+                           checked: !options.docLibPreferences.hideBreadcrumbTrail,
                            iconClass: "alf-showpath-icon",
                            publishTopic: "ALF_DOCLIST_SHOW_PATH"
                         }
@@ -1014,7 +1014,7 @@ function getDocLibConfigMenu(options) {
                         config: {
                            label: msg.get("show-sidebar.label"),
                            iconClass: "alf-showsidebar-icon",
-                           checked: options.docLibPrefrences.showSidebar,
+                           checked: options.docLibPreferences.showSidebar,
                            publishTopic: "ALF_DOCLIST_SHOW_SIDEBAR"
                         }
                      }
@@ -1050,10 +1050,10 @@ function getDocLibList(options) {
          containerId: options.containerId,
          rootNode: options.rootNode,
          usePagination: true,
-         showFolders: options.docLibPrefrences.showFolders,
-         sortAscending: options.docLibPrefrences.sortAscending,
-         sortField: options.docLibPrefrences.sortField,
-         view: options.docLibPrefrences.viewRendererName,
+         showFolders: options.docLibPreferences.showFolders,
+         sortAscending: options.docLibPreferences.sortAscending,
+         sortField: options.docLibPreferences.sortField,
+         view: options.docLibPreferences.viewRendererName,
          widgets: [
             {
                name: "alfresco/documentlibrary/views/AlfSimpleView"
@@ -1064,7 +1064,7 @@ function getDocLibList(options) {
             {
                name: "alfresco/documentlibrary/views/AlfGalleryView",
                config: {
-                  columns: options.docLibPrefrences.galleryColumns
+                  columns: options.docLibPreferences.galleryColumns || 4
                }
             },
             {
@@ -1128,7 +1128,7 @@ function getDocLibToolbar(options) {
                         id: (options.idPrefix || "") + "DOCLIB_SORT_ORDER_TOGGLE",
                         name: "alfresco/menus/AlfMenuBarToggle",
                         config: {
-                           checked: options.docLibPrefrences.sortAscending,
+                           checked: options.docLibPreferences.sortAscending,
                            onConfig: {
                               iconClass: "alf-sort-ascending-icon",
                               publishTopic: "ALF_DOCLIST_SORT",
@@ -1178,7 +1178,7 @@ function getDocLibBreadcrumbTrail(options) {
       id: (options.idPrefix || "") + "DOCLIB_BREADCRUMB_TRAIL",
       name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
       config: {
-         hide: options.docLibPrefrences.hideBreadcrumbTrail,
+         hide: options.docLibPreferences.hideBreadcrumbTrail,
          rootLabel: options.rootLabel || "root.label",
          lastBreadcrumbIsCurrentNode: true,
          useHash: (options.useHash !== false),
@@ -1242,7 +1242,7 @@ function getDocLib(options) {
       id: (options.idPrefix || "") + "DOCLIB_SIDEBAR",
       name: "alfresco/layout/AlfSideBarContainer",
       config: {
-         showSidebar: options.docLibPrefrences.showSidebar,
+         showSidebar: options.docLibPreferences.showSidebar,
          customResizeTopics: ["ALF_DOCLIST_READY","ALF_RESIZE_SIDEBAR"],
          footerHeight: 50,
          widgets: [

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
@@ -26,213 +26,229 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "intern/chai!expect",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, expect, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "GalleryView Tests",
-      
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/GalleryView", "Gallery View Tests (Resizing)").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
-      
-      "Test gallery view resize slider is displayed": function() {
-         return browser.findByCssSelector("#TOOLBAR .alfresco-documentlibrary-AlfGalleryViewSlider")
-            .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === true, "The gallery view slider was found but is not displayed");
-            });
-      },
-      
-      "Test initial layout": function() {
-         // NOTE: That gallery view has been configured to have a non-default number of columns, 7 instead of 4...
-         // Check that the page has been initialised with 7 items per row...
-         return browser.findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
-            .then(function(elements) {
-               assert.lengthOf(elements, 7, "The view initially displays an unexpected number of items per row");
-            });
-      },
-      
-      "Test slider change decreases items per row": function() {
-         // Increment the view size and check that the number of of items per row has decreased to 4....
-         return browser.findByCssSelector("#TOOLBAR .dijitSliderIncrementIconH")
-            .clearLog()
-            .click()
-         .end()
-         .getLastPublish("ALF_PREFERENCE_SET", "Preference not set")
-         .end()
-         .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "The number of items per row was not decreased");
-            });
-      },
-      
-      "Test slider change increases items per row (show 7)": function() {
-         // Decrement the view size and check the number of items per row increases...
-         return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
-            .click()
-         .end()
-         .getLastPublish("HAS_ITEMS_ALF_DOCLIST_SET_GALLERY_COLUMNS")
-         .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
-            .then(function(elements) {
-               assert.lengthOf(elements, 7, "The number of items per row was not increased");
-            });
-      },
-      
-      "Test slider change increases items per row (show 10)": function() {
-         return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
-            .click()
-         .end()
-         .getLastPublish("HAS_ITEMS_ALF_DOCLIST_SET_GALLERY_COLUMNS")
-         .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
-            .then(function(elements) {
-               assert.lengthOf(elements, 10, "The number of items per row was not increased");
-            });
-      },
-      
-      "Test 'no-items' slider exists": function() {
-         // Check that the 2nd AlfGalleryViewSlider is hidden because there are no items...
-         return browser.findByCssSelector("#TOOLBAR_NO_ITEMS .alfresco-documentlibrary-AlfGalleryViewSlider")
-            .then(null, function() {
-               assert(false, "The 'no-items' gallery view slider was not found");
-            });
-      },
-      
-      "Test 'no-items' slider is not displayed": function() {
-         // Check that the 2nd AlfGalleryViewSlider is hidden because there are no items...
-         return browser.findByCssSelector("#TOOLBAR_NO_ITEMS .alfresco-documentlibrary-AlfGalleryViewSlider")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "The 'no-items' gallery view slider was found but should be hidden");
-            });
-      },
+      return {
+         name: "GalleryView Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/GalleryView", "Gallery View Tests (Resizing)").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "Test gallery view resize slider is displayed": function() {
+            return browser.findByCssSelector("#TOOLBAR .alfresco-documentlibrary-AlfGalleryViewSlider")
+               .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED")
+               .isDisplayed()
+               .then(function(result) {
+                  assert(result === true, "The gallery view slider was found but is not displayed");
+               });
+         },
+         
+         "Test initial layout": function() {
+            // NOTE: That gallery view has been configured to have a non-default number of columns, 7 instead of 4...
+            // Check that the page has been initialised with 7 items per row...
+            return browser.findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 7, "The view initially displays an unexpected number of items per row");
+               });
+         },
+         
+         "Test slider change decreases items per row": function() {
+            // Increment the view size and check that the number of of items per row has decreased to 4....
+            return browser.findByCssSelector("#TOOLBAR .dijitSliderIncrementIconH")
+               .clearLog()
+               .click()
+            .end()
+            .getLastPublish("ALF_PREFERENCE_SET", "Preference not set")
+            .end()
+            .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "The number of items per row was not decreased");
+               });
+         },
+         
+         "Test slider change increases items per row (show 7)": function() {
+            // Decrement the view size and check the number of items per row increases...
+            return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
+               .click()
+            .end()
+            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+            .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 7, "The number of items per row was not increased");
+               });
+         },
+         
+         "Test slider change increases items per row (show 10)": function() {
+            return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
+               .click()
+            .end()
+            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_SET_GALLERY_COLUMNS")
+            .findAllByCssSelector("#DOCLIST .alfresco-lists-views-layouts-Grid > tr:first-child > td")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 10, "The number of items per row was not increased");
+               });
+         },
+         
+         "Test 'no-items' slider exists": function() {
+            // Check that the 2nd AlfGalleryViewSlider is hidden because there are no items...
+            return browser.findByCssSelector("#TOOLBAR_NO_ITEMS .alfresco-documentlibrary-AlfGalleryViewSlider")
+               .then(null, function() {
+                  assert(false, "The 'no-items' gallery view slider was not found");
+               });
+         },
+         
+         "Test 'no-items' slider is not displayed": function() {
+            // Check that the 2nd AlfGalleryViewSlider is hidden because there are no items...
+            return browser.findByCssSelector("#TOOLBAR_NO_ITEMS .alfresco-documentlibrary-AlfGalleryViewSlider")
+               .isDisplayed()
+               .then(function(result) {
+                  assert(result === false, "The 'no-items' gallery view slider was found but should be hidden");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-registerSuite(function(){
-   var browser;
-   var alfPause = 500;
+   registerSuite(function(){
+      var browser;
+      var alfPause = 500;
 
-   return {
-      name: "GalleryView Keyboard Tests",
-      
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/GalleryView", "Gallery View Tests (Keyboard Navigation)")
-         // Using the slider ensures everything is setup for keyboard navigation
-         .findByCssSelector("#TOOLBAR .dijitSliderIncrementIconH")
-            .click()
-         .end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
-      
-      "Test selecting first item (Folder 1)": function () {
-         return browser.findByCssSelector("body")
-            .tabToElement(".alfresco-lists-views-layouts-Grid tr:first-child td:first-child .alfresco-renderers-Thumbnail .alfresco-renderers-Selector")
-            .pressKeys(keys.SPACE)
-            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
+      return {
+         name: "GalleryView Keyboard Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/GalleryView", "Gallery View Tests (Keyboard Navigation)")
+            // Using the slider ensures everything is setup for keyboard navigation
+            .findByCssSelector("#TOOLBAR .dijitSliderIncrementIconH")
+               .click()
+            .end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "Test selecting first item (Folder 1)": function () {
+            return browser.findByCssSelector("body")
+               .tabToElement(".alfresco-lists-views-layouts-Grid tr:first-child td:first-child .alfresco-renderers-Thumbnail .alfresco-renderers-Selector")
+               .pressKeys(keys.SPACE)
+               .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
+                  .then(function(payload) {
+                     assert.deepPropertyVal(payload, "value.displayName", "Folder 1", "The wrong document was selected");
+                  });
+         },
+
+         "Check selector click doesn't navigate": function() {
+            return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_NAVIGATE_TO_PAGE","publish","any"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Should not have been able to find a navigation request");
+               });
+         },
+         
+         "Test showing more info on first thumbnail": function() {
+            // 3. Display the More Info dialog...
+            return browser.pressKeys(keys.TAB)
+            .sleep(alfPause)
+            .pressKeys(keys.RETURN)
+            .findByCssSelector(".alfresco-dialog-AlfDialog .dijitDialogTitleBar > span")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "Folder 1", "The More Info dialog was not displayed");
+               });
+         },
+         
+         "Test moving to second row (Wiki Page)": function() {
+            return browser.sleep(alfPause)
+               .pressKeys(keys.ESCAPE)
+               .sleep(alfPause)
+               // 4. Use the keys to move around...
+               .pressKeys(keys.ARROW_DOWN)
+               .sleep(alfPause)
+               .pressKeys(keys.TAB)
+               .sleep(alfPause)
+               .pressKeys(keys.SPACE)
+               .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "value.displayName", "Wiki Page", "The wrong document was selected");
+               });
+         },
+         
+         "Test left cursor moves to last item on first row (Calendar Event)": function() {
+            return browser.sleep(alfPause)
+               .pressKeys(keys.ARROW_LEFT)
+               .sleep(alfPause)
+               .pressKeys(keys.TAB)
+               .sleep(alfPause)
+               .pressKeys(keys.SPACE)
+               .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "value.displayName", "Calendar Event", "The wrong document was selected");
+               });
+         },
+         
+         "Test up cursor loops to bottom (Folder 4)": function() {
+            return browser.sleep(alfPause)
+               .pressKeys(keys.ARROW_UP)
+               .sleep(alfPause)
+               .pressKeys(keys.TAB)
+               .sleep(alfPause)
+               .pressKeys(keys.SPACE)
+               .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "value.displayName", "Folder 4", "The wrong document was selected");
+               });
+         },
+         
+         "Test right cursor on last item loops to first item (Folder 1)": function() {
+            return browser.sleep(alfPause)
+               .pressKeys(keys.ARROW_RIGHT)
+               .sleep(alfPause)
+               .pressKeys(keys.TAB)
+               .sleep(alfPause)
+               .pressKeys(keys.SPACE)
+               .sleep(alfPause)
+               .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_DESELECTED")
                .then(function(payload) {
                   assert.deepPropertyVal(payload, "value.displayName", "Folder 1", "The wrong document was selected");
+               })
+               .clearLog();
+         },
+
+         "Resize and check the selections": function() {
+            return browser.findByCssSelector("#TOOLBAR .dijitSliderDecrementIconH")
+               .click()
+            .end()
+            .getLastPublish("HAS_ITEMS_ALF_SELECTED_FILES_CHANGED")
+               .then(function(payload) {
+                  var nodeRefs = [];
+                  payload.selectedItems.forEach(function(item) {
+                     nodeRefs.push(item.nodeRef);
+                  });
+                  assert.lengthOf(nodeRefs, 3, "Unexpected number of selected items");
+                  assert.include(nodeRefs, "dummy://nodeRef/4", "Couldn't find selected calendar event");
+                  assert.include(nodeRefs, "dummy://nodeRef/5", "Couldn't find selected wiki page");
+                  assert.include(nodeRefs, "dummy://nodeRef/11", "Couldn't find selected folder");
                });
-      },
+         },
 
-      "Check selector click doesn't navigate": function() {
-         return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_NAVIGATE_TO_PAGE","publish","any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Should not have been able to find a navigation request");
-            });
-      },
-      
-      "Test showing more info on first thumbnail": function() {
-         // 3. Display the More Info dialog...
-         return browser.pressKeys(keys.TAB)
-         .sleep(alfPause)
-         .pressKeys(keys.RETURN)
-         .findByCssSelector(".alfresco-dialog-AlfDialog .dijitDialogTitleBar > span")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Folder 1", "The More Info dialog was not displayed");
-            });
-      },
-      
-      "Test moving to second row (Wiki Page)": function() {
-         return browser.sleep(alfPause)
-            .pressKeys(keys.ESCAPE)
-            .sleep(alfPause)
-            // 4. Use the keys to move around...
-            .pressKeys(keys.ARROW_DOWN)
-            .sleep(alfPause)
-            .pressKeys(keys.TAB)
-            .sleep(alfPause)
-            .pressKeys(keys.SPACE)
-            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
-            .then(function(payload) {
-               assert.deepPropertyVal(payload, "value.displayName", "Wiki Page", "The wrong document was selected");
-            });
-      },
-      
-      "Test left cursor moves to last item on first row (Calendar Event)": function() {
-         return browser.sleep(alfPause)
-            .pressKeys(keys.ARROW_LEFT)
-            .sleep(alfPause)
-            .pressKeys(keys.TAB)
-            .sleep(alfPause)
-            .pressKeys(keys.SPACE)
-            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
-            .then(function(payload) {
-               assert.deepPropertyVal(payload, "value.displayName", "Calendar Event", "The wrong document was selected");
-            });
-      },
-      
-      "Test up cursor loops to bottom (Folder 4)": function() {
-         return browser.sleep(alfPause)
-            .pressKeys(keys.ARROW_UP)
-            .sleep(alfPause)
-            .pressKeys(keys.TAB)
-            .sleep(alfPause)
-            .pressKeys(keys.SPACE)
-            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
-            .then(function(payload) {
-               assert.deepPropertyVal(payload, "value.displayName", "Folder 4", "The wrong document was selected");
-            });
-      },
-      
-      "Test right cursor on last item loops to first item (Folder 1)": function() {
-         return browser.sleep(alfPause)
-            .pressKeys(keys.ARROW_RIGHT)
-            .sleep(alfPause)
-            .pressKeys(keys.TAB)
-            .sleep(alfPause)
-            .pressKeys(keys.SPACE)
-            .sleep(alfPause)
-            .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_DESELECTED")
-            .then(function(payload) {
-               assert.deepPropertyVal(payload, "value.displayName", "Folder 1", "The wrong document was selected");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ActionServiceTest.js
@@ -50,8 +50,8 @@ registerSuite(function(){
 
             .getLastPublish("ALF_SELECTED_FILES_CHANGED", "Selected files change not published")
                .then(function(payload) {
-                  assert.lengthOf(payload.selectedFiles, 1, "Should have one node selected");
-                  assert.deepPropertyVal(payload, "selectedFiles[0].node.nodeRef", "workspace://SpacesStore/b0037179-f105-4858-9d8f-44bfb0f67d8a", "Incorrect node selected");
+                  assert.lengthOf(payload.selectedItems, 1, "Should have one node selected");
+                  assert.deepPropertyVal(payload, "selectedItems[0].node.nodeRef", "workspace://SpacesStore/b0037179-f105-4858-9d8f-44bfb0f67d8a", "Incorrect node selected");
                });
          },
 
@@ -62,7 +62,7 @@ registerSuite(function(){
 
             .getLastPublish("ALF_SELECTED_FILES_CHANGED", "Selected files change not published")
                .then(function(payload) {
-                  assert.lengthOf(payload.selectedFiles, 0, "Should not have a current selected node");
+                  assert.lengthOf(payload.selectedItems, 0, "Should not have a current selected node");
                });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SelectedItemsMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SelectedItemsMenu.get.js
@@ -69,6 +69,7 @@ model.jsonModel = {
                            id: "SELECTED_ITEMS",
                            name: "alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup",
                            config: {
+                              debounceTime: 0, // Remove debounce time to aid testing
                               passive: false,
                               itemKeyProperty: "itemKey",
                               label: "Selected items...",
@@ -108,10 +109,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryView.get.js
@@ -95,6 +95,7 @@ model.jsonModel = {
                         {
                            name: "alfresco/documentlibrary/views/AlfGalleryView",
                            config: {
+                              itemKeyProperty: "nodeRef",
                               columns: 7,
                               widgets: [
                                  {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryView.get.js
@@ -31,6 +31,7 @@ model.jsonModel = {
                   config: {
                      pubSubScope: "HAS_ITEMS_",
                      useHash: false,
+                     itemKeyProperty: "nodeRef",
                      additionalControlsTarget: "TOOLBAR",
                      currentData: {
                         items: [
@@ -95,7 +96,6 @@ model.jsonModel = {
                         {
                            name: "alfresco/documentlibrary/views/AlfGalleryView",
                            config: {
-                              itemKeyProperty: "nodeRef",
                               columns: 7,
                               widgets: [
                                  {
@@ -119,6 +119,7 @@ model.jsonModel = {
                   name: "alfresco/lists/AlfList",
                   config: {
                      pubSubScope: "NO_ITEMS_",
+                     itemKeyProperty: "nodeRef",
                      useHash: false,
                      additionalControlsTarget: "TOOLBAR_NO_ITEMS",
                      additionalViewControlVisibilityConfig: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-615. Details of the changes are described in the JIRA ticket, but essentially this moves the selected item state management into a new mixin module and then makes the AlfList the primary manager of item selection state (but allows both the gallery view and selected items popup menu to manage state if configured to do so).