### PR TITLE
AKU-634: Non-resizeable sidebar

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -221,6 +221,13 @@
 @dashlet-body-background: @primary-background-color;
 @dashlet-body-border-radius: 0; // This gives rounding at the top of the dashlet only
 
+// Layout containers
+@sidebar-container-sidebar-background-color: @primary-background-color;
+@sidebar-container-main-background-color: @primary-background-color;
+@sidebar-container-resize-handle-background-color: @primary-background-color;
+@sidebar-container-resize-handle-background-color-active: @primary-background-color;
+@sidebar-container-borders: @standard-border;
+
 // Notifications
 @notification-background: #666;
 @notification-foreground: @highlighted-font-color;

--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -23,7 +23,7 @@
  * <b>"sidebar"</b> will result in that widget being placed into the sidebar (widgets without an <b>align</b> attribute
  * or with the <b>align</b> attribute set to any other value will be placed into the main panel).</p>
  * <p>If you don't want the sidebar to be resizeable then you can set the 
- * [isResizeable]{@link module:alfresco/layout/AlfSideBarContainer#isResizeable} to be false. This will result in a simple
+ * [isResizable]{@link module:alfresco/layout/AlfSideBarContainer#isResizable} to be false. This will result in a simple
  * border separating the sidebar and main areas.</p>
  *
  * @example <caption>Example configuration placing one widget in the sidebar and the other in the main panel</caption>
@@ -52,7 +52,7 @@
  * {
  *    name: "alfresco/layout/AlfSideBarContainer",
  *    config: {
- *       isResizeable: false,
+ *       isResizable: false,
  *       initialSidebarWidth: 250,
  *       widgets: [
  *          {
@@ -164,7 +164,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.40
        */
-      isResizeable: true,
+      isResizable: true,
       
       /**
        * The last registered width (in pixels) of the sidebar (needed for window resize events)
@@ -264,7 +264,7 @@ define(["dojo/_base/declare",
             max = null;
          }
          
-         if (this.isResizeable)
+         if (this.isResizable)
          {
             $(this.sidebarNode).resizable({
                handles: {
@@ -360,7 +360,7 @@ define(["dojo/_base/declare",
          domStyle.set(this.sidebarNode, "height", h + "px");
          domStyle.set(this.mainNode, "width", (size - w - 16) + "px");
 
-         if (!this.isResizeable)
+         if (!this.isResizable)
          {
             // domStyle.set(this.resizeHandlerNode, "display", "none");
             domStyle.set(this.sidebarNode, "width", w + "px");
@@ -453,7 +453,7 @@ define(["dojo/_base/declare",
             }
             
             // Show the sidebar...
-            if (this.isResizeable)
+            if (this.isResizable)
             {
                $(this.sidebarNode).resizable("enable"); // Unlock the resizer when the sidebar is not shown...
             }

--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -128,6 +128,15 @@ define(["dojo/_base/declare",
        * @default
        */
       initialSidebarWidth: 350,
+
+      /**
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.40
+       */
+      isResizeable: true,
       
       /**
        * The last registered width (in pixels) of the sidebar (needed for window resize events)
@@ -227,17 +236,24 @@ define(["dojo/_base/declare",
             max = null;
          }
          
-         $(this.sidebarNode).resizable({
-            handles: {
-               "e": ".resize-handle"
-            },
-            minWidth: this.minSidebarWidth,
-            maxWidth: max,
-            resize: lang.hitch(this, this.resizeHandler),
-            stop: lang.hitch(this, this.endResizing)
-         });
-         
-         on(this.resizeHandlerButtonNode, "click", lang.hitch(this, this.onResizeHandlerClick));
+         if (this.isResizeable)
+         {
+            $(this.sidebarNode).resizable({
+               handles: {
+                  "e": ".resize-handle"
+               },
+               minWidth: this.minSidebarWidth,
+               maxWidth: max,
+               resize: lang.hitch(this, this.resizeHandler),
+               stop: lang.hitch(this, this.endResizing)
+            });
+
+            on(this.resizeHandlerButtonNode, "click", lang.hitch(this, this.onResizeHandlerClick));
+         }
+         else
+         {
+            domClass.add(this.domNode, "alfresco-layout-AlfSideBarContainer--resizeDisabled");
+         }
          
          // We need to subscribe after the resize widget has been created...
          this.alfSubscribe("ALF_DOCLIST_SHOW_SIDEBAR", lang.hitch(this, this.showEventListener));
@@ -315,6 +331,12 @@ define(["dojo/_base/declare",
 
          domStyle.set(this.sidebarNode, "height", h + "px");
          domStyle.set(this.mainNode, "width", (size - w - 16) + "px");
+
+         if (!this.isResizeable)
+         {
+            // domStyle.set(this.resizeHandlerNode, "display", "none");
+            domStyle.set(this.sidebarNode, "width", w + "px");
+         }
          
          // Fire a custom event to let contained objects know that the node has been resized.
          this.alfPublishResizeEvent(this.mainNode);

--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -130,6 +130,7 @@ define(["dojo/_base/declare",
       initialSidebarWidth: 350,
 
       /**
+       * Indicates whether or not the sidebar should be resizable or not.
        * 
        * @instance
        * @type {boolean}
@@ -425,7 +426,11 @@ define(["dojo/_base/declare",
             }
             
             // Show the sidebar...
-            $(this.sidebarNode).resizable("enable"); // Unlock the resizer when the sidebar is not shown...
+            if (this.isResizeable)
+            {
+               $(this.sidebarNode).resizable("enable"); // Unlock the resizer when the sidebar is not shown...
+            }
+            
             var width = (this.hiddenSidebarWidth) ? this.hiddenSidebarWidth : this.initialSidebarWidth;
             domStyle.set(this.sidebarNode, "width", width + "px");
 

--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -18,15 +18,42 @@
  */
 
 /**
- * This layout widget provides a resizeable sidebar that can be snapped open and closed into which widgets
+ * <p>This layout widget provides a resizeable sidebar that can be snapped open and closed into which widgets
  * can be placed. Each widget in the <b>widgets</b> array can given an optional <b>align</b> attribute that if set to
  * <b>"sidebar"</b> will result in that widget being placed into the sidebar (widgets without an <b>align</b> attribute
- * or with the <b>align</b> attribute set to any other value will be placed into the main panel).
+ * or with the <b>align</b> attribute set to any other value will be placed into the main panel).</p>
+ * <p>If you don't want the sidebar to be resizeable then you can set the 
+ * [isResizeable]{@link module:alfresco/layout/AlfSideBarContainer#isResizeable} to be false. This will result in a simple
+ * border separating the sidebar and main areas.</p>
  *
  * @example <caption>Example configuration placing one widget in the sidebar and the other in the main panel</caption>
  * {
  *    name: "alfresco/layout/AlfSideBarContainer",
  *    config: {
+ *       widgets: [
+ *          {
+ *             name: "alfresco/html/Label",
+ *             align: "sidebar",
+ *             config: {
+ *                label: "This is in the sidebar"
+ *             }
+ *          },
+ *          {
+ *             name: "alfresco/html/Label",
+ *             config: {
+ *                label: "This is in the main panel"
+ *             }
+ *          }
+ *       ]
+ *    }
+ * }
+ *
+ * @example <caption>Example configuration where the sidebar cannot be resized (with custom width)</caption>
+ * {
+ *    name: "alfresco/layout/AlfSideBarContainer",
+ *    config: {
+ *       isResizeable: false,
+ *       initialSidebarWidth: 250,
  *       widgets: [
  *          {
  *             name: "alfresco/html/Label",

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -83,6 +83,7 @@
       .alfresco-layout-AlfSideBarContainer__container {
          .alfresco-layout-AlfSideBarContainer__sidebar {
             border-right: @sidebar-container-borders;
+            padding-right: 0;
          }
       }
       

--- a/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfSideBarContainer.css
@@ -2,6 +2,7 @@
 
    .alfresco-layout-AlfSideBarContainer__container {
       overflow: hidden;
+      background-color: @sidebar-container-main-background-color;
 
       .alfresco-layout-AlfSideBarContainer__sidebar,
       .alfresco-layout-AlfSideBarContainer__main {
@@ -17,22 +18,23 @@
          color: @general-font-color;
          border: none;
          padding-right: 10px;
+         background-color: @sidebar-container-sidebar-background-color;
 
          /* Convert the YUI resize handle to be transparent and slightly wider
             to accommodate our custom image for popping the sidebar in and out */
          .alfresco-layout-AlfSideBarContainer__resizeHandle {
-            background-color: #ffffff;
+            background-color: @sidebar-container-resize-handle-background-color;
             width: 9px;
             right: 0;
-            border-right: @standard-border;
-            border-left: @standard-border;
+            border-right: @sidebar-container-borders;
+            border-left: @sidebar-container-borders;
 
             /* Override the default drag handle image */
             .alfresco-layout-AlfSideBarContainer__resizeButton {
                background-position: 0 6px;
                background-color: transparent;
                background-repeat: no-repeat;
-               border: @standard-border;
+               border: @sidebar-container-borders;
                border-left: none;
                border-right: none;
                width: 8px;
@@ -55,7 +57,7 @@
 
          /* Ensure that the resize handle gets some colour when being used */ 
          .resize-handle.active{
-            background-color: #dfdfdf;
+            background-color: @sidebar-container-resize-handle-background-color-active;
          }
       }
 
@@ -74,6 +76,18 @@
                background-image: url("./images/PopOutArrow.png");
             }
          }
+      }
+   }
+
+   &--resizeDisabled {
+      .alfresco-layout-AlfSideBarContainer__container {
+         .alfresco-layout-AlfSideBarContainer__sidebar {
+            border-right: @sidebar-container-borders;
+         }
+      }
+      
+      .alfresco-layout-AlfSideBarContainer__resizeHandle {
+         display: none;
       }
    }
 }

--- a/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfSideBarContainerTest.js
@@ -21,204 +21,186 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-   // var startSize;
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "AlfSideBarContainer Tests",
+      return {
+         name: "AlfSideBarContainer Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfSideBarContainer", "AlfSideBarContainer Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfSideBarContainer", "AlfSideBarContainer Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-     "Test preferences requested": function () {
-         return browser.findByCssSelector(".resize-handle") // Need to find something before getting logged publish data
-            .getLastPublish("ALF_PREFERENCE_GET")
-               .then(function(payload) {
-                  assert.propertyVal(payload, "preference", "org.alfresco.share.sideBarWidth", "User preferences were not requested");
-               });
-      },
+        "Test preferences requested": function () {
+            return browser.findByCssSelector(".resize-handle") // Need to find something before getting logged publish data
+               .getLastPublish("ALF_PREFERENCE_GET")
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "preference", "org.alfresco.share.sideBarWidth", "User preferences were not requested");
+                  });
+         },
 
