### PR TITLE
AKU-659: Ensure full screen dialogs have fixed position

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -486,6 +486,11 @@ define(["dojo/_base/declare",
                h: $(window).height() - dimensionAdjustment
             }]);
 
+            // NOTE: Need to set this on the element (rather than using CSS because the underlying 
+            //       Dojo code sets position, the only CSS option would be to use !important which
+            //       we'd prefer to avoid).
+            domStyle.set(this.domNode, "position", "fixed");
+
             // When in full screen mode it is also necessary to take care of the inner dimensions
             // of the dialog...
             var calculatedHeights = this.calculateHeights();
@@ -493,7 +498,7 @@ define(["dojo/_base/declare",
             var bodyHeight = containerHeight;
             if (this.widgetsButtons)
             {
-               // Dedebug height for the widgets buttons if present
+               // Deduct height for the widgets buttons if present
                bodyHeight = bodyHeight - 44;
             }
             $(this.bodyNode).height(bodyHeight);

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -22,10 +22,9 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/helpers/pollUntil"],
-        function(registerSuite, assert, require, TestCommon, pollUntil) {
+        function(registerSuite, assert, TestCommon, pollUntil) {
 
    function closeAllDialogs(browser) {
       // Todo: this fails to close multiple dialogs in Chrome
@@ -402,6 +401,37 @@ registerSuite(function(){
                assert.propertyVal(payload, "tab1tb", "one", "Published form data incorrect (tab1tb)"); 
                assert.propertyVal(payload, "tab2tb", "two", "Published form data incorrect (tab2tb)");
             });
+      },
+
+      "Full screen dialog should be fixed": function() {
+         var initial_y;
+         return browser.findById("FULL_SCREEN_DIALOG_label")
+            .click()
+         .end()
+
+         .findByCssSelector("#FSD1.dialogDisplayed")
+            .getPosition()
+               .then(function(position) {
+                  initial_y = position.y;
+               })
+         .end()
+
+         // Scroll to the bottom of the page...
+         .execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
+         .end()
+
+         .findById("FSD1")
+            .getPosition()
+            .then(function(position) {
+               assert.isAbove(position.y, initial_y, "The position of the dialog did not move with the scroll");
+            })
+         .end()
+
+         .findById("FULL_SCREEN_DIALOG_CLOSE_label")
+            .click()
+         .end()
+
+         .findByCssSelector("#FSD1.dialogHidden");
       },
 
       "Can launch dialog within dialog": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -556,6 +556,7 @@ model.jsonModel = {
                ],
                widgetsButtons: [
                   {
+                     id: "FULL_SCREEN_DIALOG_CLOSE",
                      name: "alfresco/buttons/AlfButton",
                      config: {
                         label: "OK",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-659 to ensure that full screen dialogs have a fixed position so that they are always visible even if the main window is scrolled.