### PR TITLE
AKU-611: Search result link target config

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -31,6 +31,28 @@ define(["alfresco/core/TemporalUtils",
    return declare([TemporalUtils], {
 
       /**
+       * The URL type used for links. By default this is "PAGE_RELATIVE" as all the links are expected to be
+       * relative to the application page context.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.39
+       */
+      navigationType: "PAGE_RELATIVE",
+
+      /**
+       * The navigation target for links. By default this will result in links being opened in the current window/tab
+       * but this can be configured to be "NEW" so that links are opened in a new window/tab.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.39
+       */
+      navigationTarget: "CURRENT",
+
+      /**
        * This function generates a payload for the [NavigationService]{@link module:alfresco/services/NavigationService}
        * that varies depending upon the type of search result (e.g. a document or folder, in a site or in
        * the repository, etc) which can also be used to extrapolate an HTML anchor for 
@@ -42,8 +64,8 @@ define(["alfresco/core/TemporalUtils",
       generateSearchLinkPayload: function alfresco_renderers__SearchResultLinkMixin__generateSearchLinkPayload() {
          // jshint maxcomplexity:false
          var payload = {
-            type: "PAGE_RELATIVE",
-            target: "CURRENT",
+            type: this.navigationType,
+            target: this.navigationTarget,
             url: null
          };
          var type = lang.getObject("type", false, this.currentItem),

--- a/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_SearchResultLinkMixin.js
@@ -32,7 +32,11 @@ define(["alfresco/core/TemporalUtils",
 
       /**
        * The URL type used for links. By default this is "PAGE_RELATIVE" as all the links are expected to be
-       * relative to the application page context.
+       * relative to the application page context. The available options are 
+       * ["PAGE_RELATIVE"]{@link module:alfresco/services/_NavigationServiceTopicMixin#pageRelativePath}, 
+       * ["CONTEXT_RELATIVE"]{@link module:alfresco/services/_NavigationServiceTopicMixin#contextRelativePath},
+       * ["FULL_PATH"]{@link module:alfresco/services/_NavigationServiceTopicMixin#fullPath} and
+       * ["HASH"]{@link module:alfresco/services/_NavigationServiceTopicMixin#hashPath}
        * 
        * @instance
        * @type {string}
@@ -43,7 +47,9 @@ define(["alfresco/core/TemporalUtils",
 
       /**
        * The navigation target for links. By default this will result in links being opened in the current window/tab
-       * but this can be configured to be "NEW" so that links are opened in a new window/tab.
+       * but this can be configured to be "NEW" so that links are opened in a new window/tab. The available options are 
+       * ["CURRENT"]{@link module:alfresco/services/_NavigationServiceTopicMixin#currentTarget} and
+       * ["NEW"]{@link module:alfresco/services/_NavigationServiceTopicMixin#newTarget}.
        * 
        * @instance
        * @type {string}

--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -145,6 +145,17 @@ define(["dojo/_base/declare",
       mergeActions: false,
 
       /**
+       * The navigation target for links. By default this will result in links being opened in the current window/tab
+       * but this can be configured to be "NEW" so that links are opened in a new window/tab.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.39
+       */
+      navigationTarget: "CURRENT",
+
+      /**
        * This can be configured to override the default filter for the actions that are applicable to 
        * all nodes that are neither folders nor documents. Actions need to be filtered as Aikau does not 
        * currently support all of the actions that can be configured in Alfresco Share. However, if custom 
@@ -342,7 +353,8 @@ define(["dojo/_base/declare",
             publishPayloadModifiers: ["processCurrentItemTokens"],
             publishPayload: {
                url: "user/{modifiedByUser}/profile",
-               type: "PAGE_RELATIVE"
+               type: "PAGE_RELATIVE",
+               target: this.navigationTarget
             }
          }, this.dateNode);
       },
@@ -357,13 +369,18 @@ define(["dojo/_base/declare",
        */
       createDisplayNameRenderer: function alfresco_search_AlfSearchResult__createDisplayNameRenderer() {
          // jshint nonew:false
-         new SearchResultPropertyLink({
+         var config = {
             id: this.id + "_DISPLAY_NAME",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
             propertyToRender: "displayName",
             renderSize: "large"
-         }, this.nameNode);
+         };
+         if (this.navigationTarget)
+         {
+            config.navigationTarget = this.navigationTarget;
+         }
+         new SearchResultPropertyLink(config, this.nameNode);
       },
 
       /**
@@ -435,7 +452,8 @@ define(["dojo/_base/declare",
                publishPayloadModifiers: ["processCurrentItemTokens"],
                publishPayload: {
                   url: isRepo ? "repository?path={pathLink}" : "site/{site.shortName}/documentlibrary?path={pathLink}",
-                  type: "PAGE_RELATIVE"
+                  type: "PAGE_RELATIVE",
+                  target: this.navigationTarget
                }
             }, this.pathNode);
          }
@@ -499,7 +517,8 @@ define(["dojo/_base/declare",
                publishPayloadModifiers: ["processCurrentItemTokens"],
                publishPayload: {
                   url: "site/{site.shortName}" + this.siteLandingPage.replace(/^\/*/, "/"),
-                  type: "PAGE_RELATIVE"
+                  type: "PAGE_RELATIVE",
+                  target: this.navigationTarget
                }
             }, this.siteNode);
          }
