### PR TITLE
AKU-622: DND highlighting and drag suppression

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -101,6 +101,17 @@ define(["dojo/_base/declare",
       parentNavTopic: "ALF_DOCLIST_PARENT_NAV",
 
       /**
+       * Overrides the [default configuration]{@link module:alfresco/lists/AlfList#suppressDndUploading}
+       * to ensure that document lists support drag-and-drop uploading (unless otherwise configured).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      suppressDndUploading: false,
+    
+      /**
        * Overrides the [inherited default]{@link module:alfresco/lists/AlfHashList#updateInstanceValues}
        * to ensure that instance values should be updated from the hash. This only appliees when
        * [useHash]{@link module:alfresco/lists/AlfHashList#useHash} is configured to be true.

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -61,6 +61,17 @@ define(["dojo/_base/declare",
        * @default
        */
       dndUploadCapable: false, 
+
+      /**
+       * Indicates whether or not the mixing module should take advantage of the drag-and-drop uploading capabilities. 
+       * This makes it possible to "opt-out" through configuration or extension.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      suppressDndUploading: false,
     
       /**
        * Determines whether or not the browser supports drag and drop file upload.
@@ -111,7 +122,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       subscribeToCurrentNodeChanges: function alfresco_documentlibrary__AlfDndDocumentUploadMixin__subscribeToCurrentNodeChanges(domNode) {
-         if (this.dndUploadCapable)
+         if (this.dndUploadCapable && !this.suppressDndUploading)
          {
             // Handle updates to the metadata (this is required in order for the view to know what
             // root Node it represents is)
@@ -194,7 +205,7 @@ define(["dojo/_base/declare",
        * @param {object} domNode The DOM node to add drag and drop listeners to
        */
       addUploadDragAndDrop: function alfresco_documentlibrary__AlfDndDocumentUploadMixin__addUploadDragAndDrop(domNode) {
-         if (this.dndUploadCapable)
+         if (this.dndUploadCapable && !this.suppressDndUploading)
          {
             this.alfLog("log", "Adding DND upload capabilities", this);
             try
@@ -212,10 +223,9 @@ define(["dojo/_base/declare",
                
                // Add listeners for the mouse entering (these handlers allow us to normalise browser events that
                // are "broken" due to firing across all child nodes...
-               this.dndUploadEventHandlers.push(on(win.body(), "dragenter", lang.hitch(this, "onDndUploadDragEnter")));
-               this.dndUploadEventHandlers.push(on(this.dragAndDropNode, "dragover", lang.hitch(this, "onDndUploadDragOver")));
-               this.dndUploadEventHandlers.push(on(this.dragAndDropNode, "drop", lang.hitch(this, "onDndUploadDrop")));
-               this.alfLog("log", "Handlers: ", this.dndUploadEventHandlers);
+               this.dndUploadEventHandlers.push(on(win.body(), "dragenter", lang.hitch(this, this.onDndUploadDragEnter)));
+               this.dndUploadEventHandlers.push(on(this.dragAndDropNode, "dragover", lang.hitch(this, this.onDndUploadDragOver)));
+               this.dndUploadEventHandlers.push(on(this.dragAndDropNode, "drop", lang.hitch(this, this.onDndUploadDrop)));
             }
             catch(exception)
             {

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -155,6 +155,18 @@ define(["dojo/_base/declare",
       loadDataImmediately: true,
 
       /**
+       * Indicates whether or not views should apply drag-and-drop highlighting. Each view used by the
+       * list will have this value applied (even if it overrides custom configuration) as it is up to
+       * the list to control whether or not it supported drag-and-drop behaviour.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      suppressDndUploading: true,
+    
+      /**
        * Subscribe the document list topics.
        *
        * @instance
@@ -202,7 +214,6 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-
       noDataMessage: "alflist.no.data.message",
 
       /**
@@ -213,7 +224,6 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-
       fetchingDataMessage: "alflist.loading.data.message",
 
       /**
@@ -224,7 +234,6 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-
       renderingViewMessage: "alflist.rendering.data.message",
 
       /**
@@ -235,7 +244,6 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-
       fetchingMoreDataMessage: "alflist.loading.data.message",
 
       /**
@@ -297,6 +305,13 @@ define(["dojo/_base/declare",
          // Process the array of widgets. Only views should be included as widgets of the DocumentList.
          if (this.widgets)
          {
+            // Iterate over all the configured views and apply the DND upload suppression
+            // configuration to each of them...
+            array.forEach(this.widgets, function(view) {
+               var viewConfig = lang.getObject("config", true, view); // NOTE: Create the config object if it doesn't exist
+               viewConfig.suppressDndUploading = this.suppressDndUploading;
+            }, this);
+
             // Opting to NOT clone the widgets for performance here, but leaving the code commented out
             // for hasty re-insertion if necessary. It *shouldn't* be necessary to clone here because
             // the views will clone as necessary...

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -116,6 +116,18 @@ define(["dojo/_base/declare",
       documentSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS",
 
       /**
+       * Overrides the 
+       * [inherited default configuration]{@link module:alfresco/documentlibrary/_AlfDndDocumentUploadMixin#suppressDndUploading}
+       * to suppress the drag-and-drop upload highlighting.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      suppressDndUploading: true,
+    
+      /**
        * Whether the list that's creating this view has infinite scroll turned on
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/node/DraggableNodeMixin.js
+++ b/aikau/src/main/resources/alfresco/node/DraggableNodeMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,7 +18,7 @@
  */
 
 /**
- * This module simply provides a set of attributes that define topic names for publications
+ * This module provides a set of attributes that define topic names for publications
  * and subscriptions. This should be mixed into any widget that wishes to use those topics
  * to ensure consistency. It also allows the actual values to be managed from a single file. 
  * 
@@ -50,6 +50,17 @@ define(["dojo/_base/declare",
       draggableNode: null,
       
       /**
+       * Indicates whether or not the mixing module should take advantage of the capabilities. This makes
+       * it possible to "opt-out" through configuration or extension.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      isDraggable: true,
+
+      /**
        * This will be assigned a reference to the "dojo/dnd/Moveable" instance created by the 
        * [postCreate function]{@link module:alfresco/node/DraggableNodeMixin#onDragStart}
        * 
@@ -76,32 +87,32 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_node_DraggableNodeMixin__postCreate() {
          this.inherited(arguments);
-         
-         if (this.draggableNode == null && 
-             this.domNode != null)
+         if (this.isDraggable)
          {
-            this.draggableNode = this.domNode;
-         }
-         if (this.draggableNode != null)
-         {
-            // It's important to set a delay (this is a measure of pixels NOT time) so that
-            // regular click events can be processed...
-            this.moveable = new Moveable(this.draggableNode, {
-               delay: 20
-            });
-            // Use aspect to hitch some events to work around 2nd drag event bugs...
-            aspect.before(this.moveable, "onMoveStart", lang.hitch(this, "onDragStart"));
-            aspect.after(this.moveable, "onMoveStop", lang.hitch(this, "onDragEnd"), true);
-            on(this.moveable.handle, "mousedown", lang.hitch(this, "onMouseDown"));
-            on(this.moveable.handle, "mouseup", lang.hitch(this, "onMouseUp"));
-            on(this.moveable.handle, "click", lang.hitch(this, "onDraggableClick"));
+            if (!this.draggableNode && this.domNode)
+            {
+               this.draggableNode = this.domNode;
+            }
+            if (this.draggableNode)
+            {
+               // It's important to set a delay (this is a measure of pixels NOT time) so that
+               // regular click events can be processed...
+               this.moveable = new Moveable(this.draggableNode, {
+                  delay: 20
+               });
+               // Use aspect to hitch some events to work around 2nd drag event bugs...
+               aspect.before(this.moveable, "onMoveStart", lang.hitch(this, "onDragStart"));
+               aspect.after(this.moveable, "onMoveStop", lang.hitch(this, "onDragEnd"), true);
+               on(this.moveable.handle, "mousedown", lang.hitch(this, "onMouseDown"));
+               on(this.moveable.handle, "mouseup", lang.hitch(this, "onMouseUp"));
+               on(this.moveable.handle, "click", lang.hitch(this, "onDraggableClick"));
+            }
          }
       },
       
       onMouseDown: function alfresco_node_DraggableNodeMixin__onMouseDown(evt) {
          this.alfLog("log", "On mouse down", evt);
          var output = domGeom.position(this.draggableNode);
-         this.alfLog("log", "Computed style: ", output.x, output.y);
          this.origX = output.x;
          this.origY = output.y;
       },
@@ -120,9 +131,8 @@ define(["dojo/_base/declare",
        */
       onMouseUp: function alfresco_node_DraggableNodeMixin__onMouseUp(e) {
          this.alfLog("log", "On Mouse Up", e);
-         if (this.mover != null)
+         if (this.mover)
          {
-            this.alfLog("log", "Calling mover onMouseUp");
             this.mover.onMouseUp(e);
             this.mover = null;
             event.stop(e);
@@ -137,7 +147,6 @@ define(["dojo/_base/declare",
        */
       onDraggableClick: function alfresco_node_DraggableNodeMixin__onDraggableClick(e) {
          this.alfLog("log", "On draggable click", e, this.dragInFlight);
-         
          if (this.dragInFlight)
          {
             this.alfLog("log", "Cancelling in flight");

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
@@ -46,6 +46,17 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/SearchThumbnailMixin.properties"}],
 
       /**
+       * Overrides the [inherited default configuration]{@link module:alfresco/node/DraggableNodeMixin#isDraggable}
+       * to prevent search result thumbnails from being draggable.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.39
+       */
+      isDraggable: false,
+
+      /**
        * Generates the publication payload by calling the mixed in 
        * [generatePayload]{@link module:alfresco/renderers/_SearchResultLinkMixin#generatePayload}
        * function and then wraps the property in an anchor element by calling the mixed in 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Drag-and-drop upload highlighting</shortname>
+  <description>This page is used for testing various configurations for drag-and-drop upload highlighting and thumbnail dragging.</description>
+  <family>aikau-unit-tests</family>
+  <url>/DNDUploadBehaviour</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.js
@@ -1,0 +1,168 @@
+// Data object to use for the lists/views...
+var data = {
+   items: [
+      {
+         nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
+         type: "folder",
+         name: "test1 & test2",
+         displayName: "Normal result",
+         title: "Normal result title",
+         modifiedBy: "Barry Smith",
+         modifiedOn: "13th December 2010",
+         modifiedByUser: "bsmith",
+         description: "Normal result description",
+         site: {
+            title: "Normal result site title",
+            shortName: "normalResult"
+         },
+         path: "/one/two/three/four",
+         size: 283746
+      }
+   ]
+};
+
+// Function to create a thumbnail with the option to stop it from being draggable
+// When the thumbnail isn't draggable it can still be dragged but the browser treats it
+// as a file (which enables us to check the DND upload highlighting!)
+function getThumbnail(id, isDraggable) {
+   var thumbnail = {
+      id: id + "_THUMBNAIL",
+      name: "alfresco/renderers/Thumbnail",
+      config: {}
+   };
+   if (isDraggable === true || isDraggable === false)
+   {
+      thumbnail.config.isDraggable = isDraggable;
+   }
+   return thumbnail;
+}
+
+// Function to create a view with the options to configure DND upload hightlighting
+// suppression, whether or not to make the thumbnail draggable and whether or not
+// to set data directly on the view (so that it can be used outside of the list)
+function getView(id, viewSuppress, isDraggable, setData) {
+   var view = {
+      id: id + "_VIEW",
+      name: "alfresco/lists/views/AlfListView",
+      config: {
+         widgets: [
+            {
+               id: id + "_ROW",
+               name: "alfresco/lists/views/layouts/Row",
+               config: {
+                  widgets: [
+                     {
+                        id: id + "_CELL",
+                        name: "alfresco/lists/views/layouts/Cell",
+                        config: {
+                           widgets: [
+                              getThumbnail(id, isDraggable),
+                              {
+                                 id: id + "_NAME",
+                                 name: "alfresco/renderers/Property",
+                                 config: {
+                                    propertyToRender: "displayName"
+                                 }
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   };
+
+   if (viewSuppress === true || viewSuppress === false)
+   {
+      view.config.suppressDndUploading = viewSuppress;
+   }
+   if (setData === true)
+   {
+      view.config.currentData = data;
+   }
+   return view;
+}
+
+// Function to create a list with the options to pass onto the getView and
+// getThumbnail functions
+function getList(id, listSuppress, viewSuppress, isDraggable) {
+   var list = {
+      id: id,
+      name: "alfresco/lists/AlfList",
+      config: {
+         currentData: data,
+         widgets: [
+            getView(id, viewSuppress, isDraggable, false)
+         ]
+      }
+   };
+   if (listSuppress === true || listSuppress === false)
+   {
+      list.config.suppressDndUploading = listSuppress;
+   }
+   return list;
+}
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "List (defaults)",
+                     widgets: [
+                        getList("NO_OVERRIDES")
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "List (no suppression, no dragging)",
+                     widgets: [
+                        getList("FULLY_SUPPRESSED", false, false, false)
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "View (defaults)",
+                     widgets: [
+                        getView("JUST", null, null, true)
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "View (no suppression, no dragging)",
+                     widgets: [
+                        getView("NO_VIEW_DRAG", false, false, true)
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-622 to make the drag-and-drop highlighting behaviour configurable as well as the thumbnail dragging behaviour configurable. Lists by default to not expect to support drag-and-drop upload (but the document library overrides this so that it can show the appropriate highlighting). Thumbnails continue to be draggable by default (for backwards compatibility) but the search thumbnails override this setting so that they are not.

I've created a unit test page to verify that everything works but was unable to bend Intern to my will in order to actually get a test working.