### PR TITLE
AKU-660: MultiSelectInput form control not working with fixed options

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -159,6 +159,27 @@ define([
          }],
 
          /**
+          * <p>Whether to infer missing properties on retrieved option objects.</p>
+          *
+          * <p><strong>NOTE:</strong> The "name", "label" and "value" properties are retrieved using
+          * the "query", "label" and "value" attribute names as configured in the store.</p>
+          *
+          * <p>Priorities are:</p>
+          *
+          * <ul>
+          *   <li>Missing name takes label if available, else value</li>
+          *   <li>Missing label takes name if available, else value</li>
+          *   <li>Missing value takes name if available, else label</li>
+          * </ul>
+          *
+          * @instance
+          * @type {boolean}
+          * @default
+          * @since 1.0.42
+          */
+         inferMissingProperties: false,
+
+         /**
           * An object that defines the formats of the labels. See main module example for example.
           * It should be a format string for each of the three label strings
           *
@@ -345,14 +366,6 @@ define([
          _suppressKeyUp: false,
 
          /**
-          * The attribute name against which to store the value of an item in the HTML
-          *
-          * @instance
-          * @type {string}
-          */
-         _valueHtmlAttribute: "data-aikau-value",
-
-         /**
           * Widget template has been turned into a DOM
           *
           * @override
@@ -434,6 +447,54 @@ define([
          },
 
          /**
+          * Normalise an individual item, to make the data suitable for use with this widget.
+          *
+          * @instance
+          * @param {object} item The item to be normalised
+          * @returns {object} The normalised item (returned for convenience)
+          * @since 1.0.42
+          */
+         normaliseItem: function alfresco_forms_controls_MultiSelect__normaliseItem(item) {
+            /*jshint maxcomplexity:false*/
+
+            // Get the current attributes of the item
+            var itemName = item[this.store.queryAttribute],
+               itemLabel = item[this.store.labelAttribute],
+               itemValue = item[this.store.valueAttribute];
+
+            // Infer missing properties
+            if (this.inferMissingProperties && (itemName || itemLabel || itemValue)) {
+               if (!this.store.queryAttribute && !this.store.labelAttribute && !this.store.valueAttribute) {
+                  this.alfLog("error", "Invalid item", item);
+                  throw new Error("Item provided with no " + this.store.queryAttribute + ", " + this.store.labelAttribute + " or " + this.store.valueAttribute + "");
+               } else if (itemName && !itemLabel && !itemValue) {
+                  itemLabel = itemValue = itemName;
+               } else if (!itemName && itemLabel && !itemValue) {
+                  itemName = itemValue = itemLabel;
+               } else if (!itemName && !itemLabel && itemValue) {
+                  itemName = itemLabel = itemValue;
+               } else if (!itemName) {
+                  itemName = itemLabel;
+               } else if (!itemLabel) {
+                  itemLabel = itemName;
+               } else if (!itemValue) {
+                  itemValue = itemName;
+               }
+               item[this.store.queryAttribute] = itemName;
+               item[this.store.labelAttribute] = itemLabel;
+               item[this.store.valueAttribute] = itemValue;
+            }
+
+            // Items MUST have values for the widget to work
+            if (itemValue === null || typeof itemValue === "undefined") {
+               this.alfLog("error", "Option provided to MultiSelect control does not have a value: ", item);
+            }
+
+            // Pass back the modified item for convenience (it's already been mutated)
+            return item;
+         },
+
+         /**
           * Set the specified property
           *
           * @instance
@@ -472,65 +533,42 @@ define([
          setValue: function alfresco_forms_controls_MultiSelect__setValue(newValueParam) {
 
             // Setup helper vars
-            var nameAttrName = this.store.nameAttribute,
-               labelAttrName = this.store.labelAttribute,
-               valueAttrName = this.store.valueAttribute,
-               newValuesArray = newValueParam;
+            var newValuesArray = newValueParam;
             if (!ObjectTypeUtils.isArray(newValuesArray)) {
                newValuesArray = (newValueParam && [newValueParam]) || [];
-            }
-
-            // Normalise attrNames 
-            if (!nameAttrName && !labelAttrName && !valueAttrName) {
-               throw new Error("No attribute names available!");
-            } else if (nameAttrName && !labelAttrName && !valueAttrName) {
-               labelAttrName = valueAttrName = nameAttrName;
-            } else if (!nameAttrName && labelAttrName && !valueAttrName) {
-               nameAttrName = valueAttrName = labelAttrName;
-            } else if (!nameAttrName && !labelAttrName && valueAttrName) {
-               nameAttrName = labelAttrName = valueAttrName;
-            } else if (!nameAttrName) {
-               nameAttrName = labelAttrName;
-            } else if (!labelAttrName) {
-               labelAttrName = nameAttrName;
-            } else if (!valueAttrName) {
-               valueAttrName = nameAttrName;
             }
 
             // Clear existing values
             array.forEach(this._choices, this._removeChoice, this);
 
+            // Normalise the passed-in values
+            var normalisedValues = array.map(newValuesArray, function(nextNewValue) {
+               var valueIsString = typeof nextNewValue === "string",
+                  item;
+               if (valueIsString) {
+                  item = {};
+                  item[this.store.queryAttribute] = item[this.store.labelAttribute] = item[this.store.valueAttribute] = nextNewValue;
+               } else {
+                  item = this.normaliseItem(nextNewValue);
+               }
+               return item;
+            }, this);
+
             // Create an items array
-            var chosenItems = array.map(newValuesArray, function(nextNewValue) {
+            var chosenItems = array.map(normalisedValues, function(nextItem) {
+               /*jshint maxcomplexity:false*/
 
                // Try and get the value from the existing result items
