### PR TITLE
Add form field focus and submit on enter

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -117,9 +117,10 @@ define(["dojo/_base/declare",
         "dijit/registry",
         "dojo/Deferred",
         "dojo/dom-construct",
-        "dojo/dom-class"], 
+        "dojo/dom-class",
+        "dojo/on"], 
         function(declare, _Widget, _Templated, Form, AlfCore, CoreWidgetProcessing, topics, _AlfHashMixin, RulesEngineMixin, 
-                 template, ioQuery, Warning, hashUtils, lang, AlfButton, array, registry, Deferred, domConstruct, domClass) {
+                 template, ioQuery, Warning, hashUtils, lang, AlfButton, array, registry, Deferred, domConstruct, domClass, on) {
    
    return declare([_Widget, _Templated, AlfCore, CoreWidgetProcessing, _AlfHashMixin, RulesEngineMixin], {
       
@@ -309,7 +310,27 @@ define(["dojo/_base/declare",
        * @since 1.0.32
        */
       warningsPosition: "top",
-      
+
+      /**
+       * Should the first field in the form be focused when the form is loaded?
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.40
+       */
+      firstFieldFocusOnLoad: false,
+
+      /**
+       * Should the form automatically submit when the enter key is pressed?
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.40
+       */
+      submitOnEnter: false,
+
       /**
        * @instance
        */
@@ -383,6 +404,24 @@ define(["dojo/_base/declare",
             }, this);
 
             this.processWidgets(this.widgets, this._form.domNode, "FIELDS");
+         }
+
+         // If configured, focus the first field in the form
+         if (this.firstFieldFocusOnLoad)
+         {
+            this.focus();
+         }
+
+         // If configured, allow the form to be submitted by pressing the enter key
+         if (this.submitOnEnter && !this.autoSavePublishTopic)
+         {
+            on(this, "keydown", lang.hitch(this, function(event){
+               if (event.keyCode === dojo.keys.ENTER && this.invalidFormControls.length === 0)
+               {
+                  var payload = lang.mixin(this.okButtonPublishPayload || {}, this.getValue());
+                  this.alfPublish(this.okButtonPublishTopic, payload, (this.okButtonPublishGlobal !== undefined && this.okButtonPublishGlobal === true));
+               }  
+            }));
          }
       },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -29,146 +29,193 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, keys, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Base Form Control Tests",
+      return {
+         name: "Base Form Control Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/BaseForm", "Base Form Control Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/BaseForm", "Base Form Control Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Checking the form field is initially empty": function() {
-         return browser.findByCssSelector("div#FORM_FIELD div.control input[name='control']")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "", "Form field not initially empty");
-            });
-      },
+         "Checking the form field is initially empty": function() {
+            return browser.findByCssSelector("div#FORM_FIELD div.control input[name='control']")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "", "Form field not initially empty");
+               });
+         },
 
-      "No payload does not update value": function() {
-         return browser.findById("SET_FORM_VALUE_1")
-            .click()
-            .end()
+         "No payload does not update value": function() {
+            return browser.findById("SET_FORM_VALUE_1")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "", "No payload published but field value updated");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "", "No payload published but field value updated");
+               });
+         },
 
-      "Invalid field name does not update value": function() {
-         return browser.findById("SET_FORM_VALUE_2")
-            .click()
-            .end()
+         "Invalid field name does not update value": function() {
+            return browser.findById("SET_FORM_VALUE_2")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "", "Invalid field name provided but value updated");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "", "Invalid field name provided but value updated");
+               });
+         },
 
-      "Setting string value updates field appropriately": function() {
-         return browser.findById("SET_FORM_VALUE_3")
-            .click()
-            .end()
+         "Setting string value updates field appropriately": function() {
+            return browser.findById("SET_FORM_VALUE_3")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "this is the new value", "Field value not updated to published string value");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "this is the new value", "Field value not updated to published string value");
+               });
+         },
 
-      "Setting number value updates field appropriately": function() {
-         return browser.findById("SET_FORM_VALUE_4")
-            .click()
-            .end()
+         "Setting number value updates field appropriately": function() {
+            return browser.findById("SET_FORM_VALUE_4")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "3.14159265", "Field value not updated to published numeric value");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "3.14159265", "Field value not updated to published numeric value");
+               });
+         },
 
-      "Setting boolean value updates field appropriately": function() {
-         return browser.findById("SET_FORM_VALUE_5")
-            .click()
-            .end()
+         "Setting boolean value updates field appropriately": function() {
+            return browser.findById("SET_FORM_VALUE_5")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "true", "Field value not updated to published boolean value");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "true", "Field value not updated to published boolean value");
+               });
+         },
 
-      "Autosave on a form removes OK/Cancel buttons": function() {
-         return browser.findAllByCssSelector("#BASIC_FORM .confirmationButton, #BASIC_FORM .cancelButton")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "OK/Cancel buttons not found on basic form");
-            })
-            .end()
+         "Autosave on a form removes OK/Cancel buttons": function() {
+            return browser.findAllByCssSelector("#BASIC_FORM .confirmationButton, #BASIC_FORM .cancelButton")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "OK/Cancel buttons not found on basic form");
+               })
+               .end()
 
-         .findAllByCssSelector("#AUTOSAVE_FORM .confirmationButton, #AUTOSAVE_FORM .cancelButton")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "OK/Cancel buttons found on autosave form");
-            });
-      },
+            .findAllByCssSelector("#AUTOSAVE_FORM .confirmationButton, #AUTOSAVE_FORM .cancelButton")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "OK/Cancel buttons found on autosave form");
+               });
+         },
 
