### PR TITLE
AKU-605: Dialog width changes on hover in IE10

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -46,7 +46,8 @@
 
 .alfresco-dialog-AlfDialog .dialog-body {
    padding: 12px; /* NOTE: If this is changed, the associated paddingAdjustment in the JS needs updating */
-   overflow: auto;
+   overflow-x: hidden;
+   overflow-y: auto;
    margin-bottom: 40px; /* NOTE: If this is changed, the associated margin adjustment in the JS needs updating */
    min-width: 560px;
 }


### PR DESCRIPTION
This pull request is to do with [AKU-605](https://issues.alfresco.com/jira/browse/AKU-605). It was not possible to easily reproduce the problem, however we did notice a horizontal scrollbar in IE, so this has been fixed and is worth merging anyway. It might fix the issue in the ticket, but would need help confirming this.