### PR TITLE
AKU-633: Have Logo widget able to publish and link

### DIFF
--- a/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *

--- a/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
@@ -32,8 +32,6 @@
  * [_PublishPayloadMixin]{@link module:alfresco/renderers/_PublishPayloadMixin} are also available to
  * anyone mixing in this class.</p>
  *
- * <p><em>NOTE:</em> This widget's test cases are fulfilled by the Logo test page</p>
- *
  * @module alfresco/core/_PublishOrLinkMixin
  * @extends module:alfresco/navigation/_HtmlAnchorMixin
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
@@ -62,6 +60,7 @@ define(["alfresco/navigation/_HtmlAnchorMixin",
 
       /**
        * When set to true, the widget/anchors will be removed from the page tab-order by setting the tabindex to -1.
+       * This overrides and changes the [inherited value]{@link alfresco/navigation/_HtmlAnchorMixin#excludeFromTabOrder}.
        *
        * @instance
        * @override
@@ -104,6 +103,7 @@ define(["alfresco/navigation/_HtmlAnchorMixin",
       /**
        * When set to true, all of the direct children of this widget's root node will be wrapped in a single anchor,
        * rather than the default [_HtmlAnchorMixin]{@link module:alfresco/navigation/_HtmlAnchorMixin} behaviour.
+       * This overrides and changes the [inherited value]{@link alfresco/navigation/_HtmlAnchorMixin#wrapAllChildren}.
        *
        * @instance
        * @override

--- a/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>This mixin makes it easy to add clickable functionality to a widget that will either publish a topic
+ * or navigate to a page.</p>
+ *
+ * <p>By providing a publishTopic in the config, the widget will publish to that topic when clicked
+ * (publishPayload, publishGlobal and publishToParent are also supported).</p>
+ *
+ * <p>By providing a targetUrl (and optional targetUrlType), the widget will act as a link when clicked</p>
+ *
+ * <p>This mixin derives its functionality from two other mixins in order to provide a simple way of
+ * decorating a widget to add "clicking functionality". Please note though that the enhanced capabilities of
+ * [_HtmlAnchorMixin]{@link module:alfresco/navigation/_HtmlAnchorMixin} and
+ * [_PublishPayloadMixin]{@link module:alfresco/renderers/_PublishPayloadMixin} are also available to
+ * anyone mixing in this class.</p>
+ *
+ * <p><em>NOTE:</em> This widget's test cases are fulfilled by the Logo test page</p>
+ *
+ * @module alfresco/core/_PublishOrLinkMixin
+ * @extends module:alfresco/navigation/_HtmlAnchorMixin
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
+ * @author Martin Doyle
+ * @since 1.0.40
+ */
+define(["alfresco/navigation/_HtmlAnchorMixin",
+        "alfresco/renderers/_PublishPayloadMixin",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/dom-class",
+        "dojo/keys",
+        "dojo/on"],
+        function(_HtmlAnchorMixin, _PublishPayloadMixin, declare, lang, domClass, keys, on) {
+
+   return declare([_HtmlAnchorMixin, _PublishPayloadMixin], {
+
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/_PublishOrLinkMixin.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/_PublishOrLinkMixin.css"}],
+
+      /**
+       * When set to true, the widget/anchors will be removed from the page tab-order by setting the tabindex to -1.
+       *
+       * @instance
+       * @override
+       * @see module:alfresco/navigation/_HtmlAnchorMixin#excludeFromTabOrder
+       * @type {boolean}
+       * @default
+       */
+      excludeFromTabOrder: false,
+
+      /**
+       * The title text to put on the generated link(s).
+       *
+       * @instance
+       * @override
+       * @type {string}
+       * @default
+       */
+      label: null,
+
+      /**
+       * This is the URL to navigate to when the widget is clicked.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      targetUrl: null,
+
+      /**
+       * Indicates how the target URL should be handled. This defaults to "PAGE_RELATIVE" which means that the URL
+       * will be appended to the 'AlfConstants.URL_PAGECONTEXT' Global JavaScript constant. This can be overridden
+       * on instantiation to indicate that another URL type, such as "FULL_PATH" should be used.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      targetUrlType: "PAGE_RELATIVE",
+
+      /**
+       * When set to true, all of the direct children of this widget's root node will be wrapped in a single anchor,
+       * rather than the default [_HtmlAnchorMixin]{@link module:alfresco/navigation/_HtmlAnchorMixin} behaviour.
+       *
+       * @instance
+       * @override
+       * @see module:alfresco/navigation/_HtmlAnchorMixin#wrapAllChildren
+       * @type {boolean}
+       * @default
+       */
+      wrapAllChildren: true,
+
+      /**
+       * Run after widget created
+       *
+       * @instance
+       * @override
+       */
+      postCreate: function alfresco_core__PublishOrLinkMixin__postCreate() {
+         this.inherited(arguments);
+         domClass.add(this.domNode, "alfresco-core-PublishOrLinkMixin");
+         if (this.targetUrl) {
+            this.makeAnchor(this.targetUrl, this.targetUrlType);
+         } else if (this.publishTopic) {
+            this.domNode.setAttribute("tabIndex", this.excludeFromTabOrder ? -1 : 0);
+            domClass.add(this.domNode, "alfresco-core-PublishOrLinkMixin--clickable");
+            this.own(on(this.domNode, "click", lang.hitch(this, this.doPublish)));
+            this.own(on(this.domNode, "keydown", lang.hitch(this, function(evt) {
+               if (evt.keyCode === keys.ENTER) {
+                  this.doPublish();
+               }
+            })));
+         }
+      },
+
+      /**
+       * Publish to the specified topic.
+       *
+       * @instance
+       */
+      doPublish: function alfresco_core__PublishOrLinkMixin__doPublish() {
+         this.alfPublish(this.publishTopic, this.publishPayload, this.publishGlobal, this.publishToParent);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/core/css/_PublishOrLinkMixin.css
+++ b/aikau/src/main/resources/alfresco/core/css/_PublishOrLinkMixin.css
@@ -1,0 +1,8 @@
+.alfresco-core-PublishOrLinkMixin {
+   .alfresco-navigation-_HtmlAnchorMixin {
+      display: inline-block;
+   }
+   &--clickable {
+      cursor: pointer;
+   }
+}

--- a/aikau/src/main/resources/alfresco/logo/Logo.js
+++ b/aikau/src/main/resources/alfresco/logo/Logo.js
@@ -18,27 +18,32 @@
  */
 
 /**
- * Displays an image typically used as an application logo. Provides a number of Alfresco and
- * Surf logos out-of-the-box but can be configured with a specific URL to render any image.
+ * <p>Displays an image typically used as an application logo. Provides a number of Alfresco and
+ * Surf logos out-of-the-box but can be configured with a specific URL to render any image.</p>
+ *
+ * <p>By providing a publishTopic in the config, the logo will publish to that topic when clicked
+ * (publishPayload, publishGlobal and publishToParent are also supported).</p>
+ *
+ * <p>By providing a targetUrl (and optional targetUrlType), the logo will act as a link when
+ * clicked</p>
  * 
  * @module alfresco/logo/Logo
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/core/_PublishOrLinkMixin
  * @author Dave Draper
  */
-define(["dojo/_base/declare",
+define(["dojo/_base/declare", 
         "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Logo.html",
-        "alfresco/core/Core",
-        "dojo/dom-construct",
-        "dojo/dom-style",
-        "dojo/dom-class"], 
-        function(declare, _Widget, _Templated, template, Core, domConstruct, domStyle, domClass) {
-   
-   return declare([_Widget, _Templated, Core], {
-      
+        "dijit/_TemplatedMixin", 
+        "dojo/text!./templates/Logo.html", 
+        "alfresco/core/Core", 
+        "alfresco/core/_PublishOrLinkMixin"], 
+        function(declare, _Widget, _Templated, template, Core, _PublishOrLinkMixin) {
+
+   return declare([_Widget, _Templated, Core, _PublishOrLinkMixin], {
+
       /**
        * An array of the i18n files to use with this widget.
        * 
@@ -47,7 +52,7 @@ define(["dojo/_base/declare",
        * @default [{i18nFile: "./i18n/Logo.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/Logo.properties"}],
-      
+
       /**
        * An array of the CSS files to use with this widget.
        * 
@@ -55,7 +60,7 @@ define(["dojo/_base/declare",
        * @type {object[]}
        * @default [{cssFile:"./css/Logo.css"}]
        */
-      cssRequirements: [{cssFile:"./css/Logo.css"}],
+      cssRequirements: [{cssFile: "./css/Logo.css"}],
 
       /**
        * The CSS class or classes to use to generate the logo
@@ -64,7 +69,7 @@ define(["dojo/_base/declare",
        * @default
        */
       logoClasses: "alfresco-logo-large",
-      
+
       /**
        * @instance
        * @type {string} 
@@ -78,7 +83,7 @@ define(["dojo/_base/declare",
        * @default
        */
       cssNodeStyle: "display: none;",
-      
+
       /**
        * 
        * @instance
@@ -86,14 +91,14 @@ define(["dojo/_base/declare",
        * @default
        */
       imgNodeStyle: "display: none;",
-         
+
       /**
        * The HTML template to use for the widget.
        * @instance
        * @type {string}
        */
       templateString: template,
-      
+
       /**
        * Some alt text for the logo image.
        *
@@ -115,13 +120,26 @@ define(["dojo/_base/declare",
          this.altText = this.encodeHTML(this.message(this.altText));
          if (this.logoSrc)
          {
-            this.imgNodeStyle = "display: block;";
+            this.imgNodeStyle = "display: inline-block;";
          }
          else
          {
-            this.cssNodeStyle = "display: block";
+            this.cssNodeStyle = "display: inline-block";
          }
          this.inherited(arguments);
+      },
+
+      /**
+       * Called after properties have been mixed into this instance.
+       *
+       * @instance
+       * @override
+       */
+      postMixInProperties: function alfresco_logo_Logo__postMixInProperties() {
+         this.inherited(arguments);
+         if (this.targetUrl && !this.label) {
+            this.label = this.altText;
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/logo/Logo.js
+++ b/aikau/src/main/resources/alfresco/logo/Logo.js
@@ -134,6 +134,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @override
+       * @since 1.0.40
        */
       postMixInProperties: function alfresco_logo_Logo__postMixInProperties() {
          this.inherited(arguments);

--- a/aikau/src/main/resources/alfresco/logo/css/Logo.css
+++ b/aikau/src/main/resources/alfresco/logo/css/Logo.css
@@ -1,48 +1,39 @@
 .alfresco-logo-Logo {
    margin: 9px 16px 8px 8px;
-}
-
-.alfresco-logo-Logo.right-border {
-   border-right: @standard-border;
-   padding-right: 14px;
-}
-
-.alfresco-logo-Logo img {
-   height: 48px;
-}
-
-.alfresco-logo-Logo .alfresco-logo-large {
-   background-image: url("./images/alfresco.png");
-   background-repeat: no-repeat;
-   background-position: 5px 5px;
-   height: 48px;
-   width: 184px;
-}
-
-.alfresco-logo-Logo .alfresco-logo-only {
-   background-image: url("./images/app-logo-48.png");
-   background-repeat: no-repeat;
-   height: 48px;
-   width: 48px;
-}
-
-.alfresco-logo-Logo .alfresco-logo-grey {
-   background-image: url("./images/alfresco_grey.png");
-   background-repeat: no-repeat;
-   height: 43px;
-   width: 187px;
-}
-
-.alfresco-logo-Logo .surf-logo-large {
-   background-image: url("./images/SurfLogo200.jpg");
-   background-repeat: no-repeat;
-   height: 85px;
-   width: 200px;
-}
-
-.alfresco-logo-Logo .surf-logo-small {
-   background-image: url("./images/surf32.jpg");
-   background-repeat: no-repeat;
-   height: 34px;
-   width: 32px;
+   &.right-border {
+      border-right: @standard-border;
+      padding-right: 14px;
+   }
+   img {
+      height: 48px;
+   }
+   &__default {
+      background-repeat: no-repeat;
+      &.alfresco-logo-large {
+         background-image: url("./images/alfresco.png");
+         background-position: 5px 5px;
+         height: 48px;
+         width: 184px;
+      }
+      &.alfresco-logo-only {
+         background-image: url("./images/app-logo-48.png");
+         height: 48px;
+         width: 48px;
+      }
+      &.alfresco-logo-grey {
+         background-image: url("./images/alfresco_grey.png");
+         height: 43px;
+         width: 187px;
+      }
+      &.surf-logo-large {
+         background-image: url("./images/SurfLogo200.jpg");
+         height: 85px;
+         width: 200px;
+      }
+      &.surf-logo-small {
+         background-image: url("./images/surf32.jpg");
+         height: 34px;
+         width: 32px;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/logo/templates/Logo.html
+++ b/aikau/src/main/resources/alfresco/logo/templates/Logo.html
@@ -1,5 +1,5 @@
 <div class="alfresco-logo-Logo" data-dojo-attach-point="containerNode">
-   <div class="${logoClasses}" style="${cssNodeStyle}" data-dojo-attach-point="logoNode">&nbsp;</div>
+   <div class="alfresco-logo-Logo__default ${logoClasses}" style="${cssNodeStyle}" data-dojo-attach-point="logoNode">&nbsp;</div>
    <div style="${imgNodeStyle}">
       <img src="${logoSrc}" alt="${altText}"/>
    </div>

--- a/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
@@ -32,6 +32,7 @@
  * @extends module:alfresco/core/Core
  * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
  * @author Dave Draper
+ * @author Martin Doyle
  */
 define(["dojo/_base/declare",
         "alfresco/core/Core",
@@ -39,10 +40,11 @@ define(["dojo/_base/declare",
         "service/constants/Default",
         "dojo/_base/lang",
         "dojo/_base/array",
+        "dojo/dom-construct",
         "dojo/query",
         "dojo/NodeList",
         "dojo/NodeList-manipulate"], 
-        function(declare, AlfCore, _NavigationServiceTopicMixin, AlfConstants, lang, array, query /*, NodeList, NodeListManipulate*/) {
+        function(declare, AlfCore, _NavigationServiceTopicMixin, AlfConstants, lang, array, domConstruct, query /*, NodeList, NodeListManipulate*/) {
    
    return declare([AlfCore, _NavigationServiceTopicMixin], {
 
@@ -54,6 +56,36 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/_HtmlAnchorMixin.css"}]
        */
       cssRequirements: [{cssFile:"./css/_HtmlAnchorMixin.css"}],
+
+      /**
+       * When set to true, the resulting anchor(s) will be removed from the page tab-order by setting their tabindex to -1.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.40
+       */
+      excludeFromTabOrder: true,
+
+      /**
+       * The title text to put on the generated link(s).
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      label: null,
+
+      /**
+       * When set to true, all of the direct children of this widget's root node will be wrapped in a single anchor,
+       * when [makeAnchor()]{@link module:alfresco/navigation/_HtmlAnchorMixin#makeAnchor} is called.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.40
+       */
+      wrapAllChildren: false,
 
       /**
        * When a targetUrl is specified we want to wrap menu item labels in <a> elements to allow the browsers context menu
@@ -97,9 +129,31 @@ define(["dojo/_base/declare",
        * @param {string} url The URL to use for the anchor
        */
       _addAnchors: function alfresco_navigation__HtmlAnchorMixin__addAnchors(url) {
-         array.forEach(this.getAnchorTargetSelectors(), function(selector) {
-            query(selector, this.domNode).wrapInner("<a tabIndex='-1' class='alfresco-navigation-_HtmlAnchorMixin' title='" + this.label + "' href='" + url + "'></a>");
-         }, this);
+
+         // Setup and create the anchor
+         var anchorAttrs = {
+            className: "alfresco-navigation-_HtmlAnchorMixin",
+            href: url
+         };
+         if (this.label) {
+            anchorAttrs.title = this.label;
+         }
+         if (this.excludeFromTabOrder) {
+            anchorAttrs.tabIndex = "-1";
+         }
+         var anchor = domConstruct.create("A", anchorAttrs);
+
+         // Create anchor(s) based upon wrapAllChildren setting
+         if (this.wrapAllChildren) {
+            this.domNode.appendChild(anchor);
+            while (this.domNode.firstChild !== anchor) {
+               anchor.appendChild(this.domNode.firstChild);
+            }
+         } else {
+            array.forEach(this.getAnchorTargetSelectors(), function(selector) {
+               query(selector, this.domNode).wrapInner(anchor);
+            }, this);
+         }
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/logo/LogoTest.js
+++ b/aikau/src/test/resources/alfresco/logo/LogoTest.js
@@ -19,64 +19,128 @@
 
 /**
  * @author Dave Draper
+ * @author Martin Doyle
  */
-define(["intern!object",
-        "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+define([
+      "alfresco/TestCommon",
+      "intern!object",
+      "intern/chai!assert",
+      "intern/dojo/node!leadfoot/keys"
+   ],
+   function(TestCommon, registerSuite, assert, keys) {
 
-registerSuite(function(){
-   var browser;
+      registerSuite(function() {
+         var browser;
 
-   return {
-      name: "Logo Tests",
+         return {
+            name: "Logo Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Logo", "Logo Tests").end();
-      },
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/Logo", "Logo Tests");
+            },
 
-      beforeEach: function() {
-         browser.end();
-      },
+            beforeEach: function() {
+               browser.end();
+            },
 
-     "Check CSS logo": function () {
-         return browser.findByCssSelector("#LOGO1.alfresco-logo-Logo .alfresco-logo-large")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "CSS logo was not displayed");
-            });
-      },
+            "Check CSS logo": function() {
+               return browser.findByCssSelector("#LOGO1.alfresco-logo-Logo .alfresco-logo-large")
+                  .isDisplayed()
+                  .then(function(displayed) {
+                     assert.isTrue(displayed, "CSS logo was not displayed");
+                  });
+            },
 
-      "Check image logo": function () {
-         return browser.findByCssSelector("#LOGO2.alfresco-logo-Logo .alfresco-logo-large")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "CSS logo was not displayed for Logo with image source");
-            });
-      },
+            "Check image logo": function() {
+               return browser.findByCssSelector("#LOGO2.alfresco-logo-Logo .alfresco-logo-large")
+                  .isDisplayed()
+                  .then(function(displayed) {
+                     assert.isFalse(displayed, "CSS logo was not displayed for Logo with image source");
+                  });
+            },
 
-      "Check image logo height": function() {
-         return browser.findByCssSelector("#LOGO2 img")
-            .getComputedStyle("height")
-            .then(function(height) {
-               assert.equal(height, "48px", "The height of the image logo was incorrect");
-            });
-      },
+            "Check image logo height": function() {
+               return browser.findByCssSelector("#LOGO2 img")
+                  .getComputedStyle("height")
+                  .then(function(height) {
+                     assert.equal(height, "48px", "The height of the image logo was incorrect");
+                  });
+            },
 
-      "Check image logo width": function() {
-         // The width of image logo should be set to auto, only CSS logos should have fixed widths
-         return browser.findByCssSelector("#LOGO2 img")
-            .getComputedStyle("width")
-            .then(function(width) {
-               assert.equal(width, "auto", "The width of the image should be auto");
-            });
-      },
+            "Check image logo width": function() {
+               // The width of image logo should be set to auto, only CSS logos should have fixed widths
+               return browser.findByCssSelector("#LOGO2 img")
+                  .getComputedStyle("width")
+                  .then(function(width) {
+                     assert.equal(width, "auto", "The width of the image should be auto");
+                  });
+            },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+            "Logo will publish topic when configured to do so": function() {
+               return browser.findById("LOGO_WITH_TOPIC")
+                  .click()
+                  .getLastPublish("LOGO_TOPIC_PUBLISHED");
+            },
+
+            "Logo will act as link when configured to do so": function() {
+               return browser.findByCssSelector("#LOGO_WITH_URL a")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#TDAC .title")
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Aikau Unit Tests");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "Logo Keyboard Tests",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/Logo", "Logo Keyboard Tests");
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "Logo will publish topic when ENTER pressed": function() {
+               return browser.findByCssSelector("body")
+                  .tabToElement("#LOGO_WITH_TOPIC")
+                  .screenie(true)
+                  .pressKeys(keys.ENTER)
+                  .getLastPublish("LOGO_TOPIC_PUBLISHED");
+            },
+
+            "Logo will act as link when ENTER pressed": function() {
+               return browser.findByCssSelector("body")
+                  .tabToElement("#LOGO_WITH_URL a")
+                  .screenie(true)
+                  .pressKeys(keys.ENTER)
+                  .end()
+
+               .findByCssSelector("#TDAC .title")
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Aikau Unit Tests");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
    });
-});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/documentlibrary/views/GalleryViewTest"
+      "src/test/resources/alfresco/logo/LogoTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/dnd/FormCreationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/logo/Logo.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/logo/Logo.get.js
@@ -23,7 +23,23 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "LOGO_WITH_TOPIC",
+         name: "alfresco/logo/Logo",
+         config: {
+            logoClasses: "surf-logo-small",
+            publishTopic: "LOGO_TOPIC_PUBLISHED"
+         }
+      },
+      {
+         id: "LOGO_WITH_URL",
+         name: "alfresco/logo/Logo",
+         config: {
+            logoClasses: "surf-logo-large",
+            targetUrl: "tp/ws/Index"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses [AKU-633](https://issues.alfresco.com/jira/browse/AKU-633) and enables the Logo widget to publish and navigate when clicked. This was achieved by the creation of a new mixin that can now be applied to any widget to achieve a similar effect.