### PR TITLE
AKU-627: Thumbnail select on click

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -178,6 +178,9 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
+       * @property {string} [value] One of "selectAll", "selectNone", "selectInvert", "selectFolders" or "selectDocuments"
+       * @property {object[]} [selectedItems] An array of items that have been selected
        */
       documentSelectionTopic: topics.DOCUMENT_SELECTION_UPDATE,
       
@@ -187,6 +190,8 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
+       * @property {object} value The item selected
        */
       documentSelectedTopic: topics.DOCUMENT_SELECTED,
       
@@ -205,6 +210,8 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
+       * @property {object} value The item de-selected
        */
       documentDeselectedTopic: topics.DOCUMENT_DESELECTED,
       

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -177,10 +177,8 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {string} 
-       * @default
+       * @default [DOCUMENT_SELECTION_UPDATE]{@link module:alfresco/core/topics#DOCUMENT_SELECTION_UPDATE}
        * @event
-       * @property {string} [value] One of "selectAll", "selectNone", "selectInvert", "selectFolders" or "selectDocuments"
-       * @property {object[]} [selectedItems] An array of items that have been selected
        */
       documentSelectionTopic: topics.DOCUMENT_SELECTION_UPDATE,
       

--- a/aikau/src/main/resources/alfresco/lists/ItemSelectionMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/ItemSelectionMixin.js
@@ -87,8 +87,7 @@ define(["dojo/_base/declare",
       updateOnSelection: true,
 
       /**
-       * The CSS class to apply to the DOM element returned from calling
-       * [getSelectorNode]{@link module:alfresco/lists/ItemSelectionMixin#getSelectorNode}.
+       * The CSS class to apply to the root DOM node of the widget
        *
        * @instance
        * @type {string}
@@ -150,18 +149,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This function is called to get the DOM node to add the CSS class that indicates whether or not the 
-       * item is selected. It attempts to return a "selectorNode" in the widget template but if one is not available
-       * then it will return the widgets outer node.
-       * 
-       * @instance
-       * @overridable
-       */
-      getSelectorNode: function alfresco_lists_ItemSelectionMixin__getSelectorNode() {
-         return this.selectorNode || this.domNode;
-      },
-
-      /**
        * Handles selection request events for the following values: "selectAll", "selectNone",
        * "selectInvert", "selectFolders" & "selectDocuments". All other selection requests are
        * ignored.
@@ -220,7 +207,7 @@ define(["dojo/_base/declare",
                   var b = lang.getObject(this.itemKey, false, this.currentItem);
                   var match = ((a || a === 0) && a === b);
                   if (match) {
-                     domClass.add(this.getSelectorNode(), this.selectedCssClass);
+                     domClass.add(this.domNode, this.selectedCssClass);
                   }
                   return match;
                }, this);
@@ -237,7 +224,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentSelectedTopic
        */
       select: function alfresco_lists_ItemSelectionMixin__select() {
-         domClass.add(this.getSelectorNode(), this.selectedCssClass);
+         domClass.add(this.domNode, this.selectedCssClass);
          this.alfPublish(this.documentSelectedTopic, {
             value: this.currentItem
          }, this.getSelectionPublishGlobal(), this.getSelectionPublishToParent());
@@ -252,7 +239,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentDeselectedTopic
        */
       deselect: function alfresco_lists_ItemSelectionMixin__deselect() {
-         domClass.remove(this.getSelectorNode(), this.selectedCssClass);
+         domClass.remove(this.domNode, this.selectedCssClass);
          this.alfPublish(this.documentDeselectedTopic, {
             value: this.currentItem
          }, this.getSelectionPublishGlobal(), this.getSelectionPublishToParent());
@@ -270,7 +257,7 @@ define(["dojo/_base/declare",
          if (this.selectOnClick)
          {
             evt && event.stop(evt);
-            if (domClass.contains(this.getSelectorNode(), this.selectedCssClass))
+            if (domClass.contains(this.domNode, this.selectedCssClass))
             {
                // De-select if currently selected...
                this.deselect();

--- a/aikau/src/main/resources/alfresco/lists/ItemSelectionMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/ItemSelectionMixin.js
@@ -34,7 +34,7 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/dom-class",
         "dojo/_base/event"], 
-        function( declare, Core, topics, _AlfDocumentListTopicMixin, lang, array, domClass, Event) {
+        function( declare, Core, topics, _AlfDocumentListTopicMixin, lang, array, domClass, event) {
    
    return declare([Core, _AlfDocumentListTopicMixin], {
       
@@ -85,6 +85,16 @@ define(["dojo/_base/declare",
        * @default
        */
       updateOnSelection: true,
+
+      /**
+       * The CSS class to apply to the DOM element returned from calling
+       * [getSelectorNode]{@link module:alfresco/lists/ItemSelectionMixin#getSelectorNode}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      selectedCssClass: "alfresco-lists-ItemSelectionMixin--selected",
 
       /**
        * This indicates whether or not clicking on the widget mixed by this module will trigger it's selection
@@ -210,7 +220,7 @@ define(["dojo/_base/declare",
                   var b = lang.getObject(this.itemKey, false, this.currentItem);
                   var match = ((a || a === 0) && a === b);
                   if (match) {
-                     domClass.add(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected");
+                     domClass.add(this.getSelectorNode(), this.selectedCssClass);
                   }
                   return match;
                }, this);
@@ -227,7 +237,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentSelectedTopic
        */
       select: function alfresco_lists_ItemSelectionMixin__select() {
-         domClass.add(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected");
+         domClass.add(this.getSelectorNode(), this.selectedCssClass);
          this.alfPublish(this.documentSelectedTopic, {
             value: this.currentItem
          }, this.getSelectionPublishGlobal(), this.getSelectionPublishToParent());
@@ -242,7 +252,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentDeselectedTopic
        */
       deselect: function alfresco_lists_ItemSelectionMixin__deselect() {
-         domClass.remove(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected");
+         domClass.remove(this.getSelectorNode(), this.selectedCssClass);
          this.alfPublish(this.documentDeselectedTopic, {
             value: this.currentItem
          }, this.getSelectionPublishGlobal(), this.getSelectionPublishToParent());
@@ -259,8 +269,8 @@ define(["dojo/_base/declare",
       onSelectionClick: function alfresco_lists_ItemSelectionMixin__onSelectionClick(evt) {
          if (this.selectOnClick)
          {
-            evt && Event.stop(evt);
-            if (domClass.contains(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected"))
+            evt && event.stop(evt);
+            if (domClass.contains(this.getSelectorNode(), this.selectedCssClass))
             {
                // De-select if currently selected...
                this.deselect();

--- a/aikau/src/main/resources/alfresco/lists/ItemSelectionMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/ItemSelectionMixin.js
@@ -50,6 +50,30 @@ define(["dojo/_base/declare",
       itemKey: "nodeRef",
 
       /**
+       * Indicates whether the subscriptions made by 
+       * [createItemSelectionSubscriptions]{@link module:alfresco/lists/ItemSelectionMixin#createItemSelectionSubscriptions}
+       * and the publications made by [select]{@link module:alfresco/lists/ItemSelectionMixin#select} and 
+       * [deselect]{@link module:alfresco/lists/ItemSelectionMixin#deselect} should be made on the global scope.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      publishGlobal: null,
+
+      /**
+       * Indicates whether the subscriptions made by 
+       * [createItemSelectionSubscriptions]{@link module:alfresco/lists/ItemSelectionMixin#createItemSelectionSubscriptions}
+       * and the publications made by [select]{@link module:alfresco/lists/ItemSelectionMixin#select} and 
+       * [deselect]{@link module:alfresco/lists/ItemSelectionMixin#deselect} should be made on the parent scope.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      publishToParent: null,
+
+      /**
        * This indicates whether or not the mixing widget should subscribe to item selection events. This
        * attribute is inspected by the [createItemSelectionSubscriptions]{@link module:alfresco/lists/ItemSelectionMixin#createItemSelectionSubscriptions}
        * function to determine whether to bind the 
@@ -186,7 +210,7 @@ define(["dojo/_base/declare",
                   var b = lang.getObject(this.itemKey, false, this.currentItem);
                   var match = ((a || a === 0) && a === b);
                   if (match) {
-                     domClass.add(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--checked");
+                     domClass.add(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected");
                   }
                   return match;
                }, this);
@@ -203,7 +227,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentSelectedTopic
        */
       select: function alfresco_lists_ItemSelectionMixin__select() {
-         domClass.add(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--checked");
+         domClass.add(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected");
          this.alfPublish(this.documentSelectedTopic, {
             value: this.currentItem
          }, this.getSelectionPublishGlobal(), this.getSelectionPublishToParent());
@@ -218,7 +242,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#documentDeselectedTopic
        */
       deselect: function alfresco_lists_ItemSelectionMixin__deselect() {
-         domClass.remove(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--checked");
+         domClass.remove(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected");
          this.alfPublish(this.documentDeselectedTopic, {
             value: this.currentItem
          }, this.getSelectionPublishGlobal(), this.getSelectionPublishToParent());
@@ -236,7 +260,7 @@ define(["dojo/_base/declare",
          if (this.selectOnClick)
          {
             evt && Event.stop(evt);
-            if (domClass.contains(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--checked"))
+            if (domClass.contains(this.getSelectorNode(), "alfresco-lists-ItemSelectionMixin--selected"))
             {
                // De-select if currently selected...
                this.deselect();

--- a/aikau/src/main/resources/alfresco/renderers/Selector.js
+++ b/aikau/src/main/resources/alfresco/renderers/Selector.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,29 +18,27 @@
  */
 
 /**
+ * This renderer can be used to both indicate whether or not an item is selected and to allow the selection
+ * or de-selection the [item]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} that it represents.
+ * The selection capabilities of this widget are provided by the 
+ * [ItemSelectionMixin]{@link module:alfresco/lists/ItemSelectionMixin} module.
+ * 
  * @module alfresco/renderers/Selector
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes external:dojo/_OnDijitClickMixin
- * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
- * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/lists/ItemSelectionMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
         "dijit/_TemplatedMixin",
         "dijit/_OnDijitClickMixin",
-        "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "dojo/text!./templates/Selector.html",
-        "alfresco/core/Core",
-        "dojo/_base/lang",
-        "dojo/_base/array",
-        "dojo/dom-class",
-        "dojo/_base/event"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _AlfDocumentListTopicMixin, template, 
-                 AlfCore, lang, array, domClass, Event) {
+        "alfresco/lists/ItemSelectionMixin",
+        "dojo/text!./templates/Selector.html"], 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin, template) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _AlfDocumentListTopicMixin, AlfCore], {
+   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -59,143 +57,17 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
-       * The dot-notation property in the currentItem that uniquely idenfities that item. This defaults
-       * to "nodeRef" as the most likely use case is for working with Nodes but this can be configured
-       * to a different value.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       * @since 1.0.35
-       */
-      itemKey: "nodeRef",
-
-      /**
        * Set up the attributes to be used when rendering the template.
        * 
        * @instance
        * @listens module:alfresco/core/topics~event:DOCUMENT_SELECTION_UPDATE
        */
       postMixInProperties: function alfresco_renderers_Selector__postMixInProperties() {
-         this.intialClass = "unchecked";
-         
          // Set up a subscription to handle file selection events, these will be along the lines of
          // select all, select none, invert, etc. Each individual selector will respond to these
          // events...
-         this.alfSubscribe(this.documentSelectionTopic, lang.hitch(this, this.onFileSelection), this.publishGlobal, this.publishToParent);
-      },
-      
-      /**
-       * Handles selection request events for the following values: "selectAll", "selectNone",
-       * "selectInvert", "selectFolders" & "selectDocuments". All other selection requests are
-       * ignored.
-       * 
-       * @instance
-       * @param {object} payload The details of the selection request.
-       */
-      onFileSelection: function alfresco_renderers_Selector__onFileSelection(payload) {
-         if (payload)
-         {
-            if (payload.value === "selectAll")
-            {
-               // Select regardless of current status...
-               this.select();
-            }
-            else if (payload.value === "selectNone")
-            {
-               // De-select regardless of current status...
-               this.deselect();
-            }
-            else if (payload.value === "selectInvert")
-            {
-               // Invert the current status
-               this.onClick();
-            }
-            else if (payload.value === "selectFolders" && this.currentItem && this.currentItem.jsNode)
-            {
-               // Select if the current item is a container
-               if (this.currentItem.jsNode.isContainer)
-               {
-                  this.select();
-               }
-               else
-               {
-                  this.deselect();
-               }
-            }
-            else if (payload.value === "selectDocuments" && this.currentItem && this.currentItem.jsNode)
-            {
-               // Select if the current item is NOT a container
-               if (this.currentItem.jsNode.isContainer)
-               {
-                  this.deselect();
-               }
-               else
-               {
-                  this.select();
-               }
-            }
-            else if (payload.selectedItems)
-            {
-               // Check to see if the list of selected items contains the item that this instance has
-               // renderered.
-               array.some(payload.selectedItems, function(item) {
-                  var a = lang.getObject(this.itemKey, false, item);
-                  var b = lang.getObject(this.itemKey, false, this.currentItem);
-                  var match = ((a || a === 0) && a === b);
-                  if (match) {
-                     domClass.add(this.selectorNode, "checked");
-                     domClass.remove(this.selectorNode, "unchecked");
-                  }
-                  return match;
-               }, this);
-            }
-         }
-      },
-      
-      /**
-       * Publishes on the "documentSelectedTopic" attribute to with the details of the current item.
-       * 
-       * @instance
-       */
-      select: function alfresco_renderers_Selector__select() {
-         domClass.add(this.selectorNode, "checked");
-         domClass.remove(this.selectorNode, "unchecked");
-         this.alfPublish(this.documentSelectedTopic, {
-            value: this.currentItem
-         }, this.publishGlobal, this.publishToParent);
-      },
-      
-      /**
-       * Publishes on the "documentDeselectedTopic" attribute to with the details of the current item.
-       * 
-       * @instance
-       */
-      deselect: function alfresco_renderers_Selector__deselect() {
-         domClass.remove(this.selectorNode, "checked");
-         domClass.add(this.selectorNode, "unchecked");
-         this.alfPublish(this.documentDeselectedTopic, {
-            value: this.currentItem
-         }, this.publishGlobal, this.publishToParent);
-      },
-      
-      /**
-       * Toggle between the on and off states
-       * 
-       * @instance
-       */
-      onClick: function alfresco_renderers_Selector__onClick(evt) {
-         evt && Event.stop(evt);
-         if (domClass.contains(this.selectorNode, "checked"))
-         {
-            // De-select if currently selected...
-            this.deselect();
-         }
-         else
-         {
-            // Select if currently not selected...
-            this.select();
-         }
+         // this.alfSubscribe(this.documentSelectionTopic, lang.hitch(this, this.onFileSelection), this.publishGlobal, this.publishToParent);
+         this.createItemSelectionSubscriptions();
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -151,7 +151,7 @@ define(["dojo/_base/declare",
       
       /**
        * The name of the folder image to use. Valid options are: "folder-32.png", "folder-48.png", "folder-64.png"
-       * and "folder-256.png". The default is "folder-64.png".
+       * and "folder-256.png".
        *
        * @instance
        * @type {string}
@@ -160,7 +160,7 @@ define(["dojo/_base/declare",
       folderImage: "folder-64.png",
 
       /**
-       * The property to use for the image id. Defaults to "jsNode.nodeRef.nodeRef"
+       * The property to use for the image id.
        * 
        * @instance
        * @type {string}
@@ -169,7 +169,7 @@ define(["dojo/_base/declare",
       imageIdProperty: "jsNode.nodeRef.nodeRef",
 
       /**
-       * The property to use for the image title. Defaults to "displayName"
+       * The property to use for the image title.
        *
        * @instance
        * @type {string}

--- a/aikau/src/main/resources/alfresco/renderers/css/Selector.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Selector.css
@@ -6,7 +6,7 @@
    background-image: url(./images/NoneSelected.png);
 
    /* NOTE: Using class provided by mixin module */;
-   &.alfresco-lists-ItemSelectionMixin--checked {
+   &.alfresco-lists-ItemSelectionMixin--selected {
       background-image: url(./images/AllSelected.png);
    }
 }

--- a/aikau/src/main/resources/alfresco/renderers/css/Selector.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Selector.css
@@ -3,12 +3,10 @@
    height: 20px;
    width: 20px;
    display: inline-block;
-}
-
-.alfresco-renderers-Selector.checked {
-   background-image: url(./images/AllSelected.png);
-}
-
-.alfresco-renderers-Selector.unchecked {
    background-image: url(./images/NoneSelected.png);
+
+   /* NOTE: Using class provided by mixin module */;
+   &.alfresco-lists-ItemSelectionMixin--checked {
+      background-image: url(./images/AllSelected.png);
+   }
 }

--- a/aikau/src/main/resources/alfresco/renderers/templates/Selector.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/Selector.html
@@ -1,1 +1,1 @@
-<span data-dojo-attach-point="selectorNode" class="alfresco-renderers-Selector ${intialClass}" data-dojo-attach-event="ondijitclick:onClick" tabindex="0"></span>
+<span data-dojo-attach-point="selectorNode" class="alfresco-renderers-Selector" data-dojo-attach-event="ondijitclick:onSelectionClick" tabindex="0"></span>

--- a/aikau/src/main/resources/alfresco/renderers/templates/Selector.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/Selector.html
@@ -1,1 +1,1 @@
-<span data-dojo-attach-point="selectorNode" class="alfresco-renderers-Selector" data-dojo-attach-event="ondijitclick:onSelectionClick" tabindex="0"></span>
+<span class="alfresco-renderers-Selector" data-dojo-attach-event="ondijitclick:onSelectionClick" tabindex="0"></span>

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -227,17 +227,17 @@ registerSuite(function(){
       
       "Select items and switch views": function() {
          // Select an item and make sure it is shown as selected...
-         return browser.findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.unchecked")
+         return browser.findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0")
             .click()
          .end()
-         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.checked")
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--checked")
          .end()
 
          // Select another item and make sure it is shown as selected...
-         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.unchecked")
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2")
             .click()
          .end()
-         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.checked")
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--checked")
          .end()
 
          // Clear the log so that we can tell when view switching is complete...
@@ -258,13 +258,13 @@ registerSuite(function(){
          .end()
 
          // Check the item selection has been retained...
-         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_0.checked")
+         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--checked")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Item 0 selection was not retained switching views");
             })
          .end()
 
-         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_2.checked")
+         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--checked")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Item 2 selection was not retained switching views");
             });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -230,14 +230,14 @@ registerSuite(function(){
          return browser.findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0")
             .click()
          .end()
-         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--checked")
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--selected")
          .end()
 
          // Select another item and make sure it is shown as selected...
          .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2")
             .click()
          .end()
-         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--checked")
+         .findByCssSelector("#DETAILED_VIEW_SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--selected")
          .end()
 
          // Clear the log so that we can tell when view switching is complete...
@@ -258,13 +258,13 @@ registerSuite(function(){
          .end()
 
          // Check the item selection has been retained...
-         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--checked")
+         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--selected")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Item 0 selection was not retained switching views");
             })
          .end()
 
-         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--checked")
+         .findAllByCssSelector("#SIMPLE_VIEW_SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--selected")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Item 2 selection was not retained switching views");
             });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentListTest.js
@@ -21,11 +21,9 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
 registerSuite(function(){
    var browser;
@@ -42,167 +40,118 @@ registerSuite(function(){
          browser.end();
       },
 
-      "Test path initialised correctly": function () {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "path", "/"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'path' not initialised correctly");
-            });
+      "Test initial data request": function () {
+         return browser.findByCssSelector("body").end()
+            .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST", "No load data request published")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "filter.path", "/", "Path wrong for intial load request");
+                  assert.propertyVal(payload, "type", "all", "Type wrong for intial load request");
+                  assert.propertyVal(payload, "site", "fake-site", "Site wrong for intial load request");
+                  assert.propertyVal(payload, "container", "documentlibrary", "Container wrong for intial load request");
+                  assert.propertyVal(payload, "sortAscending", false, "Sort direction wrong for intial load request");
+                  assert.propertyVal(payload, "sortField", "cm:title", "Sort field wrong for intial load request");
+                  assert.propertyVal(payload, "page", 1, "Page wrong for intial load request");
+                  assert.propertyVal(payload, "pageSize", 3, "Page size wrong for intial load request");
+               });
       },
-      
-      "Test folder display initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "type", "all"))
-            .then(function(elements) {
-               assert(elements.length === 1, "not initialised to show folders");
-            });
-      },
-      
-      "Test site data initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "site", "fake-site"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'site' not initialised correctly");
-            });
-      },
-      
-      "Test container data initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "container", "documentlibrary"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'container' not initialised correctly");
-            });
-      },
-      
-      "Test sort direction initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "sortAscending", "false"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortAscending' not initialised correctly");
-            });
-      },
-      
-      "Test sort field initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "sortField", "cm:title"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortField' not initialised correctly");
-            });
-      },
-      
-      "Test page initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "page", "1"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'page' not initialised correctly");
-            });
-      },
-      
-      "Test page size initialised correctly": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("any", "pageSize", "3"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'pageSize' not initialised correctly");
-            });
-      },
-      
+
       "Test sort order toggles": function() {
-         return browser.findByCssSelector("#SORT_ASC_REQUEST")
+         return browser.findById("SORT_ASC_REQUEST_label")
+            .clearLog()
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "sortAscending", "true"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortAscending' not updated correctly");
-            });
-      },
-      
-      "Test sort field updates with sort toggle": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "sortField", "cm:name"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortField' not updated correctly");
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sortAscending", true, "Sort direction not updated");
+               assert.propertyVal(payload, "sortField", "cm:name", "Sort field not updated");
             });
       },
       
       "Test sort field selection doesn't change sort order": function() {
-         return browser.findByCssSelector("#SORT_FIELD_SELECTION")
+         return browser.findById("SORT_FIELD_SELECTION_label")
+            .clearLog()
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "sortAscending", "true"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortAscending' changed unexpectedly");
-            });
-      },
-      
-      "Test sort field selection updates": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "sortField", "cm:title"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortField' not updated correctly");
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sortField", "cm:title", "Sort field not updated");
+
+               // Sort order should remain the same
+               assert.propertyVal(payload, "sortAscending", true, "Sort direction not updated");
             });
       },
       
       "Test sort order toggle (to descending)": function() {
-         return browser.findByCssSelector("#SORT_DESC_REQUEST")
+         return browser.findById("SORT_DESC_REQUEST_label")
+            .clearLog()
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "sortAscending", "false"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortAscending' not updated correctly");
-            });
-      },
-      
-      "Test sort field doesn't change on sort order": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "sortField", "cm:title"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'sortField' changed unexpectedly");
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sortAscending", false, "Sort direction not updated");
+
+               // Sort field should remain the same
+               assert.propertyVal(payload, "sortField", "cm:title", "Sort field not updated"); 
             });
       },
       
       "Test hide folder toggle": function() {
-         return browser.findByCssSelector("#HIDE_FOLDERS")
+         return browser.findByCssSelector("#HIDE_FOLDERS_label")
+            .clearLog()
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "documents"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'type' not updated correctly");
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "type", "documents", "Type not updated");
             });
       },
       
       "Test show folder toggle": function() {
-         return browser.findByCssSelector("#SHOW_FOLDERS")
+         return browser.findByCssSelector("#SHOW_FOLDERS_label")
+            .clearLog()
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "type", "all"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'type' not updated correctly");
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "type", "all", "Type not updated");
             });
       },
       
       "Test set page number": function() {
-         return browser.findByCssSelector("#SET_PAGE")
+         return browser.findByCssSelector("#SET_PAGE_label")
+            .clearLog()
             .click()
          .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "page", "2"))
