### PR TITLE
AKU-640: TagFilters - additional tests

### DIFF
--- a/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/TagFiltersTest.js
@@ -22,66 +22,84 @@
  */
 define(["alfresco/TestCommon",
       "intern!object",
-      "intern/chai!assert"
-   ],
-   function(TestCommon, registerSuite, assert) {
+      "intern/chai!assert"],
+      function(TestCommon, registerSuite, assert) {
 
-      registerSuite(function() {
-         var browser;
+   registerSuite(function() {
+      var browser;
 
-         return {
-            name: "TagFilters Tests",
+      return {
+         name: "TagFilters Tests",
 
-            setup: function() {
-               browser = this.remote;
-               return TestCommon.loadTestWebScript(this.remote, "/TagFilters", "TagFilters Tests");
-            },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/TagFilters", "TagFilters Tests");
+         },
 
-            "Can retrieve tags in unscoped context": function() {
-               return browser.findAllByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter")
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 9);
-                  });
-            },
+         beforeEach: function() {
+            browser.end();
+         },
 
-            "Can retrieve tags in scoped context": function() {
-               return browser.findAllByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter")
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 9);
-                  });
-            },
-
-            "Clicked tags publish change notification (unscoped)": function() {
-               return browser.findByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
-                  .clearLog()
-                  .click()
-                  .getLastPublish("ALF_DOCUMENTLIST_TAG_CHANGED", true);
-            },
-
-            "Clicked tags publish change notification (scoped)": function() {
-               return browser.findByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
-                  .clearLog()
-                  .click()
-                  .getLastPublish("SCOPED_ALF_DOCUMENTLIST_TAG_CHANGED", true);
-            },
-
-            "Document tagged event forces reload of scoped list": function() {
-               return browser.findById("PUBLISH_TAGGED_BUTTON_label")
-                  .click()
-                  .getLastPublish("SCOPED_ALF_DOCUMENT_TAGGED", true)
-                  .getLastPublish("ALF_TAG_QUERY", true)
+         // See AKU-640 - this test needs to be first before we start manipulating the filters...
+         "Check root node tag publication": function() {
+            return browser.findByCssSelector("body").end()
+               .getLastPublish("ALF_TAG_QUERY")
                   .then(function(payload) {
-                     assert.propertyVal(payload, "alfResponseScope", "SCOPED_");
+                     assert.propertyVal(payload, "siteId", null, "Unexpected siteId");
+                     assert.propertyVal(payload, "containerId", null, "Unexpected containerId");
+                     assert.propertyVal(payload, "rootNode", "some://fake/node", "Unexpected containerId");
                   });
-            },
+         },
 
-            beforeEach: function() {
-               browser.end();
-            },
+         "Check root node XHR request": function() {
+            // We know that a rootNode query uses "tagQuery" as opposed to "tags" as used for siteId/containerId
+            // It's important to make sure that a rootNode request is made because then we know that no
+            // spurious siteId/containerId attributes have been provided...
+            return browser.findByCssSelector("body").end()
+               .getLastXhr("/tagQuery", "No root node XHR request");
+         },
 
-            "Post Coverage Results": function() {
-               TestCommon.alfPostCoverageResults(this, browser);
-            }
-         };
-      });
+         "Can retrieve tags in unscoped context": function() {
+            return browser.findAllByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 9);
+               });
+         },
+
+         "Can retrieve tags in scoped context": function() {
+            return browser.findAllByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 9);
+               });
+         },
+
+         "Clicked tags publish change notification (unscoped)": function() {
+            return browser.findByCssSelector("#TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
+               .clearLog()
+               .click()
+               .getLastPublish("ALF_DOCUMENTLIST_TAG_CHANGED", true);
+         },
+
+         "Clicked tags publish change notification (scoped)": function() {
+            return browser.findByCssSelector("#SCOPED_TAG_FILTERS .alfresco-documentlibrary-AlfDocumentFilter:last-child")
+               .clearLog()
+               .click()
+               .getLastPublish("SCOPED_ALF_DOCUMENTLIST_TAG_CHANGED", true);
+         },
+
+         "Document tagged event forces reload of scoped list": function() {
+            return browser.findById("PUBLISH_TAGGED_BUTTON_label")
+               .click()
+               .getLastPublish("SCOPED_ALF_DOCUMENT_TAGGED", true)
+               .getLastPublish("ALF_TAG_QUERY", true)
+               .then(function(payload) {
+                  assert.propertyVal(payload, "alfResponseScope", "SCOPED_");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
+});

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/TagFilters.get.js
@@ -45,6 +45,15 @@ model.jsonModel = {
                      containerId: "documentLibrary",
                      pubSubScope: "SCOPED_"
                   }
+               },
+               {
+                  name: "alfresco/documentlibrary/AlfTagFilters",
+                  id: "TAG_FILTERS_ROOT_NODE",
+                  config: {
+                     label: "Tags (Root Node - none expected)",
+                     rootNode: "some://fake/node",
+                     pubSubScope: "ROOT_NODE_SCOPE_"
+                  }
                }
             ]
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-640. Although there is no bug to fix I am adding additional tests for rootNode tags in order to be able to demonstrate there is no bug.