### PR TITLE
AKU-671: Dialogs not re-centered on content change

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -920,7 +920,7 @@ define(["dojo/_base/declare",
        * currentMetadata objects if they are available.
        * 
        * @instance
-       * @param  {[type]} value The value to look for tokens in
+       * @param  {*} value The value to look for tokens in
        * @return {string} The value with any tokens substituted
        * @since 1.0.43
        */

--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -110,7 +110,8 @@ define(["dojo/_base/declare",
 
       /**
        * Setup a listener that will call [alfPublishResizeEvent]{@link module:alfresco/core/ResizeMixin#alfPublishResizeEvent}
-       * whenever a resize is detected in the specified node.
+       * whenever a resize is detected in the specified node. If there is an own method on the instance, then it will be called,
+       * so that the listener is removed on widget destruction (encapsulated here to avoid widespread boilerplate-code duplication).
        *
        * @instance
        * @param {object} monitoredNode The node to monitor
@@ -119,26 +120,10 @@ define(["dojo/_base/declare",
        * @since 1.0.42
        */
       addResizeListener: function alfresco_core_ResizeMixin__addResizeListener(monitoredNode, resizeNode) {
-         var resizeHandler = lang.hitch(this, this.alfPublishResizeEvent, resizeNode || monitoredNode.parentNode);
-         return domUtils.addPollingResizeListener(monitoredNode, resizeHandler);
-      },
-
-      /**
-       * A node has been resized, but we don't know whether we need to publish an event. This
-       * function will check for an ancestor "resizable", and publish an event if found, with that
-       * resizable's parent as the resizing node.
-       *
-       * @instance
-       * @param {object} node The node to be checked
-       */
-      onNodeResized: function alfresco_core_ResizeMixin__onNodeResized(node) {
-         var parent = node;
-         while ((parent = parent.parentNode)) {
-            if (domClass.contains(parent, "alfresco-core-ResizeMixin--resizable")) {
-               this.alfPublishResizeEvent(parent.parentNode);
-               break;
-            }
-         }
+         var resizeHandler = lang.hitch(this, this.alfPublishResizeEvent, resizeNode || monitoredNode.parentNode),
+            resizeListener = domUtils.addPollingResizeListener(monitoredNode, resizeHandler);
+         this.own && this.own(resizeListener);
+         return resizeListener;
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -34,12 +34,10 @@ define(["dojo/_base/declare",
         "alfresco/core/_EventsMixin",
         "alfresco/core/topics",
         "alfresco/util/domUtils",
-        "alfresco/util/functionUtils",
         "dojo/_base/lang",
         "dojo/on",
-        "dojo/dom",
-        "dojo/dom-class"], 
-        function(declare, _EventsMixin, topics, domUtils, funcUtils, lang, on, dom, domClass) {
+        "dojo/dom"], 
+        function(declare, _EventsMixin, topics, domUtils, lang, on, dom) {
 
    return declare([_EventsMixin], {
       

--- a/aikau/src/main/resources/alfresco/core/_EventsMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_EventsMixin.js
@@ -149,7 +149,6 @@ define(["alfresco/core/Core",
          } else {
             resizeSubscription = this.alfSubscribe(topics.NODE_RESIZED, lang.hitch(this, function(payload) {
                var resizedNode = payload.node,
-                  resizedNodeIsAncestor = false,
                   testNode = nodeToMonitor;
                while (testNode && testNode !== resizedNode) {
                   testNode = testNode.parentNode;

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -172,6 +172,7 @@ define(["dojo/_base/declare",
        * @instance
        * @readonly
        * @type {object}
+       * @since 1.0.43
        */
       resizeListener: null,
 

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -415,6 +415,7 @@ define(["dojo/_base/declare",
                "max-height": calculatedHeights.maxBodyHeight + "px"
             });
          }
+         this.resize();
       },
 
       /**
@@ -524,7 +525,6 @@ define(["dojo/_base/declare",
          // jshint unused:false
          if (this.domNode)
          {
-            this.resize();
             this.onWindowResize();
          }
       },

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -166,6 +166,16 @@ define(["dojo/_base/declare",
       handleOverflow: true,
 
       /**
+       * A placeholder for the resize-listener that's enabled while the dialog is visible. This
+       * value is set automatically.
+       *
+       * @instance
+       * @readonly
+       * @type {object}
+       */
+      resizeListener: null,
+
+      /**
        * Widgets to be processed into the main node
        * 
        * @instance
@@ -371,6 +381,9 @@ define(["dojo/_base/declare",
                return returnVal;
             }));
          }
+
+         // Listen to resize events
+         this.resizeListener = this.addResizeListener(this.containerNode, this.domNode.parentNode);
       },
 
       /**
@@ -397,6 +410,10 @@ define(["dojo/_base/declare",
          domStyle.set(document.documentElement, "overflow", "");
          domClass.remove(this.domNode, "dialogDisplayed");
          domClass.add(this.domNode, "dialogHidden");
+         if (this.resizeListener) {
+            this.resizeListener.remove();
+            this.resizeListener = null;
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -253,7 +253,7 @@ define(["alfresco/core/ProcessWidgets",
        * @deprecated Since 1.0.42 - use [ResizeMixin.addResizeListener]{@link module:alfresco/core/ResizeMixin#addResizeListener} instead.
        */
       addHeaderResizeListener: function alfresco_layout_FixedHeaderFooter__addHeaderResizeListener() {
-         this.addResizeListener(this.header);
+         this.addResizeListener(this.header, this.domNode);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/util/domUtils.js
+++ b/aikau/src/main/resources/alfresco/util/domUtils.js
@@ -26,18 +26,26 @@
  * @since 1.0.42
  */
 define([
+      "alfresco/util/functionUtils",
+      "dojo/_base/array",
       "dojo/_base/lang",
       "dojo/dom-style",
       "dojo/on",
       "dojo/sniff"
    ],
-   function(lang, domStyle, on, has) {
+   function(funcUtils, array, lang, domStyle, on, has) {
+
+      // An object for containing resize-monitoring state information
+      var resizeMonitor = {
+         nodes: {},
+         removeObj: null
+      };
 
       // The private container for the functionality and properties of the util
       var util = {
 
          // See API below
-         addResizeListener: function alfresco_util_domUtils__addResizeListener(node, resizeHandler) {
+         addObjectResizeListener: function alfresco_util_domUtils__addObjectResizeListener(node, resizeHandler) {
 
             // Setup the listener-removal object
             var listenerRemovalObj = {};
@@ -121,6 +129,60 @@ define([
 
             // Pass back the listener-removal object
             return listenerRemovalObj;
+         },
+
+         // See API below
+         addPollingResizeListener: function alfresco_util_domUtils__addPollingResizeListener(node, resizeHandler) {
+
+            // Add the new monitoring nodes
+            var nodes = resizeMonitor.nodes,
+               monitorKey = Date.now();
+            while (nodes.hasOwnProperty(monitorKey)) {
+               monitorKey = Date.now();
+            }
+            nodes[monitorKey] = {
+               node: node,
+               height: node.offsetHeight,
+               width: node.offsetWidth,
+               callbackFunc: resizeHandler
+            };
+
+            // If there is no monitoring running, start it up
+            if (!resizeMonitor.removeObj) {
+               resizeMonitor.removeObj = funcUtils.addRepeatingFunction(this._checkNodesForResize, "SHORT");
+            }
+
+            // Pass back the removal object
+            return {
+               remove: function() {
+                  delete nodes[monitorKey]; // Remove this monitored node
+                  if (resizeMonitor.removeObj && !Object.keys(nodes).length) {
+                     resizeMonitor.removeObj.remove(); // If no nodes are monitored, remove the monitoring function
+                     resizeMonitor.removeObj = null;
+                  }
+               }
+            };
+         },
+
+         // Run through the nodes registered to notify on resize, calling the function if necessary
+         // NOTE: All of the size-checks are completed before any callback functions are called because
+         // if the callbacks cause any redraws then each access of offsetXXX will cause another re-calculation
+         // of the current layout (i.e. it could be wildly inefficient if we don't do all the size-checking first)
+         _checkNodesForResize: function alfresco_util_domUtils___checkNodesForResize() {
+            var callbackFuncs = [];
+            array.forEach(resizeMonitor.nodes, function(node) {
+               var newWidth = node.offsetWidth,
+                  newHeight = node.offsetHeight,
+                  sizeChanged = node.width !== newWidth || node.height !== newHeight;
+               if (sizeChanged) {
+                  node.width = newWidth;
+                  node.height = newHeight;
+                  callbackFuncs.push(node.callbackFunc);
+               }
+            });
+            array.forEach(callbackFuncs, function(func) {
+               func();
+            });
          }
       };
 
@@ -137,11 +199,43 @@ define([
           * <p>NOTE: This is based on a technique described at
           * {@link http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection}</p>
           *
+          * <p><strong>WARNING:</strong> This is NOT scalable, as it adds approx 500KB to the page's memory usage every time it's used, however
+          * it has been left here in case it's more suitable than polling, which might be the case for very limited usage as there's no polling
+          * overhead associated with this technique.</p>
+          *
           * @instance
+          * @function
           * @param {object} node The node to monitor
           * @param {function} resizeHandler The function to call on resize
           * @returns {object} A pointer to the listener, with a remove function on it (i.e. it can be passed to this.own)
+          * @since 1.0.43
           */
-         addResizeListener: lang.hitch(util, util.addResizeListener)
+         addObjectResizeListener: lang.hitch(util, util.addObjectResizeListener),
+
+         /**
+          * Setup a listener on a specific node that will call the supplied handler-function whenever that node resizes. This works
+          * by having a single "process" polling every 100ms and then checking all registered nodes for size-changes.
+          *
+          * @instance
+          * @function
+          * @param {object} node The node to monitor
+          * @param {function} resizeHandler The function to call on resize
+          * @returns {object} A pointer to the listener, with a remove function on it (i.e. it can be passed to this.own)
+          * @since 1.0.43
+          */
+         addPollingResizeListener: lang.hitch(util, util.addPollingResizeListener),
+
+         /**
+          * See the replacement [addPollingResizeListener]{@link module:alfresco/util/domUtils#addPollingResizeListener} for more
+          * information.
+          *
+          * @instance
+          * @function
+          * @param {object} node The node to monitor
+          * @param {function} resizeHandler The function to call on resize
+          * @returns {object} A pointer to the listener, with a remove function on it (i.e. it can be passed to this.own)
+          * @deprecated Since 1.0.43 - Use [addPollingResizeListener]{@link module:alfresco/util/domUtils#addPollingResizeListener} instead
+          */
+         addResizeListener: lang.hitch(util, util.addPollingResizeListener)
       };
    });

--- a/aikau/src/main/resources/alfresco/util/functionUtils.js
+++ b/aikau/src/main/resources/alfresco/util/functionUtils.js
@@ -168,13 +168,18 @@ define([
 
          // Start calling a repeating function
          _startRepeatingTimeout: function alfresco_util_functionUtils___startRepeatingTimeout(period) {
-            setTimeout(function timeoutFunc() {
+            setTimeout(function alfresco_util_functionUtils___timeoutFunc() {
                var funcKeys = Object.keys(period.funcs);
                if (funcKeys.length) {
-                  array.forEach(period.funcs, function(func) {
-                     func();
+                  array.forEach(funcKeys, function(funcKey) {
+                     try {
+                        period.funcs[funcKey]();
+                     } catch (e) {
+                        console.error("Removing erroring periodic function: " + period.funcs[funcKey]);
+                        delete period.funcs[funcKey];
+                     }
                   });
-                  setTimeout(timeoutFunc, period.delay);
+                  setTimeout(alfresco_util_functionUtils___timeoutFunc, period.delay);
                } else {
                   delete period.running;
                }
@@ -216,7 +221,7 @@ define([
           * @param {string} period One of "SHORT" (100ms), "MEDIUM" (1000ms) or "LONG" (10000ms), to determine how often the function is called
           * @returns {object} An object with a remove method on it, which will de-register this function
           */
-         addRepeatingFunction: util.addRepeatingFunction,
+         addRepeatingFunction: lang.hitch(util, util.addRepeatingFunction),
 
          /**
           * <p>Debounce the supplied function.</p>

--- a/aikau/src/main/resources/alfresco/util/functionUtils.js
+++ b/aikau/src/main/resources/alfresco/util/functionUtils.js
@@ -24,8 +24,27 @@
  * @module alfresco/util/functionUtils
  * @author Martin Doyle
  */
-define(["dojo/_base/lang"],
-   function(lang) {
+define([
+      "dojo/_base/array",
+      "dojo/_base/lang"
+   ],
+   function(array, lang) {
+
+      // Define the repeating periods variables.
+      var REPEATING_PERIODS = {
+         "SHORT": {
+            delay: 100,
+            funcs: {}
+         },
+         "MEDIUM": {
+            delay: 1000,
+            funcs: {}
+         },
+         "LONG": {
+            delay: 10000,
+            funcs: {}
+         }
+      };
 
       // The private container for the functionality and properties of the util
       var util = {
@@ -46,6 +65,33 @@ define(["dojo/_base/lang"],
          throttleVars: {
             lastExecutions: {},
             timeouts: {}
+         },
+
+         // See API below
+         addRepeatingFunction: function alfresco_util_functionUtils__addRepeatingFunction(newFunc, periodType) {
+
+            // Put the new function into the appropriate collection
+            var period = REPEATING_PERIODS[periodType],
+               currentFuncs = period.funcs,
+               newFuncKey = Date.now();
+            if (currentFuncs) {
+               while (currentFuncs.hasOwnProperty(newFuncKey)) {
+                  newFuncKey = Date.now();
+               }
+               currentFuncs[newFuncKey] = newFunc;
+            }
+
+            // Make sure the period's functions are running
+            if (!period.running) {
+               this._startRepeatingTimeout(period);
+            }
+
+            // Pass back the removal object
+            return {
+               remove: function() {
+                  delete currentFuncs[newFuncKey];
+               }
+            };
          },
 
          // See API below
@@ -117,7 +163,22 @@ define(["dojo/_base/lang"],
                remove: function() {
                   clearTimeout(currentTimeout);
                }
-            }
+            };
+         },
+
+         // Start calling a repeating function
+         _startRepeatingTimeout: function alfresco_util_functionUtils___startRepeatingTimeout(period) {
+            setTimeout(function timeoutFunc() {
+               var funcKeys = Object.keys(period.funcs);
+               if (funcKeys.length) {
+                  array.forEach(period.funcs, function(func) {
+                     func();
+                  });
+                  setTimeout(timeoutFunc, period.delay);
+               } else {
+                  delete period.running;
+               }
+            }, period.delay);
          }
       };
 
@@ -145,6 +206,17 @@ define(["dojo/_base/lang"],
           * @default 250
           */
          defaultThrottleMs: util.defaultThrottleMs,
+
+         /**
+          * Register a new repeating function.
+          *
+          * @instance
+          * @function
+          * @param {function} func The function to be added
+          * @param {string} period One of "SHORT" (100ms), "MEDIUM" (1000ms) or "LONG" (10000ms), to determine how often the function is called
+          * @returns {object} An object with a remove method on it, which will de-register this function
+          */
+         addRepeatingFunction: util.addRepeatingFunction,
 
          /**
           * <p>Debounce the supplied function.</p>

--- a/aikau/src/main/resources/alfresco/util/functionUtils.js
+++ b/aikau/src/main/resources/alfresco/util/functionUtils.js
@@ -172,6 +172,7 @@ define([
                var funcKeys = Object.keys(period.funcs);
                if (funcKeys.length) {
                   array.forEach(funcKeys, function(funcKey) {
+                     /*jshint devel:true*/
                      try {
                         period.funcs[funcKey]();
                      } catch (e) {

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -113,6 +113,7 @@ define(["dojo/_base/array",
        * a suppresssDecoding argument of true is provided.
        *
        * @instance
+       * @function
        * @param {boolean} [suppressDecoding] Optionally suppress URI decoding
        * @returns {Object} The hash value as an object
        */
@@ -122,6 +123,7 @@ define(["dojo/_base/array",
        * Get the current hash value as a string. All values will be URI decoded.
        *
        * @instance
+       * @function
        * @returns {string} The hash value as a string
        */
       getHashString: lang.hitch(util, util.getHashString),
@@ -131,6 +133,7 @@ define(["dojo/_base/array",
        * a suppressEncoding argument of true is provided.
        *
        * @instance
+       * @function
        * @param {Object} hashObj The new hash object
        * @param {boolean} [replace] Replace the current hash, rather than changing
        *                            (i.e. do not add to the history)
@@ -142,6 +145,7 @@ define(["dojo/_base/array",
        * Set the current hash value from a string. All values will be URI encoded.
        *
        * @instance
+       * @function
        * @param {string} hashString The new hash string
        * @param {boolean} [replace] Replace the current hash, rather than changing
        *                            (i.e. do not add to the history)
@@ -154,6 +158,7 @@ define(["dojo/_base/array",
        * or undefined. All values will be URI encoded.
        *
        * @instance
+       * @function
        * @param {Object} newValues The new hash values with hash names as keys and
        *                           hash values as their values (will only change
        *                           values for hash names with keys in this object)

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -46,440 +46,504 @@ define(["intern!object",
          }, 5000));
    }
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Dialog Service Tests",
+      return {
+         name: "Dialog Service Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/DialogService", "Dialog Service Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/DialogService", "Dialog Service Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Test that dialog with no ID can be created": function() {
-         return browser.findByCssSelector("#CREATE_FORM_DIALOG_NO_ID")
-            .click()
+         "Test that dialog with no ID can be created": function() {
+            return browser.findByCssSelector("#CREATE_FORM_DIALOG_NO_ID")
+               .click()
+               .end()
+
+            .findByCssSelector(".alfresco-dialog-AlfDialog")
+               .then(null, function() {
+                  assert(false, "The Dialog did not appear");
+               });
+         },
+
+         "Test publication on dialog show": function() {
+            return browser.findByCssSelector(".alfresco-dialog-AlfDialog")
             .end()
+            .getLastPublish("DISPLAYED_FD1", "Could not find topic published when displayed dialog");
+         },
 
-         .findByCssSelector(".alfresco-dialog-AlfDialog")
-            .then(null, function() {
-               assert(false, "The Dialog did not appear");
-            });
-      },
+         "Test recreating dialog with no ID": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("CREATE_FORM_DIALOG_NO_ID")
+                     .click()
+                     .end()
 
-      "Test publication on dialog show": function() {
-         return browser.findByCssSelector(".alfresco-dialog-AlfDialog")
-         .end()
-         .getLastPublish("DISPLAYED_FD1", "Could not find topic published when displayed dialog");
-      },
+                  .findAllByCssSelector(".alfresco-dialog-AlfDialog")
+                     .then(function(elements) {
+                        assert.lengthOf(elements, 1, "The previous dialog without an ID was not destroyed");
+                     });
+               });
+         },
 
-      "Test recreating dialog with no ID": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("CREATE_FORM_DIALOG_NO_ID")
-                  .click()
+         "Test creating dialog with an ID": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("CREATE_FORM_DIALOG")
+                     .click()
+                     .end()
+
+                  .findAllByCssSelector(".alfresco-dialog-AlfDialog")
+                     .then(function(elements) {
+                        assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed");
+                     });
+               });
+         },
+
+         "Test recreating dialog with an ID": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("CREATE_FORM_DIALOG")
+                     .clearLog()
+                     .click()
                   .end()
 
-               .findAllByCssSelector(".alfresco-dialog-AlfDialog")
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 1, "The previous dialog without an ID was not destroyed");
-                  });
-            });
-      },
+                  .findAllByCssSelector(".alfresco-dialog-AlfDialog")
+                     .then(function(elements) {
+                        assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed");
+                     });
+               });
+         },
 
-      "Test creating dialog with an ID": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("CREATE_FORM_DIALOG")
-                  .click()
-                  .end()
+         "Test that updated value is included in post": function() {
+            // Type a value into the field...
+            return browser.findByCssSelector("#FD2.dialogDisplayed").end()
 
-               .findAllByCssSelector(".alfresco-dialog-AlfDialog")
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed");
-                  });
-            });
-      },
+               .findByCssSelector("#TB2 .dijitInputContainer input")
+                  .clearValue()
+                  .type("Some value")
+               .end()
 
-      "Test recreating dialog with an ID": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("CREATE_FORM_DIALOG")
-                  .clearLog()
+               // Post the form...
+               .findByCssSelector("#FD2 .confirmationButton > span")
                   .click()
                .end()
 
-               .findAllByCssSelector(".alfresco-dialog-AlfDialog")
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 2, "The previous dialog (without an ID) was destroyed");
-                  });
-            });
-      },
+               // Check the values have been set
+               .getLastPublish("POST_DIALOG_2")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "text","Some value", "Textbox value was not posted");
+                  assert.propertyVal(payload, "bonusData","test", "Additional data was not posted");
+               });
+         },
 
-      "Test that updated value is included in post": function() {
-         // Type a value into the field...
-         return browser.findByCssSelector("#FD2.dialogDisplayed").end()
+         "Check that form dialog dimensions can be set": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("CREATE_FORM_DIALOG")
+                     .click()
+                  .end()
+                  .findByCssSelector("#FD2 .dialog-body")
+                     .getComputedStyle("width")
+                        .then(function(width) {
+                           assert.equal(width, "700px", "Width was not set correctly");
+                        })
+                     .getComputedStyle("height")
+                        .then(function(height) {
+                           assert.equal(height, "300px", "Height was not set correctly");
+                        });
+               });
+         },
 
-            .findByCssSelector("#TB2 .dijitInputContainer input")
+         "Dialog is closed when dialogCloseTopic is set": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("LAUNCH_FAILURE_DIALOG")
+                     .click()
+                  .end()
+
+                  .findByCssSelector("#TB3 .dijitInputContainer input")
+                     .clearValue()
+                     .type("Succeed")
+                  .end()
+
+                  .findByCssSelector("#FD3 .confirmationButton > span")
+                     .click()
+                  .end()
+                  .sleep(250) // Give the dialog a chance to be hidden
+                  .findByCssSelector("#FD3")
+                     .isDisplayed()
+                     .then(function(displayed) {
+                        assert.isFalse(displayed, "The dialog was not hidden");
+                     });
+               });
+         },
+
+         "Dialog remains open when dialogCloseTopic is set": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("LAUNCH_FAILURE_DIALOG")
+                     .click()
+                  .end()
+
+                  .findByCssSelector("#TB3 .dijitInputContainer input")
+                     .clearValue()
+                     .type("fail")
+                  .end()
+
+                  .findByCssSelector("#FD3 .confirmationButton > span")
+                     .click()
+                  .end()
+                  .sleep(250) // Give the dialog a chance to be hidden
+                  .findByCssSelector("#FD3")
+                     .isDisplayed()
+                     .then(function(displayed) {
+                        assert.isTrue(displayed, "The dialog was not hidden");
+                     });
+               });
+         },
+
+         "Check that non-form dialog dimensions can be set": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
+                     .click()
+                  .end()
+                  .findByCssSelector("#OUTER_DIALOG .dialog-body")
+                     .getComputedStyle("width")
+                        .then(function(width) {
+                           assert.equal(width, "600px", "Width was not set correctly");
+                        })
+                     .getComputedStyle("height")
+                        .then(function(height) {
+                           assert.equal(height, "400px", "Height was not set correctly");
+                        });
+               });
+         },
+
+         "Check form dialog has customised IDs for buttons": function () {
+            return closeAllDialogs(browser)
+               .then(function () {
+                  return browser.findById("LAUNCH_CUSTOM_BUTTON_ID_DIALOG")
+                     .click()
+                     .end()
+
+                     .findAllByCssSelector("#CUSTOM_OK_BUTTON_ID")
+                     .then(function (elements) {
+                        assert.lengthOf(elements, 1, "OK Button missing custom id");
+                     })
+                     .end()
+
+                     .findAllByCssSelector("#CUSTOM_DIALOG_CANCEL")
+                     .then(function (elements) {
+                        assert.lengthOf(elements, 1, "CANCEL Button missing default id");
+                     });
+
+               });
+         },
+
+         "Count golden path repeating dialog buttons": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("CREATE_AND_CREATE_ANOTHER_1")
+                     .click()
+                  .end()
+                  .findAllByCssSelector("#CUSTOM_DIALOG .footer .alfresco-buttons-AlfButton")
+                     .then(function(elements) {
+                        assert.lengthOf(elements, 3, "Unexpected number of buttons");
+                     });
+               });
+         },
+
+         "Check that golden path repeating dialog repeats on repeat confirmation": function() {
+            return browser.findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
                .clearValue()
-               .type("Some value")
+               .type("another")
+               .end()
+
+            .findById("CUSTOM_REPEAT_BUTTON_ID")
+               .click()
+               .end()
+
+            .waitForDeletedByClassName(".dialogDisplayed")
+               .getLastPublish("POST_FORM_DIALOG")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "text", "another", "Textbox value was not posted");
+               })
+
+            .findAllByCssSelector("#CUSTOM_DIALOG.dialogDisplayed")
+               .end()
+
+            .findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
+               .getProperty("value")
+               .then(function(resultText) {
+                  assert.equal(resultText, "", "The form was not reset on repeat");
+               });
+         },
+
+         "Check that golden path repeating dialog does NOT repeat on basic confirmation": function() {
+            return browser.findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
+               .clearValue()
+               .type("encore")
             .end()
 
-            // Post the form...
-            .findByCssSelector("#FD2 .confirmationButton > span")
+            .findById("CUSTOM_OK_BUTTON_ID")
                .click()
             .end()
 
-            // Check the values have been set
-            .getLastPublish("POST_DIALOG_2")
-            .then(function(payload) {
-               assert.propertyVal(payload, "text","Some value", "Textbox value was not posted");
-               assert.propertyVal(payload, "bonusData","test", "Additional data was not posted");
-            });
-      },
-
-      "Check that form dialog dimensions can be set": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("CREATE_FORM_DIALOG")
-                  .click()
-               .end()
-               .findByCssSelector("#FD2 .dialog-body")
-                  .getComputedStyle("width")
-                     .then(function(width) {
-                        assert.equal(width, "700px", "Width was not set correctly");
-                     })
-                  .getComputedStyle("height")
-                     .then(function(height) {
-                        assert.equal(height, "300px", "Height was not set correctly");
-                     });
-            });
-      },
-
-      "Dialog is closed when dialogCloseTopic is set": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("LAUNCH_FAILURE_DIALOG")
-                  .click()
-               .end()
-
-               .findByCssSelector("#TB3 .dijitInputContainer input")
-                  .clearValue()
-                  .type("Succeed")
-               .end()
-
-               .findByCssSelector("#FD3 .confirmationButton > span")
-                  .click()
-               .end()
-               .sleep(250) // Give the dialog a chance to be hidden
-               .findByCssSelector("#FD3")
-                  .isDisplayed()
-                  .then(function(displayed) {
-                     assert.isFalse(displayed, "The dialog was not hidden");
-                  });
-            });
-      },
-
-      "Dialog remains open when dialogCloseTopic is set": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("LAUNCH_FAILURE_DIALOG")
-                  .click()
-               .end()
-
-               .findByCssSelector("#TB3 .dijitInputContainer input")
-                  .clearValue()
-                  .type("fail")
-               .end()
-
-               .findByCssSelector("#FD3 .confirmationButton > span")
-                  .click()
-               .end()
-               .sleep(250) // Give the dialog a chance to be hidden
-               .findByCssSelector("#FD3")
-                  .isDisplayed()
-                  .then(function(displayed) {
-                     assert.isTrue(displayed, "The dialog was not hidden");
-                  });
-            });
-      },
-
-      "Check that non-form dialog dimensions can be set": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
-                  .click()
-               .end()
-               .findByCssSelector("#OUTER_DIALOG .dialog-body")
-                  .getComputedStyle("width")
-                     .then(function(width) {
-                        assert.equal(width, "600px", "Width was not set correctly");
-                     })
-                  .getComputedStyle("height")
-                     .then(function(height) {
-                        assert.equal(height, "400px", "Height was not set correctly");
-                     });
-            });
-      },
-
-      "Check form dialog has customised IDs for buttons": function () {
-         return closeAllDialogs(browser)
-            .then(function () {
-               return browser.findById("LAUNCH_CUSTOM_BUTTON_ID_DIALOG")
-                  .click()
-                  .end()
-
-                  .findAllByCssSelector("#CUSTOM_OK_BUTTON_ID")
-                  .then(function (elements) {
-                     assert.lengthOf(elements, 1, "OK Button missing custom id");
-                  })
-                  .end()
-
-                  .findAllByCssSelector("#CUSTOM_DIALOG_CANCEL")
-                  .then(function (elements) {
-                     assert.lengthOf(elements, 1, "CANCEL Button missing default id");
-                  });
-
-            });
-      },
-
-      "Count golden path repeating dialog buttons": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("CREATE_AND_CREATE_ANOTHER_1")
-                  .click()
-               .end()
-               .findAllByCssSelector("#CUSTOM_DIALOG .footer .alfresco-buttons-AlfButton")
-                  .then(function(elements) {
-                     assert.lengthOf(elements, 3, "Unexpected number of buttons");
-                  });
-            });
-      },
-
-      "Check that golden path repeating dialog repeats on repeat confirmation": function() {
-         return browser.findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
-            .clearValue()
-            .type("another")
-            .end()
-
-         .findById("CUSTOM_REPEAT_BUTTON_ID")
-            .click()
-            .end()
-
-         .waitForDeletedByClassName(".dialogDisplayed")
+            .waitForDeletedByClassName(".dialogDisplayed")
             .getLastPublish("POST_FORM_DIALOG")
-            .then(function(payload) {
-               assert.propertyVal(payload, "text", "another", "Textbox value was not posted");
-            })
-
-         .findAllByCssSelector("#CUSTOM_DIALOG.dialogDisplayed")
-            .end()
-
-         .findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(resultText) {
-               assert.equal(resultText, "", "The form was not reset on repeat");
-            });
-      },
-
-      "Check that golden path repeating dialog does NOT repeat on basic confirmation": function() {
-         return browser.findByCssSelector("#GOLDEN_REPEATING_INPUT .dijitInputContainer input")
-            .clearValue()
-            .type("encore")
-         .end()
-
-         .findById("CUSTOM_OK_BUTTON_ID")
-            .click()
-         .end()
-
-         .waitForDeletedByClassName(".dialogDisplayed")
-         .getLastPublish("POST_FORM_DIALOG")
-            .then(function(payload) {
-               assert.propertyVal(payload, "text","encore", "Textbox value was not posted");
-            })
-
-         .findAllByCssSelector("#CUSTOM_DIALOG.dialogHidden")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Dialog was not hidden");
-            });
-      },
-
-      "Count error path repeating dialog buttons": function() {
-         return browser.findById("CREATE_AND_CREATE_ANOTHER_2")
-            .click()
-         .end()
-         .findAllByCssSelector("#ERROR_REPEATING .footer .alfresco-buttons-AlfButton")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "Unexpected number of buttons");
-            });
-      },
-
-      "Check that error path repeating dialog repeats on repeat confirmation with GOOD data": function() {
-         return browser.findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
-            .clearValue()
-            .type("more")
-            .end()
-
-         .findById("ERROR_REPEATING_OK_AND_REPEAT")
-            .click()
-            .end()
-
-         .waitForDeletedByClassName(".dialogDisplayed")
-            .getLastPublish("POST_FORM_DIALOG")
-            .then(function(payload) {
-               assert.propertyVal(payload, "text", "more", "Textbox value was not posted");
-            })
-
-         .findAllByCssSelector("#ERROR_REPEATING.dialogDisplayed")
-            .end()
-            
-         .findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(resultText) {
-               assert.equal(resultText, "", "The form was not reset on repeat");
-            });
-      },
-
-      "Check that error path repeating dialog does NOT repeat on basic confirmation": function() {
-         return browser.findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
-            .clearValue()
-            .type("repeat")
-         .end()
-
-         .findById("DIFFERENT_OK_BUTTON_ID")
-            .click()
-         .end()
-            
-         .getLastPublish("POST_FORM_DIALOG")
-            .then(function(payload) {
-               assert.propertyVal(payload, "text", "repeat", "Textbox value was not posted");
-            })
-
-         .findAllByCssSelector("#ERROR_REPEATING.dialogHidden")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Dialog was not hidden");
-            });
-      },
-
-      "Check tabs in form dialog": function() {
-         return browser.findById("CREATE_FORM_DIALOG_WITH_TABBED_LAYOUT")
-            .click()
-         .end()
-         .findAllByCssSelector("#TABBED_FORM_DIALOG.dialogDisplayed")
-         .end()
-         .findAllByCssSelector("#TABBED_FORM_DIALOG.alfresco-layout-AlfTabContainer--tabsDisplayed")
-         .end()
-         .findByCssSelector("#TABBED_FORM_DIALOG .dijitTabController")
-            .getSize()
-            .then(function(size) {
-               assert(size.height > 0, "Tabs were not displayed correctly when dialog is initially shown, height = " + size.height);
-            });
-      },
-
-      "Ensure that all tabbed form values are included in published value": function() {
-         return browser.findByCssSelector("#TAB1_TB .dijitInputContainer input")
-            .type("one")
-         .end()
-         .findByCssSelector("#TABBED_FORM_DIALOG .dijitTab:nth-child(2) .tabLabel")
-            .click()
-         .end()
-         .findByCssSelector("#TAB2_TB .dijitInputContainer input")
-            .type("two")
-         .end()
-         .findByCssSelector("#TABBED_FORM_DIALOG .alfresco-buttons-AlfButton.confirmationButton > span")
-            .click()
-         .end()
-         .findAllByCssSelector("#TABBED_FORM_DIALOG.dialogHidden")
-         .end()
-         .getLastPublish("TABBED_FORM")
-            .then(function(payload) {
-               assert.propertyVal(payload, "tab1tb", "one", "Published form data incorrect (tab1tb)"); 
-               assert.propertyVal(payload, "tab2tb", "two", "Published form data incorrect (tab2tb)");
-            });
-      },
-
-      "Full screen dialog should be fixed": function() {
-         var initial_y;
-         return browser.findById("FULL_SCREEN_DIALOG_label")
-            .click()
-         .end()
-
-         .findByCssSelector("#FSD1.dialogDisplayed")
-            .getPosition()
-               .then(function(position) {
-                  initial_y = position.y;
+               .then(function(payload) {
+                  assert.propertyVal(payload, "text","encore", "Textbox value was not posted");
                })
-         .end()
 
-         // Scroll to the bottom of the page...
-         .execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
-         .end()
+            .findAllByCssSelector("#CUSTOM_DIALOG.dialogHidden")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Dialog was not hidden");
+               });
+         },
 