-            .then(function(elements) {
-               assert(elements.length === 1, "'page' not updated correctly");
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "page", 2, "Page not updated");
             });
       },
       
       "Test data update renders current view": function() { 
-         return browser.findByCssSelector("#PUBLISH_DATA")
+         return browser.findByCssSelector("#PUBLISH_DATA_label")
             .click()
          .end()
         .findAllByCssSelector(".alfresco-lists-views-AlfListView .alfresco-lists-views-layouts-Cell span.alfresco-renderers-Property:nth-child(2)")
             .then(function(elements) {
-               assert(elements.length === 3, "'VIEW1' was not displayed");
+               assert.lengthOf(elements, 3, "'VIEW1' was not displayed");
             });
       },
       
       "Test update does not render hidden views": function() {
          return browser.findAllByCssSelector(".alfresco-lists-views-AlfListView .alfresco-lists-views-layouts-Cell span.alfresco-renderers-Property:nth-child(3)")
             .then(function(elements) {
-               assert(elements.length === 0, "'VIEW2' was displayed unexpectedly");
+               assert.lengthOf(elements, 0, "'VIEW2' was displayed unexpectedly");
             });
       },
       
       "Test changing view renders current data": function() {
-         return browser.findByCssSelector("#CHANGE_VIEW")
+         return browser.findByCssSelector("#CHANGE_VIEW_label")
             .click()
          .end()
          .findAllByCssSelector(".alfresco-lists-views-AlfListView .alfresco-lists-views-layouts-Cell span.alfresco-renderers-Property:nth-child(3)")
             .then(function(elements) {
-               assert(elements.length === 3, "'VIEW2' was not displayed");
+               assert.lengthOf(elements, 3, "'VIEW2' was not displayed");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
@@ -48,7 +48,7 @@ define(["intern!object",
          // },
 
          // "Count the checked selectors": function() {
-         //     return browser.findAllByCssSelector("#VIEW tr .alfresco-lists-ItemSelectionMixin--checked")
+         //     return browser.findAllByCssSelector("#VIEW tr .alfresco-lists-ItemSelectionMixin--selected")
          //       .then(function(elements) {
          //          assert.lengthOf(elements, 0, "An unexpected number of CHECKED selectors were found");
          //       });
@@ -102,14 +102,14 @@ define(["intern!object",
          //    .findDisplayedByCssSelector(".dijitMenuItem:nth-child(4) > td.dijitMenuItemLabel")
          //       .click()
          //    .end()
-         //    .findByCssSelector("#SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--checked")
+         //    .findByCssSelector("#SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--selected")
          //       .then(null, function() {
          //          assert(false, "First item was not checked when 'Documents' selected");
          //       });
          // },
 
          // "Check that second item is not checked": function() {
-         //    return browser.findAllByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--checked")
+         //    return browser.findAllByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--selected")
          //       .then(function(elements) {
          //          assert.lengthOf(elements, 0, "Second item was unexpectedly checked when 'Documents' selected");
          //       });
@@ -124,14 +124,14 @@ define(["intern!object",
          //       .click()
          //    .end()
 
-         //    .findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--checked")
+         //    .findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--selected")
          //       .then(null, function() {
          //          assert(false, "First item was unexpectedly checked when 'Folders' selected");
          //       });
          // },
 
          // "Check that second item is checked": function() {
-         //    return browser.findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--checked")
+         //    return browser.findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--selected")
          //       .then(null, function() {
          //          assert(false, "Second item was not checked when 'Folders' selected");
          //       });

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
@@ -21,160 +21,191 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-   // Use this function for getting an individual selector...
-   var selectorSelector = function(row) {
-      return "#VIEW tr:nth-child(" + row + ") .alfresco-renderers-Selector";
-   };
-   // Use this function for getting all checked selectors...
-   var checkedSelectorSelector = function() {
-      return "#VIEW tr .alfresco-renderers-Selector.checked";
-   };
-   // Use this function for getting all unchecked selectors...
-   var uncheckedSelectorSelector = function() {
-      return "#VIEW tr .alfresco-renderers-Selector.unchecked";
-   };
-   // Use this function to check if a specific entry is checked...
-   var specificCheckedSelectorSelector = function(row) {
-      return "#VIEW tr:nth-child(" + row + ") .alfresco-renderers-Selector.checked";
-   };
-   // Use this function for getting all unchecked selectors...
-   var specificUncheckedSelectorSelector = function(row) {
-      return "#VIEW tr:nth-child(" + row + ") .alfresco-renderers-Selector.unchecked";
-   };
+   registerSuite(function(){
+      var browser;
 
-registerSuite(function(){
-   var browser;
+      return {
+         name: "Document Selector Tests",
 
-   return {
-      name: "Document Selector Tests",
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/DocumentSelector", "Document Selector Tests").end();
+         },
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/DocumentSelector", "Document Selector Tests").end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         // "Count the rows": function () {
+         //    return browser.findAllByCssSelector("#VIEW tr")
+         //       .then(function(elements) {
+         //          assert.lengthOf(elements, 3, "An unexpected number of rows were detected");
+         //       });
+         // },
 
-      // teardown: function() {
-      //    browser.end();
-      // },
-     
-      "Count the rows": function () {
-         return browser.findAllByCssSelector("#VIEW tr")
-            .then(function(elements) {
-               assert(elements.length === 3, "An unexpected number of rows were detected: " + elements.length);
-            });
-      },
+         // "Count the checked selectors": function() {
+         //     return browser.findAllByCssSelector("#VIEW tr .alfresco-lists-ItemSelectionMixin--checked")
+         //       .then(function(elements) {
+         //          assert.lengthOf(elements, 0, "An unexpected number of CHECKED selectors were found");
+         //       });
+         // },
 
-      "Count the unchecked selectors": function() {
-         return browser.findAllByCssSelector(uncheckedSelectorSelector())
-            .then(function(elements) {
-               assert(elements.length === 3, "An unexpected number of UNCHECKED selectors were found: " + elements.length);
-            });
-      },
+         // "Check that the overall selector indicates that none have been selected": function() {
+         //    return browser.findByCssSelector("#SELECTED_ITEMS .alf-noneselected-icon")
+         //       .then(null, function() {
+         //          assert(false, "The selected items widget doesn't indicate that NO items are selected");
+         //       });
+         // },
 
-      "Count the checked selectors": function() {
-          return browser.findAllByCssSelector(checkedSelectorSelector())
-            .then(function(elements) {
-               assert(elements.length === 0, "An unexpected number of CHECKED selectors were found: " + elements.length);
-            });
-      },
+         // "Check the first selector": function() {
+         //    return browser.findById("SELECTOR_ITEM_0")
+         //       .click()
+         //    .end()
+         //    .findByCssSelector("#SELECTED_ITEMS .alf-someselected-icon")
+         //       .then(null, function() {
+         //          assert(false, "The selected items widget doesn't indicate that SOME items are selected");
+         //       });
+         // },
 
-      "Check that the overall selector indicates that none have been selected": function() {
-         return browser.findByCssSelector("#SELECTED_ITEMS .alf-noneselected-icon")
-            .then(null, function() {
-               assert(false, "The selected items widget doesn't indicate that NO items are selected");
-            });
-      },
+         // "Check the other two selectors": function() {
+         //    return browser.findById("SELECTOR_ITEM_1")
+         //       .click()
+         //    .end()
+         //    .findById("SELECTOR_ITEM_2")
+         //       .click()
+         //    .end()
+         //    .findByCssSelector("#SELECTED_ITEMS .alf-allselected-icon")
+         //       .then(null, function() {
+         //          assert(false, "The selected items widget doesn't indicate that ALL items are selected");
+         //       });
+         // },
 
-      "Check the first selector": function() {
-         return browser.findByCssSelector(selectorSelector(1))
-            .click()
-         .end()
-         .findByCssSelector("#SELECTED_ITEMS .alf-someselected-icon")
-            .then(null, function() {
-               assert(false, "The selected items widget doesn't indicate that SOME items are selected");
-            });
-      },
+         // "Uncheck the middle selector": function() {
+         //    return browser.findById("SELECTOR_ITEM_1")
+         //       .click()
+         //    .end()
+         //    .findByCssSelector("#SELECTED_ITEMS .alf-someselected-icon")
+         //       .then(null, function() {
+         //          assert(false, "The selected items widget doesn't indicate that SOME items are selected");
+         //       });
+         // },
 
-      "Check the other two selectors": function() {
-         return browser.findByCssSelector(selectorSelector(2))
-            .click()
-         .end()
-         .findByCssSelector(selectorSelector(3))
-            .click()
-         .end()
-         .findByCssSelector("#SELECTED_ITEMS .alf-allselected-icon")
-            .then(null, function() {
-               assert(false, "The selected items widget doesn't indicate that ALL items are selected");
-            });
-      },
+         // "Open the menu and select documents": function() {
+         //    return browser.findByCssSelector(".alf-menu-arrow")
+         //       .click()
+         //    .end()
 
-      "Uncheck the middle selector": function() {
-         return browser.findByCssSelector(selectorSelector(2))
-            .click()
-         .end()
-         .findByCssSelector("#SELECTED_ITEMS .alf-someselected-icon")
-            .then(null, function() {
-               assert(false, "The selected items widget doesn't indicate that SOME items are selected");
-            });
-      },
+         //    .findDisplayedByCssSelector(".dijitMenuItem:nth-child(4) > td.dijitMenuItemLabel")
+         //       .click()
+         //    .end()
+         //    .findByCssSelector("#SELECTOR_ITEM_0.alfresco-lists-ItemSelectionMixin--checked")
+         //       .then(null, function() {
+         //          assert(false, "First item was not checked when 'Documents' selected");
+         //       });
+         // },
 
-      "Open the menu and select documents": function() {
-         return browser.findByCssSelector(".alf-menu-arrow")
-            .click()
-         .end()
-         .sleep(150)
-         .findByCssSelector(".dijitMenuItem:nth-child(4) > td.dijitMenuItemLabel")
-            .click()
-         .end()
-         .findByCssSelector(specificCheckedSelectorSelector(1))
-            .then(null, function() {
-               assert(false, "First item was not checked when 'Documents' selected");
-            });
-      },
+         // "Check that second item is not checked": function() {
+         //    return browser.findAllByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--checked")
+         //       .then(function(elements) {
+         //          assert.lengthOf(elements, 0, "Second item was unexpectedly checked when 'Documents' selected");
+         //       });
+         // },
 
-      "Check that second item is not checked": function() {
-         return browser.findByCssSelector(specificUncheckedSelectorSelector(2))
-            .then(null, function() {
-               assert(false, "Second item was unexpectedly checked when 'Documents' selected");
-            });
-      },
+         // "Open the menu and select folders": function() {
+         //    return browser.findByCssSelector(".alf-menu-arrow")
+         //       .click()
+         //    .end()
 
-      "Open the menu and select folders": function() {
-         return browser.findByCssSelector(".alf-menu-arrow")
-            .click()
-         .end()
-         .sleep(150)
+         //    .findDisplayedByCssSelector(".dijitMenuItem:nth-child(5) > td.dijitMenuItemLabel")
+         //       .click()
+         //    .end()
 
-         .findByCssSelector(".dijitMenuItem:nth-child(5) > td.dijitMenuItemLabel")
-            .click()
-         .end()
+         //    .findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--checked")
+         //       .then(null, function() {
+         //          assert(false, "First item was unexpectedly checked when 'Folders' selected");
+         //       });
+         // },
 
-         .findByCssSelector(specificCheckedSelectorSelector(2))
-            .then(null, function() {
-               assert(false, "First item was unexpectedly checked when 'Folders' selected");
-            });
-      },
+         // "Check that second item is checked": function() {
+         //    return browser.findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--checked")
+         //       .then(null, function() {
+         //          assert(false, "Second item was not checked when 'Folders' selected");
+         //       });
+         // },
 
-      "Check that second item is checked": function() {
-         return browser.findByCssSelector(specificUncheckedSelectorSelector(1))
-            .then(null, function() {
-               assert(false, "Second item was not checked when 'Folders' selected");
-            });
-      },
+         "Select via thumbnail (selection only capability)": function() {
+            return browser.findByCssSelector("#SELECT_THUMBNAIL_ITEM_0 .inner img")
+               .clearLog()
+               .click()
+            .end()
+            .getLastPublish("ALF_DOCLIST_DOCUMENT_SELECTED", "Thumbnail click did not publish selection")
+            .getAllPublishes("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payloads) {
+                  assert.lengthOf(payloads, 0, "Navigation publication should not have been made");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Deselect via thumbnail (selection only capability)": function() {
+            return browser.findByCssSelector("#SELECT_THUMBNAIL_ITEM_0 .inner img")
+               .clearLog()
+               .click()
+            .end()
+            .getLastPublish("ALF_DOCLIST_DOCUMENT_DESELECTED", "Thumbnail click did not publish de-selection")
+            .getAllPublishes("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payloads) {
+                  assert.lengthOf(payloads, 0, "Navigation publication should not have been made");
+               });
+         },
+
+         "Select via thumbnail (selection and navigation capability)": function() {
+            return browser.findByCssSelector("#MIXED_THUMBNAIL_ITEM_0 .inner img")
+               .clearLog()
+               .click()
+            .end()
+            .getLastPublish("ALF_DOCLIST_DOCUMENT_SELECTED", "Thumbnail click did not publish selection")
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE", "Navigation publication not made");
+         },
+
+         "Deselect via thumbnail (selection and navigation capability)": function() {
+            return browser.findByCssSelector("#MIXED_THUMBNAIL_ITEM_0 .inner img")
+               .clearLog()
+               .click()
+            .end()
+            .getLastPublish("ALF_DOCLIST_DOCUMENT_DESELECTED", "Thumbnail click did not publish de-selection")
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE", "Navigation publication not made");
+         },
+
+         "Select via thumbnail (selection disabled)": function() {
+            return browser.findByCssSelector("#NON_SELECT_THUMBNAIL_ITEM_0 .inner img")
+               .clearLog()
+               .click()
+            .end()
+            .getAllPublishes("ALF_DOCLIST_DOCUMENT_SELECTED")
+               .then(function(payloads) {
+                  assert.lengthOf(payloads, 0, "Selection publication should not have been made");
+               })
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE", "Navigation publication not made");
+         },
+
+         "Deselect via thumbnail (selection disabled)": function() {
+            return browser.findByCssSelector("#NON_SELECT_THUMBNAIL_ITEM_0 .inner img")
+               .clearLog()
+               .click()
+            .end()
+            .getAllPublishes("ALF_DOCLIST_DOCUMENT_SELECTED")
+               .then(function(payloads) {
+                  assert.lengthOf(payloads, 0, "Selection publication should not have been made");
+               })
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE", "Navigation publication not made");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -76,7 +76,7 @@ registerSuite(function(){
          return browser.findByCssSelector("#PRESET_STATUS > div.lastUpdate > span")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "over 15 years ago", "Preset status time not displayed as expected");
+               assert.equal(resultText, "over 16 years ago", "Preset status time not displayed as expected");
             });
       },
 
@@ -165,7 +165,7 @@ registerSuite(function(){
          return browser.findByCssSelector("#NO_STATUS > div.lastUpdate > span")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "over 15 years ago", "Status time not updated");
+               assert.equal(resultText, "over 16 years ago", "Status time not updated");
             })
             .end();
 

--- a/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
@@ -22,95 +22,94 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Thumbnail Tests",
+      return {
+         name: "Thumbnail Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Thumbnail", "Thumbnail Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Thumbnail", "Thumbnail Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check there are the expected number of thumbnails successfully rendered": function () {
-         return browser.findAllByCssSelector("span.alfresco-renderers-Thumbnail")
-            .then(function (elements){
-               assert.lengthOf(elements, 9, "There should be 9 thumbnails successfully rendered");
-            });
-      },
+         "Check there are the expected number of thumbnails successfully rendered": function () {
+            return browser.findAllByCssSelector("span.alfresco-renderers-Thumbnail")
+               .then(function (elements){
+                  assert.lengthOf(elements, 9, "There should be 9 thumbnails successfully rendered");
+               });
+         },
 
-      "Standard document link": function() {
-         return browser.findByCssSelector("#DOCLIB_RENDITIONS tr:nth-child(2) .alfresco-renderers-Thumbnail .inner img")
-            .click()
-         .end();
-         // TODO: Link is currently not created properly outside of Share, raised https://issues.alfresco.com/jira/browse/AKU-240
-      },
+         "Standard document link": function() {
+            return browser.findByCssSelector("#DOCLIB_RENDITIONS tr:nth-child(2) .alfresco-renderers-Thumbnail .inner img")
+               .click()
+            .end();
+            // TODO: Link is currently not created properly outside of Share, raised https://issues.alfresco.com/jira/browse/AKU-240
+         },
 
-      "Standard container link": function() {
-         return browser.findByCssSelector("#DOCLIB_RENDITIONS tr:nth-child(1) .alfresco-renderers-Thumbnail .inner img")
-            .click()
-         .end()
-         .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
-            .then(function(payload) {
-               assert.propertyVal(payload, "path", "/Budget Files/Invoices/Folder", "Could not find standard container link publication");
-            });
-      },
+         "Standard container link": function() {
+            return browser.findByCssSelector("#DOCLIB_RENDITIONS tr:nth-child(1) .alfresco-renderers-Thumbnail .inner img")
+               .click()
+            .end()
+            .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "path", "/Budget Files/Invoices/Folder", "Could not find standard container link publication");
+               });
+         },
 
-      "Custom thumbnail link": function() {
-         return browser.findByCssSelector("#IMGPREVIEW_RENDITIONS tr:nth-child(2) .alfresco-renderers-Thumbnail .inner img")
-            .click()
-         .end()
+         "Custom thumbnail link": function() {
+            return browser.findByCssSelector("#IMGPREVIEW_RENDITIONS tr:nth-child(2) .alfresco-renderers-Thumbnail .inner img")
+               .click()
+            .end()
 
-         .getLastPublish("CUSTOM_SCOPE_CUSTOM_CLICK_TOPIC", "Topic was not published at the correct scope")
-            .then(function(payload) {
-               assert.propertyVal(payload, "nodeRef", "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8", "Could not find custom link click publication");
-            });
-      },
+            .getLastPublish("CUSTOM_SCOPE_CUSTOM_CLICK_TOPIC", "Topic was not published at the correct scope")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "nodeRef", "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8", "Could not find custom link click publication");
+               });
+         },
 
-      "Lightbox preview": function() {
-         return browser.findByCssSelector("#TASKS1 .alfresco-renderers-Thumbnail .inner img")
-            .click()
-         .end()
-         .sleep(1000) // Give the lightbox a chance to populate
-         .findByCssSelector("#aikauLightbox")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The lightbox preview was not displayed");
-            });
-      },
-
-      "Escape closes lightbox preview": function() {
-         return browser.pressKeys([keys.ESCAPE])
+         "Lightbox preview": function() {
+            return browser.findByCssSelector("#TASKS1 .alfresco-renderers-Thumbnail .inner img")
+               .click()
+            .end()
+            .sleep(1000) // Give the lightbox a chance to populate
             .findByCssSelector("#aikauLightbox")
                .isDisplayed()
                .then(function(displayed) {
-                  assert.isFalse(displayed, "The lightbox preview was not hidden on ESC");
+                  assert.isTrue(displayed, "The lightbox preview was not displayed");
                });
-      },
+         },
 
-      "PDFjs Preview": function() {
-         return browser.findByCssSelector("#HARDCODED .alfresco-renderers-Thumbnail .inner img")
-            .click()
-         .end()
-         .findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-preview-PdfJs")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "PDFjs preview not displayed");
-            });
-      },
+         "Escape closes lightbox preview": function() {
+            return browser.pressKeys([keys.ESCAPE])
+               .findByCssSelector("#aikauLightbox")
+                  .isDisplayed()
+                  .then(function(displayed) {
+                     assert.isFalse(displayed, "The lightbox preview was not hidden on ESC");
+                  });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "PDFjs Preview": function() {
+            return browser.findByCssSelector("#HARDCODED .alfresco-renderers-Thumbnail .inner img")
+               .click()
+            .end()
+            .findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-preview-PdfJs")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "PDFjs preview not displayed");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocumentList.get.js
@@ -10,8 +10,7 @@ model.jsonModel = {
                error: true
             }
          }
-      },
-      "alfresco/services/ErrorReporter"
+      }
    ],
    widgets: [
       {
@@ -251,10 +250,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocumentSelector.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocumentSelector.get.js
@@ -10,8 +10,7 @@ model.jsonModel = {
                error: true
             }
          }
-      },
-      "alfresco/services/ErrorReporter"
+      }
    ],
    widgets: [
       {
@@ -48,20 +47,26 @@ model.jsonModel = {
                         items: [
                            {
                               name: "Not a container",
-                              jsNode: {
-                                 isContainer: false
+                              node: {
+                                 displayName: "Not a container",
+                                 isContainer: false,
+                                 nodeRef: "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8"
                               }
                            },
                            {
                               name: "Container",
-                              jsNode: {
-                                 isContainer: true
+                              node: {
+                                 displayName: "Container",
+                                 isContainer: true,
+                                 nodeRef: "some://node/2"
                               }
                            },
                            {
                               name: "Another Container",
-                              jsNode: {
-                                 isContainer: true
+                              node: {
+                                 displayName: "Another Container",
+                                 isContainer: true,
+                                 nodeRef: "some://node/3"
                               }
                            }
                         ]
@@ -72,22 +77,120 @@ model.jsonModel = {
                            name: "alfresco/lists/views/AlfListView",
                            config: {
                               additionalCssClasses: "bordered",
-                              widgets: [
+                              widgetsForHeader: [
+                                    {
+                                       name: "alfresco/lists/views/layouts/HeaderCell",
+                                       config: {
+                                          id: "ID",
+                                          label: "Selector"
+                                       }
+                                    },
+                                    {
+                                       name: "alfresco/lists/views/layouts/HeaderCell",
+                                       config: {
+                                          id: "NAME",
+                                          label: "Name"
+                                       }
+                                    },
+                                    {
+                                       name: "alfresco/lists/views/layouts/HeaderCell",
+                                       config: {
+                                          id: "OPTION",
+                                          label: "Thumbnail (selection only)"
+                                       }
+                                    },
+                                    {
+                                       name: "alfresco/lists/views/layouts/HeaderCell",
+                                       config: {
+                                          id: "OPTION",
+                                          label: "Thumbnail (selection plus regular action)"
+                                       }
+                                    },
+                                    {
+                                       name: "alfresco/lists/views/layouts/HeaderCell",
+                                       config: {
+                                          id: "OPTION",
+                                          label: "Thumbnail (regular action only)"
+                                       }
+                                    }
+                                 ],
+                                 widgets: [
                                  {
+                                    id: "ROW",
                                     name: "alfresco/lists/views/layouts/Row",
                                     config: {
                                        widgets: [
                                           {
+                                             id: "COL1",
                                              name: "alfresco/lists/views/layouts/Cell",
                                              config: {
                                                 widgets:[
                                                    {
+                                                      id: "SELECTOR",
                                                       name: "alfresco/renderers/Selector"
-                                                   },
+                                                   }
+                                                ]
+                                             }
+                                          },
+                                          {
+                                             id: "COL2",
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets:[
                                                    {
+                                                      id: "NAME",
                                                       name: "alfresco/renderers/Property",
                                                       config: {
                                                          propertyToRender: "name"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          },
+                                          {
+                                             id: "COL3",
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets:[
+                                                   {
+                                                      id: "SELECT_THUMBNAIL",
+                                                      name: "alfresco/renderers/Thumbnail",
+                                                      config: {
+                                                         updateOnSelection: true,
+                                                         selectOnClick: true,
+                                                         onlySelectOnClick: true
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          },
+                                          {
+                                             id: "COL4",
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets:[
+                                                   {
+                                                      id: "MIXED_THUMBNAIL",
+                                                      name: "alfresco/renderers/Thumbnail",
+                                                      config: {
+                                                         updateOnSelection: true,
+                                                         selectOnClick: true
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          },
+                                          {
+                                             id: "COL5",
+                                             name: "alfresco/lists/views/layouts/Cell",
+                                             config: {
+                                                widgets:[
+                                                   {
+                                                      id: "NON_SELECT_THUMBNAIL",
+                                                      name: "alfresco/renderers/Thumbnail",
+                                                      config: {
+                                                         updateOnSelection: false,
+                                                         selectOnClick: false
                                                       }
                                                    }
                                                 ]
@@ -106,10 +209,10 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "aikauTesting/mockservices/ThumbnailsMockXhr"
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-627 to add optional support for item selection by clicking on it's thumbnail. A new mixin module ItemSelectionMixin has been abstracted from the Selector widget and mixed into both the Selector and Thumbnail widgets. The unit tests have been updated to verify the new functionality works as expected.