### PR TITLE
AKU-644: Ensure that ClassicWindow overflows when it has fixed dimensions

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/ClassicWindow.js
+++ b/aikau/src/main/resources/alfresco/layout/ClassicWindow.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -99,8 +99,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_layout_ClassicWindow__postCreate() {
-         domClass.add(this.domNode, (this.additionalCssClasses != null ? this.additionalCssClasses : ""));
-         if (this.widgets != null)
+         if (this.widgets)
          {
             this.processWidgets(this.widgets, this.contentNode);
          }

--- a/aikau/src/main/resources/alfresco/layout/css/ClassicWindow.css
+++ b/aikau/src/main/resources/alfresco/layout/css/ClassicWindow.css
@@ -1,32 +1,32 @@
 .alfresco-layout-ClassicWindow {
-   border: 1px solid #CCC;
+   border: @standard-border;
    margin: 10px;
    border-top-left-radius: 6px;
    border-top-right-radius: 6px;
-}
 
-.alfresco-layout-ClassicWindow > div.titlebar {
-   background-color: #EEEEEE;
-   border-bottom: 1px solid #CCC;
-   padding: 5px;
-   border-top-left-radius: 6px;
-   border-top-right-radius: 6px;
-}
+   &__titlebar {
+      background-color: #EEEEEE;
+      border-bottom: @standard-border;
+      padding: 5px;
+      border-top-left-radius: 6px;
+      border-top-right-radius: 6px;
+   }
 
-.alfresco-layout-ClassicWindow > div.content {
-   margin: 10px 0;
-   padding: 10px;
-}
+   &__content {
+      overflow: auto;
+      padding: 10px;
+   }
 
-.alfresco-layout-ClassicWindow.shadow {
-   box-shadow: @standard-box-shadow;
-}
+   &.shadow {
+      box-shadow: @standard-box-shadow;
+   }
 
-.alfresco-layout-ClassicWindow.bottomBorderRadius {
-   border-bottom-left-radius: 6px;
-   border-bottom-right-radius: 6px;
-}
+   &.bottomBorderRadius {
+      border-bottom-left-radius: 6px;
+      border-bottom-right-radius: 6px;
+   }
 
-.alfresco-layout-ClassicWindow.borderLess {
-   border: none;
+   .borderLess {
+      border: none;
+   }
 }

--- a/aikau/src/main/resources/alfresco/layout/templates/ClassicWindow.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/ClassicWindow.html
@@ -1,4 +1,4 @@
 <div class="alfresco-layout-ClassicWindow">
-   <div class="titlebar" data-dojo-attach-point="titleBarNode">${title}</div>
-   <div class="content" data-dojo-attach-point="contentNode"></div>
+   <div class="alfresco-layout-ClassicWindow__titlebar" data-dojo-attach-point="titleBarNode">${title}</div>
+   <div class="alfresco-layout-ClassicWindow__content" data-dojo-attach-point="contentNode"></div>
 </div>

--- a/aikau/src/test/resources/alfresco/layout/ClassicWindowTest.js
+++ b/aikau/src/test/resources/alfresco/layout/ClassicWindowTest.js
@@ -50,10 +50,10 @@ define(["intern!object",
          },
 
          "Check the Classic Windows have appropriate title bars shown": function() {
-            return browser.findByCssSelector("#WINDOW1 .titlebar")
+            return browser.findByCssSelector("#WINDOW1 .alfresco-layout-ClassicWindow__titlebar")
             .end()
 
-            .findByCssSelector("#WINDOW2 .titlebar")
+            .findByCssSelector("#WINDOW2 .alfresco-layout-ClassicWindow__titlebar")
                .then(function () {
                   assert.fail(null, null, "Classic Window 2 should not have a titlebar");
                },
@@ -62,12 +62,30 @@ define(["intern!object",
                });
          },
 
-         "Check Classic Window 1 has the appropariate title": function() {
-            return browser.findByCssSelector("#WINDOW1 .titlebar")
+         "Check Classic Window 1 has the appropriate title": function() {
+            return browser.findByCssSelector("#WINDOW1 .alfresco-layout-ClassicWindow__titlebar")
                .getVisibleText()
                .then(function (text) {
                   assert.strictEqual(text, "Test title");
                });
+         },
+
+         /* global document*/
+         "Check for scrollbars on overflow": function() {
+            function nodeOverflows(selector) {
+               var node = document.querySelector(selector);
+               return node.scrollWidth > node.clientWidth;
+            }
+
+            return browser.execute(nodeOverflows, ["#WINDOW3 .alfresco-layout-ClassicWindow__content"])
+               .then(function(overflows) {
+                  assert.isTrue(overflows, "Scroll bar is not displayed");
+               });
+            // return browser.findByCssSelector("#WINDOW3 .alfresco-layout-ClassicWindow__content")
+            //    .then(function(element) {
+            //       console.log("Scroll width=" + element.scrollWidth + ", client width=" + element.clientWidth);
+            //       assert(element.scrollWidth > element.clientWidth, "Scroll bar is not displayed");
+            //    });
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ClassicWindow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ClassicWindow.get.js
@@ -32,6 +32,34 @@ model.jsonModel = {
                }
             ]
          }
+      },
+      {
+         id: "HORIZONTAL_WIDGETS",
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "WINDOW3",
+                  name: "alfresco/layout/ClassicWindow",
+                  widthPx: "200",
+                  config: {
+                     title: "Overflow",
+                     additionalCssClasses: "bottomBorderRadius shadow",
+                     widgets: [
+                        {
+                           name: "alfresco/logo/Logo",
+                           config: {
+                              logoClasses: "surf-logo-large"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-644 to ensure that the ClassicWindow widget will show scrollbar when its content is too large to be displayed.