-               var newValueIsString = typeof nextNewValue === "string",
-                  realValue = (newValueIsString && nextNewValue) || nextNewValue[valueAttrName],
-                  nextItem = this._storeItems[realValue];
+               var itemValue = nextItem[this.store.valueAttribute],
+                  storeItem = this._storeItems[itemValue];
 
                // If we already have the item, return immediately
-               if (nextItem) {
-                  return nextItem;
-               }
-
-               // Use value if object, otherwise add as value property to new object
-               if (newValueIsString) {
-                  nextItem = {};
-                  nextItem[valueAttrName] = realValue;
-               } else {
-                  nextItem = nextNewValue;
-               }
-
-               // Add a temporary name and label property if not present
-               if (!nextItem.hasOwnProperty(nameAttrName)) {
-                  nextItem[nameAttrName] = nextItem[valueAttrName];
-               }
-               if (!nextItem.hasOwnProperty(labelAttrName)) {
-                  nextItem[labelAttrName] = nextItem[nameAttrName];
+               if (storeItem) {
+                  return storeItem;
                }
 
                // Put the new item into the items map
-               this._storeItems[realValue] = nextItem;
+               this._storeItems[itemValue] = nextItem;
 
                // Mark this item as needing updating from the store
                this._itemsToUpdateFromStore.push(nextItem);
@@ -597,8 +635,7 @@ define([
             });
             this._choices.push(choiceObject);
 
-            // Add the label and value
-            contentNode.setAttribute(this._valueHtmlAttribute, value);
+            // Add the label
             contentNode.setAttribute("title", labelObj.full);
             contentNode.appendChild(document.createTextNode(labelObj.choice));
          },
@@ -871,11 +908,12 @@ define([
          _handleSearchSuccess: function alfresco_forms_controls_MultiSelect___handleSearchSuccess(responseItems) {
             this._hideLoadingMessage();
             this._results = array.map(responseItems, function(nextItem) {
-               var value = nextItem[this.store.valueAttribute];
-               this._storeItems[value] = nextItem;
+               var safeItem = this.normaliseItem(nextItem),
+                  value = safeItem[this.store.valueAttribute];
+               this._storeItems[value] = safeItem;
                return {
                   domNode: null,
-                  item: nextItem,
+                  item: safeItem,
                   value: value
                };
             }, this);
@@ -984,7 +1022,7 @@ define([
           *
           * @instance
           */
-         _onFocus: function alfresco_forms_controls_MultiSelect___onSearchFocus() {
+         _onFocus: function alfresco_forms_controls_MultiSelect___onFocus() {
             domClass.add(this.domNode, this.rootClass + "--focused");
             this._showOrSearch();
          },
@@ -1341,8 +1379,8 @@ define([
                      name: this.id,
                      func: lang.hitch(this, this._positionDropdown),
                      timeoutMs: 50
-                  })
-               })))
+                  });
+               })));
             }, this);
          },
 
