### PR TITLE
AKU-644: SearchService no hash sort fix

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -229,7 +229,8 @@ define(["dojo/_base/declare",
             }
             else
             {
-               sort = (payload.sortField || this.sort) + "|" + (payload.sortAscending || this.sortAscending);
+               var sortAscending = (payload.sortAscending !== null && typeof payload.sortAscending !== "undefined") ? payload.sortAscending : this.sortAscending;
+               sort = (payload.sortField || this.sort) + "|" + sortAscending;
             }
 
             var data = {

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -27,123 +27,164 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Search Service Test",
+      return {
+         name: "Search Service Test",
 
-      setup: function() {
-         browser = this.remote;
-         // NOTE: Load with a scope set because one will be set regardless...
-         return TestCommon.loadTestWebScript(this.remote, "/SearchService#searchTerm=&scope=repo", "Search Service Test").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            // NOTE: Load with a scope set because one will be set regardless...
+            return TestCommon.loadTestWebScript(this.remote, "/SearchService#searchTerm=&scope=repo", "Search Service Test").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check there are the expected number of mocked results": function() {
-         // See AKU-619 - it should not be necessary to provide a search term in order for searching to occur...
-         return browser.findAllByCssSelector("#FCTSRCH_SEARCH_RESULTS_LIST tr.alfresco-search-AlfSearchResult")
-            .then(function (results){
-               assert.lengthOf(results, 24, "There should be 24 mocked results");
-            });
-      },
+         "Check there are the expected number of mocked results": function() {
+            // See AKU-619 - it should not be necessary to provide a search term in order for searching to occur...
+            return browser.findAllByCssSelector("#FCTSRCH_SEARCH_RESULTS_LIST tr.alfresco-search-AlfSearchResult")
+               .then(function (results){
+                  assert.lengthOf(results, 24, "There should be 24 mocked results");
+               });
+         },
 
-      "Check there are still the expected number of mocked results": function() {
-         return browser.execute("location.hash='#searchTerm=test&allSites=false&repo=true&sortField=cm%3Aname&facetFilters=%7Bhttp%3A%2F%2Fwww.alfresco.org%2Fmodel%2Fcontent%2F1.0%7Dcreator.__.u%7Cadmin&sortAscending=false'")
-         .end()
-
-         .findAllByCssSelector("#FCTSRCH_SEARCH_RESULTS_LIST tr.alfresco-search-AlfSearchResult")
-            .then(function (results){
-               assert.lengthOf(results, 24, "There should still be 24 mocked results");
-            });
-      },
-
-      "Check there are no unexpected queries": function() {
-         return browser.findByCssSelector("body")
+         "Check there are still the expected number of mocked results": function() {
+            return browser.execute("location.hash='#searchTerm=test&allSites=false&repo=true&sortField=cm%3Aname&facetFilters=%7Bhttp%3A%2F%2Fwww.alfresco.org%2Fmodel%2Fcontent%2F1.0%7Dcreator.__.u%7Cadmin&sortAscending=false'")
             .end()
 
-         .getXhrEntries({url: "&query={"})
-            .then(function(entries) {
-               assert.lengthOf(entries, 0);
-            });
-      },
+            .findAllByCssSelector("#FCTSRCH_SEARCH_RESULTS_LIST tr.alfresco-search-AlfSearchResult")
+               .then(function (results){
+                  assert.lengthOf(results, 24, "There should still be 24 mocked results");
+               });
+         },
 
-      "Repository scope should be used by default": function() {
-         return browser.findByCssSelector("body").end().getLastPublish("ALF_SEARCH_REQUEST")
+         "Check there are no unexpected queries": function() {
+            return browser.findByCssSelector("body")
+               .end()
+
+            .getXhrEntries({url: "&query={"})
+               .then(function(entries) {
+                  assert.lengthOf(entries, 0);
+               });
+         },
+
+         "Repository scope should be used by default": function() {
+            return browser.findByCssSelector("body").end().getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "repo", true, "Repository scope not requested");
+               })
+            .end()
+            .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+               .then(function(xhr){
+                  assert.include(xhr.request.url, "repo=true");
+               })
+               .clearLog();
+         },
+
+         "Switch to All Sites scope": function() {
+            return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+               .click()
+            .end()
+            .findById("FCTSRCH_SET_ALL_SITES_SCOPE_text")
+               .click()
+            .end()
+            .getLastPublish("ALF_SEARCH_REQUEST")
             .then(function(payload) {
-               assert.propertyVal(payload, "repo", true, "Repository scope not requested");
+               assert.propertyVal(payload, "repo", false, "Repository scope used");
+               assert.propertyVal(payload, "site", "", "Site incorrect");
             })
-         .end()
-         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
-            .then(function(xhr){
-               assert.include(xhr.request.url, "repo=true");
-            })
-            .clearLog();
-      },
+            .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+               .then(function(xhr){
+                  assert.include(xhr.request.url, "repo=false");
+               })
+               .clearLog();
+         },
 