-      "Test Resized Handle Exists": function () {
-         return browser.findByCssSelector(".resize-handle")
-            .then(
-               function() {
-                  // No action required - resize handler found
-               },
-               function() {
-                  assert(false, "Couldn't find resize handle");
-               });
-      },
+         "Test Resized Handle Exists": function () {
+            return browser.findByCssSelector(".resize-handle");
+         },
 
-      "Test Sidebar Placement": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar #SIDEBAR_LOGO")
-            .then(
-               function() {
-                  // No action required - found logo in sidebar
-               },
-               function() {
-                  assert(false, "Logo wasn't placed correctly into the sidebar");
-               });
-      },
+         "Test Sidebar Placement": function () {
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar #SIDEBAR_LOGO");
+         },
 
-      "Test Main Panel Placement": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__main #MAIN_LOGO")
-            .then(
-               function() {
-                  // No action required - found logo in main panel
-               },
-               function() {
-                  assert(false, "Main logo wasn't placed correctly into main panel");
-               });
-      },
+         "Test Main Panel Placement": function () {
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__main #MAIN_LOGO");
+         },
 
-      "Test Initial Widths": function () {
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-            .getSize()
-            .then(function(size) {
-               // NOTE: The width has to take the 10px right padding into account
-               assert.equal(size.width, 360, "The sidebar width wasn't initialised correctly");
-            });
-      },
-
-      "Test Hide Sidebar": function () {
-         return browser.findByCssSelector(".resize-handle-button")
-            .click()
-         .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.width, 9, "The sidebar wasn't hidden via the bar control");
-            });
-      },
-
-      "Test Show Sidebar": function() {
-         return browser.findByCssSelector(".resize-handle-button")
-            .click()
-         .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-            .getSize()
-            .then(function(size) {
-               // NOTE: The width has to take the 10px right padding into account
-               assert.equal(size.width, 360, "The sidebar wasn't shown via the bar control");
-            });
-      },
-
-      "Test Hide Sidebar via PubSub": function() {
-         return this.remote.findByCssSelector("#HIDE_BUTTON")
-            .click()
-         .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-            .getSize()
-            .then(function(size) {
-               assert.equal(size.width, 9, "The sidebar wasn't hidden via publication");
-            });
-      },
-
-      "Test Show Sidebar via PubSub": function() {
-         return browser.findByCssSelector("#SHOW_BUTTON")
-            .click()
-         .end()
-         .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-            .getSize()
-            .then(function(size) {
-               // NOTE: The width has to take the 10px right padding into account
-               assert.equal(size.width, 360, "The sidebar wasn't shown via publication");
-            })
-         .end();
-      },
-
-      "Increase window size and check sidebar height": function() {
-         var bodyHeight;
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
-            .end()
-            .clearLog() // Clear the logs otherwise they'll force the size of the window
-            .setWindowSize(null, 1024, 968)
-            .findByCssSelector("body")
+         "Test Initial Widths": function () {
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
-                  // We need the body size, not the window size because the window size includes all the OS chrome
-                  bodyHeight = size.height;
-               })
+                  // NOTE: The width has to take the 10px right padding into account
+                  assert.equal(size.width, 360, "The sidebar width wasn't initialised correctly");
+               });
+         },
+
+         "Test Hide Sidebar": function () {
+            return browser.findByCssSelector(".resize-handle-button")
+               .click()
+            .end()
             .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
-                  // Substracting the padding from the height!
-                  assert.closeTo(size.height, (bodyHeight - 20), 5, "The sidebar height didn't increase with the window size");
+                  assert.equal(size.width, 9, "The sidebar wasn't hidden via the bar control");
                });