@@ -1398,7 +1436,7 @@ define([
          },
 
          /**
-          * If we have current results then toggle the dropdown, otherwise perform a new search.
+          * If we have current results then open the dropdown, otherwise perform a new search.
           *
           * @instance
           */
@@ -1409,8 +1447,6 @@ define([
                   if (!this._focusedResult) {
                      this._gotoNextResult();
                   }
-               } else {
-                  this._hideResultsDropdown();
                }
             } else {
                this._debounceNewSearch(this.searchBox.value);
@@ -1497,8 +1533,7 @@ define([
                   }, this._nodes.resultsDropdown);
                }
 
-               // Update the value and title
-               itemNode.setAttribute(this._valueHtmlAttribute, nextResult.value);
+               // Update the title
                itemNode.setAttribute("title", labelObj.full);
 
                // Recreate the label
@@ -1542,8 +1577,11 @@ define([
             // Setup handlers
             var successHandler = lang.hitch(this, function(responseItems) {
 
+                  // Normalise the response items
+                  var normalisedItems = array.map(responseItems, this.normaliseItem, this);
+
                   // Update the result items map
-                  array.forEach(responseItems, function(nextItem) {
+                  array.forEach(normalisedItems, function(nextItem) {
                      var value = nextItem[this.store.valueAttribute];
                      if (this._storeItems[value]) {
                         lang.mixin(this._storeItems[value], nextItem);

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -464,10 +464,7 @@ define([
 
             // Infer missing properties
             if (this.inferMissingProperties && (itemName || itemLabel || itemValue)) {
-               if (!this.store.queryAttribute && !this.store.labelAttribute && !this.store.valueAttribute) {
-                  this.alfLog("error", "Invalid item", item);
-                  throw new Error("Item provided with no " + this.store.queryAttribute + ", " + this.store.labelAttribute + " or " + this.store.valueAttribute + "");
-               } else if (itemName && !itemLabel && !itemValue) {
+               if (itemName && !itemLabel && !itemValue) {
                   itemLabel = itemValue = itemName;
                } else if (!itemName && itemLabel && !itemValue) {
                   itemName = itemValue = itemLabel;

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
@@ -63,6 +63,13 @@ define([
                choiceCanWrap: this.optionsConfig.choiceCanWrap,
                choiceMaxWidth: this.optionsConfig.choiceMaxWidth,
                labelFormat: this.optionsConfig.labelFormat
+
+               // NOTE: This is not currently enabled, as it would create inconsistencies between
+               // controls' abilities, however the intention is at some point to use this control
+               // as a template to enable this option across all controls that take options (as
+               // long as it's deemed appropriate to do so when we next look at it)
+               // 
+               // inferMissingProperties: this.optionsConfig.inferMissingProperties
             };
 
             // Don't want to pass through undefined values (will override defaults)

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
@@ -281,7 +281,7 @@ define(["dojo/_base/declare",
        * @param {object} options The optional arguments to apply to the resultset.
        * @returns {object} The results of the query, extended with iterative methods.
        */
-      queryXhrOptions: function alfresco_forms_controls_utilities_ServiceStore__query(query, /*jshint unused:false*/ options) {
+      queryXhrOptions: function alfresco_forms_controls_utilities_ServiceStore__queryXhrOptions(query, /*jshint unused:false*/ options) {
          var response = new Deferred();
          var responseTopic = this.generateUuid();
          var payload = lang.clone(this.publishPayload);

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -29,734 +29,793 @@ define([
    ],
    function(registerSuite, assert, require, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+      registerSuite(function() {
+         var browser;
 
-   return {
-         name: "Multi Select Input Tests",
+         return {
+            name: "Multi Select Input Tests",
 
-         // STARTING STATE
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: none
-         //    
-         setup: function() {
-            browser = this.remote;
-            return TestCommon.loadTestWebScript(this.remote, "/MultiSelectInput", "Multi Select Input Tests").end();
-         },
+            // STARTING STATE
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: none
+            //    
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/MultiSelectInput", "Multi Select Input Tests").end();
+            },
 
-         beforeEach: function() {
-            browser.end();
-         },
+            beforeEach: function() {
+               browser.end();
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: none
-         //    
-         "Controls are fully loaded": function() {
-            return browser.findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect--loaded")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "First MultiSelect control not fully loaded");
-               })
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: none
+            //    
+            "Controls are fully loaded": function() {
+               return browser.findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect--loaded")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "First MultiSelect control not fully loaded");
+                  })
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect--loaded")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Second MultiSelect control not fully loaded");
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect--loaded")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Second MultiSelect control not fully loaded");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: none
-         //    
-         "Preset values are rendered by control": function() {
-            return browser.findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 2, "Did not render two preset values for control");
-               })
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: none
+            //    
+            "Preset values are rendered by control": function() {
+               return browser.findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 2, "Did not render two preset values for control");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag1", "Did not display first tag label correctly");
-               })
-               .end()
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag1", "Did not display first tag label correctly");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag11", "Did not display second tag label correctly");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag11", "Did not display second tag label correctly");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    *results dropdown: visible
-         //    
-         // Misc
-         //    *focused element: Control 2
-         //    
-         "Clicking on control no longer loses responses to a second query": function() {
-            return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
-               .click()
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    *results dropdown: visible
+            //    
+            // Misc
+            //    *focused element: Control 2
+            //    
+            "Clicking on control no longer loses responses to a second query": function() {
+               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+                  .click()
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 14, "Did not bring up results");
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 14, "Did not bring up results");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    *results dropdown: visible
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    *results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Control 1
-         //    
-         "Focusing on control brings up initial results": function() {
-            return browser.findById("FOCUS_HELPER_BUTTON")
-               .click()
-               .pressKeys(keys.TAB)
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    *results dropdown: visible
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    *results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Control 1
+            //    
+            "Focusing on control brings up initial results": function() {
+               return browser.findById("FOCUS_HELPER_BUTTON")
+                  .click()
+                  .pressKeys(keys.TAB)
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 7, "Did not bring up initial results");
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 7, "Did not bring up initial results");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    *results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Selecting already-chosen item in dropdown does not choose item again": function() {
-            return browser.findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
-               .click()
-               .pressKeys(keys.ESCAPE)
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    *results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Selecting already-chosen item in dropdown does not choose item again": function() {
+               return browser.findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
+                  .click()
+                  .pressKeys(keys.ESCAPE)
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 2, "Added already-selected choice to control");
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 2, "Added already-selected choice to control");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    *choices: "tag1", "tag11", "tag2"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Selecting item in dropdown chooses that item": function() {
-            return browser.findById("FOCUS_HELPER_BUTTON")
-               .click()
-               .pressKeys(keys.TAB)
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    *choices: "tag1", "tag11", "tag2"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Selecting item in dropdown chooses that item": function() {
+               return browser.findById("FOCUS_HELPER_BUTTON")
+                  .click()
+                  .pressKeys(keys.TAB)
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-               .click()
-               .end()
+               .findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+                  .click()
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 3, "Did not add new choice to control");
-               })
-               .end()
+               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 3, "Did not add new choice to control");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag2", "Did not add selected tag at end of choices");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag2", "Did not add selected tag at end of choices");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11", "tag2"
-         //    *searchbox: "tag2"
-         //    *results dropdown: visible
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Typing into search box filters results": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
-               .type("tag2")
-               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11", "tag2"
+            //    *searchbox: "tag2"
+            //    *results dropdown: visible
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Typing into search box filters results": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+                  .type("tag2")
+                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Did not filter results");
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Did not filter results");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11", "tag2"
-         //    *searchbox: "12"
-         //    results dropdown: visible
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Typing into search box filters results for strings in middle of name": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
-               .clearValue()
-               .type("12")
-               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(2)")
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11", "tag2"
+            //    *searchbox: "12"
+            //    results dropdown: visible
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Typing into search box filters results for strings in middle of name": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+                  .clearValue()
+                  .type("12")
+                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(2)")
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Did not filter results for string in middle of name" + elements);
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Did not filter results for string in middle of name" + elements);
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag11", "tag2"
-         //    *searchbox: "(a"
-         //    results dropdown: visible
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Search box correctly filters on special reg exp chars": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
-               .clearValue()
-               .type("(a")
-               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag11", "tag2"
+            //    *searchbox: "(a"
+            //    results dropdown: visible
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Search box correctly filters on special reg exp chars": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+                  .clearValue()
+                  .type("(a")
+                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Did not filter results using special reg exp character");
-               })
-               .end()
+               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Did not filter results using special reg exp character");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
-               .clearValue();
-         },
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+                  .clearValue();
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    *choices: "tag1", "tag2"
-         //    *searchbox: ""
-         //    *results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Clicking cross on a chosen item removes it": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__close-button")
-               .click()
-               .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    *choices: "tag1", "tag2"
+            //    *searchbox: ""
+            //    *results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Clicking cross on a chosen item removes it": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__close-button")
+                  .click()
+                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 2, "Did not remove choice");
-               });
-         },
+               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 2, "Did not remove choice");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag2"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Form 1 submit
-         //    
-         "Submitting form submits correct values from control": function() {
-            return browser.findByCssSelector("#FORM1 .confirmationButton .dijitButtonNode")
-               .click()
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag2"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Form 1 submit
+            //    
+            "Submitting form submits correct values from control": function() {
+               return browser.findByCssSelector("#FORM1 .confirmationButton .dijitButtonNode")
+                  .click()
+                  .end()
 
-            .getLastPublish("FORM_POST", "Could not find form submission")
-               .then(function(payload) {
-                  assert.deepPropertyVal(payload, "tags[0].name", "tag1", "Failed to submit tag1 name");
-                  assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "Failed to submit tag1 value");
-                  assert.deepPropertyVal(payload, "tags[1].name", "tag2", "Failed to submit tag2 name");
-                  assert.deepPropertyVal(payload, "tags[1].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value");
-               });
-         },
+               .getLastPublish("FORM_POST", "Could not find form submission")
+                  .then(function(payload) {
+                     assert.deepPropertyVal(payload, "tags[0].name", "tag1", "Failed to submit tag1 name");
+                     assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/06bd4708-8998-47be-a4ea-0f418bc7bb38", "Failed to submit tag1 value");
+                     assert.deepPropertyVal(payload, "tags[1].name", "tag2", "Failed to submit tag2 name");
+                     assert.deepPropertyVal(payload, "tags[1].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    *choices: "tag1", "tag2", "newtag13(a)"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Control 1
-         //    
-         "Keyboard can navigate and select items in dropdown": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
-               .type("new")
-               .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
-               .pressKeys([keys.ARROW_DOWN, keys.ARROW_DOWN, keys.ARROW_UP, keys.ENTER])
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    *choices: "tag1", "tag2", "newtag13(a)"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Control 1
+            //    
+            "Keyboard can navigate and select items in dropdown": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+                  .type("new")
+                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+                  .pressKeys([keys.ARROW_DOWN, keys.ARROW_DOWN, keys.ARROW_UP, keys.ENTER])
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 3, "Did not add new choice to control");
-               })
-               .end()
+               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 3, "Did not add new choice to control");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "newtag13(a)", "Did not add selected tag at end of choices");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "newtag13(a)", "Did not add selected tag at end of choices");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: "tag1", "tag2", "newtag13(a)"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Focus helper
-         //    
-         "Selecting item with keyboard does not persist previous search": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
-               .pressKeys(keys.ARROW_DOWN)
-               .end()
-            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
-            .end()
-            .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 7, "Did not return full list of results after keyboard choice selection");
-               })
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: "tag1", "tag2", "newtag13(a)"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Focus helper
+            //    
+            "Selecting item with keyboard does not persist previous search": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+                  .pressKeys(keys.ARROW_DOWN)
+                  .end()
+                  .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+                  .end()
+                  .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 7, "Did not return full list of results after keyboard choice selection");
+                  })
+                  .end()
 
