### PR TITLE
AKU-678: Button causing WAVE a11y error

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -138,6 +138,10 @@ define(["dojo/_base/declare",
             this.alfSubscribe(this.invalidTopic, lang.hitch(this, "onInvalidControl"));
             this.alfSubscribe(this.validTopic, lang.hitch(this, "onValidControl"));
          }
+
+         if (!this.value && this.publishTopic) {
+            this.valueNode.setAttribute("value", this.publishTopic);
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -239,7 +239,7 @@ define(["alfresco/core/ProcessWidgets",
          this.alfPublishResizeEvent(this.domNode);
 
          // Setup the header resize listener
-         this.addResizeListener(this.header);
+         this.own(this.addResizeListener(this.header));
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/util/domUtils.js
+++ b/aikau/src/main/resources/alfresco/util/domUtils.js
@@ -39,71 +39,76 @@ define([
          // See API below
          addResizeListener: function alfresco_util_domUtils__addResizeListener(node, resizeHandler) {
 
-            // Setup the resize listener function
-            var resizeObj,
-               onLoadListener,
-               removeListenerFunc;
+            // Setup the listener-removal object
+            var listenerRemovalObj = {};
 
-            // NOTE: Dojo IE detection not working very well here, so done manually instead
-            var ieRegex = /(Trident\/)|(Edge\/)/,
-               isIE = has("IE") || ieRegex.test(navigator.userAgent);
+            // Do the rest of the work asynchronously to prevent widget-loading problems
+            setTimeout(function() {
 
-            // Create the resize object
-            resizeObj = document.createElement("object");
-            resizeObj.className = "alfresco-core-ResizeMixin__resize-object";
-            resizeObj.type = "text/html";
-            domStyle.set(resizeObj, {
-               "display": "block",
-               "height": "100%",
-               "left": 0,
-               "overflow": "hidden",
-               "position": "absolute",
-               "top": 0,
-               "width": "100%",
-               "z-index": -1
-            });
+               // Setup the resize listener function
+               var resizeObj,
+                  onLoadListener,
+                  removeListenerFunc;
 
-            // Setup the resize listener functionality
-            onLoadListener = on(resizeObj, "load", function() {
-               resizeObj.contentDocument.defaultView.addEventListener("resize", resizeHandler);
-               removeListenerFunc = function() {
-                  resizeObj.contentDocument.defaultView.removeEventListener("resize", resizeHandler);
-               };
-               onLoadListener.remove();
-            });
+               // NOTE: Dojo IE detection not working very well here, so done manually instead
+               var ieRegex = /(Trident\/)|(Edge\/)/,
+                  isIE = has("IE") || ieRegex.test(navigator.userAgent);
 
-            // Node cannot have position static
-            var nodeStyle = getComputedStyle(node),
-               nodeIsStatic = nodeStyle.position === "static";
-            if (nodeIsStatic) {
-               node.style.position = "relative";
-            }
+               // Create the resize object
+               resizeObj = document.createElement("object");
+               resizeObj.className = "alfresco-core-ResizeMixin__resize-object";
+               resizeObj.type = "text/html";
+               domStyle.set(resizeObj, {
+                  "display": "block",
+                  "height": "100%",
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                  "z-index": -1
+               });
 
-            // FF doesn't like visibility hidden (interferes with the resize event), Chrome doesn't care, IE needs it
-            if (isIE) {
-               resizeObj.style.visibility = "hidden";
-            }
+               // Setup the resize listener functionality
+               onLoadListener = on(resizeObj, "load", function() {
+                  resizeObj.contentDocument.defaultView.addEventListener("resize", resizeHandler);
+                  removeListenerFunc = function() {
+                     resizeObj.contentDocument.defaultView.removeEventListener("resize", resizeHandler);
+                  };
+                  onLoadListener.remove();
+               });
 
-            // Normal browsers do this before appending to the DOM
-            if (!isIE) {
-               resizeObj.data = "about:blank";
-            }
+               // Node cannot have position static
+               var nodeStyle = getComputedStyle(node),
+                  nodeIsStatic = nodeStyle.position === "static";
+               if (nodeIsStatic) {
+                  node.style.position = "relative";
+               }
 
-            // Add the object to the document
-            if (node.hasChildNodes()) {
-               node.insertBefore(resizeObj, node.firstChild);
-            } else {
-               node.appendChild(resizeObj);
-            }
+               // FF doesn't like visibility hidden (interferes with the resize event), Chrome doesn't care, IE needs it
+               if (isIE) {
+                  resizeObj.style.visibility = "hidden";
+               }
 
-            // IE needs to do this after
-            if (isIE) {
-               resizeObj.data = "about:blank";
-            }
+               // Normal browsers do this before appending to the DOM
+               if (!isIE) {
+                  resizeObj.data = "about:blank";
+               }
 
-            // Pass back the listener-removal object
-            return {
-               remove: function() {
+               // Add the object to the document
+               if (node.hasChildNodes()) {
+                  node.insertBefore(resizeObj, node.firstChild);
+               } else {
+                  node.appendChild(resizeObj);
+               }
+
+               // IE needs to do this after
+               if (isIE) {
+                  resizeObj.data = "about:blank";
+               }
+
+               // Update the listener removal object to add the remove function
+               listenerRemovalObj.remove = function() {
                   /*jshint devel:true*/
                   try {
                      removeListenerFunc();
@@ -111,8 +116,11 @@ define([
                   } catch (e) {
                      console.warn("Error attempting to remove resize listener", e);
                   }
-               }
-            };
+               };
+            }, 0);
+
+            // Pass back the listener-removal object
+            return listenerRemovalObj;
          }
       };
 

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -166,6 +166,21 @@ registerSuite(function(){
             });
       },
 
+      "Ensure hidden button inputs have value": function() {
+         return browser.findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(1) input[type=\"button\"]")
+            .getAttribute("value")
+            .then(function(value) {
+               assert.equal(value, "OK");
+            })
+            .end()
+
+         .findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(2) input[type=\"button\"]")
+            .getAttribute("value")
+            .then(function(value) {
+               assert.equal(value, "CANCEL");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -82,6 +82,8 @@ model.jsonModel = {
                   name: "alfresco/forms/Form",
                   id: "BASIC_FORM",
                   config: {
+                     okButtonPublishTopic: "OK",
+                     cancelButtonPublishTopic: "CANCEL",
                      widgets: [
                         {
                            id: "FORM_FIELD",


### PR DESCRIPTION
This addresses [AKU-678](https://issues.alfresco.com/jira/browse/AKU-678) and fixes an automated error-generation from the WAVE plugin to do with an input[type=button] not having a value. This PR also tweaks the resizing code slightly to fix a failing test discovered while running a full test suite for this change.