-      "Switch to All Sites scope": function() {
-         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
-            .click()
-         .end()
-         .findById("FCTSRCH_SET_ALL_SITES_SCOPE_text")
-            .click()
-         .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.propertyVal(payload, "repo", false, "Repository scope used");
-            assert.propertyVal(payload, "site", "", "Site incorrect");
-         })
-         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
-            .then(function(xhr){
-               assert.include(xhr.request.url, "repo=false");
+         "Switch to Site scope": function() {
+            return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+               .click()
+            .end()
+            .findById("FCTSRCH_SET_SPECIFIC_SITE_SCOPE_text")
+               .click()
+            .end()
+            .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", false, "Repository scope used");
+               assert.propertyVal(payload, "site", "site", "Site incorrect");
             })
-            .clearLog();
-      },
+            .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+               .then(function(xhr){
+                  assert.include(xhr.request.url, "repo=false");
+                  assert.include(xhr.request.url, "site=site");
+               })
+               .clearLog();
+         },
 
-      "Switch to Site scope": function() {
-         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
-            .click()
-         .end()
-         .findById("FCTSRCH_SET_SPECIFIC_SITE_SCOPE_text")
-            .click()
-         .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.propertyVal(payload, "repo", false, "Repository scope used");
-            assert.propertyVal(payload, "site", "site", "Site incorrect");
-         })
-         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
-            .then(function(xhr){
-               assert.include(xhr.request.url, "repo=false");
-               assert.include(xhr.request.url, "site=site");
+         "Switch to Repository scope": function() {
+            return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+               .click()
+            .end()
+            .findById("FCTSRCH_SET_REPO_SCOPE_text")
+               .click()
+            .end()
+            .getLastPublish("ALF_SEARCH_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "repo", true, "Repository scope NOT used");
             })
-            .clearLog();
-      },
+            .getLastXhr("aikau/proxy/alfresco/slingshot/search")
+               .then(function(xhr){
+                  assert.include(xhr.request.url, "repo=true");
+               })
+               .clearLog();
+         },
 
-      "Switch to Repository scope": function() {
-         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
-            .click()
-         .end()
-         .findById("FCTSRCH_SET_REPO_SCOPE_text")
-            .click()
-         .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-         .then(function(payload) {
-            assert.propertyVal(payload, "repo", true, "Repository scope NOT used");
-         })
-         .getLastXhr("aikau/proxy/alfresco/slingshot/search")
-            .then(function(xhr){
-               assert.include(xhr.request.url, "repo=true");
-            })
-            .clearLog();
-      },
+         "Change sort field": function() {
+            return browser.findById("FCTSRCH_SORT_MENU_text")
+               .click()
+            .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+            .clearLog()
+            .clearXhrLog()
+
+            .findDisplayedById("SORT_BY_NAME_text")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "sortField", "cm:name", "Sort field not updated correctly");
+               })
+
+            .getLastXhr()
+               .then(function(xhr) {
+                  assert.include(xhr.request.url, encodeURIComponent("cm:name|true"), "Sort not correctly requested");
+               });
+         },
+
+         "Change sort order": function() {
+            return browser.findByCssSelector("#FCTSRCH_SORT_ORDER_TOGGLE img.dijitMenuItemIcon")
+               .clearLog()
+               .clearXhrLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "sortAscending", "false", "Sort order not updated correctly");
+               })
+
+            .getLastXhr()
+               .then(function(xhr) {
+                  assert.include(xhr.request.url, encodeURIComponent("cm:name|false"), "Sort order not correctly requested");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SearchServiceTest.js
@@ -187,4 +187,67 @@ define(["intern!object",
          }
       };
    });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Search Service Test (no hashing)",