-            .findById("FOCUS_HELPER_BUTTON")
-               .click();
-         },
+               .findById("FOCUS_HELPER_BUTTON")
+                  .click();
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    *choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Control 1
-         //    
-         "Deleting all items disables confirmation button": function() {
-            return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
-               .click()
-               .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    *choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Control 1
+            //    
+            "Deleting all items disables confirmation button": function() {
+               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
+                  .click()
+                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(3)")
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
-               .click()
-               .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
-               .end()
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
+                  .click()
+                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
-               .click()
-               .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1)")
-               .end()
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__close-button")
+                  .click()
+                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1)")
+                  .end()
 
-            .findAllByCssSelector("#FORM1 .confirmationButton.dijitDisabled")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "The confirmation button was not disabled when all the items were removed");
-               });
-         },
+               .findAllByCssSelector("#FORM1 .confirmationButton.dijitDisabled")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "The confirmation button was not disabled when all the items were removed");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 1
-         //    
-         "Custom label format is used for choices": function() {
-            return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "Those that belong to the emperor", "Did not display custom label format (type=choice) for choice");
-               })
-               .getAttribute("title")
-               .then(function(title) {
-                  assert.equal(title, "ID=CAT_01, Name=Those that belong to the emperor", "Did not display custom label format (type=full) for choice");
-               });
-         },
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 1
+            //    
+            "Custom label format is used for choices": function() {
+               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "Those that belong to the emperor", "Did not display custom label format (type=choice) for choice");
+                  })
+                  .getAttribute("title")
+                  .then(function(title) {
+                     assert.equal(title, "ID=CAT_01, Name=Those that belong to the emperor", "Did not display custom label format (type=full) for choice");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    *searchbox: "the"
-         //    *results dropdown: visible
-         //    
-         // Misc
-         //    *focused element: Control 2
-         //    
-         "Custom label format is used for results": function() {
-            return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
-               .type("the")
-               .waitForDeletedByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    *searchbox: "the"
+            //    *results dropdown: visible
+            //    
+            // Misc
+            //    *focused element: Control 2
+            //    
+            "Custom label format is used for results": function() {
+               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+                  .type("the")
+                  .waitForDeletedByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "CAT_01: Those that belong to the emperor", "Did not display custom label format (type=result) for result");
-               })
-               .getAttribute("title")
-               .then(function(title) {
-                  assert.equal(title, "ID=CAT_01, Name=Those that belong to the emperor", "Did not display custom label format (type=full) for result");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "CAT_01: Those that belong to the emperor", "Did not display custom label format (type=result) for result");
+                  })
+                  .getAttribute("title")
+                  .then(function(title) {
+                     assert.equal(title, "ID=CAT_01, Name=Those that belong to the emperor", "Did not display custom label format (type=full) for result");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor", "Innumerable ones"
-         //    searchbox: "the"
-         //    results dropdown: visible
-         //    
-         // Misc
-         //    focused element: Control 2
-         //    
-         "Choices do not exceed max width": function() {
-            return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getSize()
-               .then(function(size) {
-                  assert(size.width < 151, "Choice was not restricted to under 150px as requested");
-               });
-         },
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor", "Innumerable ones"
+            //    searchbox: "the"
+            //    results dropdown: visible
+            //    
+            // Misc
+            //    focused element: Control 2
+            //    
+            "Choices do not exceed max width": function() {
+               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getSize()
+                  .then(function(size) {
+                     assert(size.width < 151, "Choice was not restricted to under 150px as requested");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    *choices: "Those that belong to the emperor"
-         //    *searchbox: ""
-         //    *results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Control 2
-         //    
-         "Arrow key selects choice and backspace key deletes selected choice only": function() {
-            return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
-               .pressKeys(keys.ESCAPE)
-               .sleep(100)
-               .pressKeys(keys.ARROW_LEFT)
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    *choices: "Those that belong to the emperor"
+            //    *searchbox: ""
+            //    *results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Control 2
+            //    
+            "Arrow key selects choice and backspace key deletes selected choice only": function() {
+               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+                  .pressKeys(keys.ESCAPE)
+                  .sleep(100)
+                  .pressKeys(keys.ARROW_LEFT)
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice--selected .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(visibleText) {
-                  assert.equal(visibleText, "Innumerable ones", "Did not select correct choice");
-               })
-               .end()
+               .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice--selected .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Innumerable ones", "Did not select correct choice");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
-               .pressKeys(keys.BACKSPACE)
-               .waitForDeletedByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
-               .end()
+               .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+                  .pressKeys(keys.BACKSPACE)
+                  .waitForDeletedByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice:nth-child(2)")
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(visibleText) {
-                  assert.equal(visibleText, "Those that belong to the emperor", "Did not delete correct choice");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__choice .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Those that belong to the emperor", "Did not delete correct choice");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Dialog control
-         //    *[Dialog displayed and dialog control has results visible]
-         //    
-         "Opening MultiSelect in dialog still displays dropdown properly": function() {
-            return browser.findByCssSelector("[widgetid=\"CREATE_FORM_DIALOG\"] .dijitButtonNode")
-               .click()
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Dialog control
+            //    *[Dialog displayed and dialog control has results visible]
+            //    
+            "Opening MultiSelect in dialog still displays dropdown properly": function() {
+               return browser.findByCssSelector("[widgetid=\"CREATE_FORM_DIALOG\"] .dijitButtonNode")
+                  .click()
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-               .isDisplayed()
-               .then(function(isDisplayed) {
-                  assert.isTrue(isDisplayed, "Unable to see result in dropdown");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isTrue(isDisplayed, "Unable to see result in dropdown");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Create dialog button
-         //    *
-         //    
-         "Dialog MultiSelect submits correct data": function() {
-            return browser.findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-               .click()
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Create dialog button
+            //    *
+            //    
+            "Dialog MultiSelect submits correct data": function() {
+               return browser.findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+                  .click()
+                  .end()
 
-            .findByCssSelector("#DIALOG_WITH_MULTISELECT .footer .confirmationButton .dijitButtonNode")
-               .click()
-               .end()
+               .findByCssSelector("#DIALOG_WITH_MULTISELECT .footer .confirmationButton .dijitButtonNode")
+                  .click()
+                  .end()
 
-            .getLastPublish("DIALOG_POST", "Could not find dialog submission")
-               .then(function(payload) {
-                  assert.deepPropertyVal(payload, "tags[0].name", "tag2", "Failed to submit tag2 name from dialog");
-                  assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value from dialog");
-               });
-         },
+               .getLastPublish("DIALOG_POST", "Could not find dialog submission")
+                  .then(function(payload) {
+                     assert.deepPropertyVal(payload, "tags[0].name", "tag2", "Failed to submit tag2 name from dialog");
+                     assert.deepPropertyVal(payload, "tags[0].value", "workspace://SpacesStore/84a27335-6008-4ddc-8a27-724225bbed3d", "Failed to submit tag2 value from dialog");
+                  });
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    choices: None
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    focused element: Create dialog button
-         //    
-         "Third control is disabled": function() {
-            return browser.findByCssSelector("#FORM3 .alfresco-forms-controls-MultiSelect--disabled");
-         },
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    choices: None
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    focused element: Create dialog button
+            //    
+            "Third control is disabled": function() {
+               return browser.findByCssSelector("#FORM3 .alfresco-forms-controls-MultiSelect--disabled");
+            },
 
-         // STATE AFTER THIS TEST
-         // 
-         // Control 1
-         //    *choices: "tag1", "tag11"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Control 2
-         //    choices: "Those that belong to the emperor"
-         //    searchbox: ""
-         //    results dropdown: hidden
-         //    
-         // Misc
-         //    *focused element: Set tags value button
-         //    
-         "Setting a value replaces not appends": function() {
-            return browser.findById("SET_TAGS_VALUE_BUTTON")
-               .click()
-               .end()
+            // STATE AFTER THIS TEST
+            // 
+            // Control 1
+            //    *choices: "tag1", "tag11"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Control 2
+            //    choices: "Those that belong to the emperor"
+            //    searchbox: ""
+            //    results dropdown: hidden
+            //    
+            // Misc
+            //    *focused element: Set tags value button
+            //    
+            "Setting a value replaces not appends": function() {
+               return browser.findById("SET_TAGS_VALUE_BUTTON")
+                  .click()
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 2, "Did not render two values for control");
-               })
-               .end()
+               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 2, "Did not render two values for control");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag1", "Did not display first tag label correctly");
-               })
-               .end()
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag1", "Did not display first tag label correctly");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag11", "Did not display second tag label correctly");
-               })
-               .end()
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag11", "Did not display second tag label correctly");
+                  })
+                  .end()
 
-            .findById("SET_TAGS_VALUE_BUTTON")
-               .click()
-               .end()
+               .findById("SET_TAGS_VALUE_BUTTON")
+                  .click()
+                  .end()
 
-            .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 2, "Does not still render two values for control");
-               })
-               .end()
+               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 2, "Does not still render two values for control");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag1", "Did not display first tag label correctly");
-               })
-               .end()
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(1) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag1", "Did not display first tag label correctly");
+                  })
+                  .end()
 
