### PR TITLE
AKU-653: AlfDocumentList now extends AlfFilteredList

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -20,11 +20,11 @@
 /**
  *
  * @module alfresco/documentlibrary/AlfDocumentList
- * @extends module:alfresco/lists/AlfSortablePaginatedList
+ * @extends module:alfresco/lists/AlfFilteredList
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/lists/AlfSortablePaginatedList",
+        "alfresco/lists/AlfFilteredList",
         "alfresco/core/JsNode",
         "alfresco/core/topics",
         "dojo/_base/array",
@@ -568,6 +568,17 @@ define(["dojo/_base/declare",
                this.loadData();
             }
          }
-      }
+      },
+
+      /**
+       * Overrides the [default filters]{@link module:alfresco/lists/AlfFilteredList#widgetsForFilters} as 
+       * there should be no filters for document lists unless explicitly configured.
+       *
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.42
+       */
+      widgetsForFilters: null
    });
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/FilteredDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/FilteredDocumentListTest.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfDocumentList Tests (filters)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/FilteredDocumentList", "AlfDocumentList Tests (filters)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Document request includes initial filter": function() {
+
+            return browser.findByCssSelector("body").end().getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "dataType", "PERSONAL", "Initial filter not included in request");
+               });
+         },
+
+         "Change filter": function() {
+            return browser.findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL input[value=\"DOCLIBS\"]")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST", "Filter did not trigger reload")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "dataType", "DOCLIBS", "Updated filter not included in request");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -89,6 +89,7 @@ define({
       "src/test/resources/alfresco/documentlibrary/DocumentLibraryTest",
       "src/test/resources/alfresco/documentlibrary/DocumentListTest",
       "src/test/resources/alfresco/documentlibrary/DocumentSelectorTest",
+      "src/test/resources/alfresco/documentlibrary/FilteredDocumentListTest",
       "src/test/resources/alfresco/documentlibrary/PaginationTest",
       "src/test/resources/alfresco/documentlibrary/SearchListScrollTest",
       "src/test/resources/alfresco/documentlibrary/SearchListTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfDocumentList (filtered)</shortname>
+  <description>This page shows how the alfresco/documentlibrary/AlfDocumentList widget can be configured to use filters for controlling the requests made for data to display.</description>
+  <family>aikau-unit-tests</family>
+  <url>/FilteredDocumentList</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.js
@@ -1,0 +1,93 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+      // ,
+      // "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "DOCUMENT_LIST",
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            useHash: true,
+            currentPath: "/",
+            siteId: "fake-site",
+            containerId: "documentlibrary",
+            filteringTopics: ["_valueChangeOf_FILTER"],
+            widgetsForFilters: [
+               {
+                  id: "COMPOSITE_DROPDOWN",
+                  name: "alfresco/forms/controls/RadioButtons",
+                  config: {
+                     fieldId: "DROPDOWN_FILTER",
+                     name: "dataType",
+                     label: "Document List Type...",
+                     value: "PERSONAL",
+                     optionsConfig: {
+                        fixed: [
+                           {
+                              label: "Personal Files",
+                              value: "PERSONAL"
+                           },
+                           {
+                              label: "Document Libraries",
+                              value: "DOCLIBS"
+                           }
+                        ],
+                        queryAttribute: "label",
+                        labelAttribute: "label",
+                        valueAttribute: "value"
+                     }
+                  }
+               }
+            ],
+            widgets: [
+               {
+                  id: "VIEW",
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [
+                        {
+                           id: "ROW",
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "CELL",
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets:[
+                                          {
+                                             id: "PROPERTY",
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/FilteredDocumentList.get.js
@@ -11,8 +11,6 @@ model.jsonModel = {
             }
          }
       }
-      // ,
-      // "alfresco/services/DocumentService"
    ],
    widgets: [
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-647 to make the AlfDocumentList extend the AlfFilteredList rather than the AlfSortablePaginatedList.