### PR TITLE
AKU-666: Ensure that file select form control is required when uploading/updating

### DIFF
--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -326,7 +326,10 @@ define(["dojo/_base/declare",
             name: "alfresco/forms/controls/FileSelect",
             config: {
                label: "contentService.uploader.dialog.fileSelect.label",
-               name: "files"
+               name: "files",
+               requirementConfig: {
+                  initialValue: true
+               }
             }
          }
       ],
@@ -343,7 +346,10 @@ define(["dojo/_base/declare",
             name: "alfresco/forms/controls/FileSelect",
             config: {
                label: "contentService.updater.dialog.fileSelect.label",
-               name: "files"
+               name: "files",
+               requirementConfig: {
+                  initialValue: true
+               }
             }
          },
          {

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -27,195 +27,213 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, require, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "ContentService Tests",
+      return {
+         name: "ContentService Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/ContentService", "ContentService Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ContentService", "ContentService Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Delete node (basic data)": function() {
-         return browser.findByCssSelector("#DELETE_CONTENT_1_label")
-            .click()
+         "Delete node (basic data)": function() {
+            return browser.findByCssSelector("#DELETE_CONTENT_1_label")
+               .click()
+               .end()
+
+            .findByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogDisplayed .dijitDialogTitle")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The confirmation dialog was not displayed");
+               })
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Confirm Deletion", "The confirmation dialog title was wrong");
+               });
+         },
+
+         "Count displayed items for deletion": function() {
+            return browser.findAllByCssSelector(".dialog-body .alfresco-renderers-Property .value")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Unexpected number of items to delete");
+               });
+         },
+
+         "Check display name for item to delete": function() {
+            return browser.findByCssSelector(".dialog-body .alfresco-renderers-Property .value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Some Node Title", "The item display name was wrong");
+               });
+         },
+
+         "Confirm delete (basic data)": function() {
+            return browser.findByCssSelector("#ALF_DELETE_CONTENT_DIALOG .dijitButton:first-child .dijitButtonNode")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
+               .end()
+
+            .getLastPublish("ALF_DISPLAY_NOTIFICATION")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "message", "Delete successful", "Did not display successful delete notification");
+               })
+               .clearLog();
+         },
+
+         "Delete node (doclib data)": function() {
+            return browser.findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
+               .end()
+
+            .findByCssSelector("#DELETE_CONTENT_2_label")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogDisplayed")
+               .end()
+
+            .findByCssSelector(".dialog-body .alfresco-renderers-Property .value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Some Node", "The item property name was not displayed");
+               });
+         },
+
+         "Confirm delete (doclib data)": function() {
+            return browser.findByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogDisplayed .dijitButton:first-child .dijitButtonNode")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
+               .end()
+
+            .getLastPublish("ALF_DISPLAY_NOTIFICATION")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "message", "Delete successful", "Did not display successful delete notification");
+               });
+         },
+
+         "Edit basic metadata": function() {
+            return browser.findByCssSelector("#EDIT_BASIC_METADATA_label")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogDisplayed") // Wait for dialog
+               .end()
+
+            .findByCssSelector(".alfresco-forms-controls-TextBox:nth-child(2) .dijitInputContainer input")
+               .getProperty("value")
+               .then(function(text) {
+                  assert.equal(text, "Some Node", "The node name was not set correctly");
+               })
+               .end()
+
+            .findByCssSelector(".alfresco-forms-controls-TextBox:nth-child(3) .dijitInputContainer input")
+               .getProperty("value")
+               .then(function(text) {
+                  assert.equal(text, "With this title", "The node title was not set correctly");
+               })
+               .end()
+
+            .findByCssSelector(".alfresco-forms-controls-TextArea:nth-child(4) .dijitTextArea")
+               .getProperty("value")
+               .then(function(text) {
+                  assert.equal(text, "And this description", "The node title was not set correctly");
+               });
+         },
+
+         "Save basic metadata": function() {
+            return browser.findByCssSelector("#ALF_BASIC_METADATA_DIALOG .confirmationButton > span")
+               .click()
+               .end()
+
+            .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e/formprocessor")
+               .then(function(xhr){
+                  assert.deepPropertyVal(xhr.request.body, "prop_cm_name", "Some Node");
+                  assert.deepPropertyVal(xhr.request.body, "prop_cm_title", "With this title");
+                  assert.deepPropertyVal(xhr.request.body, "prop_cm_description", "And this description");
+               });
+         },
+
+         "Edit basic metadata (nodeRef only)": function() {
+            return browser.findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogHidden")
+               .end()
+
+            .findByCssSelector("#EDIT_BASIC_METADATA_NODEREF_ONLY_label")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogDisplayed") // Wait for dialog
+               .end()
+
+            .getLastPublish("ALF_BASIC_METADATA_SUCCESS", "Did not publish basic metadata success");
+         },
+
+         "Check retrieved node data": function() {
+            return browser.findByCssSelector(".alfresco-forms-controls-TextBox:nth-child(2) .dijitInputContainer input")
+               .getProperty("value")
+               .then(function(text) {
+                  assert.equal(text, "PDF.pdf", "The node name was not set correctly");
+               })
+               .end()
+
+            .findByCssSelector("#ALF_BASIC_METADATA_DIALOG .dijitDialogTitle")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Edit Properties: PDF.pdf", "The dialog title was not set correctly");
+               })
+               .end()
+
+            .findByCssSelector("#ALF_BASIC_METADATA_DIALOG .cancellationButton > span")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogHidden");
+         },
+
+         "Upload file dialog submit button should be disabled": function() {
+            // See AKU-666
+            return browser.findById("UPLOAD_NEW_FILE_label")
+               .click()
             .end()
 
-         .findByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogDisplayed .dijitDialogTitle")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The confirmation dialog was not displayed");
-            })
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Confirm Deletion", "The confirmation dialog title was wrong");
-            });
-      },
-
-      "Count displayed items for deletion": function() {
-         return browser.findAllByCssSelector(".dialog-body .alfresco-renderers-Property .value")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Unexpected number of items to delete");
-            });
-      },
-
-      "Check display name for item to delete": function() {
-         return browser.findByCssSelector(".dialog-body .alfresco-renderers-Property .value")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Some Node Title", "The item display name was wrong");
-            });
-      },
-
-      "Confirm delete (basic data)": function() {
-         return browser.findByCssSelector("#ALF_DELETE_CONTENT_DIALOG .dijitButton:first-child .dijitButtonNode")
-            .click()
+            .findAllByCssSelector("#ALF_UPLOAD_DIALOG.dialogDisplayed") // Wait for dialog
             .end()
 
-         .findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
+            // This line is essentially the test now, make sure the confirmation button is disabled
+            // because no files are selected...
+            .findByCssSelector("#ALF_UPLOAD_DIALOG .confirmationButton.dijitDisabled")
             .end()
 
-         .getLastPublish("ALF_DISPLAY_NOTIFICATION")
-            .then(function(payload) {
-               assert.propertyVal(payload, "message", "Delete successful", "Did not display successful delete notification");
-            })
-            .clearLog();
-      },
-
-      "Delete node (doclib data)": function() {
-         return browser.findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
+            .findById("ALF_UPLOAD_DIALOG_CANCEL_label")
+               .click()
             .end()
 
-         .findByCssSelector("#DELETE_CONTENT_2_label")
-            .click()
+            .findAllByCssSelector("#ALF_UPLOAD_DIALOG.dialogHidden"); // Wait for dialog to close
+         },
+
+         "Upload new version dialog submit button should be disabled": function() {
+            // See AKU-666
+            return browser.findById("UPDATE_FILE_label")
+               .click()
             .end()
 
-         .findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogDisplayed")
+            .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed") // Wait for dialog
             .end()
 
-         .findByCssSelector(".dialog-body .alfresco-renderers-Property .value")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Some Node", "The item property name was not displayed");
-            });
-      },
+            .findByCssSelector("#ALF_UPLOAD_DIALOG .confirmationButton.dijitDisabled");
+         },
 
