### PR TITLE
AKU-673: Dialog should take more space if required

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/CommentsList.js
+++ b/aikau/src/main/resources/alfresco/renderers/CommentsList.js
@@ -49,6 +49,33 @@ define(["dojo/_base/declare",
        * @default [{i18nFile: "./i18n/CommentsList.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/CommentsList.properties"}],
+
+      /**
+       * Whether to use a full-screen dialog when adding comments.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.43
+       */
+      addCommentsFullScreen: false,
+
+      /**
+       * Executed after properties mixed in and before widget created
+       *
+       * @instance
+       * @override
+       * @since 1.0.43
+       */
+      postMixInProperties: function alfresco_renderers_CommentsList__postMixInProperties() {
+         this.inherited(arguments);
+         if (this.addCommentsFullScreen) {
+            var addCommentPayload = lang.getObject("widgets.0.config.widgetsBefore.0.config.publishPayload", false, this);
+            if(addCommentPayload) {
+               addCommentPayload.fullScreenMode = true;
+            }
+         }
+      },
       
       /**
        * Widget has been started, but not necessarily any sub-widgets.

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/CommentsList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/CommentsList.get.js
@@ -19,6 +19,7 @@ model.jsonModel = {
          name: "alfresco/renderers/CommentsList",
          id: "COMMENT_LIST",
          config: {
+            addCommentsFullScreen: true,
             pubSubScope: "COMMENTS1_",
             currentItem: {
                node: {


### PR DESCRIPTION
This addresses [AKU-673](https://issues.alfresco.com/jira/browse/AKU-673) by allowing passthrough of the fullscreen option when adding a comment. Specifically, one can now specify `addCommentsFullScreen: true` to the config of the `CommentsList` widget.