### PR TITLE
AKU-652: Logo-link title attribute incorrect

### DIFF
--- a/aikau/src/main/resources/alfresco/html/Image.js
+++ b/aikau/src/main/resources/alfresco/html/Image.js
@@ -280,14 +280,14 @@ define(["alfresco/core/_PublishOrLinkMixin",
       postMixInProperties: function alfresco_html_Image__postMixInProperties() {
          this.inherited(arguments);
 
-         // If this is being made into a link, try and make sure we have some "title" text
-         if (this.targetUrl && !this.label) {
-            this.label = this.altText;
-         }
-
          // Encode the alt text, after checking for properties
          if (this.altText) {
             this.altText = this.encodeHTML(this.message(this.altText));
+         }
+
+         // If this is being made into a link, try and make sure we have some "title" text
+         if (this.targetUrl && !this.label) {
+            this.label = this.altText;
          }
 
          // It's possible to provide a dimensions object, so use this if available

--- a/aikau/src/main/resources/alfresco/html/Image.js
+++ b/aikau/src/main/resources/alfresco/html/Image.js
@@ -280,11 +280,6 @@ define(["alfresco/core/_PublishOrLinkMixin",
       postMixInProperties: function alfresco_html_Image__postMixInProperties() {
          this.inherited(arguments);
 
-         // Encode the alt text, after checking for properties
-         if (this.altText) {
-            this.altText = this.encodeHTML(this.message(this.altText));
-         }
-
          // If this is being made into a link, try and make sure we have some "title" text
          if (this.targetUrl && !this.label) {
             this.label = this.altText;
@@ -309,6 +304,11 @@ define(["alfresco/core/_PublishOrLinkMixin",
        */
       postCreate: function alfresco_html_Image__postCreate() {
          this.inherited(arguments);
+
+         // Set the alt attribute value (the JS will make it "safe" automatically)
+         if (this.altText) {
+            this.imageNode.setAttribute("alt", this.message(this.altText));
+         }
 
          // Add any image classes
          if (this.classes) {

--- a/aikau/src/main/resources/alfresco/html/templates/Image.html
+++ b/aikau/src/main/resources/alfresco/html/templates/Image.html
@@ -1,3 +1,3 @@
 <div class="alfresco-html-Image">
-   <img class="alfresco-html-Image__img" data-dojo-attach-point="imageNode" src="${src}" alt="${altText}" style="${imgStyle}">
+   <img class="alfresco-html-Image__img" data-dojo-attach-point="imageNode" src="${src}" style="${imgStyle}">
 </div>

--- a/aikau/src/main/resources/alfresco/logo/Logo.js
+++ b/aikau/src/main/resources/alfresco/logo/Logo.js
@@ -142,10 +142,7 @@ define(["alfresco/enums/urlTypes",
          if (this.logoSrc) {
             this.src = this.logoSrc;
          }
-         if (this.targetUrl && !this.label) {
-            this.label = this.altText;
-         }
-         this.inherited(arguments);
+         this.inherited(arguments); // At end of func because inherited func uses this.src
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
@@ -118,7 +118,7 @@ define(["dojo/_base/declare",
             href: url
          };
          if (this.label) {
-            anchorAttrs.title = this.label;
+            anchorAttrs.title = this.message(this.label);
          }
          if (this.excludeFromTabOrder) {
             anchorAttrs.tabIndex = "-1";

--- a/aikau/src/test/resources/alfresco/logo/LogoTest.js
+++ b/aikau/src/test/resources/alfresco/logo/LogoTest.js
@@ -83,9 +83,18 @@ define([
                   .getLastPublish("LOGO_TOPIC_PUBLISHED");
             },
 
+            "Title text of link is correctly substituted": function() {
+               return browser.findByCssSelector("#LOGO_WITH_URL .alfresco-navigation-_HtmlAnchorMixin")
+                  .getAttribute("title")
+                  .then(function(attributeValue) {
+                     assert.equal(attributeValue, "Logo image");
+                  });
+            },
+
             "Logo will act as link when configured to do so": function() {
                return browser.findByCssSelector("#LOGO_WITH_URL a")
                   .click()
+                  .sleep(2000)
                   .end()
 
                .findByCssSelector("#TDAC .title")

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,8 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/MultiSelectInputTest"
+      "src/test/resources/alfresco/html/ImageTest",
+      "src/test/resources/alfresco/logo/LogoTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",


### PR DESCRIPTION
This addresses [AKU-652](https://issues.alfresco.com/jira/browse/AKU-652) and incorrect generation of the title attribute, because it's not looking up the value in the properties file. Test now added to prevent regression.