### PR TITLE
AKU-656: Update to AlfDocument to ensure "" can be used as itemProperty

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocument.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocument.js
@@ -160,7 +160,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the document that have been provided.
        */
       onDocumentLoaded: function alfresco_documentlibrary_AlfDocument__onDocumentLoaded(payload) {
-         if (this.itemProperty && lang.exists(this.itemProperty, payload))
+         if ((this.itemProperty || this.itemProperty === "") && lang.exists(this.itemProperty, payload))
          {
             this.currentItem = lang.getObject(this.itemProperty, false, payload);
             this.renderDocument();

--- a/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentTest.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfDocument Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfDocument", "AlfDocument").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         // See AKU-656 for the reasons for these tests...
+         "First document loads data": function() {
+            return browser.findById("PROPERTYLINK");
+         },
+
+         "Click first document property to populate second document": function() {
+            return browser.findByCssSelector("#PROPERTYLINK .value")
+               .click()
+            .end()
+
+            .findById("PROPERTY");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -83,6 +83,7 @@ define({
       "src/test/resources/alfresco/dnd/NestedConfigurationTest",
       "src/test/resources/alfresco/dnd/NestedReorderTest",
 
+      "src/test/resources/alfresco/documentlibrary/AlfDocumentTest",
       "src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest",
       "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest",
       "src/test/resources/alfresco/documentlibrary/CreateContentTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocument.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocument.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfDocument</shortname>
+  <description>This page shows how the alfresco/documentlibrary/AlfDocument widget can be used to render the details of an individual node.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfDocument</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocument.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocument.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocument.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocument.get.js
@@ -1,0 +1,60 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "LOADING_DOCUMENT",
+         name: "alfresco/documentlibrary/AlfDocument",
+         config: {
+            itemProperty: "response",
+            nodeRef: "some://dummy/node",
+            widgets: [
+               {
+                  id: "PROPERTYLINK",
+                  name: "alfresco/renderers/PropertyLink",
+                  config: {
+                     label: "Click to populate second AlfDocument",
+                     propertyToRender: "displayName",
+                     publishTopic: "SCOPED_ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST_SUCCESS"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "NON_LOADING_DOCUMENT",
+         name: "alfresco/documentlibrary/AlfDocument",
+         config: {
+            pubSubScope: "SCOPED_",
+            itemProperty: "",
+            widgets: [
+               {
+                  id: "PROPERTY",
+                  name: "alfresco/renderers/Property",
+                  config: {
+                     propertyToRender: "displayName"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/AlfDocumentMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/AlfDocumentMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/AlfDocumentMockXhr.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This mock XHR server has been written to unit test the [AlfDocument]{@Link module:alfresco/documentlibrary/AlfDocument},
+ * [AlfDocumentPreview]{@link module:alfresco/preview/AlfDocumentPreview} and the [Image Plugin]
+ * {@link module:alfresco/preview/Image}.
+ * 
+ * @module aikauTesting/mockservices/PreviewMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/MockXhr",
+        "dojo/text!./responseTemplates/Document/DocumentAsObject.json"], 
+        function(declare, MockXhr, DocumentAsObject) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_PreviewMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("GET",
+                                    /\/aikau\/service\/components\/documentlibrary\/data\/node\/some\/dummy\/node\?(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":7962},
+                                     DocumentAsObject]);
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Document/DocumentAsObject.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Document/DocumentAsObject.json
@@ -1,0 +1,313 @@
+{
+   "thumbnailDefinitions": ["avatar32", "doclib", "avatar", "medium", "imgpreview"],
+   "node": {
+      "isLink": false,
+      "aspects": ["cm:auditable", "cm:geographic", "cm:thumbnailModification", "sys:referenceable", "exif:exif", "cm:titled", "rn:renditioned", "cm:author", "sys:localized", "cm:versionable"],
+      "properties": {
+         "cm:modified": {
+            "value": "Tue Jul 01 13:35:11 BST 2014",
+            "iso8601": "2014-07-01T12:35:11.803Z"
+         },
+         "sys:node-uuid": null,
+         "exif:pixelXDimension": "160",
+         "exif:exposureTime": "0.002257336343115124",
+         "cm:lastThumbnailModification": ["doclib:1404218824503", "imgpreview:1404218963212"],
+         "sys:node-dbid": null,
+         "cm:creator": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "exif:fNumber": "2.6",
+         "exif:software": "Exif Software Version 1.0.2.0",
+         "exif:model": "GT-I9305",
+         "exif:isoSpeedRatings": "80",
+         "exif:orientation": "1",
+         "sys:store-identifier": null,
+         "exif:pixelYDimension": "120",
+         "cm:content": null,
+         "cm:longitude": "-1.636389",
+         "cm:name": "2013-12-29 09.58.43.jpg",
+         "sys:store-protocol": null,
+         "sys:locale": null,
+         "exif:dateTimeOriginal": {
+            "value": "Sun Dec 29 09:58:43 GMT 2013",
+            "iso8601": "2013-12-29T09:58:43.000Z"
+         },
+         "cm:autoVersion": "true",
+         "cm:initialVersion": "true",
+         "exif:manufacturer": "SAMSUNG",
+         "cm:created": {
+            "value": "Tue Jul 01 13:35:11 BST 2014",
+            "iso8601": "2014-07-01T12:35:11.803Z"
+         },
+         "exif:flash": "false",
+         "cm:versionLabel": "1.0",
+         "cm:latitude": "50.893056",
+         "cm:autoVersionOnUpdateProps": "false",
+         "cm:modifier": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "exif:focalLength": "3.7"
+      },
+      "type": "cm:content",
+      "isLocked": false,
+      "size": 4327152,
+      "mimetypeDisplayName": "JPEG Image",
+      "mimetype": "image\/jpeg",
+      "encoding": "UTF-8",
+      "permissions": {
+         "roles": ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;INHERITED", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;INHERITED"],
+         "inherited": true,
+         "user": {
+            "ChangePermissions": true,
+            "CancelCheckOut": false,
+            "CreateChildren": true,
+            "Write": true,
+            "Delete": true,
+            "Unlock": false
+         }
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4",
+      "isContainer": false,
+      "contentURL": "\/slingshot\/node\/content\/workspace\/SpacesStore\/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4\/2013-12-29%2009.58.43.jpg"
+   },
+   "parent": {
+      "isLink": false,
+      "aspects": ["cm:auditable", "st:siteContainer", "cm:ownable", "cm:tagscope", "sys:referenceable", "cm:titled", "sys:localized"],
+      "permissions": {
+         "roles": ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;DIRECT", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;DIRECT", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;DIRECT", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;DIRECT"],
+         "inherited": false,
+         "user": {
+            "ChangePermissions": true,
+            "CancelCheckOut": false,
+            "CreateChildren": true,
+            "Write": true,
+            "Delete": true,
+            "Unlock": false
+         }
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/21e286a5-3330-4497-8807-26ff6b5125f3",
+      "properties": {
+         "cm:modified": {
+            "value": "Tue Aug 05 08:56:58 BST 2014",
+            "iso8601": "2014-08-05T07:56:58.987Z"
+         },
+         "sys:node-dbid": null,
+         "cm:description": "Document Library",
+         "cm:creator": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "sys:node-uuid": null,
+         "cm:created": {
+            "value": "Tue Jul 01 13:34:39 BST 2014",
+            "iso8601": "2014-07-01T12:34:39.709Z"
+         },
+         "st:componentId": "documentLibrary",
+         "cm:name": "documentLibrary",
+         "sys:store-protocol": null,
+         "cm:owner": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "sys:locale": null,
+         "cm:modifier": {
+            "lastName": "",
+            "userName": "admin",
+            "displayName": "Administrator",
+            "firstName": "Administrator"
+         },
+         "sys:store-identifier": null
+      },
+      "type": "cm:folder",
+      "isContainer": true,
+      "isLocked": false
+   },
+   "version": "1.0",
+   "webdavUrl": "\/webdav\/Sites\/site1\/documentLibrary\/2013-12-29%2009.58.43.jpg",
+   "isFavourite": false,
+   "likes": {
+      "isLiked": false,
+      "totalLikes": 0
+   },
+   "location": {
+      "repositoryId": "80537f78-b489-4e8e-966c-9a0307fd4fa8",
+      "site": {
+         "name": "site1",
+         "title": "Site1",
+         "preset": ""
+      },
+      "container": {
+         "name": "documentLibrary",
+         "type": "cm:folder",
+         "nodeRef": ""
+      },
+      "path": "\/",
+      "file": "2013-12-29 09.58.43.jpg",
+      "parent": {}
+   },
+   "nodeRef": "workspace:\/\/SpacesStore\/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4",
+   "fileName": "2013-12-29 09.58.43.jpg",
+   "displayName": "2013-12-29 09.58.43.jpg",
+   "actionGroupId": "document-browse",
+   "actions": [{
+      "id": "document-download",
+      "icon": "document-download",
+      "type": "link",
+      "label": "actions.document.download",
+      "params": {
+         "href": "{downloadUrl}"
+      },
+      "index": "100"
+   }, {
+      "id": "document-view-content",
+      "icon": "document-view-content",
+      "type": "link",
+      "label": "actions.document.view",
+      "params": {
+         "href": "{viewUrl}"
+      },
+      "index": "110"
+   }, {
+      "id": "document-edit-properties",
+      "icon": "document-edit-properties",
+      "type": "javascript",
+      "label": "actions.document.edit-metadata",
+      "params": {
+         "function": "onActionDetails"
+      },
+      "index": "130"
+   }, {
+      "id": "document-upload-new-version",
+      "icon": "document-upload-new-version",
+      "type": "javascript",
+      "label": "actions.document.upload-new-version",
+      "params": {
+         "function": "onActionUploadNewVersion"
+      },
+      "index": "140"
+   }, {
+      "id": "document-edit-offline",
+      "icon": "document-edit-offline",
+      "type": "javascript",
+      "label": "actions.document.edit-offline",
+      "params": {
+         "function": "onActionEditOffline"
+      },
+      "index": "210"
+   }, {
+      "id": "document-copy-to",
+      "icon": "document-copy-to",
+      "type": "javascript",
+      "label": "actions.document.copy-to",
+      "params": {
+         "function": "onActionCopyTo"
+      },
+      "index": "250"
+   }, {
+      "id": "document-move-to",
+      "icon": "document-move-to",
+      "type": "javascript",
+      "label": "actions.document.move-to",
+      "params": {
+         "function": "onActionMoveTo"
+      },
+      "index": "260"
+   }, {
+      "id": "document-delete",
+      "icon": "document-delete",
+      "type": "javascript",
+      "label": "actions.document.delete",
+      "params": {
+         "function": "onActionDelete"
+      },
+      "index": "270"
+   }, {
+      "id": "document-assign-workflow",
+      "icon": "document-assign-workflow",
+      "type": "javascript",
+      "label": "actions.document.assign-workflow",
+      "params": {
+         "function": "onActionAssignWorkflow"
+      },
+      "index": "280"
+   }, {
+      "id": "document-manage-granular-permissions",
+      "icon": "document-manage-permissions",
+      "type": "link",
+      "label": "actions.document.manage-permissions",
+      "params": {
+         "href": "{managePermissionsUrl}"
+      },
+      "index": "297"
+   }, {
+      "id": "document-publish",
+      "icon": "document-publish",
+      "type": "javascript",
+      "label": "actions.document.publish",
+      "params": {
+         "function": "onActionPublish"
+      },
+      "index": "300"
+   }, {
+      "id": "document-view-googlemaps",
+      "icon": "document-view-googlemaps",
+      "type": "pagelink",
+      "label": "actions.document.view-google-map",
+      "params": {
+         "page": "geographic-map?nodeRef={node.nodeRef}"
+      },
+      "index": "310"
+   }, {
+      "id": "document-cloud-sync",
+      "icon": "document-cloud-sync",
+      "type": "javascript",
+      "label": "actions.document.cloud-sync",
+      "params": {
+         "function": "onActionCloudSync"
+      },
+      "index": "330"
+   }],
+   "indicators": [{
+      "id": "exif",
+      "index": "40",
+      "icon": "exif-16.png",
+      "label": "status.exif"
+   }, {
+      "id": "geographic",
+      "index": "50",
+      "icon": "geographic-16.png",
+      "label": "status.geographic"
+   }],
+   "metadataTemplate": {
+      "id": "default",
+      "title": null,
+      "banners": [],
+      "lines": [{
+         "index": "10",
+         "template": "{date}{size}",
+         "view": ""
+      }, {
+         "index": "20",
+         "template": "{description}",
+         "view": "detailed"
+      }, {
+         "index": "30",
+         "template": "{tags}",
+         "view": "detailed"
+      }, {
+         "index": "50",
+         "template": "{social}",
+         "view": "detailed"
+      }]
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-656 to restore the ability to use "" as the itemProperty on AlfDocument (previously regressed due to overzealous JSHint cleanup). A unit test has been added to prevent future regressions.