### PR TITLE
AKU-677: Smart download action

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -322,21 +322,6 @@ define([],function() {
       DOWNLOAD_NODE: "ALF_DOWNLOAD_FILE",
 
       /**
-       * This is the response topic for requests to obtain node data that will be immediately
-       * followed by the downloading of that node. It is set as the response topic for smart
-       * downloads of nodes included in Search API requests where the "nodeRef" attribute
-       * is available but the "contentURL" attribute is not. This is not intended to be used by 
-       * widgets or services other than the 
-       * [DocumentService]{@link module:alfresco/services/DocumentService}.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       * @since 1.0.43
-       */
-      DOWNLOAD_ON_NODE_RETRIEVAL: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL",
-
-      /**
        * This topic subscribed to by the [DocumentService]{@link module:alfresco/services/DocumentService}
        * in order to trigger a download of a node that has just had its full metadata successfully
        * retrieved. This is not intended to be used by widgets or services other than the 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -348,6 +348,8 @@ define([],function() {
        * @since 1.0.43
        *
        * @event
+       * @property {object} response The reponse from the XHR request to retrieve the node metadata
+       * @property {object} response.item The metadata for the requested node
        */
       DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS",
 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -322,6 +322,36 @@ define([],function() {
       DOWNLOAD_NODE: "ALF_DOWNLOAD_FILE",
 
       /**
+       * This is the response topic for requests to obtain node data that will be immediately
+       * followed by the downloading of that node. It is set as the response topic for smart
+       * downloads of nodes included in Search API requests where the "nodeRef" attribute
+       * is available but the "contentURL" attribute is not. This is not intended to be used by 
+       * widgets or services other than the 
+       * [DocumentService]{@link module:alfresco/services/DocumentService}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.43
+       */
+      DOWNLOAD_ON_NODE_RETRIEVAL: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL",
+
+      /**
+       * This topic subscribed to by the [DocumentService]{@link module:alfresco/services/DocumentService}
+       * in order to trigger a download of a node that has just had its full metadata successfully
+       * retrieved. This is not intended to be used by widgets or services other than the 
+       * [DocumentService]{@link module:alfresco/services/DocumentService}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.43
+       *
+       * @event
+       */
+      DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS",
+
+      /**
        * This topic can be published to request that a notification be displayed. It is subscribed to 
        * by the [NotificationService]{@link module:alfresco/services/NotificationService}.
        *
@@ -743,6 +773,20 @@ define([],function() {
        * @property {number} value - The size (in pixels) to make the thumbnails.
        */
       SET_THUMBNAIL_SIZE: "ALF_SET_THUMBNAIL_SIZE",
+
+      /**
+       * This can be published to request a "smart" download. It is smart because it will determine whether
+       * or not to download a single item individually or multiple items as a ZIP.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.43
+       *
+       * @event
+       * @property {object[]} nodes The node or nodes to download.
+       */
+      SMART_DOWNLOAD: "ALF_SMART_DOWNLOAD",
 
       /**
        * This topic is published in order to make the actual request to sync a node or nodes

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -262,10 +262,7 @@ define(["dojo/_base/declare",
          //       release we won't be able to remove these inconsistencies. By including the selected items
          //       as "nodes" it allows us to forward to "actionTopics" without the need to create individual
          //       actions to alias all the capabilities provided by other services.
-         if (!payload.nodes)
-         {
-            payload.nodes = payload.documents;
-         }
+         payload.nodes = payload.documents;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -262,7 +262,10 @@ define(["dojo/_base/declare",
          //       release we won't be able to remove these inconsistencies. By including the selected items
          //       as "nodes" it allows us to forward to "actionTopics" without the need to create individual
          //       actions to alias all the capabilities provided by other services.
-         payload.nodes = payload.documents;
+         if (!payload.nodes)
+         {
+            payload.nodes = payload.documents;
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -399,7 +399,7 @@ define(["dojo/_base/declare",
                   // Search style API document, it is necessary to request the full metadata of the node...
                   this.onRetrieveSingleDocumentRequest({
                      nodeRef: node.nodeRef,
-                     alfResponseTopic: topics.DOWNLOAD_ON_NODE_RETRIEVAL
+                     alfResponseTopic: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL"
                   });
                }
                else if (node.type === "folder")

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -131,6 +131,8 @@ define(["dojo/_base/declare",
        * @listens module:alfresco/core/topics#DOWNLOAD_GENERATED_ARCHIVE
        * @listens module:alfresco/core/topics#CANCEL_EDIT
        * @listens module:alfresco/core/topics#GET_PARENT_NODEREF
+       * @listens module:alfresco/core/topics#SMART_DOWNLOAD
+       * @listens module:alfresco/core/topics#DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS
        */
       registerSubscriptions: function alfresco_services_DocumentService__registerSubscriptions() {
          // Bind to document topics:
@@ -149,6 +151,8 @@ define(["dojo/_base/declare",
          this.alfSubscribe(topics.DOWNLOAD_NODE, lang.hitch(this, this.onDownloadFile));
          this.alfSubscribe(topics.CANCEL_EDIT, lang.hitch(this, this.onCancelEdit));
          this.alfSubscribe(topics.GET_PARENT_NODEREF, lang.hitch(this, this.onGetParentNodeRef));
+         this.alfSubscribe(topics.SMART_DOWNLOAD, lang.hitch(this, this.onSmartDownload));
+         this.alfSubscribe(topics.DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS, lang.hitch(this, this.onDocumentRetrievedForDownload));
       },
 
       /**
@@ -354,6 +358,86 @@ define(["dojo/_base/declare",
          else
          {
             this.alfLog("warn", "A request was made to download a document but no 'node.contentURL' attribute was found in the payload provided", payload, this);
+         }
+      },
+
+      /**
+       * This function is provided to handle downloads of selected items with some intelligence. If a single
+       * document is selected then it will be downloaded
+       * (via the [onDownload]{@link module:alfresco/services/DocumentService#onDownload}), but if multiple items 
+       * are selected then they will be downloaded as an archive 
+       * (via the [onDownloadAsZip]{@link module:alfresco/services/DocumentService#onDownloadAsZip}) function.
+       * If a single folder is selected then it will be downloaded as an archive. This function is also able to cope
+       * with data provided by either the Document Library or Search APIs.
+       * 
+       * @instance
+       * @param {object} payload An object containing the items to download.
+       * @since 1.0.43
+       */
+      onSmartDownload: function alfresco_servicews_DocumentService__onSmartDownload(payload) {
+         if (payload.nodes)
+         {
+            if (payload.nodes.length === 1)
+            {
+               // For single items perform a single download...
+               // However, we still need to check the item type (i.e. whether it is a document or folder)...
+               var node = payload.nodes[0];
+               if (node.node)
+               {
+                  // Document Library style API 
+                  if (node.node.isContainer === true)
+                  {
+                     this.onDownloadAsZip(payload);
+                  }
+                  else
+                  {
+                     this.onDownload(node);
+                  }
+               }
+               else if (node.type === "document" && node.nodeRef)
+               {
+                  // Search style API document, it is necessary to request the full metadata of the node...
+                  this.onRetrieveSingleDocumentRequest({
+                     nodeRef: node.nodeRef,
+                     alfResponseTopic: topics.DOWNLOAD_ON_NODE_RETRIEVAL
+                  });
+               }
+               else if (node.type === "folder")
+               {
+                  // Search style API folder...
+                  this.onDownloadAsZip(payload);
+               }
+               else
+               {
+                  this.alfLog("warn", "A request was made to perform a smart download on a single item but it was not able to determine if the item was a document or a folder", payload, this);
+               }
+            }
+            else
+            {
+               // Always download multiple files as a zip...
+               this.onDownloadAsZip(payload);
+            }
+         }
+         else
+         {
+            this.alfLog("warn", "A request was made to perform a smart download but no 'nodes' attribute was provided in the payload", payload, this);
+         }
+      },
+
+      /**
+       * This is the callback function from requests to retrieve the metadata for a node defined by the
+       * Search API called from the [onSmartDownload]{@link module:alfresco/services/DocumentService#onSmartDownload}
+       * function.
+       * 
+       * @instance
+       * @param {object} payload The full metadata of a node to download.
+       * @since 1.0.43
+       */
+      onDocumentRetrievedForDownload: function alfresco_services_DocumentService__onDocumentRetrievedForDownload(payload) {
+         var node = lang.getObject("response.item", false, payload);
+         if (node)
+         {
+            this.onDownload(node);
          }
       },
 

--- a/aikau/src/test/resources/alfresco/services/DocumentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DocumentServiceTest.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Document Service Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/DocumentService", "Document Service Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Single document download (DocLib API)": function() {
+            return browser.findById("SINGLE_DOCUMENT_DOCLIB_label")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.include(payload.url, 
+                                 "proxy/alfresco/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/2013-12-29%2009.58.43.jpg?a=true",
+                                 "Individual download request not detected");
+               })
+               .clearLog();
+         },
+
+         "Single folder download (DocLib API)": function() {
+            return browser.findById("SINGLE_FOLDER_DOCLIB_label")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_ARCHIVE_DELETE", "Archive download not requested")
+            .clearLog();
+         },
+
+         "Single document download (Search API)": function() {
+            return browser.findById("SINGLE_DOCUMENT_SEARCH_label")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.include(payload.url, 
+                                 "proxy/alfresco/slingshot/node/content/workspace/SpacesStore/26ae500c-91a9-496f-aca6-14101f985c28/PDF.pdf?a=true",
+                                 "Individual download request not detected");
+               })
+               .clearLog();
+         },
+
+         "Single folder download (Search API)": function() {
+            return browser.findById("SINGLE_FOLDER_SEARCH_label")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_ARCHIVE_DELETE", "Archive download not requested")
+            .clearLog();
+         },
+
+         "Single item download": function() {
+            return browser.findById("MULTIPLE_DOCUMENTS_label")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_ARCHIVE_DELETE", "Archive download not requested")
+            .clearLog();
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -252,6 +252,7 @@ define({
       "src/test/resources/alfresco/services/CrudServiceTest",
       "src/test/resources/alfresco/services/DeleteSiteTest",
       "src/test/resources/alfresco/services/DialogServiceTest",
+      "src/test/resources/alfresco/services/DocumentServiceTest",
       "src/test/resources/alfresco/services/FullScreenDialogTest",
       "src/test/resources/alfresco/services/LoggingServiceTest",
       "src/test/resources/alfresco/services/NavigationServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>DocumentService Test</shortname>
+  <description>This page is used to test the alfresco/services/DocumentService</description>
+  <family>aikau-unit-tests</family>
+  <url>/DocumentService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.js
@@ -1,0 +1,120 @@
+model.jsonModel = {
+   services: [
+      {
+            name: "alfresco/services/LoggingService",
+            config: {
+               loggingPreferences: {
+                  enabled: true,
+                  all: true
+               }
+            }
+      },
+      "alfresco/services/ActionService",
+      "alfresco/services/DocumentService",
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         id: "SINGLE_DOCUMENT_DOCLIB",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Single document (DocLib API)",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_SMART_DOWNLOAD",
+               nodes: [
+                  {
+                     node: {
+                        isContainer: false,
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/2013-12-29%2009.58.43.jpg"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "SINGLE_FOLDER_DOCLIB",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Single folder (DocLib API)",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_SMART_DOWNLOAD",
+               nodes: [
+                  {
+                     node: {
+                        isContainer: true,
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "SINGLE_DOCUMENT_SEARCH",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Single document (Search API)",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_SMART_DOWNLOAD",
+               nodes: [
+                  {
+                     type: "document",
+                     nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339"
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "SINGLE_FOLDER_SEARCH",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Single folder (Search API)",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_SMART_DOWNLOAD",
+               nodes: [
+                  {
+                     type: "folder",
+                     nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "MULTIPLE_DOCUMENTS",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Multiple documents",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               actionTopic: "ALF_SMART_DOWNLOAD",
+               nodes: [
+                  {
+                     node: {
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                     }
+                  },
+                  {
+                     node: {
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/SmartDownloadMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DocumentService.get.js
@@ -22,7 +22,7 @@ model.jsonModel = {
             publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
                actionTopic: "ALF_SMART_DOWNLOAD",
-               nodes: [
+               documents: [
                   {
                      node: {
                         isContainer: false,
@@ -42,7 +42,7 @@ model.jsonModel = {
             publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
                actionTopic: "ALF_SMART_DOWNLOAD",
-               nodes: [
+               documents: [
                   {
                      node: {
                         isContainer: true,
@@ -61,7 +61,7 @@ model.jsonModel = {
             publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
                actionTopic: "ALF_SMART_DOWNLOAD",
-               nodes: [
+               documents: [
                   {
                      type: "document",
                      nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339"
@@ -78,7 +78,7 @@ model.jsonModel = {
             publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
                actionTopic: "ALF_SMART_DOWNLOAD",
-               nodes: [
+               documents: [
                   {
                      type: "folder",
                      nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
@@ -95,7 +95,7 @@ model.jsonModel = {
             publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
             publishPayload: {
                actionTopic: "ALF_SMART_DOWNLOAD",
-               nodes: [
+               documents: [
                   {
                      node: {
                         nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SmartDownloadMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SmartDownloadMockXhr.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @module aikauTesting/SmartDownloadMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "aikauTesting/mockservices/DownloadArchiveMockXhr",
+        "dojo/text!./responseTemplates/previews/PDF.json"], 
+        function(declare, DownloadArchiveMockXhr, PdfNode) {
+   
+   return declare([DownloadArchiveMockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_DownloadArchiveMockXhr__setupServer() {
+         try
+         {
+            this.server.respondWith("GET",
+                                    /\/aikau\/service\/components\/documentlibrary\/data\/node\/workspace\/SpacesStore\/f8394454-0651-48a5-b583-d067c7d03339(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     PdfNode]);
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+         this.inherited(arguments);
+      }
+   });
+});


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-677 to provide a "smart" download for multiple selection actions such that a single selected document is downloaded as the document, but multiple selected documents are downloaded as an archive.