### PR TITLE
AKU-690: Focus on widgets in grid without focus function

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -42,13 +42,17 @@ define(["dojo/_base/declare",
         "dojo/keys",
         "dojo/_base/lang",
         "dojo/_base/array",
+        "dojo/dom-attr",
+        "dojo/dom-class",
         "dojo/dom-construct",
         "dojo/dom-geometry",
         "dojo/query",
         "dojo/dom-style",
-        "dijit/registry"],
+        "dijit/registry",
+        "dijit/focus"],
         function(declare, _WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, template, _MultiItemRendererMixin,
-                 AlfCore, _LayoutMixin, keys, lang, array, domConstruct, domGeom, query, domStyle, registry) {
+                 AlfCore, _LayoutMixin, keys, lang, array, domAttr, domClass, domConstruct, domGeom, query, domStyle,
+                 registry, focusUtil) {
 
    return declare([_WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, _MultiItemRendererMixin, AlfCore, _LayoutMixin], {
 
@@ -189,6 +193,35 @@ define(["dojo/_base/declare",
          {
             focusedChild.blur();
          }
+         domClass.remove(focusedChild.domNode, "alfresco-lists-views-layouts-Grid--focused");
+      },
+
+      /**
+       * This function ensures that the widget requested to be focused has a focus function
+       * and if so calls the "focusChild" function provided by the _KeyNavContainer. Otherwise
+       * it manually takes case of setting the focus.
+       *
+       * @instance
+       * @param {object} widget The widget to focus
+       * @since 1.0.43
+       */
+      focusOnCell: function alfresco_lists_views_layouts_Grid__focusOnCell(widget) {
+         if (typeof widget.focus === "function")
+         {
+            this.focusChild(widget);
+         }
+         else
+         {
+            if(this.focusedChild && widget !== this.focusedChild){
+               this._onChildBlur(this.focusedChild);  // used to be used by _MenuBase
+            }
+            if (widget.domNode)
+            {
+               domAttr.set(widget.domNode, "tabIndex", this.tabIndex); // for IE focus outline to appear, must set tabIndex before focus
+               focusUtil.focus(widget.domNode);
+            }
+         }
+         domClass.add(widget.domNode, "alfresco-lists-views-layouts-Grid--focused");
       },
 
       /**
@@ -209,7 +242,7 @@ define(["dojo/_base/declare",
          {
             target = allChildren[childCount-1];
          }
-         this.focusChild(target);
+         this.focusOnCell(target);
       },
 
       /**
@@ -230,7 +263,7 @@ define(["dojo/_base/declare",
          {
             target = allChildren[0];
          }
-         this.focusChild(target);
+         this.focusOnCell(target);
       },
 
       /**
@@ -265,7 +298,7 @@ define(["dojo/_base/declare",
          {
             target = allChildren[focusIndex - this.columns];
          }
-         this.focusChild(target);
+         this.focusOnCell(target);
       },
 
       /**
@@ -288,7 +321,7 @@ define(["dojo/_base/declare",
          {
             target = allChildren[focusIndex + this.columns];
          }
-         this.focusChild(target);
+         this.focusOnCell(target);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -193,13 +193,13 @@ define(["dojo/_base/declare",
          {
             focusedChild.blur();
          }
-         domClass.remove(focusedChild.domNode, "alfresco-lists-views-layouts-Grid--focused");
+         domClass.remove(focusedChild.domNode, "alfresco-lists-views-layouts-Grid__cell--focused");
       },
 
       /**
        * This function ensures that the widget requested to be focused has a focus function
        * and if so calls the "focusChild" function provided by the _KeyNavContainer. Otherwise
-       * it manually takes case of setting the focus.
+       * it manually takes care of setting the focus.
        *
        * @instance
        * @param {object} widget The widget to focus
@@ -221,7 +221,7 @@ define(["dojo/_base/declare",
                focusUtil.focus(widget.domNode);
             }
          }
-         domClass.add(widget.domNode, "alfresco-lists-views-layouts-Grid--focused");
+         domClass.add(widget.domNode, "alfresco-lists-views-layouts-Grid__cell--focused");
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/lists/views/GalleryViewFocusTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/GalleryViewFocusTest.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"], 
+        function (registerSuite, assert, TestCommon, keys) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Gallery View (focus) Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/GalleryViewFocus", "Gallery View (focus) Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Keyboard focus works": function() {
+            return browser.findDisplayedByCssSelector("#PROPERTY_ITEM_0")
+               .click()
+            .end()
+
+            .pressKeys(keys.ARROW_RIGHT)
+
+            .getActiveElement()
+               .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "Telford and Wrekin Council", "Focus not moved");
+                  });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -172,6 +172,7 @@ define({
       "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
       "src/test/resources/alfresco/lists/PaginatorVisibilityTest",
       "src/test/resources/alfresco/lists/views/AlfListViewTest",
+      "src/test/resources/alfresco/lists/views/GalleryViewFocusTest",
       "src/test/resources/alfresco/lists/views/GalleryViewInfiniteScrollTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Gallery View (focus tests)</shortname>
+  <description>This test page shows an AlfGalleryView with a custom widget model consisting of a primary widget that does not have a focus function in order to verify that keyboard navigation still works.</description>
+  <family>aikau-unit-tests</family>
+  <url>/GalleryViewFocus</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.js
@@ -1,0 +1,59 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "TOOLBAR",
+         name: "alfresco/documentlibrary/AlfToolbar"
+      },
+      {
+         id: "DOCLIST",
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            useHash: false,
+            useInfiniteScroll: false,
+            additionalControlsTarget: "TOOLBAR",
+            currentPageSize: 16,
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/views/AlfGalleryView",
+                  config: {
+                     columns: 4,
+                     widgets: [
+                        {
+                           id: "PROPERTY",
+                           name: "alfresco/renderers/Property",
+                           config: {
+                              propertyToRender: "displayName"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/NodesMockXhr",
+         config: {
+            totalItems: 16,
+            folderRatio: [100]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-690 to ensure that widgets in an alfresco/lists/views/layouts/Grid can be focused even when they do not have a "focus" function. A unit test has been added to support the fix.