@@ -539,12 +558,17 @@ define(["dojo/_base/declare",
        */
       createThumbnailRenderer: function alfresco_search_AlfSearchResult__createThumbnailRenderer() {
          // jshint nonew:false
-         new SearchThumbnail({
+         var config = {
             id: this.id + "_THUMBNAIL",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
             showDocumentPreview: true
-         }, this.thumbnailNode);
+         };
+         if (this.navigationTarget)
+         {
+            config.navigationTarget = this.navigationTarget;
+         }
+         new SearchThumbnail(config, this.thumbnailNode);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -130,4 +130,69 @@ define(["intern!object",
          }
       };
    });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfSearchResult Tests (navigation overrides)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfSearchResult?override=navigation", "AlfSearchResult Tests (navigation overrides)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Name goes to new target": function() {
+            return browser.findByCssSelector("#SR_DISPLAY_NAME .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Site goes to new target": function() {
+            return browser.findByCssSelector("#SR_SITE .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Path goes to new target": function() {
+            return browser.findByCssSelector("#SR_PATH .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Date goes to new target": function() {
+            return browser.findByCssSelector("#SR_DATE .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -1,3 +1,41 @@
+/* global page */
+function getSearchResult() {
+   var searchResult = {
+      id: "SR",
+      name: "alfresco/search/AlfSearchResult",
+      config: {
+         siteLandingPage: "landing",
+         pubSubScope: "AlfSearchResultScope",
+         mergeActions: true,
+         additionalDocumentAndFolderActions: [
+            "CUSTOM3"
+         ],
+         customActions: [
+            {
+               id: "CUSTOM3",
+               label: "Custom Action 3",
+               icon: "document-delete",
+               index: "10",
+               publishTopic: "DELETE_ACTION_TOPIC",
+               type: "javascript"
+            }
+         ],
+         widgetsForActions: [
+            {
+               name: "alfresco/renderers/actions/ManageAspects"
+            }
+         ]
+      }
+   };
+   /* jshint sub:true */
+   if (page.url.args["override"])
+   {
+      searchResult.config.navigationTarget = "NEW";
+   }
+
+   return searchResult;
+}
+
 model.jsonModel = {
    services: [
       {
@@ -231,35 +269,8 @@ model.jsonModel = {
                }
             ],
             widgets:[
-               {
-                  id: "SR",
-                  name: "alfresco/search/AlfSearchResult",
-                  config: {
-                     siteLandingPage: "landing",
-                     pubSubScope: "AlfSearchResultScope",
-                     mergeActions: true,
-                     additionalDocumentAndFolderActions: [
-                        "CUSTOM3"
-                     ],
-                     customActions: [
-                        {
-                           id: "CUSTOM3",
-                           label: "Custom Action 3",
-                           icon: "document-delete",
-                           index: "10",
-                           publishTopic: "DELETE_ACTION_TOPIC",
-                           type: "javascript"
-                        }
-                     ],
-                     widgetsForActions: [
-                        {
-                           name: "alfresco/renderers/actions/ManageAspects"
-                        }
-                     ]
-                  }
-               }
+               getSearchResult()
             ]
-            
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-611 (and issue https://github.com/Alfresco/Aikau/issues/586) to make the target links in the alfresco/renderers/_SearchResultLinkMixin configurable so that they can navigate to a new window/tab. This configuration is exposed through the alfresco/search/AlfSearchResult