-            .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
-               .getVisibleText()
-               .then(function(text) {
-                  assert.equal(text, "tag11", "Did not display second tag label correctly");
-               });
-         },
+               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "tag11", "Did not display second tag label correctly");
+                  });
+            },
 
-         "Post Coverage Results": function() {
-            TestCommon.alfPostCoverageResults(this, browser);
-         }
-      };
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "Multi Select Input Tests (Fixed Options)",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/MultiSelectInput", "Multi Select Input Tests").end();
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "Can click on control and choose an option": function() {
+               return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#MULTISELECT_4_CONTROL_RESULTS [title=\"Foam Strawberries\"]")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Foam Strawberries");
+                  });
+            },
+
+            "Can click on control again and choose a second option": function() {
+               return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#MULTISELECT_4_CONTROL_RESULTS [title=\"Refreshers\"]")
+                  .click()
+                  .end()
+
+               .findAllByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 2);
+                  })
+                  .end()
+
+               .findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Refreshers");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
       });
    }
 );

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,13 +32,12 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/layout/FixedHeaderFooterTest"
+      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
-      // "src/test/resources/alfresco/dnd/FormCreationTest",
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
+      // "src/test/resources/alfresco/layout/HeightMixinTest",
       // "src/test/resources/alfresco/preview/PdfJsPreviewTest"
