### PR TITLE
AKU-416: Download action

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -287,6 +287,20 @@ define([],function() {
       DOCUMENTLIST_TAG_CHANGED: "ALF_DOCUMENTLIST_TAG_CHANGED",
       
       /**
+       * This topic is published to request the download of a single document
+       * 
+       * @instance
+       * @type {string}
+       * @default 
+       * @since 1.0.43
+       *
+       * @event
+       * @property {object} [node] - An object containing the node data.
+       * @property {string} [node.contentURL] - The URL to use for the node to download
+       */
+      DOWNLOAD: "ALF_DOWNLOAD",
+
+      /**
        * This topic is published to request either the download of a single document or folder (or a selection
        * of documents and folder) as a ZIP file.
        * 

--- a/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
@@ -153,6 +153,9 @@ define(["dojo/_base/declare",
        */
       widgetsForActions: [
          {
+            name: "alfresco/renderers/actions/Download"
+         },
+         {
             name: "alfresco/renderers/actions/DownloadAsZip"
          },
          {

--- a/aikau/src/main/resources/alfresco/renderers/actions/Download.js
+++ b/aikau/src/main/resources/alfresco/renderers/actions/Download.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>This module provides the configuration that can be used for rendering a [menu item]{@link module:alfresco/menus/AlfMenuItem}
+ * for the "Download" action.</p>
+ * 
+ * @module alfresco/renderers/actions/Download
+ * @author Dave Draper
+ * @since 1.0.43
+ */
+define(["alfresco/core/topics"],
+       function(topics) {
+
+   return  {
+      id: "DOWNLOAD",
+      label: "actions.download",
+      iconClass: "alf-doclib-action alf-download-icon",
+      publishTopic: topics.DOWNLOAD,
+      publishPayloadType: "CONFIGURED",
+      publishPayloadItemMixin: true,
+      publishPayload: {},
+      publishGlobal: true,
+      renderFilterMethod: "ALL",
+      renderFilter: [
+         {
+            property: "node.contentURL",
+            values: [],
+            renderOnAbsentProperty: true,
+            negate: true
+         }
+      ]
+   };
+});

--- a/aikau/src/main/resources/alfresco/renderers/css/_ActionsMixin.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/_ActionsMixin.css
@@ -12,6 +12,9 @@
          &.alf-copy-to-icon {
             background-image: url("./images/actions/document-copy-to-16.png");
          }
+         &.alf-download-icon {
+            background-image: url("./images/actions/document-download-16.png");
+         }
          &.alf-download-as-zip-icon {
             background-image: url("./images/actions/document-download-16.png");
          }

--- a/aikau/src/main/resources/alfresco/renderers/i18n/_ActionsMixin.properties
+++ b/aikau/src/main/resources/alfresco/renderers/i18n/_ActionsMixin.properties
@@ -1,5 +1,6 @@
 actions.copy-to=Copy to...
 actions.delete=Delete
+actions.download=Download
 actions.download-as-zip=Download as Zip
 actions.manage-aspects.label=Manage Aspects
 actions.move-to=Move to...

--- a/aikau/src/test/resources/alfresco/services/actions/DownloadTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/DownloadTest.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Download Action Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Download", "Download Action Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Test that action does appear for document": function() {
+            return browser.findById("ACTIONS_ITEM_0_MENU_text")
+               .click()
+            .end()
+            .findById("ACTIONS_ITEM_0_DOWNLOAD");
+         },
+
+         "Test that action does NOT appear for folder": function() {
+            return browser.findById("ACTIONS_ITEM_1_MENU_text")
+               .click()
+            .end()
+            .findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Download action should not be present for folder");
+               });
+         },
+
+         "Test download action": function() {
+            return browser.findById("ACTIONS_ITEM_0_MENU_text")
+               .click()
+            .end()
+            
+            .findById("ACTIONS_ITEM_0_DOWNLOAD_text")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.property(payload, "url", "No 'url' attribute");
+                  assert.include(payload.url, "/proxy/alfresco/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/2013-12-29%2009.58.43.jpg?a=true", "Incorrect URL");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -264,6 +264,7 @@ define({
       "src/test/resources/alfresco/services/UserServiceTest",
 
       "src/test/resources/alfresco/services/actions/CopyMoveTest",
+      "src/test/resources/alfresco/services/actions/DownloadTest",
       "src/test/resources/alfresco/services/actions/DownloadAsZipTest",
       "src/test/resources/alfresco/services/actions/ManageAspectsTest",
       "src/test/resources/alfresco/services/actions/NodeLocationTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Download.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Download.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Download</shortname>
+  <description>A test page for verifying the Download action</description>
+  <family>aikau-unit-tests</family>
+  <url>/Download</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Download.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Download.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Download.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/Download.get.js
@@ -1,0 +1,79 @@
+// jshint undef:false
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "LIST",
+         name: "alfresco/lists/views/AlfListView",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     displayName: "Document",
+                     nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                     node: {
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/2013-12-29%2009.58.43.jpg"
+                     }
+                  },
+                  {
+                     displayName: "Folder",
+                     nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                     node: {
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                     }
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  name: "alfresco/lists/views/layouts/Row",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "DISPLAY_NAME",
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "displayName"
+                                    }
+                                 },
+                                 {
+                                    id: "ACTIONS",
+                                    name: "alfresco/renderers/Actions",
+                                    config: {
+                                       widgetsForActions: [
+                                          {
+                                             name: "alfresco/renderers/actions/Download"
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-416 to add support for a "pure" Aikau download action.