-         .findById("FSD1")
-            .getPosition()
-            .then(function(position) {
-               assert.isAbove(position.y, initial_y, "The position of the dialog did not move with the scroll");
-            })
-         .end()
+         "Count error path repeating dialog buttons": function() {
+            return browser.findById("CREATE_AND_CREATE_ANOTHER_2")
+               .click()
+            .end()
+            .findAllByCssSelector("#ERROR_REPEATING .footer .alfresco-buttons-AlfButton")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "Unexpected number of buttons");
+               });
+         },
 
-         .findById("FULL_SCREEN_DIALOG_CLOSE_label")
-            .click()
-         .end()
+         "Check that error path repeating dialog repeats on repeat confirmation with GOOD data": function() {
+            return browser.findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
+               .clearValue()
+               .type("more")
+               .end()
 
-         .findByCssSelector("#FSD1.dialogHidden");
-      },
+            .findById("ERROR_REPEATING_OK_AND_REPEAT")
+               .click()
+               .end()
 
-      "Can launch dialog within dialog": function() {
-         return closeAllDialogs(browser)
-            .then(function() {
-               return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
-                  .click()
-                  .end()
+            .waitForDeletedByClassName(".dialogDisplayed")
+               .getLastPublish("POST_FORM_DIALOG")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "text", "more", "Textbox value was not posted");
+               })
 
