### PR TITLE
AKU-630: Truncate GalleryView thumbnail text

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/css/GalleryThumbnail.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/GalleryThumbnail.css
@@ -1,39 +1,41 @@
-.alfresco-renderers-Thumbnail.gallery {
-  overflow: hidden;
-  cursor: pointer;
-}
-
-.alfresco-renderers-Thumbnail.gallery .displayName,
-.alfresco-renderers-Thumbnail.gallery .selectBar {
-   position: absolute;
-   width: 100%;
-   background-color: black;
-   opacity: 0.5;
-   color: #fff;
-   padding: 10px 10px;
-   text-shadow: 1px 1px #333333;
-}
-
-.alfresco-renderers-Thumbnail.gallery img {
-   width: 100%;
-}
-
-.alfresco-renderers-Thumbnail.gallery .alfresco-renderers-Selector.checked {
-   background-image: url(./images/AllSelectedWhite.png);
-}
-
-.alfresco-renderers-Thumbnail.gallery .alfresco-renderers-Selector.unchecked {
-   background-image: url(./images/NoneSelectedWhite.png);
-}
-
-.alfresco-renderers-Thumbnail.gallery .displayName {
-   bottom: 0;
-}
-
-.alfresco-renderers-Thumbnail.gallery .selectBar {
-   top: 0;
-}
-
-.alfresco-renderers-Thumbnail.gallery:hover .selectBar {
-   display: block;
+.alfresco-renderers-Thumbnail {
+   &.gallery {
+      cursor: pointer;
+      overflow: hidden;
+      .displayName, .selectBar {
+         background-color: black;
+         color: #fff;
+         opacity: .5;
+         padding: 10px 10px;
+         position: absolute;
+         text-shadow: 1px 1px #333;
+         width: 100%;
+      }
+      .displayName {
+         bottom: 0;
+         box-sizing: border-box;
+         &__content {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+         }
+      }
+      .selectBar {
+         top: 0;
+      }
+      img {
+         width: 100%;
+      }
+      .alfresco-renderers-Selector {
+         &.checked {
+            background-image: url(./images/AllSelectedWhite.png);
+         }
+         &.unchecked {
+            background-image: url(./images/NoneSelectedWhite.png);
+         }
+      }
+      &:hover .selectBar {
+         display: block;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/renderers/templates/GalleryThumbnail.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/GalleryThumbnail.html
@@ -4,7 +4,9 @@
    <div class="selectBar share-hidden" data-dojo-attach-point="titleNode">
       <div data-dojo-attach-point="selectBarNode"></div>
    </div>
-   <div class="displayName" data-dojo-attach-point="displayNameNode">${imgTitle}</div>
+   <div class="displayName" data-dojo-attach-point="displayNameNode">
+      <div class="displayName__content" title="${imgTitle}">${imgTitle}</div>
+   </div>
    <span class="inner">
       <img data-dojo-attach-point="imgNode" id="${imgId}" src="${thumbnailUrl}" alt="${imgAltText}" title="${imgTitle}"/>
    </span>

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
@@ -117,6 +117,26 @@ define(["intern!object",
                });
          },
 
+         "Long item names are truncated": function(){
+            var normalNameHeight;
+            return browser.findByCssSelector("#DOCLIST tr:nth-child(1) td:nth-child(1) .displayName")
+               .getSize()
+               .then(function(size){
+                  normalNameHeight = size.height;
+               })
+               .end()
+
+            .findByCssSelector("#DOCLIST tr:nth-child(1) td:nth-child(6) .displayName")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "Link with a really, really long title that won't fit properly", "Incorrect item being tested for height")
+               })
+               .getSize()
+               .then(function(size){
+                  assert.equal(normalNameHeight, size.height, "Height not consistent with being truncated (i.e. is probably wrapping)");
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/SiteServiceTest"
+      "src/test/resources/alfresco/documentlibrary/views/GalleryViewTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/dnd/FormCreationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryView.get.js
@@ -61,7 +61,7 @@ model.jsonModel = {
                               type: "wikipage"
                            },
                            {
-                              displayName: "Link",
+                              displayName: "Link with a really, really long title that won't fit properly",
                               nodeRef: "dummy://nodeRef/6",
                               type: "link"
                            },


### PR DESCRIPTION
This addresses [AKU-630](https://issues.alfresco.com/jira/browse/AKU-630) and now truncates long text on gallery view thumbnails. It's been tested (as much as possible), and a full test suite run successfully.