### PR TITLE
AKU-653: Upload to row

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -114,6 +114,19 @@ define(["dojo/_base/declare",
       dndUploadEventHandlers: null,
       
       /**
+       * This is the length of time (in milliseconds) that the highlight will be displayed on the screen without the mouse 
+       * moving over any element within the element on which the highlight can be applied. This exists so 
+       * that if the drag moves out of the browser without leaving the element (i.e. if it is moved onto
+       * an overlapping window) the highlight will not remain displayed forever.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.42
+       */
+      dndUploadHighlightDebounceTime: 2500,
+
+      /**
        * The image to use for the upload highlighting. Currently the only other option apart from the default is
        * "elipse-cross.png"
        * 
@@ -134,6 +147,17 @@ define(["dojo/_base/declare",
        * @since 1.0.41
        */
       dndUploadHighlightText: "dnd.upload.highlight.label",
+
+      /**
+       * This is used as a reference for a timeout handle that will remove the highlight if the mouse
+       * does not move over an element within the element that the upload highlight can be applied to.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.42
+       */
+      dndUploadHighlightTimeout: null,
 
       /**
        * Indicates whether or not the mixing module should take advantage of the drag-and-drop uploading capabilities. 
@@ -316,6 +340,15 @@ define(["dojo/_base/declare",
              this.checkApplicable(e.target, "onDndUploadDragEnter"))
          {
             this.addDndHighlight();
+
+            // We want to set a timeout for showing the highlight, if a timeout has previously been set we want
+            // to clear it, and then set a new timeout for this highlight. This is done in order to prevent the
+            // highlight remaining displayed when the drag event leaves the element by going onto an overlaid window
+            if (this.dndUploadHighlightTimeout)
+            {
+               clearTimeout(this.dndUploadHighlightTimeout);
+            }
+            this.dndUploadHighlightTimeout = setTimeout(lang.hitch(this, this.removeDndHighlight), this.dndUploadHighlightDebounceTime);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/_AlfDndDocumentUploadMixin.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/_AlfDndDocumentUploadMixin.css
@@ -23,6 +23,7 @@
       width: 100%;
       text-align: center;
       vertical-align: middle;
+      /* NOTE: Waiting for background image with alpha channel */
       /*background-image: url("./images/panel.gif");*/
 
       &__title {

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/_AlfDndDocumentUploadMixin.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/_AlfDndDocumentUploadMixin.css
@@ -11,6 +11,7 @@
    position: absolute;
    border: @upload-highlight-border;
    border-radius: 10px;
+   pointer-events: none;
    
    &--display {
       display: table;
@@ -22,7 +23,7 @@
       width: 100%;
       text-align: center;
       vertical-align: middle;
-      background-image: url("./images/panel.gif");
+      /*background-image: url("./images/panel.gif");*/
 
       &__title {
          color: @de-emphasized-font-color;

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -35,10 +35,12 @@ define(["dojo/_base/declare",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
         "alfresco/lists/views/layouts/_LayoutMixin",
+        "alfresco/documentlibrary/_AlfDndDocumentUploadMixin",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, _LayoutMixin, domClass) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, _LayoutMixin, 
+                 _AlfDndDocumentUploadMixin, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, _LayoutMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, _LayoutMixin, _AlfDndDocumentUploadMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -67,6 +69,40 @@ define(["dojo/_base/declare",
       additionalCssClasses: null,
 
       /**
+       * Overrides the [mixed in default]{@link module:alfresco/documentlibrary/_AlfDndDocumentUploadMixin#dndUploadHighLightImage}
+       * to use the smaller image.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.42
+       */
+      dndUploadHighlightImage: "elipse-cross.png",
+
+      /**
+       * Overrides the [mixed in default]{@link module:alfresco/documentlibrary/_AlfDndDocumentUploadMixin#dndUploadText}
+       * to hide the upload message.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.42
+       */
+      dndUploadHighlightText: "",
+
+      /**
+       * Overrides the 
+       * [default mixed in configuration]{@link module:alfresco/documentlibrary/_AlfDndDocumentUploadMixin#suppressDndUploading}
+       * to suppress upload highlighting by default.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.42
+       */
+      suppressDndUploading: true,
+    
+      /**
        * Indicates that a "zebra striping" style should be applied (e.g. odd and even rows being different
        * colours). 
        *
@@ -90,6 +126,12 @@ define(["dojo/_base/declare",
                this.processObject(this.widgetModelModifiers, this.widgets);
             }
             this.processWidgets(this.widgets, this.containerNode);
+         }
+
+         if (this.hasUploadPermissions() === true)
+         {
+            this.addUploadDragAndDrop(this.domNode);
+            this._currentNode = this.currentItem.node;
          }
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.js
@@ -1,3 +1,4 @@
+// jshint maxlen:false
 // Data object to use for the lists/views...
 var data = {
    items: [
@@ -16,7 +17,27 @@ var data = {
             shortName: "normalResult"
          },
          path: "/one/two/three/four",
-         size: 283746
+         size: 283746,
+
+         // From regular node
+         node: {
+            nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
+            isContainer: true,
+            permissions: {
+               roles: ["ALLOWED;GROUP_site_site1_SiteConsumer;SiteConsumer;DIRECT", "ALLOWED;GROUP_site_site1_SiteManager;SiteManager;DIRECT", "ALLOWED;GROUP_site_site1_SiteCollaborator;SiteCollaborator;DIRECT", "ALLOWED;GROUP_site_site1_SiteContributor;SiteContributor;DIRECT"],
+               inherited: false,
+               user: {
+                  ChangePermissions: true,
+                  CancelCheckOut: false,
+                  CreateChildren: true,
+                  Write: true,
+                  Delete: true,
+                  Unlock: false
+               }
+            }
+         }
+         
+         
       }
    ]
 };
@@ -24,15 +45,19 @@ var data = {
 // Function to create a thumbnail with the option to stop it from being draggable
 // When the thumbnail isn't draggable it can still be dragged but the browser treats it
 // as a file (which enables us to check the DND upload highlighting!)
-function getThumbnail(id, isDraggable) {
+function getThumbnail(options) {
    var thumbnail = {
-      id: id + "_THUMBNAIL",
+      id: options.id + "_THUMBNAIL",
       name: "alfresco/renderers/Thumbnail",
       config: {}
    };
-   if (isDraggable === true || isDraggable === false)
+   if (options.dragableThumbnail === true || options.dragableThumbnail === false)
    {
-      thumbnail.config.isDraggable = isDraggable;
+      thumbnail.config.isDraggable = options.dragableThumbnail;
+   }
+   if (options.thumbnailSuppress === true || options.thumbnailSuppress === false)
+   {
+      thumbnail.config.suppressDndUploading = options.thumbnailSuppress;
    }
    return thumbnail;
 }
@@ -40,25 +65,34 @@ function getThumbnail(id, isDraggable) {
 // Function to create a view with the options to configure DND upload hightlighting
 // suppression, whether or not to make the thumbnail draggable and whether or not
 // to set data directly on the view (so that it can be used outside of the list)
-function getView(id, viewSuppress, isDraggable, setData) {
+function getView(options) {
+   //id, viewSuppress, isDraggable, setData, rowSuppress
    var view = {
-      id: id + "_VIEW",
+      id: options.id + "_VIEW",
       name: "alfresco/lists/views/AlfListView",
       config: {
          widgets: [
             {
-               id: id + "_ROW",
+               id: options.id + "_ROW",
                name: "alfresco/lists/views/layouts/Row",
                config: {
                   widgets: [
                      {
-                        id: id + "_CELL",
+                        id: options.id + "_CELL1",
                         name: "alfresco/lists/views/layouts/Cell",
                         config: {
                            widgets: [
-                              getThumbnail(id, isDraggable),
+                              getThumbnail(options)
+                           ]
+                        }
+                     },
+                     {
+                        id: options.id + "_CELL2",
+                        name: "alfresco/lists/views/layouts/Cell",
+                        config: {
+                           widgets: [
                               {
-                                 id: id + "_NAME",
+                                 id: options.id + "_NAME",
                                  name: "alfresco/renderers/Property",
                                  config: {
                                     propertyToRender: "displayName"
@@ -74,11 +108,15 @@ function getView(id, viewSuppress, isDraggable, setData) {
       }
    };
 
-   if (viewSuppress === true || viewSuppress === false)
+   if (options.rowSuppress === true || options.rowSuppress === false)
    {
-      view.config.suppressDndUploading = viewSuppress;
+      view.config.widgets[0].config.suppressDndUploading = options.rowSuppress;
    }
-   if (setData === true)
+   if (options.viewSuppress === true || options.viewSuppress === false)
+   {
+      view.config.suppressDndUploading = options.viewSuppress;
+   }
+   if (options.setData === true)
    {
       view.config.currentData = data;
    }
@@ -87,20 +125,21 @@ function getView(id, viewSuppress, isDraggable, setData) {
 
 // Function to create a list with the options to pass onto the getView and
 // getThumbnail functions
-function getList(id, listSuppress, viewSuppress, isDraggable) {
+function getList(options) {
+   // id, listSuppress, viewSuppress, isDraggable, rowSuppress
    var list = {
-      id: id,
+      id: options.id,
       name: "alfresco/lists/AlfList",
       config: {
          currentData: data,
          widgets: [
-            getView(id, viewSuppress, isDraggable, false)
+            getView(options)
          ]
       }
    };
-   if (listSuppress === true || listSuppress === false)
+   if (options.listSuppress === true || options.listSuppress === false)
    {
-      list.config.suppressDndUploading = listSuppress;
+      list.config.suppressDndUploading = options.listSuppress;
    }
    return list;
 }
@@ -127,7 +166,9 @@ model.jsonModel = {
                   config: {
                      title: "List (defaults)",
                      widgets: [
-                        getList("NO_OVERRIDES")
+                        getList({
+                           id: "NO_OVERRIDES"
+                        })
                      ]
                   }
                },
@@ -136,7 +177,15 @@ model.jsonModel = {
                   config: {
                      title: "List (no suppression, no dragging)",
                      widgets: [
-                        getList("FULLY_SUPPRESSED", false, false, false)
+                        getList({
+                           id: "FULLY_SUPPRESSED", 
+                           listSuppress: false,
+                           viewSuppress: false,
+                           rowSuppress: false,
+                           setData: false,
+                           thumbnailSuppress: false,
+                           dragableThumbnail: false
+                        })
                      ]
                   }
                },
@@ -145,7 +194,15 @@ model.jsonModel = {
                   config: {
                      title: "View (defaults)",
                      widgets: [
-                        getView("JUST", null, null, true)
+                        getView({
+                           id: "JUST", 
+                           listSuppress: null,
+                           viewSuppress: null,
+                           rowSuppress: null,
+                           setData: true,
+                           thumbnailSuppress: false,
+                           dragableThumbnail: null
+                        })
                      ]
                   }
                },
@@ -154,7 +211,32 @@ model.jsonModel = {
                   config: {
                      title: "View (no suppression, no dragging)",
                      widgets: [
-                        getView("NO_VIEW_DRAG", false, false, true)
+                        getView({
+                           id: "NO_VIEW_DRAG", 
+                           listSuppress: false,
+                           viewSuppress: false,
+                           rowSuppress: false,
+                           setData: true,
+                           thumbnailSuppress: false,
+                           dragableThumbnail: false
+                        })
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "View (row upload, thumbnail supress, no dragging)",
+                     widgets: [
+                        getView({
+                           id: "ROW_UPLOAD",
+                           listSuppress: true,
+                           viewSuppress: true,
+                           rowSuppress: false,
+                           setData: true,
+                           thumbnailSuppress: true,
+                           dragableThumbnail: false
+                        })
                      ]
                   }
                }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/DNDUploadBehaviour.get.js
@@ -51,9 +51,9 @@ function getThumbnail(options) {
       name: "alfresco/renderers/Thumbnail",
       config: {}
    };
-   if (options.dragableThumbnail === true || options.dragableThumbnail === false)
+   if (options.draggableThumbnail === true || options.draggableThumbnail === false)
    {
-      thumbnail.config.isDraggable = options.dragableThumbnail;
+      thumbnail.config.isDraggable = options.draggableThumbnail;
    }
    if (options.thumbnailSuppress === true || options.thumbnailSuppress === false)
    {
@@ -184,7 +184,7 @@ model.jsonModel = {
                            rowSuppress: false,
                            setData: false,
                            thumbnailSuppress: false,
-                           dragableThumbnail: false
+                           draggableThumbnail: false
                         })
                      ]
                   }
@@ -201,7 +201,7 @@ model.jsonModel = {
                            rowSuppress: null,
                            setData: true,
                            thumbnailSuppress: false,
-                           dragableThumbnail: null
+                           draggableThumbnail: null
                         })
                      ]
                   }
@@ -218,7 +218,7 @@ model.jsonModel = {
                            rowSuppress: false,
                            setData: true,
                            thumbnailSuppress: false,
-                           dragableThumbnail: false
+                           draggableThumbnail: false
                         })
                      ]
                   }
@@ -235,7 +235,7 @@ model.jsonModel = {
                            rowSuppress: false,
                            setData: true,
                            thumbnailSuppress: true,
-                           dragableThumbnail: false
+                           draggableThumbnail: false
                         })
                      ]
                   }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-653 to add support for mixing the alfresco/documentlibrary/_AlfDndDocumentUploadMixin into the alfresco/lists/views/layouts/Row. Unfortunately this required some reworking of the mixin because previously we were creating the drag overlay (to display the highlighting) in the mixing widgets parent node. This didn't work for Row because there were multiple overlays at the same node and they were positioned incorrectly and the layout was corrupted. So the overlays are now created in the body. In order to get this working we've needed to use pointer-events none, but as this is a feature only required for releases that support IE10 an up this is acceptable.