### PR TITLE
AKU-658: Update CrudService to support scoped responses

### DIFF
--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -89,12 +89,15 @@ define(["dojo/_base/declare",
          });
 
          var noRefresh = lang.getObject("data.noRefresh", false, originalRequestConfig);
-         if (noRefresh === true) {
+         if (noRefresh === true) 
+         {
             // Don't make a refresh request...
-         } else {
+         } 
+         else 
+         {
             // When refreshing, check to see if a pubSubScope was provided...
-            var pubSubScope = lang.getObject("data.pubSubScope", false, originalRequestConfig) || "";
-            this.alfPublish(pubSubScope + "ALF_DOCLIST_RELOAD_DATA");
+            var pubSubScope = lang.getObject("responseScope", false, originalRequestConfig) || "";
+            this.alfPublish("ALF_DOCLIST_RELOAD_DATA", null, false, false, pubSubScope);
          }
       },
 
@@ -187,6 +190,7 @@ define(["dojo/_base/declare",
 
          var config = {
             url: url,
+            responseScope: payload.alfResponseScope,
             data: this.clonePayload(payload),
             alfTopic: payload.alfResponseTopic || null,
             method: "GET"
@@ -215,6 +219,7 @@ define(["dojo/_base/declare",
          if (url) {
             this.serviceXhr({
                url: url,
+               responseScope: payload.alfResponseScope,
                data: this.clonePayload(payload),
                method: "GET"
             });
@@ -233,6 +238,7 @@ define(["dojo/_base/declare",
          var url = this.getUrlFromPayload(payload);
          this.serviceXhr({
             url: url,
+            responseScope: payload.alfResponseScope,
             data: this.clonePayload(payload),
             method: "POST",
             alfTopic: payload.alfResponseTopic,
@@ -253,6 +259,7 @@ define(["dojo/_base/declare",
          var url = this.getUrlFromPayload(payload);
          this.serviceXhr({
             url: url,
+            responseScope: payload.alfResponseScope,
             data: this.clonePayload(payload),
             method: "PUT",
             alfTopic: payload.alfResponseTopic,
@@ -309,19 +316,20 @@ define(["dojo/_base/declare",
          var confirmButtonLabel = payload.confirmationButtonLabel || "crudservice.generic.delete.confirmationButtonLabel";
          var cancelButtonLabel = payload.cancellationButtonLabel || "crudservice.generic.delete.cancellationButtonLabel";
 
-         var dialog = new AlfDialog({
-            generatePubSubScope: false,
-            title: this.message(title),
-            content: this.message(prompt),
+         this.alfServicePublish(topics.CREATE_DIALOG, {
+            dialogId: "ALF_CRUD_SERVICE_DELETE_CONFIRMATION_DIALOG",
+            dialogTitle: this.message(title),
+            textContent: this.message(prompt),
             widgetsButtons: [
                {
+                  id: "ALF_CRUD_SERVICE_DELETE_CONFIRMATION_DIALOG_CONFIRM",
                   name: "alfresco/buttons/AlfButton",
                   config: {
                      label: this.message(confirmButtonLabel),
                      publishTopic: responseTopic,
                      publishPayload: {
                         url: url,
-                        pubSubScope: payload.pubSubScope,
+                        responseScope: payload.alfResponseScope,
                         responseTopic: payload.responseTopic,
                         successMessage: this.message(payload.successMessage || "crudservice.generic.success.message"),
                         failureMessage: this.message(payload.failureMessage || "crudservice.generic.failure.message")
@@ -329,6 +337,7 @@ define(["dojo/_base/declare",
                   }
                },
                {
+                  id: "ALF_CRUD_SERVICE_DELETE_CONFIRMATION_DIALOG_CANCEL",
                   name: "alfresco/buttons/AlfButton",
                   config: {
                      label: this.message(cancelButtonLabel),
@@ -337,7 +346,6 @@ define(["dojo/_base/declare",
                }
             ]
          });
-         dialog.show();
       },
 
       /**
@@ -354,6 +362,7 @@ define(["dojo/_base/declare",
          this.serviceXhr({
             url: url,
             method: "DELETE",
+            responseScope: payload.alfResponseScope,
             data: this.clonePayload(payload),
             alfTopic: payload.responseTopic,
             successMessage: this.message(payload.successMessage || "crudservice.generic.success.message"),

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -89,15 +89,9 @@ define(["dojo/_base/declare",
          });
 
          var noRefresh = lang.getObject("data.noRefresh", false, originalRequestConfig);
-         if (noRefresh === true) 
+         if (noRefresh !== true)
          {
-            // Don't make a refresh request...
-         } 
-         else 
-         {
-            // When refreshing, check to see if a pubSubScope was provided...
-            var pubSubScope = lang.getObject("responseScope", false, originalRequestConfig) || "";
-            this.alfPublish("ALF_DOCLIST_RELOAD_DATA", null, false, false, pubSubScope);
+           this.alfPublish("ALF_DOCLIST_RELOAD_DATA", null, false, false, originalRequestConfig.responseScope);
          }
       },
 

--- a/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/CrudServiceTest.js
@@ -22,10 +22,9 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/helpers/pollUntil"],
-        function(registerSuite, assert, require, TestCommon, pollUntil) {
+        function(registerSuite, assert, TestCommon, pollUntil) {
 
    function closeAllDialogs(browser) {
       return browser.end()
@@ -67,10 +66,7 @@ define(["intern!object",
                .click()
             .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_SUCCESS", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Delete did not succeed");
-               });
+            .getLastPublish("ALF_CRUD_DELETED_SUCCESS", "Delete did not succeed");
          },
 
          "Invalid DELETE call fails": function() {
@@ -78,10 +74,7 @@ define(["intern!object",
                .click()
             .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_DELETED_FAILURE", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Invalid delete did not fail");
-               });
+            .getLastPublish("ALF_CRUD_DELETED_FAILURE", "Invalid delete did not fail");
          },
 
          "Failed DELETE displays failure message": function() {
@@ -102,10 +95,7 @@ define(["intern!object",
                      .click()
                   .end()
 
-                  .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_SUCCESS", "publish", "any"))
-                     .then(function(elements) {
-                        assert.lengthOf(elements, 1, "Update did not succeed");
-                     });
+                  .getLastPublish("ALF_CRUD_UPDATED_SUCCESS", "Update did not succeed");
                });
          },
 
@@ -114,10 +104,7 @@ define(["intern!object",
                .click()
             .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_UPDATED_FAILURE", "publish", "any"))
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Invalid update did not fail");
-               });
+            .getLastPublish("ALF_CRUD_UPDATED_FAILURE", "Invalid update did not fail");
          },
 
          "Failed UPDATE displays failure message": function() {
@@ -138,10 +125,7 @@ define(["intern!object",
                      .click()
                   .end()
 
-                  .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_SUCCESS", "publish", "any"))
-                     .then(function(elements) {
-                        assert.lengthOf(elements, 1, "Create did not succeed");
-                     });
+                  .getLastPublish("ALF_CRUD_CREATED_SUCCESS", "Create did not succeed");
                });
          },
 
@@ -150,10 +134,7 @@ define(["intern!object",
                .click()
             .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_CRUD_CREATED_FAILURE", "publish", "any"))
-               .then(function (elements) {
-                  assert.lengthOf(elements, 1, "Invalid create did not fail");
-               });
+            .getLastPublish("ALF_CRUD_CREATED_FAILURE", "Invalid create did not fail");
          },
 
          "Failed CREATE displays failure message": function () {
@@ -174,10 +155,7 @@ define(["intern!object",
                      .click()
                   .end()
 
-                  .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_DEFAULT_CACHE_SUCCESS", "publish", "any"))
-                     .then(function (elements) {
-                        assert.lengthOf(elements, 1, "GET ALL didn't succeed");
-                     });
+                  .getLastPublish("ALF_GET_ALL_DEFAULT_CACHE_SUCCESS", "GET ALL didn't succeed");
                });
          },
 
@@ -186,10 +164,7 @@ define(["intern!object",
                .click()
             .end()
 
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_GET_ALL_PREVENT_CACHE_SUCCESS", "publish", "any"))
-               .then(function (elements) {
-                  assert.lengthOf(elements, 1, "GET ALL with preventCache flag failed");
-               });
+            .getLastPublish("ALF_GET_ALL_PREVENT_CACHE_SUCCESS", "GET ALL with preventCache flag failed");
          },
 
          "Check URI encoding": function() {
@@ -198,6 +173,42 @@ define(["intern!object",
                .click()
             .end()
             .getLastXhr("aikau/proxy/alfresco/resources/nocache?filter=%25moomin");
+         },
+
+         "Scoped create": function() {
+            return browser.findById("SCOPED_CREATE_label")
+               .click()
+            .end()
+            .getLastPublish("SCOPE1_ALF_DOCLIST_RELOAD_DATA", "Scoped reload request not published");
+         },
+
+         "Scoped delete": function() {
+            return browser.findById("SCOPED_DELETE_label")
+               .click()
+            .end()
+            .getLastPublish("SCOPE2_ALF_DOCLIST_RELOAD_DATA", "Scoped reload request not published");
+         },
+
+         "Scoped delete with confirmation": function() {
+            return browser.findById("SCOPED_DELETE_WITH_CONFIRMATION_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_CRUD_SERVICE_DELETE_CONFIRMATION_DIALOG.dialogDisplayed")
+            .end()
+
+            .findById("ALF_CRUD_SERVICE_DELETE_CONFIRMATION_DIALOG_CONFIRM_label")
+               .click()
+            .end()
+
+            .getLastPublish("SCOPE3_ALF_DOCLIST_RELOAD_DATA", "Scoped reload request not published");
+         },
+
+         "Scoped Update": function() {
+            return browser.findById("SCOPED_UPDATE_label")
+               .click()
+            .end()
+            .getLastPublish("SCOPE4_ALF_DOCLIST_RELOAD_DATA", "Scoped reload request not published");
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/CrudService.get.js
@@ -137,13 +137,67 @@ model.jsonModel = {
          }
       },
       {
+         id: "SCOPED_CREATE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            pubSubScope: "SCOPE1_",
+            label: "Scoped create",
+            publishTopic: "ALF_CRUD_CREATE",
+            publishPayload: {
+               url: "resources/123",
+               alfResponseTopic: "ALF_CRUD_CREATED"
+            },
+            publishGlobal: true
+         }
+      },
+      {
+         id: "SCOPED_DELETE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            pubSubScope: "SCOPE2_",
+            label: "Scoped delete",
+            publishTopic: "ALF_CRUD_DELETE",
+            publishPayload: {
+               url: "resources/123",
+               responseTopic: "ALF_CRUD_DELETED"
+            },
+            publishGlobal: true
+         }
+      },
+      {
+         id: "SCOPED_DELETE_WITH_CONFIRMATION",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            pubSubScope: "SCOPE3_",
+            label: "Scoped delete (with confirmation)",
+            publishTopic: "ALF_CRUD_DELETE",
+            publishPayload: {
+               requiresConfirmation: true,
+               url: "resources/123",
+               responseTopic: "ALF_CRUD_DELETED"
+            },
+            publishGlobal: true
+         }
+      },
+      {
+         id: "SCOPED_UPDATE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            pubSubScope: "SCOPE4_",
+            label: "Scoped update",
+            publishTopic: "ALF_CRUD_UPDATE",
+            publishPayload: {
+               url: "resources/123",
+               alfResponseTopic: "ALF_CRUD_UPDATED"
+            },
+            publishGlobal: true
+         }
+      },
+      {
          name: "aikauTesting/mockservices/CrudServiceMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-658 to update the alfresco/services/CrudService to ensure that requests published from scoped originators use the responseScope when making refresh requests. The unit test has been updated to take advantage of the DebugLog and new tests have been added for scoped originators of publications.