### PR TITLE
AKU-667: Cancel upload requests

### DIFF
--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -944,6 +944,21 @@ define(["dojo/_base/declare",
        */
       onProgressDialogCancelClick: function alfresco_services_UploadService__onProgressDialogCancelClick(/*jshint unused:false*/ payload) {
          this.alfLog("log", "Upload progress dialog 'cancel' button clicked");
+
+         for (var key in this.fileStore)
+         {
+            if (this.fileStore.hasOwnProperty(key))
+            {
+               var fileInfo = this.fileStore[key];
+               if (fileInfo.state === this.STATE_UPLOADING)
+               {
+                   // We will only attempt an upload abort if the file is still being uploaded (there is
+                   // no point in aborting if the file has completed or failed)
+                   fileInfo.request.abort();
+               }
+            }
+         }
+
          this.reset();
          if (this.uploadDisplayWidget !== null && 
              this.uploadDisplayWidget !== undefined && 

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -23,9 +23,8 @@
  * @author Richard Smith
  */
 define(["dojo/_base/declare",
-        "aikauTesting/MockXhr",
-        "dojo/text!./responseTemplates/SearchTest/XhrSearchResponse.json"], 
-        function(declare, MockXhr, xhrSearchResponse) {
+        "aikauTesting/MockXhr"], 
+        function(declare, MockXhr) {
    
    return declare([MockXhr], {
 
@@ -54,7 +53,7 @@ define(["dojo/_base/declare",
                });
                request.respond(responseCode, 
                               {"Content-Type":"application/json;charset=UTF-8"},
-                              '{"nodeRef":"bob","fileName":"moomin"}');
+                               "{\"nodeRef\":\"bob\",\"fileName\":\"moomin\"}");
             });
          }
          catch(e)


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-667. The cancel upload request has been updated to actually abort any in progress requests. I've done manual testing for this but have not been able to find a satisfactory way to automate unit testing for this.