### PR TITLE
Removed transition from widget debug

### DIFF
--- a/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
+++ b/aikau/src/main/resources/alfresco/debug/css/WidgetInfo.css
@@ -20,7 +20,6 @@
 
 .alfresco-debug-Info {
    &.highlight {
-      transition: padding .5s cubic-bezier(.25, .75, .5, .9);
    }
    > .alfresco-debug-WidgetInfo {
       display: none;


### PR DESCRIPTION
Removed transition from widget debug - as is causing some UI elements to transition on initial display when client-debug is true - which is distracting and a waste of battery power.