-      // "src/test/resources/alfresco/search/SearchSuggestionsTest",
       // "src/test/resources/alfresco/services/CloudSyncServiceTest",
    ],
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -155,14 +155,14 @@ model.jsonModel = {
                   name: "alfresco/forms/Form",
                   config: {
                      okButtonPublishTopic: "FORM_POST",
-                     pubSubScope: "FORM1_",
+                     pubSubScope: "FORM3_",
                      scopeFormControls: false,
                      value: {
                         tags: tagsValue
                      },
                      widgets: [
                         {
-                           id: "MULTISELECT_1",
+                           id: "MULTISELECT_3",
                            name: "alfresco/forms/controls/MultiSelectInput",
                            config: {
                               label: "Tags (disabled)",
@@ -179,6 +179,56 @@ model.jsonModel = {
                               },
                               disablementConfig: {
                                  initialValue: true
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "FORM4",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     okButtonPublishTopic: "FORM_POST",
+                     pubSubScope: "FORM4_",
+                     widgets: [
+                        {
+                           id: "MULTISELECT_4",
+                           name: "alfresco/forms/controls/MultiSelectInput",
+                           config: {
+                              label: "Sweets (fixed options)",
+                              name: "sweets",
+                              width: "300px",
+                              optionsConfig: {
+                                 fixed: [
+                                    {
+                                       label: "Foam Strawberries",
+                                       value: "foam_strawberries"
+                                    },
+                                    {
+                                       label: "Sherbert Lemons",
+                                       value: "sherbert_lemons"
+                                    },
+                                    {
+                                       label: "White Chocolate Mice",
+                                       value: "white_chocolate_mice"
+                                    },
+                                    {
+                                       label: "Refreshers",
+                                       value: "refreshers"
+                                    },
+                                    {
+                                       label: "Flying Saucers",
+                                       value: "flying_saucers"
+                                    }
+                                 ]
                               }
                            }
                         }


### PR DESCRIPTION
This addresses [AKU-660](https://issues.alfresco.com/jira/browse/AKU-660) which suggests that the MultiSelectInput form control is not working with fixed options. In fact, the use case where it was failing was not providing value properties on the passed-in options, however the general logic around missing properties has been tidied up and some work done (while investigating the bug) on being able to configure the control to infer missing properties. Additionally, a bug whereby clicking on an unfocused control would open and then immediately close the dropdown has been fixed. Unit tests have been added to confirm that using fixed options works with the MultiSelect control, and a full test suite has been run successfully with no unexpected failures.