### PR TITLE
AKU-661: Encode URL in SiteService

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -516,7 +516,7 @@ define(["dojo/_base/declare",
                      label: this.message("button.leave-site.confirm-label"),
                      publishTopic: "ALF_NAVIGATE_TO_PAGE",
                      publishPayload: {
-                        url: "user/" + originalRequestConfig.user + this.userHomePage.replace(/^\/*/, "/"),
+                        url: "user/" + encodeURIComponent(originalRequestConfig.user) + this.userHomePage.replace(/^\/*/, "/"),
                         type: urlTypes.PAGE_RELATIVE,
                         target: "CURRENT"
                      },
@@ -763,7 +763,7 @@ define(["dojo/_base/declare",
        */
       leaveSiteSuccess: function alfresco_services_SiteService__leaveSiteSuccess(response, requestConfig) {
          this.alfServicePublish("ALF_NAVIGATE_TO_PAGE", {
-            url: "user/" + requestConfig.user + this.userHomePage.replace(/^\/*/, "/"),
+            url: "user/" + encodeURIComponent(requestConfig.user) + this.userHomePage.replace(/^\/*/, "/"),
             type: urlTypes.PAGE_RELATIVE,
             target: "CURRENT"
          });

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -56,7 +56,7 @@ define(["alfresco/TestCommon",
 
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload){
-                  assert.propertyVal(payload, "url", "user/admin/home", "Did not navigate to user home page");
+                  assert.propertyVal(payload, "url", "user/admin%40alfresco.com/home", "Did not navigate to user home page");
                });
          },
 
@@ -74,7 +74,7 @@ define(["alfresco/TestCommon",
 
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload){
-                  assert.propertyVal(payload, "url", "user/admin/home", "Did not generate URL with correct user home page");
+                  assert.propertyVal(payload, "url", "user/admin%40alfresco.com/home", "Did not generate URL with correct user home page");
                });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -297,7 +297,7 @@ model.jsonModel = {
             publishTopic: "ALF_REQUEST_SITE_MEMBERSHIP",
             publishPayload: {
                site: "swsdp",
-               user: "admin",
+               user: "admin@alfresco.com",
                role: "SiteCollaborator",
                comments: "Just for fun"
             }
@@ -468,7 +468,7 @@ model.jsonModel = {
             publishTopic: "ALF_LEAVE_SITE",
             publishPayload: {
                site: "swsdp",
-               user: "admin"
+               user: "admin@alfresco.com"
             }
          }
       },


### PR DESCRIPTION
This addresses [AKU-661](https://issues.alfresco.com/jira/browse/AKU-661) and encodes the username in the redirection-URL in SiteService that's navigated to after site join-request or departure.