-      "Confirm delete (doclib data)": function() {
-         return browser.findByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogDisplayed .dijitButton:first-child .dijitButtonNode")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#ALF_DELETE_CONTENT_DIALOG.dialogHidden")
-            .end()
-
-         .getLastPublish("ALF_DISPLAY_NOTIFICATION")
-            .then(function(payload) {
-               assert.propertyVal(payload, "message", "Delete successful", "Did not display successful delete notification");
-            });
-      },
-
-      "Edit basic metadata": function() {
-         return browser.findByCssSelector("#EDIT_BASIC_METADATA_label")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogDisplayed") // Wait for dialog
-            .end()
-
-         .findByCssSelector(".alfresco-forms-controls-TextBox:nth-child(2) .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(text) {
-               assert.equal(text, "Some Node", "The node name was not set correctly");
-            })
-            .end()
-
-         .findByCssSelector(".alfresco-forms-controls-TextBox:nth-child(3) .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(text) {
-               assert.equal(text, "With this title", "The node title was not set correctly");
-            })
-            .end()
-
-         .findByCssSelector(".alfresco-forms-controls-TextArea:nth-child(4) .dijitTextArea")
-            .getProperty("value")
-            .then(function(text) {
-               assert.equal(text, "And this description", "The node title was not set correctly");
-            });
-      },
-
-      "Save basic metadata": function() {
-         return browser.findByCssSelector("#ALF_BASIC_METADATA_DIALOG .confirmationButton > span")
-            .click()
-            .end()
-
-         .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e/formprocessor")
-            .then(function(xhr){
-               assert.deepPropertyVal(xhr.request.body, "prop_cm_name", "Some Node");
-               assert.deepPropertyVal(xhr.request.body, "prop_cm_title", "With this title");
-               assert.deepPropertyVal(xhr.request.body, "prop_cm_description", "And this description");
-            });
-      },
-
-      "Edit basic metadata (nodeRef only)": function() {
-         return browser.findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogHidden")
-            .end()
-
-         .findByCssSelector("#EDIT_BASIC_METADATA_NODEREF_ONLY_label")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogDisplayed") // Wait for dialog
-            .end()
-
-         .getLastPublish("ALF_BASIC_METADATA_SUCCESS", "Did not publish basic metadata success");
-      },
-
-      "Check retrieved node data": function() {
-         return browser.findByCssSelector(".alfresco-forms-controls-TextBox:nth-child(2) .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(text) {
-               assert.equal(text, "PDF.pdf", "The node name was not set correctly");
-            })
-            .end()
-
-         .findByCssSelector("#ALF_BASIC_METADATA_DIALOG .dijitDialogTitle")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Edit Properties: PDF.pdf", "The dialog title was not set correctly");
-            })
-            .end()
-
-         .findByCssSelector("#ALF_BASIC_METADATA_DIALOG .cancellationButton > span")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#ALF_BASIC_METADATA_DIALOG.dialogHidden");
-      },
-
-      "Upload file": function() {
-         return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"UPLOAD_NEW_FILE\"] .dijitButtonNode")
-            .click()
-            .end()
-
-         .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed") // Wait for dialog
-            .end()
-
-         .findByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed .confirmationButton .dijitButtonNode")
-            .click()
-            .end()
-
-         .getLastPublish("ALF_UPLOAD_REQUEST", "Did not publish upload request");
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
@@ -108,13 +108,29 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/buttons/AlfButton",
          id: "UPLOAD_NEW_FILE",
+         name: "alfresco/buttons/AlfButton",
          config: {
             label: "Launch upload dialog",
             publishTopic: "ALF_SHOW_UPLOADER",
             publishPayload: {
                parent: {
+                  nodeRef: "workspace/SpacesStore/f3aefe19-4436-44f1-9733-d22ffede037d"
+               }
+            }
+         }
+      },
+      {
+         id: "UPDATE_FILE",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Launch upload new version dialog",
+            publishTopic: "ALF_SHOW_UPLOADER",
+            publishPayload: {
+               parent: {
+                  nodeRef: "workspace/SpacesStore/f3aefe19-4436-44f1-9733-d22ffede037d"
+               },
+               node: {
                   nodeRef: "workspace/SpacesStore/f3aefe19-4436-44f1-9733-d22ffede037d"
                }
             }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-666 to ensure that the file select form controls in the upload and update new version dialogs provided by the content service are required (i.e. so that you can't submit the form dialog unless at least one file is selected)