### PR TITLE
AKU-663: Path tree node highlight on expand

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -130,6 +130,11 @@ define(["dojo/_base/declare",
                this.tree._expandNode(targetChildNode);
                this.expandPathElement(targetChildNode, pathElements);
             }
+            else
+            {
+               // Focus the last expanded node
+               this.tree.focusNode(node);
+            }
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -132,8 +132,7 @@ define(["dojo/_base/declare",
             }
             else
             {
-               // Focus the last expanded node
-               // this.tree.focusNode(node);
+               // Select the last expanded node
                node.setSelected(true);
             }
          }

--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -133,7 +133,8 @@ define(["dojo/_base/declare",
             else
             {
                // Focus the last expanded node
-               this.tree.focusNode(node);
+               // this.tree.focusNode(node);
+               node.setSelected(true);
             }
          }
       }

--- a/aikau/src/main/resources/alfresco/navigation/Tree.js
+++ b/aikau/src/main/resources/alfresco/navigation/Tree.js
@@ -47,6 +47,21 @@ define(["dojo/_base/declare",
         function(declare, _Widget, _Templated, template, _PublishPayloadMixin, AlfCore, CoreWidgetProcessing, topics, AlfConstants, _AlfDocumentListTopicMixin, 
                  _NavigationServiceTopicMixin, domConstruct, lang, array, TreeStore, ObjectStoreModel, Tree) {
    
+   // Extend the standard Dijit tree to support better identification of nodes (primarily for the purpose of unit testing)...
+   var AikauTree = declare([Tree], {
+      _createTreeNode: function alfresco_navigation_Tree_AikauTree___createTreeNode(){
+         var id = lang.getObject("item.id", false, arguments[0]);
+         if (id)
+         {
+            declare.safeMixin(arguments[0], {
+               id: this.id + "_" + id.replace("://", "_").replace("/", "_") // Clean up NodeRef IDs
+            });
+         }
+         return this.inherited(arguments);
+      }
+   });
+
+
    return declare([_Widget, _Templated, _PublishPayloadMixin, AlfCore, CoreWidgetProcessing, _AlfDocumentListTopicMixin, _NavigationServiceTopicMixin], {
       
       /**
@@ -271,7 +286,8 @@ define(["dojo/_base/declare",
          });
          
          // Create the tree and add it to our widget...
-         this.tree = new Tree({
+         this.tree = new AikauTree({
+            id: this.id + "_TREE",
             model: this.treeModel,
             showRoot: this.showRoot,
             onClick: lang.hitch(this, this.onClick),

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -155,12 +155,8 @@ define(["intern!object",
                });
          },
 
-         "Check that expanded node is focused": function() {
-            return browser.getActiveElement()
-               .getVisibleText()
-                  .then(function(text) {
-                     assert.equal(text, "Invoices", "The expanded node was not focused");
-                  });
+         "Check that expanded node is selected": function() {
+            return browser.findByCssSelector("#TREE2_TREE_workspace_SpacesStore_d56afdc3-0174-4f8c-bce8-977cafd712ab > .dijitTreeRowSelected");
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -21,145 +21,151 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"],
-   function(registerSuite, expect, assert, require, TestCommon) {
+   function(registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Path Tree Tests",
+      return {
+         name: "Path Tree Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/PathTree", "Path Tree Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "Test root is shown on TREE1": function() {
+            return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Custom Root", "The root node of TREE1 was not as expected");
+               });
+         },
+         
+         "Test that root is NOT shown on TREE2": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The root node of TREE2 was displayed unexpectedly");
+               });
+         },
+        
+         "Test that first node of TREE2 is Document Library": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Document Library", "The root node of TREE2 was not as expected");
+               });
+         },
+        
+         "Test that clicking on TREE1 publishes path": function() {
+            return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "path", "/", "Clicking on the root of TREE1 did not publish the expected path");
+               });
+         },
       
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/PathTree", "Path Tree Tests").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
-      
-      "Test root is shown on TREE1": function() {
-         return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Custom Root", "The root node of TREE1 was not as expected");
-            });
-      },
-      
-      "Test that root is NOT shown on TREE2": function() {
-         return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The root node of TREE2 was displayed unexpectedly");
-            });
-      },
+         "Test that clicking on TREE2 publishes custom topic": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .getLastPublish("ALF_ITEM_SELECTED", "The topic published by clicking on TREE2 nodes is not requested custom topic");
+         },
      
-      "Test that first node of TREE2 is Document Library": function() {
-         return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Document Library", "The root node of TREE2 was not as expected");
-            });
-      },
+         "Test that TREE1 has NOT filtered site containers": function() {
+            return browser.findAllByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 5, "TREE1 did not have the expected number of nodes under the root");
+               });
+         },
      
-      "Test that clicking on TREE1 publishes path": function() {
-         return browser.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
-            .click()
-         .end()
-         .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
-            .then(function(payload) {
-               assert.propertyVal(payload, "path", "/", "Clicking on the root of TREE1 did not publish the expected path");
-            });
-      },
-   
-      "Test that clicking on TREE2 publishes custom topic": function() {
-         return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
-            .click()
-         .end()
-         .getLastPublish("ALF_ITEM_SELECTED", "The topic published by clicking on TREE2 nodes is not requested custom topic");
-      },
-  
-      "Test that TREE1 has NOT filtered site containers": function() {
-         return browser.findAllByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow")
-            .then(function(elements) {
-               assert.lengthOf(elements, 5, "TREE1 did not have the expected number of nodes under the root");
-            });
-      },
-  
-      "Test that TREE2 has filtered site containers": function() {
-         return browser.findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "TREE2 did not have the expected number of nodes under the root");
-            });
-      },
+         "Test that TREE2 has filtered site containers": function() {
+            return browser.findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "TREE2 did not have the expected number of nodes under the root");
+               });
+         },
 
-      "Test that TREE2 Document Library is NOT expanded": function() {
-         return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The child nodes of the Document Library in TREE2 were initially displayed");
-            });
-      },
- 
-      "Test that child nodes of TREE2 Document Library are not loaded": function() {
-         return browser.findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "The child nodes of the Document Library in TREE2 were loaded before being requested");
-            });
-      },
+         "Test that TREE2 Document Library is NOT expanded": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The child nodes of the Document Library in TREE2 were initially displayed");
+               });
+         },
+    
+         "Test that child nodes of TREE2 Document Library are not loaded": function() {
+            return browser.findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The child nodes of the Document Library in TREE2 were loaded before being requested");
+               });
+         },
 
-      "Test that opening a node loads its children": function() {
-         return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeExpando")
-            .click()
-         .end()
-         .findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "The child nodes of the Document Library in TREE2 were not loaded when requested");
-            });
-      },
- 
-      "Test that paths are correct for child nodes": function() {
-         return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > div:first-child div.dijitTreeRow .dijitTreeLabel")
-            .click()
-         .end()
-         .getLastPublish("ALF_ITEM_SELECTED")
-            .then(function(payload) {
-               assert.propertyVal(payload, "path", "/documentLibrary/Agency Files/", "Clicking on a child node of TREE2 did not publish the expected path");
-            });
-      },
+         "Test that opening a node loads its children": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeExpando")
+               .click()
+            .end()
+            .findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "The child nodes of the Document Library in TREE2 were not loaded when requested");
+               });
+         },
+    
+         "Test that paths are correct for child nodes": function() {
+            return browser.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > div:first-child div.dijitTreeRow .dijitTreeLabel")
+               .click()
+            .end()
+            .getLastPublish("ALF_ITEM_SELECTED")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "path", "/documentLibrary/Agency Files/", "Clicking on a child node of TREE2 did not publish the expected path");
+               });
+         },
 
-      "Publish hash change": function() {
-         return browser.findById("SET_HASH_label")
-            .click()
-         .end()
-         .findAllByCssSelector("#TREE1 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Setting the hash did not expand the first tree");
-            })
-         .end()
-         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Setting the hash should not have expanded the second tree");
-            });
-      },
+         "Publish hash change": function() {
+            return browser.findById("SET_HASH_label")
+               .click()
+            .end()
+            .findAllByCssSelector("#TREE1 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Setting the hash did not expand the first tree");
+               })
+            .end()
+            .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Setting the hash should not have expanded the second tree");
+               });
+         },
 
-      "Publish path change": function() {
-         return browser.findById("SET_PATH_label")
-            .click()
-         .end()
-         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Setting the path did not expand the second tree");
-            });
-      },
+         "Publish path change": function() {
+            return browser.findById("SET_PATH_label")
+               .click()
+            .end()
+            .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Setting the path did not expand the second tree");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Check that expanded node is focused": function() {
+            return browser.getActiveElement()
+               .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "Invoices", "The expanded node was not focused");
+                  });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
   <shortname>PathTree Test</shortname>
+  <description>This test page shows the alfresco/navigation/PathTree widget configured for both URL hashing and non-URL hashing modes.</description>
   <family>aikau-unit-tests</family>
   <url>/PathTree</url>
 </webscript>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-663 to ensure that the PathTree highlights nodes when they are expanded. The unit has been updated and the PathTree has also been updated to improve the way in which tree nodes are given IDs to assist with unit testing