### PR TITLE
AKU-668: Vary-label single button on upload dialog

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -794,6 +794,31 @@ define([],function() {
       UPDATE_PAGE_TITLE: "ALF_UPDATE_PAGE_TITLE",
 
       /**
+       * This topic is published when the user acknowledges the completion of uploading files to the
+       * repository
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.43
+       *
+       * @event
+       */
+      UPLOAD_COMPLETION_ACKNOWLEDGEMENT: "ALF_UPLOAD_DIALOG_OK_CLICK",
+
+      /**
+       * This topic is published to cancel any file uploads that are currently in progress.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.43
+       *
+       * @event
+       */
+      UPLOAD_CANCELLATION: "ALF_UPLOAD_DIALOG_CANCEL_CLICK",
+
+      /**
        * This topic can be published to display a dialog that allows users to select one or more files
        * to upload and the location to upload them to. This is typically handled by the 
        * [ContentService]{@link module:alfresco/services/ContentService}.

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -216,6 +216,8 @@ define(["dojo/_base/declare",
       /**
        * @instance
        * @since 1.0.32
+       * @listens module:alfresco/core/topics#UPLOAD_COMPLETION_ACKNOWLEDGEMENT
+       * @listens module:alfresco/core/topics#UPLOAD_CANCELLATION
        */
       registerSubscriptions: function alfresco_services_UploadService__registerSubscriptions() {
          this.reset();
@@ -234,10 +236,8 @@ define(["dojo/_base/declare",
          {
             // Create topics to give to the dialog buttons, then subscribe to them to handle the
             // events...
-            var okButtonClickTopic = "ALF_UPLOAD_DIALOG_OK_CLICK",
-                cancelButtonClickTopic = "ALF_UPLOAD_DIALOG_CANCEL_CLICK";
-            this.alfSubscribe(okButtonClickTopic, lang.hitch(this, "onProgressDialogOkClick"));
-            this.alfSubscribe(cancelButtonClickTopic, lang.hitch(this, "onProgressDialogCancelClick"));
+            this.alfSubscribe(topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT, lang.hitch(this, this.onProgressDialogOkClick));
+            this.alfSubscribe(topics.UPLOAD_CANCELLATION, lang.hitch(this, this.onProgressDialogCancelClick));
 
             // Create a new dialog... the content is variable, but the widgets are fixed...
             this.progressDialog = new AlfDialog({
@@ -246,20 +246,13 @@ define(["dojo/_base/declare",
                widgetsContent: this.widgetsForProgressDialog,
                widgetsButtons: [
                   {
-                     id: "ALF_UPLOAD_PROGRESS_DIALOG_CONFIRMATION",
-                     name: "alfresco/buttons/AlfButton",
-                     config: {
-                        label: this.message("progress-dialog.ok-button.label"),
-                        publishTopic: okButtonClickTopic,
-                        additionalCssClasses: "call-to-action"
-                     }
-                  },
-                  {
                      id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
                      name: "alfresco/buttons/AlfButton",
+                     assignTo: "_uploadDialogButton",
                      config: {
                         label: this.message("progress-dialog.cancel-button.label"),
-                        publishTopic: cancelButtonClickTopic
+                        publishTopic: topics.UPLOAD_CANCELLATION,
+                        additionalCssClasses: "call-to-action"
                      }
                   }
                ]
@@ -536,6 +529,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       spawnFileUploads: function alfresco_services_UploadService__spawnFileUploads() {
+         var uploadStarted = false;
          for (var key in this.fileStore)
          {
             if (this.fileStore.hasOwnProperty(key))
@@ -545,11 +539,22 @@ define(["dojo/_base/declare",
                {
                   // Start upload
                   this.startFileUpload(fileInfo);
+                  uploadStarted = true;
 
                   // For now only allow 1 upload at a time
-                  return;
+                  break;
                }
             }
+         }
+
+         if (!uploadStarted)
+         {
+            // No-more uploads to begin, this is called at the end of every upload
+            // regardless of success or failure...
+            var button = this.progressDialog._uploadDialogButton;
+            button.setLabel(this.message("progress-dialog.ok-button.label"));
+            button.publishTopic = topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT;
+            this.progressDialog.titleNode.innerHTML = this.message("progress-dialog-complete.title");
          }
       },
 
@@ -922,6 +927,7 @@ define(["dojo/_base/declare",
              this.uploadDisplayWidget !== undefined && 
              typeof this.uploadDisplayWidget.reset === "function")
          {
+            this.resetDialog();
             this.uploadDisplayWidget.reset();
          }
          else
@@ -964,6 +970,7 @@ define(["dojo/_base/declare",
              this.uploadDisplayWidget !== undefined && 
              typeof this.uploadDisplayWidget.reset === "function")
          {
+            this.resetDialog();
             this.uploadDisplayWidget.reset();
          }
          else
@@ -975,6 +982,20 @@ define(["dojo/_base/declare",
             this.alfPublish(this.currentResponseTopic, {
             }, true);
          }
+      },
+
+      /**
+       * Resets the title and button labels of the dialog to indicate that upload is in progress
+       * (ready for start of the next upload).
+       * 
+       * @instance
+       * @since 1.0.43
+       */
+      resetDialog: function alfresco_services_UploadService__resetDialog() {
+         var button = this.progressDialog._uploadDialogButton;
+         button.setLabel(this.message("progress-dialog.cancel-button.label"));
+         button.publishTopic = topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT;
+         this.progressDialog.titleNode.innerHTML = this.message("progress-dialog.title");
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/i18n/UploadService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/UploadService.properties
@@ -1,3 +1,4 @@
 progress-dialog.title=Uploading...
+progress-dialog-complete.title=Uploading Finished
 progress-dialog.ok-button.label=OK
 progress-dialog.cancel-button.label=Cancel

--- a/aikau/src/main/resources/alfresco/upload/AlfUploadDisplay.js
+++ b/aikau/src/main/resources/alfresco/upload/AlfUploadDisplay.js
@@ -18,9 +18,6 @@
  */
 
 /**
- * This module is currently in BETA. Outstanding work:
- * - overall styling design and CSS
- *
  * This module provides simple display handling for file uploads. It displays completed, in progress and failed
  * file uploads in separate sections along with a displayed value of the overall upload progress. 
  *
@@ -70,13 +67,13 @@ define(["dojo/_base/declare",
       templateString: template,
 
       /**
-       * The title to display for upload dialog.
-       * 
+       * The description to display for the upload dialog. 
+       *
        * @instance
        * @type {string}
        * @default
-       */
-      title: "title.label",
+       */     
+      aggregateProgressLabel: "aggregate-progress.label",
 
       /**
        * The description to display for the upload dialog. 
@@ -94,7 +91,34 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
+      failedUploadsLabel: "failed.label",
+
+      /**
+       * A map of file IDs to the DOM element that describes them.
+       *
+       * @instance
+       * @type {object}
+       * @default
+       */
+      inProgressFiles: null,
+
+      /**
+       * The description to display for the upload dialog. 
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
       successfulUploadsLabel: "completed.label",
+
+      /**
+       * The title to display for upload dialog.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      title: "title.label",
 
       /**
        * The description to display for the upload dialog. 
@@ -106,22 +130,13 @@ define(["dojo/_base/declare",
       uploadsInProgressLabel: "inprogress.label",
 
       /**
-       * The description to display for the upload dialog. 
+       * A map of the uploaded files.
        *
        * @instance
-       * @type {string}
-       * @default
-       */     
-      aggregateProgressLabel: "aggregate-progress.label",
-
-      /**
-       * The description to display for the upload dialog. 
-       *
-       * @instance
-       * @type {string}
+       * @type {object}
        * @default
        */
-      failedUploadsLabel: "failed.label",
+      uploadedFiles: null,
 
       /**
        * Resets the display.
@@ -156,24 +171,6 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_upload_AlfUploadDisplay__postCreate() {
          this.reset();
       },
-
-      /**
-       * A map of file IDs to the DOM element that describes them.
-       *
-       * @instance
-       * @type {object}
-       * @default
-       */
-      inProgressFiles: null,
-
-      /**
-       * A map of the uploaded files.
-       *
-       * @instance
-       * @type {object}
-       * @default
-       */
-      uploadedFiles: null,
 
       /**
        * This function handles displaying a file that an attempt will be made to upload. The
@@ -216,12 +213,12 @@ define(["dojo/_base/declare",
          var failedFile = domConstruct.create("tr", {
             className: "file"
          }, this.failedItemsNode);
-         var fileName = domConstruct.create("td", {
+         domConstruct.create("td", {
              innerHTML: fileName,
              className: "filename"
          }, failedFile);
-         var reason = domConstruct.create("td", {
-             innerHTML: (error != null && error.reason != null) ? error.reason : message.get("unknown.failure.reason"),
+         domConstruct.create("td", {
+             innerHTML: (error && error.reason) ? error.reason : this.message("unknown.failure.reason"),
              className: "reason"
          }, failedFile);
       },
@@ -234,7 +231,7 @@ define(["dojo/_base/declare",
        * @param {number} percentageComplete The current upload progress as a percentage
        * @param {object} progressEvt The progress event
        */
-      updateUploadProgress: function alfresco_upload_AlfUploadDisplay__updateUploadProgress(fileId, percentageComplete, progressEvt) {
+      updateUploadProgress: function alfresco_upload_AlfUploadDisplay__updateUploadProgress(fileId, percentageComplete, /*jshint unused:false*/ progressEvt) {
          // Set progress position
          // var left = (-400 + ((percentage/100) * 400));
          var inProgressFile = this.inProgressFiles[fileId];
@@ -272,13 +269,13 @@ define(["dojo/_base/declare",
          // Parse the request to get the information about the resulting nodes that have been created
          // This information could be used to allow actions or links to be generated for the uploaded content
          // before the display is closed...
-         if (request != null && request.responseText != null)
+         if (request && request.responseText)
          {
             var jsonResponse = dojoJson.parse(request.responseText);
             this.uploadedFiles[fileId] = {
                nodeRef: jsonResponse.nodeRef,
                fileName: jsonResponse.fileName
-            }
+            };
          }
       },
 
@@ -296,7 +293,7 @@ define(["dojo/_base/declare",
          domConstruct.destroy(inProgressFile.node);
 
          var reason = this.message("upload.failure.reason.unknown");
-         if (request != null && request.statusText != null)
+         if (request && request.statusText)
          {
             reason = request.statusText;
          }

--- a/aikau/src/test/resources/alfresco/upload/UploadTargetTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadTargetTest.js
@@ -25,82 +25,88 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Upload Target and History Tests",
+      return {
+         name: "Upload Target and History Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/UploadDashlet", "Upload Target and History Tests").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
-      
-      "History should not be initially visible": function() {
-         return browser.findById("HISTORY")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The history widget should have been initially hidden");
-            });
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/UploadDashlet", "Upload Target and History Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "History should not be initially visible": function() {
+            return browser.findById("HISTORY")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The history widget should have been initially hidden");
+               });
+         },
 
-      "Click the upload button": function() {
-         // NOTE: It's not actually possible to perform the upload, so we just want to verify that the upload
-         //       button produces the expected dialog
-         return browser.findByCssSelector(".alfresco-upload-UploadTarget__button .alfresco-buttons-AlfButton > span")
-            .click()
-         .end()
-         .findByCssSelector("#ALF_UPLOAD_TO_LOCATION_DIALOG.dialogDisplayed")
-         .end()
+         "Click the upload button": function() {
+            // NOTE: It's not actually possible to perform the upload, so we just want to verify that the upload
+            //       button produces the expected dialog
+            return browser.findByCssSelector(".alfresco-upload-UploadTarget__button .alfresco-buttons-AlfButton > span")
+               .click()
+            .end()
 
-         // Check the form controls are in place as expected...
-         .findById("ALF_UPLOAD_TO_LOCATION_DIALOG_FILE_SELECT")
-         .end()
-         .findById("ALF_UPLOAD_TO_LOCATION_DIALOG_CONTAINER_PICKER")
-         .end()
+            .findByCssSelector("#ALF_UPLOAD_TO_LOCATION_DIALOG.dialogDisplayed")
+            .end()
 
-         // Close the dialog
-         .findById("ALF_UPLOAD_TO_LOCATION_DIALOG_CANCEL_label")
-            .click()
-         .end();
-      },
+            // Check the form controls are in place as expected...
+            .findById("ALF_UPLOAD_TO_LOCATION_DIALOG_FILE_SELECT")
+            .end()
+            
+            .findById("ALF_UPLOAD_TO_LOCATION_DIALOG_CONTAINER_PICKER")
+            .end()
 
-      "Simulate dialog completion": function() {
-         // NOTE: A button has been added to simulate a payload that might be expected to be published when the upload
-         //       dialog is submitted
-         return browser.findById("SIM_BUTTON_label")
-            .click()
-         .end()
+            // Close the dialog
+            .findById("ALF_UPLOAD_TO_LOCATION_DIALOG_CANCEL_label")
+               .click()
+            .end();
+         },
 
-         // Check that the upload progress dialog is displayed
-         .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
-         .end()
+         "Simulate dialog completion": function() {
+            // NOTE: A button has been added to simulate a payload that might be expected to be published when the upload
+            //       dialog is submitted
+            return browser.findById("SIM_BUTTON_label")
+               .click()
+            .end()
 
-         // Close the dialog...
-         .findById("ALF_UPLOAD_PROGRESS_DIALOG_CONFIRMATION_label")
-         .click();
-      },
+            // Check that the upload progress dialog is displayed
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
+            .end()
 
-      "Check that history is displayed": function() {
-         return browser.findById("HISTORY")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The history was not displayed after a successful upload");
-            })
-         .end()
-         .findAllByCssSelector(".alfresco-upload-UploadHistory__target")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Unexpected number of history targets were displayed");
-            });
-      },
+            // Close the dialog...
+            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .click()
+            .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+         },
+
+         "Check that history is displayed": function() {
+            return browser.findById("HISTORY")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The history was not displayed after a successful upload");
+               })
+            .end()
+
+            .findAllByCssSelector(".alfresco-upload-UploadHistory__target")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Unexpected number of history targets were displayed");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/upload/UploadTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadTest.js
@@ -21,11 +21,9 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, expect, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
    var uploadsSelector = ".alfresco-dialog-AlfDialog .alfresco-upload-AlfUploadDisplay .uploads";
    var successfulUploadsSelector = uploadsSelector + "> .successful table tr";
@@ -35,174 +33,188 @@ define(["intern!object",
    var cancelButtonSelector = ".alfresco-dialog-AlfDialog .footer > span:nth-child(2) > span";
    var dialogDelay = 500;
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Upload Failure Tests",
+      return {
+         name: "Upload Failure Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/aikau-upload-failure-unit-test", "Upload Failure").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
-      
-      // teardown: function() {
-      //    return browser.end().alfPostCoverageResults(browser);
-      // },
-      
-      "Upload Failure": function () {
-         // Simulate providing a zero byte file and check the output...
-         return browser.findByCssSelector("#SINGLE_UPLOAD_label")
-            .click()
-            .sleep(dialogDelay)
-         .end()
-         .findAllByCssSelector(failedUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 1, "Test #1a - Wrong number of failed uploads, expected 1, found: " + elements.length);
-            })
-         .end()
-         .findByCssSelector(cancelButtonSelector)
-            .click()
-            .sleep(dialogDelay)
-         .end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/aikau-upload-failure-unit-test", "Upload Failure").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "Upload Failure": function () {
+            // Simulate providing a zero byte file and check the output...
+            return browser.findById("SINGLE_UPLOAD_label")
+               .click()
+            .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
+            .end()
+
+            .findAllByCssSelector(failedUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Wrong number of failed uploads");
+               })
+            .end()
+
+            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Upload Tests",
-      
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/aikau-upload-unit-test", "Upload").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
-      
-      // teardown: function() {
-      //    return browser.end().alfPostCoverageResults(browser);
-      // },
-      
-      "Test bad file data": function () {
-         // Simulate providing a zero byte file and check the output...
-         return browser.findByCssSelector("#BAD_FILE_DATA_label")
-            .click()
-            .sleep(dialogDelay)
-         .end()
-         .findAllByCssSelector(failedUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 1, "Wrong number of failed uploads, expected 1, found: " + elements.length);
-            })
-         .end()
-         .findByCssSelector(cancelButtonSelector)
-            .click()
-            .sleep(dialogDelay)
-         .end();
-      },
-      
-      "Test single file upload (no failures)": function () {
-         return browser.findByCssSelector("#SINGLE_UPLOAD_label")
-            .click()
-            .sleep(dialogDelay)
-         .end()
-         .findAllByCssSelector(failedUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 0, "Wrong number of failed uploads, expected 0, found: " + elements.length);
-            })
-         .end();
-      },
-      
-      "Test single file upload (one success)": function() {
-         return browser.findAllByCssSelector(successfulUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 1, "Wrong number of successful uploads, expected 1, found: " + elements.length);
-            })
-         .end();
-      },
-      
-      "Test single file upload (progress)": function() {
-         return browser.findByCssSelector(aggProgStatusSelector)
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "100%", "The aggregate progress was not 100%: " + text);
-            })
-         .end()
-         .findByCssSelector(okButtonSelector)
-            .click()
-            .sleep(dialogDelay)
-         .end();
-      },
-      
-      "Test zero file upload (failed)": function () {
-         return browser.findByCssSelector("#NO_FILES_UPLOAD_label")
-            .click()
-            .sleep(dialogDelay)
-         .end()
-         .findAllByCssSelector(failedUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 0, "Wrong number of failed uploads, expected 0, found: " + elements.length);
-            })
-         .end();
-      },
-      
-      "Test zero file upload (successful)": function() {
-         return browser.findAllByCssSelector(successfulUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 0, "Wrong number of successful uploads, expected 0, found: " + elements.length);
-            })
-         .end()
-         .findByCssSelector(okButtonSelector)
-            .click()
-            .sleep(dialogDelay)
-         .end();
-      },
-      
-      "Test Multi-File Upload (failed)": function () {
-         return browser.findByCssSelector("#MULTI_UPLOAD_label")
-            .click()
-            .sleep(dialogDelay)
-         .end()
-         .findAllByCssSelector(failedUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 0, "Wrong number of failed uploads, expected 0, found: " + elements.length);
-            })
-         .end();
-      },
-      
-      "Test Multi-File Upload (successful)": function () {
-         return browser.findAllByCssSelector(successfulUploadsSelector)
-            .then(function(elements) {
-               assert(elements.length === 4, "Wrong number of successful uploads, expected 4, found: " + elements.length);
-            })
-         .end()
-         .findByCssSelector(aggProgStatusSelector)
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "100%", "The aggregate progress was not 100%: " + text);
-            })
-         .end()
-         .findByCssSelector(okButtonSelector)
-            .click()
-            .sleep(dialogDelay)
-         .end();
-      },
+      return {
+         name: "Upload Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/aikau-upload-unit-test", "Upload").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "Test bad file data": function () {
+            // Simulate providing a zero byte file and check the output...
+            return browser.findById("BAD_FILE_DATA_label")
+               .click()
+            .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
+            .end()
+
+            .findAllByCssSelector(failedUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Wrong number of failed uploads");
+               })
+            .end()
+
+            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+         },
+         
+         "Test single file upload (no failures)": function () {
+            return browser.findById("SINGLE_UPLOAD_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
+            .end()
+            
+            .findAllByCssSelector(failedUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Wrong number of failed uploads");
+               });
+         },
+         
+         "Test single file upload (one success)": function() {
+            return browser.findAllByCssSelector(successfulUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Wrong number of successful uploads");
+               });
+         },
+         
+         "Test single file upload (progress)": function() {
+            return browser.findByCssSelector(aggProgStatusSelector)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "100%", "The aggregate progress was not 100%");
+               })
+            .end()
+
+            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+         },
+         
+         "Test zero file upload (failed)": function () {
+            return browser.findById("NO_FILES_UPLOAD_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
+            .end()
+            
+            .findAllByCssSelector(failedUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Wrong number of failed uploads");
+               });
+         },
+         
+         "Test zero file upload (successful)": function() {
+            return browser.findAllByCssSelector(successfulUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Wrong number of successful uploads");
+               })
+            .end()
+
+            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+         },
+         
+         "Test Multi-File Upload (failed)": function () {
+            return browser.findById("MULTI_UPLOAD_label")
+               .click()
+            .end()
+            
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed")
+            .end()
+            
+            .findAllByCssSelector(failedUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Wrong number of failed uploads");
+               });
+         },
+         
+         "Test Multi-File Upload (successful)": function () {
+            return browser.findAllByCssSelector(successfulUploadsSelector)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "Wrong number of successful uploads");
+               })
+            .end()
+            
+            .findByCssSelector(aggProgStatusSelector)
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "100%", "The aggregate progress was not 100%: " + text);
+               })
+            .end()
+            
+            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/Upload.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/Upload.get.js
@@ -105,10 +105,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/UploadMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadFailure.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadFailure.get.js
@@ -44,10 +44,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-668 to ensure that there is only a single button on the upload dialog. Whilst uploads are in progress this is labelled "Cancel" and once all uploads have completed (regardless of result) it is changed to say "OK" (to indicate that cancellation is no longer possible).