### PR TITLE
AKU-662: alfresco/logo/Logo broken

### DIFF
--- a/aikau/src/main/resources/alfresco/html/Image.js
+++ b/aikau/src/main/resources/alfresco/html/Image.js
@@ -116,7 +116,9 @@ define(["alfresco/core/_PublishOrLinkMixin",
       aspectRatio: null,
 
       /**
-       * Any optional classes to be added to the wrapped image element.
+       * Any optional classes to be added to the wrapped image element. If a
+       * [src]{@link module:alfresco/html/Image#src} property is provided then
+       * this property will not be used.
        *
        * @instance
        * @type {string|string[]}
@@ -223,7 +225,9 @@ define(["alfresco/core/_PublishOrLinkMixin",
 
       /**
        * The URL of the image to use (this is used in conjunction with the
-       * [srcType]{@link module:alfresco/html/Image#srcType} property).
+       * [srcType]{@link module:alfresco/html/Image#srcType} property). If a src
+       * is provided, then the [classes]{@link module:alfresco/html/Image#classes}
+       * property will not be used.
        *
        * @instance
        * @type {string}
@@ -310,8 +314,8 @@ define(["alfresco/core/_PublishOrLinkMixin",
             this.imageNode.setAttribute("alt", this.message(this.altText));
          }
 
-         // Add any image classes
-         if (this.classes) {
+         // Add any image classes (but only if no src provided)
+         if (this.classes && !this.src) {
             domClass.add(this.imageNode, this.classes);
          }
 
@@ -439,8 +443,8 @@ define(["alfresco/core/_PublishOrLinkMixin",
             var cssDimensions = this.getCssDimensions(),
                hasCssDimensions = cssDimensions.w || cssDimensions.h;
 
-            // Do the resize only if no CSS dimensions, or if forceNatural is true
-            if (!hasCssDimensions || forceNatural) {
+            // Do the resize only if no CSS dimensions or it's a normal self-sizing image, or if forceNatural is true
+            if ((!hasCssDimensions && !this.src) || forceNatural) {
 
                // Use the natural dimensions if we have them (must have both, as an
                // image with zero width or zero height will not display at all)

--- a/aikau/src/test/resources/alfresco/logo/LogoTest.js
+++ b/aikau/src/test/resources/alfresco/logo/LogoTest.js
@@ -53,18 +53,22 @@ define([
             },
 
             "Check image logo": function() {
-               return browser.findByCssSelector("#LOGO2.alfresco-logo-Logo .alfresco-logo-large")
+               return browser.findByCssSelector("#LOGO2 .alfresco-html-Image__img")
                   .isDisplayed()
                   .then(function(displayed) {
                      assert.isTrue(displayed, "Logo with image source was not displayed");
                   });
             },
 
-            "Check image logo height": function() {
+            "Check image logo dimensions": function() {
                return browser.findByCssSelector("#LOGO2 .alfresco-html-Image__img")
                   .getComputedStyle("height")
                   .then(function(height) {
                      assert.equal(height, "48px", "The height of the image logo was incorrect");
+                  })
+                  .getComputedStyle("width")
+                  .then(function(width) {
+                     assert.equal(width, "172px", "The width of the image logo was incorrect");
                   });
             },
 


### PR DESCRIPTION
This addresses issue [AKU-662](https://issues.alfresco.com/jira/browse/AKU-662) and ensures that src property outranks the classes property, and update tests where appropriate.
