### PR TITLE
AKU-646: FixedHeaderFooter: support resizing in header and footer

### DIFF
--- a/aikau/src/main/resources/alfresco/html/Image.js
+++ b/aikau/src/main/resources/alfresco/html/Image.js
@@ -328,7 +328,6 @@ define(["alfresco/core/_PublishOrLinkMixin",
        * Prepare the image node
        *
        * @instance
-       * @returns {[type]} [description]
        */
       setupImageNode: function alfresco_html_Image__setupImageNode() {
 

--- a/aikau/src/main/resources/alfresco/html/Image.js
+++ b/aikau/src/main/resources/alfresco/html/Image.js
@@ -242,6 +242,16 @@ define(["alfresco/core/_PublishOrLinkMixin",
       srcType: urlTypes.PAGE_RELATIVE,
 
       /**
+       * We want to set a maximum time for waiting for the widget to be attached to
+       * the DOM before trying to setup the widget.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      timeForDomAttach: 5000,
+
+      /**
        * An optional CSS width to apply to the image node in pixels. If width is
        * specified without height then the other will be calculated using the
        * aspectRatio property, or the calculated naturalAspectRatio if not specified.
@@ -251,6 +261,15 @@ define(["alfresco/core/_PublishOrLinkMixin",
        * @default
        */
       width: 0,
+
+      /**
+       * In order to ensure we don't try forever to setup this widget when it's not
+       * being attached to the DOM, note when we first retry the setup.
+       *
+       * @instance
+       * @type {number?}
+       */
+      _firstAttemptedSetup: null,
 
       /**
        * This is run after the config has been mixed into this instance.
@@ -296,6 +315,41 @@ define(["alfresco/core/_PublishOrLinkMixin",
             domClass.add(this.imageNode, this.classes);
          }
 
+         // Add "block state"
+         if (this.isBlockElem) {
+            domClass.add(this.domNode, "alfresco-html-Image--block");
+         }
+
+         // Setup the image node (sizing, etc)
+         this.setupImageNode();
+      },
+
+      /**
+       * Prepare the image node
+       *
+       * @instance
+       * @returns {[type]} [description]
+       */
+      setupImageNode: function alfresco_html_Image__setupImageNode() {
+
+         // The image-node setup will only work if attached to the DOM, so try again later if necessary
+         var nextParent = this.domNode,
+            isAttached;
+         while((nextParent = nextParent.parentNode) && !isAttached) {
+            isAttached = (nextParent === document.body);
+         }
+         if(!isAttached) {
+
+            // We can't let this run forever, so break out if necessary
+            if(!this._firstAttemptedSetup) {
+               this._firstAttemptedSetup = Date.now();
+            }
+            if(Date.now() - this._firstAttemptedSetup < this.timeForDomAttach) {
+               setTimeout(lang.hitch(this, this.setupImageNode), 200);
+               return;
+            }
+         }
+
          // No configured src, so set to blank.gif if a background image is present
          if (!this.src) {
             if (this._getBackgroundImageUrl()) {
@@ -303,11 +357,6 @@ define(["alfresco/core/_PublishOrLinkMixin",
             } else {
                this.imageNode.src = this.src;
             }
-         }
-
-         // Add "block state"
-         if (this.isBlockElem) {
-            domClass.add(this.domNode, "alfresco-html-Image--block");
          }
 
          // Resize the image node

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -130,6 +130,20 @@ define(["alfresco/core/ProcessWidgets",
       }],
 
       /**
+       * If this widget is placed into a widget that has padding then this allowance can be configured which
+       * will be substituted from the calculated height to take padding into account so that an outer scroll
+       * bar is not required on the page. This defaults to 0 and has only been provided for potential 
+       * convenience. This value will only be used on when [height]{@link module:alfresco/layout/FixedHeaderFooter#height}
+       * is set to "auto" (which is also the default).
+       *
+       * @instance
+       * @type {number}
+       * @default
+       * @deprecated Since 1.0.36 use [heightAdjustment]{@link module:alfresco/layout/HeightMixin#heightAdjustment} instead
+       */
+      autoHeightPaddingAllowance: 0,
+
+      /**
        * The height of the widget (in CSS units). The default value is "auto" which means that the
        * height of the widget will automatically be set to take up the available space from its current
        * position to the bottom of the window or document (whichever is smallest) so that the entire
@@ -143,20 +157,6 @@ define(["alfresco/core/ProcessWidgets",
        * @deprecated Since 1.0.36 use [heightMode]{@link module:alfresco/layout/HeightMixin#heightMode} instead
        */
       height: "AUTO",
-
-      /**
-       * If this widget is placed into a widget that has padding then this allowance can be configured which
-       * will be substituted from the calculated height to take padding into account so that an outer scroll
-       * bar is not required on the page. This defaults to 0 and has only been provided for potential 
-       * convenience. This value will only be used on when [height]{@link module:alfresco/layout/FixedHeaderFooter#height}
-       * is set to "auto" (which is also the default).
-       *
-       * @instance
-       * @type {number}
-       * @default
-       * @deprecated Since 1.0.36 use [heightAdjustment]{@link module:alfresco/layout/HeightMixin#heightAdjustment} instead
-       */
-      autoHeightPaddingAllowance: 0,
 
       /**
        * If this is configured to be true the the height of the widget will be reset as the browser window is resized.
@@ -234,9 +234,43 @@ define(["alfresco/core/ProcessWidgets",
             }
          ]);
 
+         // Add resize listeners to the header/footer
+         this.addHeaderResizeListener();
+
          // Do the resize
          this.onResize();
          this.alfPublishResizeEvent(this.domNode);
+      },
+
+      /**
+       * Setup a listener that will call [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent}
+       * whenever a resize is detected in the header.
+       *
+       * @instance
+       */
+      addHeaderResizeListener: function alfresco_layout_FixedHeaderFooter__addHeaderResizeListener() {
+
+         // Create the resize object
+         var resizeObj = domConstruct.create("object", {
+            className: this.baseClass + "__header__resize-object",
+            type: "text/html",
+            data: "about:blank"
+         });
+
+         // Setup the onload listener for the object to add a resize event handler
+         var that = this;
+         resizeObj.onload = function() {
+            this.contentDocument.defaultView.addEventListener("resize", function() {
+               that.alfPublishResizeEvent(that.domNode);
+            });
+         }
+
+         // Add the object to the document
+         if (resizeObj.hasChildNodes()) {
+            this.header.insertBefore(resizeObj, this.header.firstChild);
+         } else {
+            this.header.appendChild(resizeObj);
+         }
       },
 
       /**
@@ -251,7 +285,7 @@ define(["alfresco/core/ProcessWidgets",
        * @param {object[]} widgets The widgets that have been created
        * @since 1.0.38
        */
-      allWidgetsProcessed: function alfresco_layout_HorizontalWidgets__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
+      allWidgetsProcessed: function alfresco_layout_FixedHeaderFooter__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
          this._allWidgetsProcessedCount--;
          if (this._allWidgetsProcessedCount === 0)
          {

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -243,8 +243,11 @@ define(["alfresco/core/ProcessWidgets",
       },
 
       /**
-       * Setup a listener that will call [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent}
-       * whenever a resize is detected in the header.
+       * <p>Setup a listener that will call [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent}
+       * whenever a resize is detected in the header.</p>
+       *
+       * <p>NOTE: This is based on a technique described at
+       * {@link http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection}</p>
        *
        * @instance
        */

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -236,7 +236,7 @@ define(["alfresco/core/ProcessWidgets",
          ]);
 
          // Add resize listeners to the header/footer
-         this.addHeaderResizeListener();
+         setTimeout(lang.hitch(this, this.addHeaderResizeListener));
 
          // Do the resize
          this.onResize();

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -236,7 +236,8 @@ define(["alfresco/core/ProcessWidgets",
          ]);
 
          // Add resize listeners to the header/footer
-         setTimeout(lang.hitch(this, this.addHeaderResizeListener));
+         // NOTE: This is done asynchronously to avoid delaying the resize event firing
+         setTimeout(lang.hitch(this, this.addHeaderResizeListener), 0);
 
          // Do the resize
          this.onResize();
@@ -251,6 +252,7 @@ define(["alfresco/core/ProcessWidgets",
        * {@link http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection}</p>
        *
        * @instance
+       * @since 1.0.41
        */
       addHeaderResizeListener: function alfresco_layout_FixedHeaderFooter__addHeaderResizeListener() {
 

--- a/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
+++ b/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
@@ -8,6 +8,16 @@
    }
    &__header {
       top: 0;
+      &__resize-object {
+         display: block;
+         height: 100%;
+         left: 0;
+         overflow: hidden;
+         position: absolute;
+         top: 0;
+         width: 100%;
+         z-index: -1;
+      }
    }
    &__footer {
       bottom: 0;

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -143,6 +143,23 @@ define(["intern!object",
                });
          },
 
+         "Header resize fires resize event": function() {
+            return browser.findById("SHOW_HEADER_label")
+               .click()
+               .clearLog()
+               .end()
+
+            .execute(function() {
+                  var header = document.querySelector(".alfresco-layout-FixedHeaderFooter__header");
+                  header.appendChild(document.createElement("BR"));
+               })
+               .getLastPublish("ALF_NODE_RESIZED")
+               .then(function(payload) {
+                  assert.property(payload, "node");
+                  assert.match(payload.node, /^div#HEADER_FOOTER/);
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/FixedHeaderFooterTest.js
@@ -146,14 +146,14 @@ define(["intern!object",
          "Header resize fires resize event": function() {
             return browser.findById("SHOW_HEADER_label")
                .click()
-               .clearLog()
                .end()
 
-            .execute(function() {
-                  var header = document.querySelector(".alfresco-layout-FixedHeaderFooter__header");
-                  header.appendChild(document.createElement("BR"));
-               })
-               .getLastPublish("ALF_NODE_RESIZED")
+            .findByCssSelector("#HEADER_TWISTER .label")
+               .clearLog()
+               .click()
+               .end()
+
+            .getLastPublish("ALF_NODE_RESIZED")
                .then(function(payload) {
                   assert.property(payload, "node");
                   assert.match(payload.node, /^div#HEADER_FOOTER/);

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/logo/LogoTest"
+      "src/test/resources/alfresco/layout/FixedHeaderFooterTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/dnd/FormCreationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -1,3 +1,5 @@
+var noDataMessage = "No data found. This page no longer works without hash parameters. By default, try /FixedHeaderFooter#currentItem";
+
 model.jsonModel = {
    services: [
       {
@@ -62,6 +64,7 @@ model.jsonModel = {
                            id: "LIST",
                            name: "alfresco/documentlibrary/AlfDocumentList",
                            config: {
+                              noDataMessage: noDataMessage,
                               useHash: true,
                               widgets: [
                                  {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/FixedHeaderFooter.get.js
@@ -57,6 +57,29 @@ model.jsonModel = {
                                  ]
                               }
                            }
+                        },
+                        {
+                           name: "alfresco/layout/Twister",
+                           id: "HEADER_TWISTER",
+                           config: {
+                              label: "Toggle me to change header size",
+                              initiallyOpen: false,
+                              widgets: [
+                                 {
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ],
+                              visibilityConfig: {
+                                 initialValue: false,
+                                 rules: [
+                                    {
+                                       topic: "HEADER_VISIBILITY",
+                                       attribute: "value",
+                                       isNot: ["HIDE"]
+                                    }
+                                 ]
+                              }
+                           }
                         }
                      ],
                      widgets: [

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/unit-test-template.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/unit-test-template.ftl
@@ -14,7 +14,7 @@
    
    <#-- Note that it's necessary to import the Sinon libs synchronously because version 1.10.3 does not support AMD and
         breaks when used with the Aikau widgets. This ensures that the global "sinon" object is available when required -->
-   <script type="text/javascript" src="${url.context}/res/js/lib/sinon-1.10.3/lib/sinon-server-1.10.3.js"/> 
+   <script type="text/javascript" src="${url.context}/res/js/lib/sinon-1.10.3/lib/sinon-server-1.10.3.js"></script> 
 
    <@generateMessages type="text/javascript" src="${url.context}/service/messages.js" locale="${locale}"/>
    


### PR DESCRIPTION
This addresses issue [AKU-646](https://issues.alfresco.com/jira/browse/AKU-646) by adding some code to detect resizes in the header node. It also fixes some discovered bugs in Image.js and the unit-tests index page template.