### PR TITLE
AKU-680: Faceted search filter encoding updates

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -468,7 +468,8 @@ define(["dojo/_base/declare",
        */
       updateFilterHash: function alfresco_search_AlfSearchList__updateFilterHash(fullFilter, mode) {
          // Get the existing hash and extract the individual facetFilters into an array
-         var aHash = hashUtils.getHash(),
+         var aHashString = hashUtils.getHashString(),
+             aHash = ioQuery.queryToObject(aHashString),
              facetFilters = aHash.facetFilters ? aHash.facetFilters : "",
              facetFiltersArr = facetFilters === "" ? [] : facetFilters.split(",");
 
@@ -705,7 +706,7 @@ define(["dojo/_base/declare",
 
          // TODO: This should probably be in the SearchService... but will leave here for now...
          var facets = lang.getObject("response.facets", false, payload);
-         var filters = lang.getObject("requestConfig.query.filters", false, payload);
+         var filters = lang.getObject("requestConfig.query.encodedFilters", false, payload);
          if (facets !== null && facets !== undefined)
          {
             for (var key in facets)

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -468,8 +468,7 @@ define(["dojo/_base/declare",
        */
       updateFilterHash: function alfresco_search_AlfSearchList__updateFilterHash(fullFilter, mode) {
          // Get the existing hash and extract the individual facetFilters into an array
-         var aHashString = hashUtils.getHashString(),
-             aHash = ioQuery.queryToObject(aHashString),
+         var aHash = hashUtils.getHash(true),
              facetFilters = aHash.facetFilters ? aHash.facetFilters : "",
              facetFiltersArr = facetFilters === "" ? [] : facetFilters.split(",");
 

--- a/aikau/src/main/resources/alfresco/search/FacetFilter.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilter.js
@@ -205,7 +205,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       onApplyFilter: function alfresco_search_FacetFilter__onApplyFilter() {
-         var fullFilter = this.facet + "|" + this.filter;
+         var fullFilter = encodeURIComponent(this.facet + "|" + this.filter);
          if(this.useHash)
          {
             this._updateHash(fullFilter, "add");
@@ -229,7 +229,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       onClearFilter: function alfresco_search_FacetFilter__onClearFilter() {
-         var fullFilter = this.facet + "|" + this.filter;
+         var fullFilter = encodeURIComponent(this.facet + "|" + this.filter);
          if(this.useHash)
          {
             this._updateHash(fullFilter, "remove");
@@ -253,7 +253,8 @@ define(["dojo/_base/declare",
        */
       _updateHash: function alfresco_search_FacetFilter___updateHash(fullFilter, mode) {
          // Get the existing hash and extract the individual facetFilters into an array
-         var aHash = hashUtils.getHash(),
+         var aHashString = hashUtils.getHashString(),
+             aHash = ioQuery.queryToObject(aHashString),
              facetFilters = ((aHash.facetFilters) ? aHash.facetFilters : ""),
              facetFiltersArr = (facetFilters === "") ? [] : facetFilters.split(",");
 

--- a/aikau/src/main/resources/alfresco/search/FacetFilter.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilter.js
@@ -253,8 +253,7 @@ define(["dojo/_base/declare",
        */
       _updateHash: function alfresco_search_FacetFilter___updateHash(fullFilter, mode) {
          // Get the existing hash and extract the individual facetFilters into an array
-         var aHashString = hashUtils.getHashString(),
-             aHash = ioQuery.queryToObject(aHashString),
+         var aHash = hashUtils.getHash(true),
              facetFilters = ((aHash.facetFilters) ? aHash.facetFilters : ""),
              facetFiltersArr = (facetFilters === "") ? [] : facetFilters.split(",");
 

--- a/aikau/src/main/resources/alfresco/search/FacetFilters.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilters.js
@@ -174,7 +174,11 @@ define(["dojo/_base/declare",
          var activeFilters = [];
          if (payload.activeFilters)
          {
-            activeFilters = payload.activeFilters.split(",");
+            var encodedActiveFilters = payload.activeFilters.split(",");
+            for(var i = 0; i < encodedActiveFilters.length; i++)
+            {
+               activeFilters.push(decodeURIComponent(encodedActiveFilters[i]));
+            }
          }
 
          // Create a new array and populate with the the facet filters...

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -235,8 +235,8 @@ define(["dojo/_base/declare",
 
             var data = {
                facetFields: payload.facetFields || "",
-               filters: payload.filters || "",
-               term: payload.term,
+               filters: decodeURIComponent(payload.filters) || "",
+               encodedFilters: payload.filters || "",term: payload.term,
                tag: payload.tag || this.tag,
                startIndex: (payload.startIndex || payload.startIndex === 0) ? payload.startIndex : this.startIndex,
                sort: sort,

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -34,12 +34,15 @@ define(["dojo/_base/array",
    var util = {
 
       // See API below
-      getHash: function alfresco_util_hashUtils__getHash() {
+      getHash: function alfresco_util_hashUtils__getHash(suppressDecoding) {
          var hashString = this.getHashString(),
             hashObj = ioQuery.queryToObject(hashString);
-         array.forEach(Object.keys(hashObj), function(hashKey) {
-            hashObj[hashKey] = decodeURIComponent(hashObj[hashKey]);
-         });
+         if (suppressDecoding !== true)
+         {
+            array.forEach(Object.keys(hashObj), function(hashKey) {
+               hashObj[hashKey] = decodeURIComponent(hashObj[hashKey]);
+            });
+         }
          return hashObj;
       },
 
@@ -49,11 +52,14 @@ define(["dojo/_base/array",
       },
 
       // See API below
-      setHash: function alfresco_util_hashUtils__setHash(hashObj, replace) {
+      setHash: function alfresco_util_hashUtils__setHash(hashObj, replace, suppressEncoding) {
          var hashObjToUse = lang.clone(hashObj);
-         array.forEach(Object.keys(hashObjToUse), function(hashKey) {
-            hashObjToUse[hashKey] = encodeURIComponent(hashObjToUse[hashKey]);
-         });
+         if (suppressEncoding !== true)
+         {
+            array.forEach(Object.keys(hashObjToUse), function(hashKey) {
+               hashObjToUse[hashKey] = encodeURIComponent(hashObjToUse[hashKey]);
+            });
+         }
          var hashString = ioQuery.objectToQuery(hashObjToUse);
          this.setHashString(hashString, replace);
       },
@@ -103,9 +109,11 @@ define(["dojo/_base/array",
    return {
 
       /**
-       * Get the current hash value as an object. All values will be URI decoded.
+       * Get the current hash value as an object. All values will be URI decoded unless
+       * a suppresssDecoding argument of true is provided.
        *
        * @instance
+       * @param {boolean} [suppressDecoding] Optionally suppress URI decoding
        * @returns {Object} The hash value as an object
        */
       getHash: lang.hitch(util, util.getHash),
@@ -119,12 +127,14 @@ define(["dojo/_base/array",
       getHashString: lang.hitch(util, util.getHashString),
 
       /**
-       * Set the current hash value from an object. All values will be URI encoded.
+       * Set the current hash value from an object. All values will be URI encoded unless
+       * a suppressEncoding argument of true is provided.
        *
        * @instance
        * @param {Object} hashObj The new hash object
        * @param {boolean} [replace] Replace the current hash, rather than changing
        *                            (i.e. do not add to the history)
+       * @param {boolean} [suppressEncoding] Optionally suppress URI encoding
        */
       setHash: lang.hitch(util, util.setHash),
 

--- a/aikau/src/test/resources/alfresco/search/NoHashSearchingTest.js
+++ b/aikau/src/test/resources/alfresco/search/NoHashSearchingTest.js
@@ -25,115 +25,114 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "No URL Hashing Search Tests",
+      return {
+         name: "No URL Hashing Search Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/NoHashSearching", "No URL Hashing Search Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NoHashSearching", "No URL Hashing Search Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check that a scope is selected": function() {
-         // See AKU-475 - because no hashName attribute is set on the AlfCheckableMenuItems the configured checked 
-         // status should result in a scope being set
-         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Repository", "An initial scope was not set");
-            })
+         "Check that a scope is selected": function() {
+            // See AKU-475 - because no hashName attribute is set on the AlfCheckableMenuItems the configured checked 
+            // status should result in a scope being set
+            return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Repository", "An initial scope was not set");
+               })
+               .clearLog();
+         },
+
+         "Perform a search without setting a hash": function() {
+            // See AKU-472 - with both the SingleComboBoxForm and AlfSearchList configured with useHash to be false
+            // then setting a search term should just perform a search without updating the URL hash
+            return browser.findByCssSelector(".dijitInputInner")
+               .type("hame")
+            .end()
+            .findByCssSelector(".confirmationButton > span")
+               .click()
+            .end()
+            .getLastPublish("SEARCH_RESULTS_SUCCESS")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "response.totalRecords", 10, "Response not published");
+               })
+            .getCurrentUrl()
+               .then(function(url) {
+                  assert.notInclude(url, "#", "A hash should not have been set");
+               })
             .clearLog();
-      },
+         },
 
-      "Perform a search without setting a hash": function() {
-         // See AKU-472 - with both the SingleComboBoxForm and AlfSearchList configured with useHash to be false
-         // then setting a search term should just perform a search without updating the URL hash
-         return browser.findByCssSelector(".dijitInputInner")
-            .type("hame")
-         .end()
-         .findByCssSelector(".confirmationButton > span")
-            .click()
-         .end()
-         .getLastPublish("SEARCH_RESULTS_SUCCESS")
-            .then(function(payload) {
-               assert.deepPropertyVal(payload, "response.totalRecords", 10, "Response not published");
-            })
-         .getCurrentUrl()
-            .then(function(url) {
-               assert.notInclude(url, "#", "A hash should not have been set");
-            })
-         .clearLog();
-      },
+         "Check search results for alternative search": function() {
+            // Searching for "hame" will actually generate an alternative search for "home"
+            return browser.findByCssSelector(".searched-for-term .search-term-link")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "home", "Did not perform the alternative search");
+               });
+         },
 
-      "Check search results for alternative search": function() {
-         // Searching for "hame" will actually generate an alternative search for "home"
-         return browser.findByCssSelector(".searched-for-term .search-term-link")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "home", "Did not perform the alternative search");
-            });
-      },
+         "Change the scope without setting a hash": function() {
+            // Switching from Repository to All Sites scope should initiate a new search search without setting the hash
+            return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
+               .click()
+            .end()
+            .findById("FCTSRCH_SET_ALL_SITES_SCOPE_text")
+               .click()
+            .end()
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "repo", false, "The search scope was not updated");
+               })
+               .clearLog();
+         },
 
-      "Change the scope without setting a hash": function() {
-         // Switching from Repository to All Sites scope should initiate a new search search without setting the hash
-         return browser.findById("FCTSRCH_SCOPE_SELECTION_MENU_text")
-            .click()
-         .end()
-         .findById("FCTSRCH_SET_ALL_SITES_SCOPE_text")
-            .click()
-         .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-            .then(function(payload) {
-               assert.propertyVal(payload, "repo", false, "The search scope was not updated");
-            })
+         "Use original search term without setting hash": function() {
+            // The AlternativeSearchLabel should present the original search term of "hame" - clicking on this
+            // should perform that search and the hash should remain unchanged
+            return browser.findByCssSelector(".searched-for-term .search-term-link")
+               .click()
+            .end()
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "term", "home", "The search request was not updated");
+               })
+            .getCurrentUrl()
+               .then(function(url) {
+                  assert.notInclude(url, "#", "A hash should not have been set");
+               })
             .clearLog();
-      },
+         },
+         
+         "Apply a facet filter without setting hash": function() {
+            // Applying a facet filter should trigger another search without the AlfSearchList updating the URL hash
+            return browser.findByCssSelector(".filters li:first-child .filterLabel")
+               .click()
+            .end()
+            .getLastPublish("ALF_SEARCH_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "filters", encodeURIComponent("{http://www.alfresco.org/model/content/1.0}created|NOW/DAY-7DAYS\"..\"NOW/DAY+1DAY"), "The search request was not updated");
+               })
+            .getCurrentUrl()
+               .then(function(url) {
+                  assert.notInclude(url, "#", "A hash should not have been set");
+               });
+         },
 
-      "Use original search term without setting hash": function() {
-         // The AlternativeSearchLabel should present the original search term of "hame" - clicking on this
-         // should perform that search and the hash should remain unchanged
-         return browser.findByCssSelector(".searched-for-term .search-term-link")
-            .click()
-         .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-            .then(function(payload) {
-               assert.propertyVal(payload, "term", "home", "The search request was not updated");
-            })
-         .getCurrentUrl()
-            .then(function(url) {
-               assert.notInclude(url, "#", "A hash should not have been set");
-            })
-         .clearLog();
-      },
-      
-      "Apply a facet filter without setting hash": function() {
-         // Applying a facet filter should trigger another search without the AlfSearchList updating the URL hash
-         return browser.findByCssSelector(".filters li:first-child .filterLabel")
-            .click()
-         .end()
-         .getLastPublish("ALF_SEARCH_REQUEST")
-            .then(function(payload) {
-               assert.propertyVal(payload, "filters", "{http://www.alfresco.org/model/content/1.0}created|NOW/DAY-7DAYS\"..\"NOW/DAY+1DAY", "The search request was not updated");
-            })
-         .getCurrentUrl()
-            .then(function(url) {
-               assert.notInclude(url, "#", "A hash should not have been set");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-680 to implement the recommended changes to support encoding of facet filters described by https://issues.alfresco.com/jira/browse/MNT-14333. One unit test needed to be updated to handle the encoding. I've also verified that the changes work fine with Share 5.0.x releases for backwards compatibility.