-               .findById("LAUNCH_INNER_DIALOG_BUTTON")
-                  .click()
-                  .end()
+            .findAllByCssSelector("#ERROR_REPEATING.dialogDisplayed")
+               .end()
+               
+            .findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
+               .getProperty("value")
+               .then(function(resultText) {
+                  assert.equal(resultText, "", "The form was not reset on repeat");
+               });
+         },
 
-               .getLastPublish("DISPLAYED_INNER_DIALOG", "Inner dialog not displayed")
-
-               .findByCssSelector("#INNER_DIALOG .dijitDialogCloseIcon")
-                  .click()
-                  .end()
-
-               .findByCssSelector("#INNER_DIALOG.dialogHidden")
-                  .end()
-
-               .findByCssSelector("#OUTER_DIALOG .dijitDialogCloseIcon")
-                  .click()
-                  .end()
-
-               .findByCssSelector("#OUTER_DIALOG.dialogHidden");
-            });
-      },
-
-      "Can publish form with custom scope information": function() {
-         return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"CREATE_FORM_DIALOG_CUSTOM_SCOPE\"] .dijitButtonNode")
-            .click()
+         "Check that error path repeating dialog does NOT repeat on basic confirmation": function() {
+            return browser.findByCssSelector("#ERROR_REPEATING_INPUT .dijitInputContainer input")
+               .clearValue()
+               .type("repeat")
             .end()
 
-         .findByCssSelector("#SCOPED_FORM.dialogDisplayed .confirmationButton .dijitButtonNode")
-            .click()
+            .findById("DIFFERENT_OK_BUTTON_ID")
+               .click()
+            .end()
+               
+            .getLastPublish("POST_FORM_DIALOG")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "text", "repeat", "Textbox value was not posted");
+               })
+
+            .findAllByCssSelector("#ERROR_REPEATING.dialogHidden")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Dialog was not hidden");
+               });
+         },
+
+         "Check tabs in form dialog": function() {
+            return browser.findById("CREATE_FORM_DIALOG_WITH_TABBED_LAYOUT")
+               .click()
+            .end()
+            .findAllByCssSelector("#TABBED_FORM_DIALOG.dialogDisplayed")
+            .end()
+            .findAllByCssSelector("#TABBED_FORM_DIALOG.alfresco-layout-AlfTabContainer--tabsDisplayed")
+            .end()
+            .findByCssSelector("#TABBED_FORM_DIALOG .dijitTabController")
+               .getSize()
+               .then(function(size) {
+                  assert(size.height > 0, "Tabs were not displayed correctly when dialog is initially shown, height = " + size.height);
+               });
+         },
+
+         "Ensure that all tabbed form values are included in published value": function() {
+            return browser.findByCssSelector("#TAB1_TB .dijitInputContainer input")
+               .type("one")
+            .end()
+            .findByCssSelector("#TABBED_FORM_DIALOG .dijitTab:nth-child(2) .tabLabel")
+               .click()
+            .end()
+            .findByCssSelector("#TAB2_TB .dijitInputContainer input")
+               .type("two")
+            .end()
+            .findByCssSelector("#TABBED_FORM_DIALOG .alfresco-buttons-AlfButton.confirmationButton > span")
+               .click()
+            .end()
+            .findAllByCssSelector("#TABBED_FORM_DIALOG.dialogHidden")
+            .end()
+            .getLastPublish("TABBED_FORM")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "tab1tb", "one", "Published form data incorrect (tab1tb)"); 
+                  assert.propertyVal(payload, "tab2tb", "two", "Published form data incorrect (tab2tb)");
+               });
+         },
+
+         "Full screen dialog should be fixed": function() {
+            var initial_y;
+            return browser.findById("FULL_SCREEN_DIALOG_label")
+               .click()
             .end()
 
-         .getLastPublish("CUSTOM_FORM_SCOPE_CUSTOM_FORM_TOPIC", true, "Did not publish correctly scoped topic")
-            .then(function(payload){
-               assert.propertyVal(payload, "text", "This is some sample text", "Did not publish correct form value to scoped topic");
-            });
-      },
+            .findByCssSelector("#FSD1.dialogDisplayed")
+               .getPosition()
+                  .then(function(position) {
+                     initial_y = position.y;
+                  })
+            .end()
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+            // Scroll to the bottom of the page...
+            .execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
+            .end()
+
+            .findById("FSD1")
+               .getPosition()
+               .then(function(position) {
+                  assert.isAbove(position.y, initial_y, "The position of the dialog did not move with the scroll");
+               })
+            .end()
+
+            .findById("FULL_SCREEN_DIALOG_CLOSE_label")
+               .click()
+            .end()
+
+            .findByCssSelector("#FSD1.dialogHidden");
+         },
+
+         "Can launch dialog within dialog": function() {
+            return closeAllDialogs(browser)
+               .then(function() {
+                  return browser.findById("LAUNCH_OUTER_DIALOG_BUTTON")
+                     .click()
+                     .end()
+
+                  .findById("LAUNCH_INNER_DIALOG_BUTTON")
+                     .click()
+                     .end()
+
+                  .getLastPublish("DISPLAYED_INNER_DIALOG", "Inner dialog not displayed")
+
+                  .findByCssSelector("#INNER_DIALOG .dijitDialogCloseIcon")
+                     .click()
+                     .end()
+
+                  .findByCssSelector("#INNER_DIALOG.dialogHidden")
+                     .end()
+
+                  .findByCssSelector("#OUTER_DIALOG .dijitDialogCloseIcon")
+                     .click()
+                     .end()
+
+                  .findByCssSelector("#OUTER_DIALOG.dialogHidden");
+               });
+         },
+
+         "Can publish form with custom scope information": function() {
+            return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"CREATE_FORM_DIALOG_CUSTOM_SCOPE\"] .dijitButtonNode")
+               .click()
+               .end()
+
+            .findByCssSelector("#SCOPED_FORM.dialogDisplayed .confirmationButton .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLastPublish("CUSTOM_FORM_SCOPE_CUSTOM_FORM_TOPIC", true, "Did not publish correctly scoped topic")
+               .then(function(payload){
+                  assert.propertyVal(payload, "text", "This is some sample text", "Did not publish correct form value to scoped topic");
+               })
+
+            .findByCssSelector("#SCOPED_FORM.dialogHidden");
+         },
+
+         "Dialog recentres after its size changes": function() {
+            var getDialogHeight = function() {
+                  return document.getElementById("RESIZING_DIALOG").offsetHeight;
+               },
+               getWindowHeight = function() {
+                  return window.innerHeight;
+               },
+               getCorrectTop = function() {
+                  return (windowHeight - dialogHeight) / 2;
+               },
+               windowHeight,
+               dialogHeight;
+
+            return browser.findById("RESIZING_DIALOG_BUTTON_label")
+               .click()
+               .end()
+
+            .execute(getWindowHeight)
+               .then(function(height) {
+                  windowHeight = height;
+               })
+
+            .findByCssSelector("#RESIZING_DIALOG.dialogDisplayed")
+               .execute(getDialogHeight)
+               .then(function(height) {
+                  dialogHeight = height;
+               })
+               .getPosition()
+               .then(function(position) {
+                  assert.closeTo(getCorrectTop(), position.y, 20, "Dialog is not initially centred");
+               })
+               .end()
+
+            .findByCssSelector("#RESIZING_DIALOG .dijitArrowButton")
+               .click()
+               .end()
+
+            .findByCssSelector(".dijitMenuActive .dijitMenuItem:nth-child(2) .dijitMenuItemLabel")
+               .click()
+               .end()
+
+            .getLastPublish("ALF_NODE_RESIZED")
+               .execute(getDialogHeight)
+               .then(function(height) {
+                  assert.isAbove(height, dialogHeight, "Dialog did not increase in size");
+                  dialogHeight = height;
+               })
+
+            .findByCssSelector("#RESIZING_DIALOG")
+               .getPosition()
+               .then(function(position) {
+                  assert.closeTo(getCorrectTop(), position.y, 20, "Dialog is not centred after size changes");
+               })
+               .end()
+
+            .findById("RESIZING_DIALOG_CANCEL")
+               .click()
+               .end()
+
+            .findByCssSelector("#RESIZING_DIALOG.dialogHidden");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -597,6 +597,109 @@ model.jsonModel = {
          }
       },
       {
+         id: "RESIZING_DIALOG_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create Resizing Form Dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "RESIZING_DIALOG",
+               dialogTitle: "Resizing Form Dialog",
+               formSubmissionTopic: "RESIZING_DIALOG_SUBMISSION",
+               widgets: [
+                  {
+                     name: "alfresco/forms/controls/Select",
+                     config: {
+                        fieldId: "DISPLAY_MORE",
+                        label: "Display more fields",
+                        name: "displayMore",
+                        optionsConfig: {
+                           fixed: [
+                              {
+                                 value: "NO",
+                                 label: "No"
+                              },
+                              {
+                                 value: "YES",
+                                 label: "Yes"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        fieldId: "OPTION_1",
+                        label: "Option 1 value",
+                        name: "option1",
+                        visibilityConfig: {
+                           initialValue: false,
+                           rules: [
+                              {
+                                 targetId: "DISPLAY_MORE",
+                                 is: ["YES"]
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        fieldId: "OPTION_2",
+                        label: "Option 2 value",
+                        name: "option2",
+                        visibilityConfig: {
+                           initialValue: false,
+                           rules: [
+                              {
+                                 targetId: "DISPLAY_MORE",
+                                 is: ["YES"]
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        fieldId: "OPTION_3",
+                        label: "Option 3 value",
+                        name: "option3",
+                        visibilityConfig: {
+                           initialValue: false,
+                           rules: [
+                              {
+                                 targetId: "DISPLAY_MORE",
+                                 is: ["YES"]
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        fieldId: "OPTION_4",
+                        label: "Option 4 value",
+                        name: "option4",
+                        visibilityConfig: {
+                           initialValue: false,
+                           rules: [
+                              {
+                                 targetId: "DISPLAY_MORE",
+                                 is: ["YES"]
+                              }
+                           ]
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This PR addresses [AKU-671](https://issues.alfresco.com/jira/browse/AKU-671) "Dialogs not re-centered on content change" by updating and then applying the updated `ResizeMixin.addResizeListener()` functionality to [`AlfDialog`](https://github.com/Alfresco/Aikau/blob/develop/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js).