-      },
+         },
 
-      "Decrease window size and check sidebar height": function() {
-         var bodyHeight;
-         return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
+         "Test Show Sidebar": function() {
+            return browser.findByCssSelector(".resize-handle-button")
+               .click()
             .end()
-            .clearLog() // Clear the logs otherwise they'll force the size of the window
-            .setWindowSize(null, 1024, 568)
-            .findByCssSelector("body")
-               .getSize()
-               .then(function(size) {
-                  // We need the body size, not the window size because the window size includes all the OS chrome
-                  bodyHeight = size.height;
-               })
             .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
                .getSize()
                .then(function(size) {
-                  // Substracting the padding from the height!
-                  assert.closeTo(size.height, (bodyHeight - 20), 5, "The sidebar height didn't decrease with the window size");
+                  // NOTE: The width has to take the 10px right padding into account
+                  assert.equal(size.width, 360, "The sidebar wasn't shown via the bar control");
                });
-      },
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-      // TODO: Re-instate when figured out how to resize with Leadfoot!
-      // ,
-      // "Test Resize": function () {
-      //    var browser = this.remote;
-      //    return this.remote.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-      //       .getSize()
-      //       .then(function(size) {
-      //          console.log("Initial sidebar width: " + size.width);
-      //          startSize = size;
-      //       })
-      //    .end()
-      //    // .releaseMouseButton()
-      //    // .catch(function(err) {
-      //    //    // No action required
-      //    // })
-      //    .findByCssSelector(".resize-handle")
-      //       .moveMouseTo()
-      //       .click()
-      //       .sleep(2000)
-      //       .pressMouseButton()
-      //       .moveMouseTo(1, 1)
-      //       .sleep(100)
-      //       .moveMouseTo(200, 1)
-      //       .sleep(2000)
-      //       .releaseMouseButton()
-      //    .end()
-      //    .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
-      //       .getSize()
-      //       .then(function(endSize) {
-      //          console.log("Final sidebar width: " + endSize.width);
-      //          expect(endSize.width).to.be.at.least(startSize.width, "The sidebar did not resize on the x axis");
-      //          // expect(endSize.height).to.equal(startSize.height, "Test #4b - The sidebar should not have resized on the y axis");
-      //       })
-      //    .end()
-      //    .alfPostCoverageResults(browser);
-      // }
-   };
+         "Test Hide Sidebar via PubSub": function() {
+            return this.remote.findByCssSelector("#HIDE_BUTTON")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.width, 9, "The sidebar wasn't hidden via publication");
+               });
+         },
+
+         "Test Show Sidebar via PubSub": function() {
+            return browser.findByCssSelector("#SHOW_BUTTON")
+               .click()
+            .end()
+            .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
+               .getSize()
+               .then(function(size) {
+                  // NOTE: The width has to take the 10px right padding into account
+                  assert.equal(size.width, 360, "The sidebar wasn't shown via publication");
+               })
+            .end();
+         },
+
+         "Increase window size and check sidebar height": function() {
+            var bodyHeight;
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
+               .end()
+               .clearLog() // Clear the logs otherwise they'll force the size of the window
+               .setWindowSize(null, 1024, 968)
+               .findByCssSelector("body")
+                  .getSize()
+                  .then(function(size) {
+                     // We need the body size, not the window size because the window size includes all the OS chrome
+                     bodyHeight = size.height;
+                  })
+               .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
+                  .getSize()
+                  .then(function(size) {
+                     // Substracting the padding from the height!
+                     assert.closeTo(size.height, (bodyHeight - 20), 5, "The sidebar height didn't increase with the window size");
+                  });
+         },
+
+         "Decrease window size and check sidebar height": function() {
+            var bodyHeight;
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar") // Need to find something before clearing logs!
+               .end()
+               .clearLog() // Clear the logs otherwise they'll force the size of the window
+               .setWindowSize(null, 1024, 568)
+               .findByCssSelector("body")
+                  .getSize()
+                  .then(function(size) {
+                     // We need the body size, not the window size because the window size includes all the OS chrome
+                     bodyHeight = size.height;
+                  })
+               .findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
+                  .getSize()
+                  .then(function(size) {
+                     // Substracting the padding from the height!
+                     assert.closeTo(size.height, (bodyHeight - 20), 5, "The sidebar height didn't decrease with the window size");
+                  });
+         },
+
+         "Test Resize": function() {
+            // TODO: We haven't figured out how to do this reliably with LeadFoot
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfSideBarContainer Tests (not resizable)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/SimpleSideBarContainer", "AlfSideBarContainer Tests (not resizable)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Resize bar is hidden": function() {
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__resizeHandle")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The resize bar should not have been displayed");
+               });
+         },
+
+         "Sidebar width is correct": function() {
+            return browser.findByCssSelector(".alfresco-layout-AlfSideBarContainer__sidebar")
+               .getSize()
+               .then(function(size) {
+                  // NOTE: Allow a single pixel for the border...
+                  assert.equal(size.width, 251, "The sidebar was not the correct width");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Simple AlfSideBarContainer</shortname>
+  <description>This page shows the AlfSideBarContainer configured to not be resizeable.</description>
+  <family>aikau-unit-tests</family>
+  <url>/SimpleSideBarContainer</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.js
@@ -1,0 +1,42 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/AlfSideBarContainer",
+         config: {
+            isResizeable: false,
+            footerHeight: 10,
+            widgets: [
+               {
+                  name: "alfresco/layout/HorizontalWidgets",
+                  align: "sidebar",
+                  config: {
+                     widgets: [
+                        {
+                           id: "SIDEBAR_LOGO",
+                           name: "alfresco/logo/Logo",
+                           config: {
+                              logoClasses: "alfresco-logo-only"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/logging/DebugLog"
+               }
+            ]
+         }
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.js
@@ -14,7 +14,7 @@ model.jsonModel = {
       {
          name: "alfresco/layout/AlfSideBarContainer",
          config: {
-            isResizeable: false,
+            isResizable: false,
             initialSidebarWidth: 250,
             footerHeight: 10,
             widgets: [

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/SimpleSideBarContainer.get.js
@@ -15,6 +15,7 @@ model.jsonModel = {
          name: "alfresco/layout/AlfSideBarContainer",
          config: {
             isResizeable: false,
+            initialSidebarWidth: 250,
             footerHeight: 10,
             widgets: [
                {

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -20,6 +20,9 @@
          @link-text-decoration-hover: underline;
          @link-title-font-color-hover: @button-color-default;
          @link-title-text-decoration-hover: underline;
+
+         @sidebar-container-sidebar-background-color: #FDFAA4;
+         @sidebar-container-main-background-color: #CCFCA5;
       </less-variables>
    </css-tokens>
 </theme>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-634 to update the AlfSideBarContainer so that it can be configured such that the sidebar cannot be resized. The CSS has also been updated to improve the use of LESS variables to make it possible to theme the background colours of the sidebar, the main panel and the borders used on the separators.