-      "Updating autosave value publishes form": function() {
-         return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD .dijitInputInner")
-            .clearValue()
-            .type("wibble")
-            .getLastPublish("AUTOSAVE_FORM_1")
-            .then(function(payload) {
-               assert.propertyVal(payload, "control", "wibble", "Did not autosave updated value");
-               assert.propertyVal(payload, "alfValidForm", true, "Did not autosave validity property");
-            });
-      },
+         "Updating autosave value publishes form": function() {
+            return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD .dijitInputInner")
+               .clearValue()
+               .type("wibble")
+               .getLastPublish("AUTOSAVE_FORM_1")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "control", "wibble", "Did not autosave updated value");
+                  assert.propertyVal(payload, "alfValidForm", true, "Did not autosave validity property");
+               });
+         },
 
-      "Updating to invalid value does not autosave form": function() {
-         return browser.findById("CLEAR_AUTOSAVE_1")
-            .click()
-            .clearLog()
-            .getAllPublishes("AUTOSAVE_FORM_1")
-            .then(function(payloads) {
-               assert.lengthOf(payloads, 0, "Published form when invalid");
-            });
-      },
+         "Updating to invalid value does not autosave form": function() {
+            return browser.findById("CLEAR_AUTOSAVE_1")
+               .click()
+               .clearLog()
+               .getAllPublishes("AUTOSAVE_FORM_1")
+               .then(function(payloads) {
+                  assert.lengthOf(payloads, 0, "Published form when invalid");
+               });
+         },
 
-      "Autosave on invalid flag publishes invalid form": function() {
-         return browser.findByCssSelector("#AUTOSAVE_INVALID_FORM_FIELD .dijitInputInner")
-            .clearLog()
-            .clearValue()
-            .pressKeys(keys.BACKSPACE) // Need to trigger an update!
-            .getLastPublish("AUTOSAVE_FORM_2")
-            .then(function(payload) {
-               assert.propertyVal(payload, "control", "", "Did not autosave updated, invalid value");
-               assert.propertyVal(payload, "alfValidForm", false, "Did not autosave validity property");
-            });
-      },
+         "Autosave on invalid flag publishes invalid form": function() {
+            return browser.findByCssSelector("#AUTOSAVE_INVALID_FORM_FIELD .dijitInputInner")
+               .clearLog()
+               .clearValue()
+               .pressKeys(keys.BACKSPACE) // Need to trigger an update!
+               .getLastPublish("AUTOSAVE_FORM_2")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "control", "", "Did not autosave updated, invalid value");
+                  assert.propertyVal(payload, "alfValidForm", false, "Did not autosave validity property");
+               });
+         },
 
-      "Autosaving with defined payload mixes payload into form values": function(){
-         return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD") // Need to get session to check for publish
-            .getLastPublish("AUTOSAVE_FORM_2")
-            .then(function(payload) {
-               assert.propertyVal(payload, "customProperty", "awooga", "Did not mix custom payload into form values");
-            });
-      },
+         "Autosaving with defined payload mixes payload into form values": function(){
+            return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD") // Need to get session to check for publish
+               .getLastPublish("AUTOSAVE_FORM_2")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "customProperty", "awooga", "Did not mix custom payload into form values");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   // This test reloads the page to clear any previous focus
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Base Form Control Tests - Focus and Enter to Submit",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/BaseForm", "Base Form Control Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check the form fields are correctly focused": function() {
+            return browser.findByCssSelector("#FOCUS_AND_SUBMIT_ON_ENTER_FORM #FORM_FIELD1 div.dijitFocused")
+               .end()
+
+            .findByCssSelector("#FOCUS_AND_SUBMIT_ON_ENTER_FORM #FORM_FIELD2 div.dijitFocused")
+               .then(function () {
+                  assert.fail(null, null, "Form field 2 should not be focused");
+               },
+               function () {
+                  
+               });
+         },
+
+         "Check the form submits by the enter key": function() {
+            return browser.findByCssSelector("#FOCUS_AND_SUBMIT_ON_ENTER_FORM #FORM_FIELD1 .dijitInputInner")
+               .clearValue()
+               .type("wibble")
+               .pressKeys(keys.ENTER)
+               .getLastPublish("SUBMIT_FOCUS_AND_SUBMIT_ON_ENTER_FORM")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "control1", "wibble", "control1 value incorrect");
+                  assert.propertyVal(payload, "control2", "", "control2 value incorrect");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -172,6 +172,34 @@ model.jsonModel = {
                         }
                      ]
                   }
+               },
+               {
+                  name: "alfresco/forms/Form",
+                  id: "FOCUS_AND_SUBMIT_ON_ENTER_FORM",
+                  config: {
+                     okButtonPublishTopic: "SUBMIT_FOCUS_AND_SUBMIT_ON_ENTER_FORM",
+                     okButtonPublishGlobal: true,
+                     firstFieldFocusOnLoad: true,
+                     submitOnEnter: true,
+                     widgets: [
+                        {
+                           id: "FORM_FIELD1",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              name: "control1",
+                              label: "Basic form control 1"
+                           }
+                        },
+                        {
+                           id: "FORM_FIELD2",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              name: "control2",
+                              label: "Basic form control 2"
+                           }
+                        }
+                     ]
+                  }
                }
             ]
          }


### PR DESCRIPTION
Add optional functionality to focus first form field and submit by pressing the enter key. Docs, tests and reformatting included.