### PR TITLE
AKU-628: Resize thumbnail view

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -690,6 +690,21 @@ define([],function() {
       SELECTED_DOCUMENTS_CHANGED: "ALF_SELECTED_FILES_CHANGED",
 
       /**
+       * Use by the [AlfGalleryViewSlider]{@link module:alfresco/documentlibrary/AlfGalleryViewSlider}
+       * to publish changes in the number of columns that should be shown in the 
+       * [AlfGalleryView]{@link module:alfresco/documentlibrary/views/AlfGalleryView}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.40
+       *
+       * @event
+       * @property {number} value - The number of columns to display.
+       */
+      SET_COLUMNS: "ALF_DOCLIST_SET_GALLERY_COLUMNS",
+
+      /**
        * This topic can be published to set a user preference. It is typically handled by 
        * the [PreferenceService]{@link module:alfresco/services/PreferenceService}.
        *
@@ -699,6 +714,21 @@ define([],function() {
        * @since 1.0.34
        */
       SET_PREFERENCE: "ALF_PREFERENCE_SET",
+
+      /**
+       * Use by the [AlfGalleryViewSlider]{@link module:alfresco/documentlibrary/ThumbnailSizeSlider}
+       * to publish changes to the size of the thumbnails that are shown in the 
+       * [AlfGalleryView]{@link module:alfresco/documentlibrary/views/AlfGalleryView}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.40
+       *
+       * @event
+       * @property {number} value - The size (in pixels) to make the thumbnails.
+       */
+      SET_THUMBNAIL_SIZE: "ALF_SET_THUMBNAIL_SIZE",
 
       /**
        * This topic is published in order to make the actual request to sync a node or nodes

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -716,7 +716,7 @@ define([],function() {
       SET_PREFERENCE: "ALF_PREFERENCE_SET",
 
       /**
-       * Use by the [AlfGalleryViewSlider]{@link module:alfresco/documentlibrary/ThumbnailSizeSlider}
+       * Use by the [ThumbnailSizeSlider]{@link module:alfresco/documentlibrary/ThumbnailSizeSlider}
        * to publish changes to the size of the thumbnails that are shown in the 
        * [AlfGalleryView]{@link module:alfresco/documentlibrary/views/AlfGalleryView}.
        *

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfGalleryViewSlider.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfGalleryViewSlider.js
@@ -33,8 +33,10 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/lists/views/_AlfAdditionalViewControlMixin",
         "alfresco/services/_PreferenceServiceTopicMixin",
+        "alfresco/core/topics",
         "dojo/dom-class"], 
-        function(declare, HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin, domClass) {
+        function(declare, HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin, 
+                 topics, domClass) {
    
    return declare([HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin], {
       
@@ -101,7 +103,7 @@ define(["dojo/_base/declare",
       /**
        * 
        * @instance
-       * @fires getPreferenceTopic
+       * @fires module:alfresco/services/_PreferenceServiceTopicMixin#getPreferenceTopic
        */
       postCreate: function alfresco_documentlibrary_AlfGalleryViewSlider__postCreate() {
          this.inherited(arguments);
@@ -119,10 +121,11 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param {number} value The number of columns to set.
+       * @fires module:alfresco/core/topics#SET_COLUMNS
        */
       onColumnPreferences: function alfresco_documentlibrary_AlfGalleryViewSlider__onColumnPreferences(value) {
          this.setColumns(value);
-         this.alfPublish("ALF_DOCLIST_SET_GALLERY_COLUMNS", {
+         this.alfPublish(topics.SET_COLUMNS, {
             value: this.columns
          });
       },
@@ -194,12 +197,12 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {number} value The value provided from the change to the slider.
-       * @fires ALF_DOCLIST_SET_GALLERY_COLUMNS
-       * @fires setPreferenceTopic
+       * @fires module:alfresco/core/topics#SET_COLUMNS
+       * @fires module:alfresco/services/_PreferenceServiceTopicMixin#setPreferenceTopic
        */
       onChange: function alfresco_documentlibrary_AlfGalleryViewSlider__onChange(value) {
          var columns = this.getColumnsFromSliderValue(value);
-         this.alfPublish("ALF_DOCLIST_SET_GALLERY_COLUMNS", {
+         this.alfPublish(topics.SET_COLUMNS, {
             value: columns
          });
          this.alfServicePublish(this.setPreferenceTopic, {
@@ -224,10 +227,10 @@ define(["dojo/_base/declare",
        * This is called whenever the control is displayed to ensure that sizes are initialised.
        *  
        * @instance
-       * @fires ALF_DOCLIST_SET_GALLERY_COLUMNS
+       * @fires module:alfresco/core/topics#SET_COLUMNS
        */
       onControlDisplayed: function alfresco_documentlibrary_AlfGalleryViewSlider__onControlDisplayed() {
-         this.alfPublish("ALF_DOCLIST_SET_GALLERY_COLUMNS", {
+         this.alfPublish(topics.SET_COLUMNS, {
             value: this.getColumnsFromSliderValue(this.value)
          });
       }

--- a/aikau/src/main/resources/alfresco/documentlibrary/ThumbnailSizeSlider.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/ThumbnailSizeSlider.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @module alfresco/documentlibrary/ThumbnailSizeSlider
+ * @extends external:dijit/form/HorizontalSlider
+ * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/lists/views/_AlfAdditionalViewControlMixin
+ * @mixes module:alfresco/services/_PreferenceServiceTopicMixin
+ * @author Dave Draper
+ * @since 1.0.40
+ */
+define(["dojo/_base/declare",
+        "dijit/form/HorizontalSlider",
+        "alfresco/core/Core",
+        "alfresco/lists/views/_AlfAdditionalViewControlMixin",
+        "alfresco/services/_PreferenceServiceTopicMixin",
+        "alfresco/core/topics",
+        "dojo/dom-class"], 
+        function(declare, HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin, 
+                 topics, domClass) {
+   
+   return declare([HorizontalSlider, AlfCore, _AlfAdditionalViewControlMixin, _PreferenceServiceTopicMixin], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance cssRequirements {Array}
+       * @type {object[]}
+       * @default [{cssFile:"./css/AlfGalleryViewSlider.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/AlfGalleryViewSlider.css"}],
+      
+      /**
+       * The preference property to use for retrieving and setting the users preferred 
+       * thumbnail size
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      preferenceProperty: "org.alfresco.share.documentList.thumbnailSize",
+
+      /**
+       * The number of steps (including the beginning and end positions) on the slider
+       * @instance
+       * @type {integer}
+       * @default
+       */
+      discreteValues: 16,
+         
+      /**
+       * The minimum value on the slider (this will represent the smalled size in pixels that a thumbnail
+       * can be decreased to).
+       * 
+       * @instance
+       * @type {number} 
+       * @default
+       */
+      minimum: 100,
+      
+      /**
+       * The maximum value on the slider (this will represent the largest size in pixels that a thumbnail
+       * can be increased to).
+       * 
+       * @instance
+       * @type {integer}
+       * @default
+       */
+      maximum: 800,
+      
+      /**
+       * Indicates whether or not to show the bigger/smaller buttons at either end of the slider
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      showButtons: true,
+      
+      /**
+       * The initial thumbnail size (in pixels).
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       */
+      value: 100,
+
+      /**
+       * 
+       * @instance
+       * @fires module:alfresco/services/_PreferenceServiceTopicMixin#getPreferenceTopic
+       */
+      postCreate: function alfresco_documentlibrary_ThumbnailSizeSlider__postCreate() {
+         this.inherited(arguments);
+         this.set("value", this.value);
+         domClass.add(this.domNode, "alfresco-documentlibrary-AlfGalleryViewSlider");
+         this.alfServicePublish(this.getPreferenceTopic, {
+            preference: this.preferenceProperty,
+            callback: this.onPreferences,
+            callbackScope: this
+         });
+      },
+      
+      /**
+       * This is called when user preferences are provided. 
+       * 
+       * @instance
+       * @param {number} value The size of thumbnails to use
+       * @fires module:alfresco/core/topics#SET_THUMBNAIL_SIZE
+       */
+      onPreferences: function alfresco_documentlibrary_ThumbnailSizeSlider__onPreferences(value) {
+         this.set("value", value);
+         this.alfPublish(topics.SET_THUMBNAIL_SIZE, {
+            value: this.value
+         });
+      },
+
+      /**
+       *
+       * @instance
+       * @param {number} value The value provided from the change to the slider.
+       * @fires module:alfresco/services/_PreferenceServiceTopicMixin#setPreferenceTopic
+       * @fires module:alfresco/core/topics#SET_THUMBNAIL_SIZE
+       */
+      onChange: function alfresco_documentlibrary_ThumbnailSizeSlider__onChange(value) {
+         this.alfPublish(topics.SET_THUMBNAIL_SIZE, {
+            value: value
+         });
+         this.alfServicePublish(this.setPreferenceTopic, {
+            preference: this.preferenceProperty,
+            value: value
+         });
+         this.value = value;
+      },
+      
+      /**
+       * This method is required in order for the slider to "behave" itself without causing errors when 
+       * placed as an item in a menu.
+       * 
+       * @instance
+       * @param {boolean} selected
+       */
+      _setSelected: function alfresco_documentlibrary_ThumbnailSizeSlider___setSelected(selected) {
+         domClass.toggle(this.domNode, "dijitMenuItemSelected", selected);
+      },
+      
+      /**
+       * This is called whenever the control is displayed to ensure that sizes are initialised.
+       *  
+       * @instance
+       * @fires module:alfresco/core/topics#SET_THUMBNAIL_SIZE
+       */
+      onControlDisplayed: function alfresco_documentlibrary_ThumbnailSizeSlider__onControlDisplayed() {
+         this.alfPublish(topics.SET_THUMBNAIL_SIZE, {
+            value: this.value
+         });
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/documentlibrary/ThumbnailSizeSlider.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/ThumbnailSizeSlider.js
@@ -60,6 +60,7 @@ define(["dojo/_base/declare",
 
       /**
        * The number of steps (including the beginning and end positions) on the slider
+       * 
        * @instance
        * @type {integer}
        * @default
@@ -67,7 +68,7 @@ define(["dojo/_base/declare",
       discreteValues: 16,
          
       /**
-       * The minimum value on the slider (this will represent the smalled size in pixels that a thumbnail
+       * The minimum value on the slider (this will represent the smallest size in pixels that a thumbnail
        * can be decreased to).
        * 
        * @instance

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -94,10 +94,10 @@ define(["dojo/_base/declare",
       /**
        * The topic to publish when the next link is clicked.
        * 
-       * @event nextLinkPublishTopic
        * @instance
        * @type {string}
        * @default [topics.SCROLL_NEAR_BOTTOM]{@link module:alfresco/core/topics#SCROLL_NEAR_BOTTOM}
+       * @event
        */
       nextLinkPublishTopic: topics.SCROLL_NEAR_BOTTOM,
 

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -32,9 +32,13 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/AlfGalleryView.html",
         "alfresco/lists/views/layouts/Grid",
         "alfresco/documentlibrary/AlfGalleryViewSlider",
+        "alfresco/documentlibrary/ThumbnailSizeSlider",
         "dojo/_base/lang",
+        "dojo/dom-style",
+        "dojo/dom-geometry",
         "alfresco/core/topics"], 
-        function(declare, AlfListView, SelectedItemStateMixin, template, Grid, AlfGalleryViewSlider, lang, topics) {
+        function(declare, AlfListView, SelectedItemStateMixin, template, Grid, AlfGalleryViewSlider, ThumbnailSizeSlider, 
+                 lang, domStyle, domGeom, topics) {
    
    return declare([AlfListView, SelectedItemStateMixin], {
       
@@ -44,6 +48,25 @@ define(["dojo/_base/declare",
        * @type {String}
        */
       templateString: template,
+
+      /**
+       * This is the number of columns to use in the grid.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       */
+      columns: 4,
+
+      /**
+       * The preference property to use for retrieving and setting the users preferred number of columns
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.35
+       */
+      columnsPreferenceProperty: "org.alfresco.share.documentList.galleryColumns",
 
       /**
        * This enables the mixed in [SelectedItemStateMixin]{@link module:alfresco/lists/SelectedItemStateMixin}
@@ -58,6 +81,75 @@ define(["dojo/_base/declare",
        * @since 1.0.39
        */
       manageSelectedItemState: false,
+
+      /**
+       * The label to use for the next link. This defaults to null, so MUST be set for the next link to be displayed.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      nextLinkLabel: null,
+
+      /**
+       * The topic to publish when the next link is clicked.
+       * 
+       * @event nextLinkPublishTopic
+       * @instance
+       * @type {string}
+       * @default [topics.SCROLL_NEAR_BOTTOM]{@link module:alfresco/core/topics#SCROLL_NEAR_BOTTOM}
+       */
+      nextLinkPublishTopic: topics.SCROLL_NEAR_BOTTOM,
+
+      /**
+       * Indicates whether resizing of thumbnails should be done by setting the number of columns to be
+       * displayed (the number of columns will remain constant and the thumbnail size will change as
+       * the size of the view changes). If this is configured to be false then a 
+       * [thumbnailSize]{@link module:alfresco/documentlibrary/views/AlfGalleryView#thumbnailSize}
+       * will be used and the number of columns will change as the size of the view changes.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.40
+       */
+      resizeByColumnCount: true,
+
+      /**
+       * When set to true this will show a link for requesting more data (if available). This should be used when
+       * the grid is rendering data in an infinite scroll view. It is required because when the grid cells are small
+       * the data may not be sufficient to allow the scrolling events to occur that will request more data.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      showNextLink: false,
+
+      /**
+       * This is the size in pixels to set thumbnails initially. This only applies when 
+       * [resizeByColumnCount]{@link module:alfresco/documentlibrary/views/AlfGalleryView#resizeByColumnCount}
+       * is configured to be false.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.40
+       */
+      thumbnailSize: 400,
+
+      /**
+       * The preference property to use for retrieving and setting the users preferred 
+       * thumbnail size. This only applies when 
+       * [resizeByColumnCount]{@link module:alfresco/documentlibrary/views/AlfGalleryView#resizeByColumnCount}
+       * is configured to be false.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.40
+       */
+      thumbnailSizePreferenceProperty: "org.alfresco.share.documentList.thumbnailSize",
 
       /**
        * Returns the name of the view that is used when saving user view preferences.
@@ -82,40 +174,39 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Subscribes to a topic to that sets the number of columns for the gallery. This topic is
-       * published on by the slider control and which calls the 
-       * [updateColumns]{@link module:alfresco/documentlibrary/views/AlfGalleryView#updateColumns} function
+       * <p>If [resizeByColumnCount]{@link module:alfresco/documentlibrary/AlfGalleryView#resizeByColumnCount}
+       * is configured to be true this will subscribe to the
+       * [SET_COLUMNS]{@link module:alfresco/core/topics#SET_COLUMNS} topic and each time the column count
+       * is changed the [updateColumns]{@link module:alfresco/documentlibrary/AlfGalleryView#updateColumns}
+       * function will be called.</p>
+       * <p>If resizeByColumnCount]{@link module:alfresco/documentlibrary/AlfGalleryView#resizeByColumnCount}
+       * is configured to be false this will subscribe to the
+       * [SET_THUMBNAIL_SIZE]{@link module:alfresco/core/topics#SET_THUMBNAIL_SIZE} topic and each time the 
+       * thumbnail size is changed the 
+       * [updateThumbnailSize]{@link module:alfresco/documentlibrary/AlfGalleryView#updateThumbnailSize} function 
+       * will be called.</p>
        * 
        * @instance
+       * @listens module:alfresco/core/topics#SET_COLUMNS
+       * @listens module:alfresco/core/topics#SET_THUMBNAIL_SIZE
        */
       postCreate: function alfresco_documentlibrary_views_AlfGalleryView__postCreate() {
          this.inherited(arguments);
-         this.alfSubscribe("ALF_DOCLIST_SET_GALLERY_COLUMNS", lang.hitch(this, this.updateColumns));
 
+         if (this.resizeByColumnCount)
+         {
+            this.alfSubscribe(topics.SET_COLUMNS, lang.hitch(this, this.updateColumns));
+         }
+         else
+         {
+            this.alfSubscribe(topics.SET_THUMBNAIL_SIZE, lang.hitch(this, this.updateThumbnailSize));
+         }
+         
          if (this.manageSelectedItemState)
          {
             this.createSelectedItemSubscriptions();
          }
       },
-
-      /**
-       * This is the number of columns to use in the grid.
-       * 
-       * @instance
-       * @type {number}
-       * @default
-       */
-      columns: 4,
-
-       /**
-       * The preference property to use for retrieving and setting the users preferred number of columns
-       *
-       * @instance
-       * @type {string}
-       * @default
-       * @since 1.0.35
-       */
-      columnsPreferenceProperty: "org.alfresco.share.documentList.galleryColumns",
 
       /**
        * This function updates the [columns]{@link module:alfresco/documentlibrary/views/AlfGalleryView#columns}
@@ -143,6 +234,32 @@ define(["dojo/_base/declare",
             }
          }
       },
+
+      /**
+       * Updates the [thumbnailSize]{@link module:alfresco/documentlibrary/views/AlfGalleryView#thumbnailSize}
+       * to of each displayed item.
+       * 
+       * @instance
+       * @param  {object} payload A payload where the value is the new thumbnail size.
+       * @since 1.0.40
+       */
+      updateThumbnailSize: function alfresco_documentlibrary_views_AlfGalleryView__updateThumbnailSize(payload) {
+         var thumbnailSize = payload && !isNaN(payload.value) && payload.value;
+         if (thumbnailSize && thumbnailSize !== this.thumbnailSize)
+         {
+            this.thumbnailSize = thumbnailSize;
+            if (this.docListRenderer)
+            {
+               // In the case of infinite scroll, we need to ensure that we reset the count for rendering
+               // data so that all the items are re-rendered and sized appropriately...
+               if (lang.exists("docListRenderer.currentData.previousItemCount"), this)
+               {
+                  this.docListRenderer.currentData.previousItemCount = 0;
+               }
+               this.renderView(false);
+            }
+         }
+      },
       
       /**
        * Overridden to return a new instance of "alfresco/documentlibrary/AlfGalleryViewSlider" to control the 
@@ -152,13 +269,29 @@ define(["dojo/_base/declare",
        * @returns {object} A new slider control {@link module:alfresco/documentlibrary/AlfGalleryViewSlider}
        */
       getAdditionalControls: function alfresco_documentlibrary_views_AlfGalleryView__getAdditionalControls() {
-         return [new AlfGalleryViewSlider({
-            relatedViewName: this.getViewName(),
-            pubSubScope: this.pubSubScope,
-            parentPubSubScope: this.parentPubSubScope,
-            columns: this.columns,
-            columnsPreferenceProperty: this.columnsPreferenceProperty
-         })];
+         if (this.resizeByColumnCount)
+         {
+            // NOTE: Can't call createWidget because it is overridden by the MultiItemMixinRenderer...
+            return [new AlfGalleryViewSlider({
+               relatedViewName: this.getViewName(),
+               pubSubScope: this.pubSubScope,
+               parentPubSubScope: this.parentPubSubScope,
+               columns: this.columns,
+               columnsPreferenceProperty: this.columnsPreferenceProperty
+            })];
+            
+         }
+         else
+         {
+            // NOTE: Can't call createWidget because it is overridden by the MultiItemMixinRenderer...
+            return [new ThumbnailSizeSlider({
+               relatedViewName: this.getViewName(),
+               pubSubScope: this.pubSubScope,
+               parentPubSubScope: this.parentPubSubScope,
+               value: this.thumbnailSize,
+               preferenceProperty: this.thumbnailSizePreferenceProperty
+            })];
+         }
       },
       
       /**
@@ -203,36 +336,6 @@ define(["dojo/_base/declare",
       },
       
       /**
-       * When set to true this will show a link for requesting more data (if available). This should be used when
-       * the grid is rendering data in an infinite scroll view. It is required because when the grid cells are small
-       * the data may not be sufficient to allow the scrolling events to occur that will request more data.
-       * 
-       * @instance
-       * @type {boolean}
-       * @default
-       */
-      showNextLink: false,
-
-      /**
-       * The label to use for the next link. This defaults to null, so MUST be set for the next link to be displayed.
-       * 
-       * @instance
-       * @type {string}
-       * @default
-       */
-      nextLinkLabel: null,
-
-      /**
-       * The topic to publish when the next link is clicked.
-       * 
-       * @event nextLinkPublishTopic
-       * @instance
-       * @type {string}
-       * @default [topics.SCROLL_NEAR_BOTTOM]{@link module:alfresco/core/topics#SCROLL_NEAR_BOTTOM}
-       */
-      nextLinkPublishTopic: topics.SCROLL_NEAR_BOTTOM,
-
-      /**
        * Creates a new [ListRenderer]{@link module:alfresco/lists/views/ListRenderer}
        * which is used to render the actual items in the view. This function can be overridden by extending views
        * (such as the [Film Strip View]{@link module:alfresco/documentlibrary/views/AlfFilmStripView}) to create
@@ -249,9 +352,11 @@ define(["dojo/_base/declare",
             pubSubScope: this.pubSubScope,
             parentPubSubScope: this.parentPubSubScope,
             columns: this.columns,
+            fixedColumns: this.resizeByColumnCount,
             showNextLink: this.showNextLink,
             nextLinkLabel: this.nextLinkLabel,
-            nextLinkPublishTopic: this.nextLinkPublishTopic
+            nextLinkPublishTopic: this.nextLinkPublishTopic,
+            thumbnailSize: this.thumbnailSize
          });
          return dlr;
       },

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -724,7 +724,7 @@ define(["dojo/_base/declare",
             {
                // If cropping to fit we require the natural image width and height to be available
                // (which are set on image load)...
-               this.naturalImageWidth && this.naturalHeight && this.cropImage();
+               this.naturalImageWidth && this.naturalImageHeight && this.cropImage();
             }
             else if (this.stretchToFit)
             {

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewThumbnailSizingTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewThumbnailSizingTest.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Gallery View Tests (Thumbnail Resizing)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/GalleryViewThumbnailSizing", "Gallery View Tests (Thumbnail Resizing)")
+               .setWindowSize(null, 900, 768) // Set a window height to ensure 2 columns
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "There are initially 6 rows": function() {
+            // The default thumbnail width is 400px and with a 900px view width we'd expect
+            // two columns... 11 items in 2 columns produces 6 rows...
+            return browser.findAllByCssSelector(".alfresco-lists-views-layouts-Grid tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 6, "Unexpected number of rows");
+               });
+         },
+
+         "Increase thumbnail size to decrease columns": function() {
+            // Increasing the thumbnail size (using the slider) should re-render the grid
+            // so that there is only a single column of thumbnails
+            return browser.findByCssSelector(".dijitSliderIncrementIconH")
+               .clearLog()
+               .click()
+            .end()
+
+            // Wait for preference to be set...
+            .getLastPublish("ALF_PREFERENCE_SET", "Preference not set")
+
+            .findAllByCssSelector(".alfresco-lists-views-layouts-Grid tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 11, "Unexpected number of rows");
+               });
+         },
+
+         "Increase the browser window to increase columns": function() {
+            // Increasing the window size should add more columns...
+            return browser.setWindowSize(null, 1500, 768)
+               .findAllByCssSelector(".alfresco-lists-views-layouts-Grid tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "Unexpected number of rows");
+               });
+         },
+
+         "Decrease the thumbnail size to increase the colums": function() {
+            // It is necessary to go down 2 steps to get to 4 columns...
+            return browser.findByCssSelector(".dijitSliderDecrementIconH")
+               .clearLog()
+               .click()
+            .end()
+
+            // Wait for preference to be set (first size reduction)...
+            .getLastPublish("ALF_PREFERENCE_SET", "Preference not set")
+
+            .findByCssSelector(".dijitSliderDecrementIconH")
+               .clearLog()
+               .click()
+            .end()
+
+            // Wait for preference to be set (second size reduction)...
+            .getLastPublish("ALF_PREFERENCE_SET", "Preference not set")
+
+            .findAllByCssSelector(".alfresco-lists-views-layouts-Grid tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "Unexpected number of rows");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -100,6 +100,7 @@ define({
       "src/test/resources/alfresco/documentlibrary/views/AlfDocumentListWithHeaderTest",
       "src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest",
       "src/test/resources/alfresco/documentlibrary/views/GalleryViewTest",
+      "src/test/resources/alfresco/documentlibrary/views/GalleryViewThumbnailSizingTest",
 
       "src/test/resources/alfresco/footer/FooterTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>GalleryView (Resizable thumbnails)</shortname>
+  <description>Shows an example gallery view where thumbnail size (rather than colum count) can be adjusted by a slide</description>
+  <family>aikau-unit-tests</family>
+  <url>/GalleryViewThumbnailSizing</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.js
@@ -1,0 +1,48 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "TOOLBAR",
+         name: "alfresco/documentlibrary/AlfToolbar"
+      },
+      {
+         id: "DOCLIST",
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            useHash: false,
+            additionalControlsTarget: "TOOLBAR",
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/views/AlfGalleryView",
+                  config: {
+                     resizeByColumnCount: false
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/NodesMockXhr",
+         config: {
+            totalItems: 11,
+            folderRatio: [100]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-628 to add support for resizing thumbnails directly (rather than indirectly by adjusting the number of columns). 