+
+         setup: function() {
+            browser = this.remote;
+            // NOTE: Load with a scope set because one will be set regardless...
+            return TestCommon.loadTestWebScript(this.remote, "/SearchService?useHash=false", "Search Service Test (no hashing)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Change sort field": function() {
+            return browser.findById("FCTSRCH_SORT_MENU_text")
+               .click()
+            .end()
+
+            .clearLog()
+            .clearXhrLog()
+
+            .findDisplayedById("SORT_BY_NAME_text")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "sortField", "cm:name", "Sort field not updated correctly");
+               })
+
+            .getLastXhr()
+               .then(function(xhr) {
+                  assert.include(xhr.request.url, encodeURIComponent("cm:name|true"), "Sort not correctly requested");
+               });
+         },
+
+         "Change sort order": function() {
+            return browser.findByCssSelector("#FCTSRCH_SORT_ORDER_TOGGLE img.dijitMenuItemIcon")
+               .clearLog()
+               .clearXhrLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "sortAscending", false, "Sort order not updated correctly");
+               })
+
+            .getLastXhr()
+               .then(function(xhr) {
+                  assert.include(xhr.request.url, encodeURIComponent("cm:name|false"), "Sort order not correctly requested");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SearchService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SearchService.get.js
@@ -1,3 +1,11 @@
+/* global page*/
+/* jshint sub:true */
+var useHash = true;
+if (page.url.args["useHash"])
+{
+   useHash = (page.url.args["useHash"] === "true");
+}
+
 model.jsonModel = {
    services: [
       {
@@ -42,7 +50,7 @@ model.jsonModel = {
                                                 group: "SEARCHLIST_SCOPE",
                                                 publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
                                                 checked: false,
-                                                hashName: "scope",
+                                                hashName: (useHash ? "scope" : null),
                                                 publishPayload: {
                                                    label: "Site",
                                                    value: "site"
@@ -58,7 +66,7 @@ model.jsonModel = {
                                                 group: "SEARCHLIST_SCOPE",
                                                 publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
                                                 checked: false,
-                                                hashName: "scope",
+                                                hashName: (useHash ? "scope" : null),
                                                 publishPayload: {
                                                    label: "All Sites",
                                                    value: "all_sites"
@@ -74,7 +82,7 @@ model.jsonModel = {
                                                 group: "SEARCHLIST_SCOPE",
                                                 publishTopic: "ALF_SEARCHLIST_SCOPE_SELECTION",
                                                 checked: true,
-                                                hashName: "scope",
+                                                hashName: (useHash ? "scope" : null),
                                                 publishPayload: {
                                                    label: "Repository",
                                                    value: "repo"
@@ -165,7 +173,7 @@ model.jsonModel = {
                   id: "FCTSRCH_SEARCH_FORM",
                   name: "alfresco/forms/SingleTextFieldForm",
                   config: {
-                     useHash: true,
+                     useHash: useHash,
                      okButtonLabel: "Ok",
                      okButtonPublishTopic: "ALF_SET_SEARCH_TERM",
                      okButtonPublishGlobal: true,
@@ -184,7 +192,7 @@ model.jsonModel = {
                      viewPreferenceProperty: "org.alfresco.share.searchList.viewRendererName",
                      view: "simple",
                      waitForPageWidgets: false,
-                     useHash: true,
+                     useHash: useHash,
                      hashVarsForUpdate: [
                         "searchTerm",
                         "facetFilters",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SearchService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SearchService.get.js
@@ -86,6 +86,77 @@ model.jsonModel = {
                                  }
                               ]
                            }
+                        },
+                        {
+                           id: "FCTSRCH_SORT_ORDER_TOGGLE",
+                           name: "alfresco/menus/AlfMenuBarToggle",
+                           config: {
+                              checked: true,
+                              onConfig: {
+                                 iconClass: "alf-sort-ascending-icon",
+                                 publishTopic: "ALF_DOCLIST_SORT",
+                                 publishPayload: {
+                                    direction: "ascending"
+                                 }
+                              },
+                              offConfig: {
+                                 iconClass: "alf-sort-descending-icon",
+                                 publishTopic: "ALF_DOCLIST_SORT",
+                                 publishPayload: {
+                                    direction: "descending"
+                                 }
+                              }
+                           }
+                        },
+                        {
+                           id: "FCTSRCH_SORT_MENU",
+                           name: "alfresco/menus/AlfMenuBarSelect",
+                           config: {
+                              title: "Sort by",
+                              selectionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+                              widgets: [
+                                 {
+                                    id: "DOCLIB_SORT_FIELD_SELECT_GROUP",
+                                    name: "alfresco/menus/AlfMenuGroup",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "SORT_BY_RELEVANCE",
+                                             name: "alfresco/menus/AlfCheckableMenuItem",
+                                             config: {
+                                                label: "Relevance",
+                                                value: "",
+                                                group: "DOCUMENT_LIBRARY_SORT_FIELD",
+                                                publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+                                                checked: true,
+                                                publishPayload: {
+                                                   label: "Relevance",
+                                                   direction: "ascending",
+                                                   sortable: false
+                                                }
+                                             }
+                                          },
+                                          {
+                                             id: "SORT_BY_NAME",
+                                             name: "alfresco/menus/AlfCheckableMenuItem",
+                                             config: {
+                                                label: "Name",
+                                                value: "cm:name",
+                                                group: "DOCUMENT_LIBRARY_SORT_FIELD",
+                                                publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+                                                checked: false,
+                                                publishPayload: {
+                                                   label: "Name",
+                                                   direction: "ascending",
+                                                   sortable: true
+                                                }
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
                         }
                      ]
                   }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-664 to ensure that the SearchService can handle requests to change sort order when URL hashing is not being used. The unit tests have been updated to support both hashing and non-hashing scenarios.