### PR TITLE
AKU-657: Make resize-detection generic

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -33,10 +33,11 @@
 define(["dojo/_base/declare",
         "alfresco/core/_EventsMixin",
         "alfresco/core/topics",
+        "alfresco/util/domUtils",
         "dojo/_base/lang",
         "dojo/on",
         "dojo/dom"], 
-        function( declare, _EventsMixin, topics, lang, on, dom) {
+        function( declare, _EventsMixin, topics, domUtils, lang, on, dom) {
    
    return declare([_EventsMixin], {
       
@@ -101,6 +102,23 @@ define(["dojo/_base/declare",
          {
             resizeHandler.apply(resizeHandlerCallScope, [payload.node]);
          }
+      },
+
+      /**
+       * <p>In IE9+ and Chrome/FF, setup a listener that will call [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent}
+       * whenever a resize is detected in the specified node.</p>
+       *
+       * <p>NOTE: This is based on a technique described at
+       * {@link http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection}</p>
+       *
+       * @instance
+       * @param {object} node The node to monitor
+       * @returns {object} A pointer to the listener, with a remove function on it (i.e. it can be passed to this.own)
+       * @since 1.0.42
+       */
+      addResizeListener: function alfresco_core_ResizeMixin__addResizeListener(node) {
+         var resizeHandler = lang.hitch(this, this.alfPublishResizeEvent, node.parentNode); // Must use parentNode to meet condition in alfOnNodeResized above
+         return domUtils.addResizeListener(node, resizeHandler);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -102,11 +102,10 @@ define(["alfresco/core/ProcessWidgets",
         "dojo/dom-class",
         "dojo/dom-construct",
         "dojo/dom-style",
-        "dojo/sniff",
         "dojo/topic",
         "dojo/text!./templates/FixedHeaderFooter.html"],
         function(ProcessWidgets, ResizeMixin, HeightMixin, DynamicVisibilityResizingMixin, array, declare, lang, aspect, 
-                 domClass, domConstruct, domStyle, has, topic, template) {
+                 domClass, domConstruct, domStyle, topic, template) {
 
    return declare([ProcessWidgets, ResizeMixin, HeightMixin, DynamicVisibilityResizingMixin], {
 
@@ -235,63 +234,26 @@ define(["alfresco/core/ProcessWidgets",
             }
          ]);
 
-         // Add resize listeners to the header/footer
-         // NOTE: This is done asynchronously to avoid delaying the resize event firing
-         setTimeout(lang.hitch(this, this.addHeaderResizeListener), 0);
-
          // Do the resize
          this.onResize();
          this.alfPublishResizeEvent(this.domNode);
+
+         // Setup the header resize listener
+         this.addResizeListener(this.header);
       },
 
       /**
        * <p>Setup a listener that will call [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent}
        * whenever a resize is detected in the header.</p>
        *
-       * <p>NOTE: This is based on a technique described at
-       * {@link http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection}</p>
+       * <p><strong>NOTE:</strong> This method is no longer called by the postCreate method, and will be removed in a future version</p>
        *
        * @instance
        * @since 1.0.41
+       * @deprecated Since 1.0.42 - use [ResizeMixin.addResizeListener]{@link module:alfresco/core/ResizeMixin#addResizeListener} instead.
        */
       addHeaderResizeListener: function alfresco_layout_FixedHeaderFooter__addHeaderResizeListener() {
-
-         // Setup the resize listener function
-         var onResize = lang.hitch(this, this.alfPublishResizeEvent, this.domNode);
-
-         // NOTE: Dojo IE detection not working very well here, so done manually instead
-         var ieRegex = /(Trident\/)|(Edge\/)/,
-            isIE = has("IE") || ieRegex.test(navigator.userAgent);
-
-         // Create the resize object
-         var resizeObj = document.createElement("object");
-         resizeObj.className = this.baseClass + "__header__resize-object";
-         resizeObj.type = "text/html";
-         resizeObj.onload = function() {
-            resizeObj.contentDocument.defaultView.addEventListener("resize", onResize);
-         };
-
-         // FF doesn't like visibility hidden (interferes with the resize event), Chrome doesn't care, IE needs it
-         if (isIE) {
-            resizeObj.style.visibility = "hidden";
-         }
-
-         // Normal browsers do this before appending to the DOM
-         if (!isIE) {
-            resizeObj.data = "about:blank";
-         }
-
-         // Add the object to the document
-         if (this.header.hasChildNodes()) {
-            this.header.insertBefore(resizeObj, this.header.firstChild);
-         } else {
-            this.header.appendChild(resizeObj);
-         }
-
-         // IE needs to do this after
-         if (isIE) {
-            resizeObj.data = "about:blank";
-         }
+         this.addResizeListener(this.header);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
+++ b/aikau/src/main/resources/alfresco/layout/css/FixedHeaderFooter.css
@@ -8,16 +8,6 @@
    }
    &__header {
       top: 0;
-      &__resize-object {
-         display: block;
-         height: 100%;
-         left: 0;
-         overflow: hidden;
-         position: absolute;
-         top: 0;
-         width: 100%;
-         z-index: -1;
-      }
    }
    &__footer {
       bottom: 0;

--- a/aikau/src/main/resources/alfresco/util/domUtils.js
+++ b/aikau/src/main/resources/alfresco/util/domUtils.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Utility object for dom-related utilities. Note that this is not a Class, and so does
+ * not need to be instantiated before use.
+ *
+ * @module alfresco/util/domUtils
+ * @author Martin Doyle
+ * @since 1.0.42
+ */
+define([
+      "dojo/_base/lang",
+      "dojo/dom-style",
+      "dojo/on",
+      "dojo/sniff"
+   ],
+   function(lang, domStyle, on, has) {
+
+      // The private container for the functionality and properties of the util
+      var util = {
+
+         // See API below
+         addResizeListener: function alfresco_util_domUtils__addResizeListener(node, resizeHandler) {
+
+            // Setup the resize listener function
+            var resizeObj,
+               onLoadListener,
+               removeListenerFunc;
+
+            // NOTE: Dojo IE detection not working very well here, so done manually instead
+            var ieRegex = /(Trident\/)|(Edge\/)/,
+               isIE = has("IE") || ieRegex.test(navigator.userAgent);
+
+            // Create the resize object
+            resizeObj = document.createElement("object");
+            resizeObj.className = "alfresco-core-ResizeMixin__resize-object";
+            resizeObj.type = "text/html";
+            domStyle.set(resizeObj, {
+               "display": "block",
+               "height": "100%",
+               "left": 0,
+               "overflow": "hidden",
+               "position": "absolute",
+               "top": 0,
+               "width": "100%",
+               "z-index": -1
+            });
+
+            // Setup the resize listener functionality
+            onLoadListener = on(resizeObj, "load", function() {
+               resizeObj.contentDocument.defaultView.addEventListener("resize", resizeHandler);
+               removeListenerFunc = function() {
+                  resizeObj.contentDocument.defaultView.removeEventListener("resize", resizeHandler);
+               };
+               onLoadListener.remove();
+            });
+
+            // Node cannot have position static
+            var nodeStyle = getComputedStyle(node),
+               nodeIsStatic = nodeStyle.position === "static";
+            if (nodeIsStatic) {
+               node.style.position = "relative";
+            }
+
+            // FF doesn't like visibility hidden (interferes with the resize event), Chrome doesn't care, IE needs it
+            if (isIE) {
+               resizeObj.style.visibility = "hidden";
+            }
+
+            // Normal browsers do this before appending to the DOM
+            if (!isIE) {
+               resizeObj.data = "about:blank";
+            }
+
+            // Add the object to the document
+            if (node.hasChildNodes()) {
+               node.insertBefore(resizeObj, node.firstChild);
+            } else {
+               node.appendChild(resizeObj);
+            }
+
+            // IE needs to do this after
+            if (isIE) {
+               resizeObj.data = "about:blank";
+            }
+
+            // Pass back the listener-removal object
+            return {
+               remove: function() {
+                  /*jshint devel:true*/
+                  try {
+                     removeListenerFunc();
+                     node.removeChild(resizeObj);
+                  } catch (e) {
+                     console.warn("Error attempting to remove resize listener", e);
+                  }
+               }
+            };
+         }
+      };
+
+      /**
+       * The public API for this utility class
+       *
+       * @alias module:alfresco/util/domUtils
+       */
+      return {
+
+         /**
+          * <p>In IE9+ and Chrome/FF, setup a listener on a specific node that will call the supplied handler-function whenever that node resizes</p>
+          *
+          * <p>NOTE: This is based on a technique described at
+          * {@link http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection}</p>
+          *
+          * @instance
+          * @param {object} node The node to monitor
+          * @param {function} resizeHandler The function to call on resize
+          * @returns {object} A pointer to the listener, with a remove function on it (i.e. it can be passed to this.own)
+          */
+         addResizeListener: lang.hitch(util, util.addResizeListener)
+      };
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,8 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/html/ImageTest",
-      "src/test/resources/alfresco/logo/LogoTest"
+      "src/test/resources/alfresco/layout/FixedHeaderFooterTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",


### PR DESCRIPTION
[AKU-657](https://issues.alfresco.com/jira/browse/AKU-657): Make resize-detection generic
Add new domUtils class, and use it in ResizeMixin to provide a generic resize listener for the FixedHeaderFooter (and other future widgets) to use. Tests unchanged but all passing.