### PR TITLE
AKU-689: Ensure resizing widgets resize within grid cells

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -51,19 +51,31 @@ define(["dojo/_base/declare",
       alfResizeNodeTopic: topics.NODE_RESIZED,
 
       /**
-       * Publishes on a topic that indicates that the supplied node has been resized.
+       * Publishes on a topic that indicates that the supplied node has been resized. By default publications
+       * will be throttled to prevent multiple resize events being published for the same node, however it
+       * is possible to provide an optional "unthrottled" argument to prevent throttling.
        *
        * @instance
        * @param {object} resizedNode The node that has been resized
+       * @param {boolean} [unthrottled] Indicates whether or not the publication should be throttled or not
        * @fires module:alfresco/core/ResizeMixin#alfResizeNodeTopic
        */
-      alfPublishResizeEvent: function alfresco_core_ResizeMixin__alfPublishResizeEvent(resizedNode) {
+      alfPublishResizeEvent: function alfresco_core_ResizeMixin__alfPublishResizeEvent(resizedNode, unthrottled) {
          // Fire a custom event to let contained objects know that the node has been resized.
-         this.throttledPublish(this.alfResizeNodeTopic, {
-            node: resizedNode
-         }, true, false, {
-            timeoutMs: 100
-         });
+         if (!unthrottled)
+         {
+            this.throttledPublish(this.alfResizeNodeTopic, {
+               node: resizedNode
+            }, true, false, {
+               timeoutMs: 100
+            });
+         }
+         else
+         {
+            this.alfPublish(this.alfResizeNodeTopic, {
+               node: resizedNode
+            }, true);
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -389,12 +389,11 @@ define(["dojo/_base/declare",
       resizeCell: function alfresco_lists_views_layouts_Grid__resizeCell(containerNodeMarginBox, widthToSet, node, /*jshint unused:false*/ index) {
          domStyle.set(node, {"width": widthToSet});
          var dimensions = {
-               w: widthToSet,
-               h: null
-            },
-            widgetsToResize = query("[widgetId]", node); // Resize all contained widgets, not just immediate children.
-
-         array.forEach(widgetsToResize, lang.hitch(this, "resizeWidget", dimensions));
+            w: widthToSet,
+            h: null
+         },
+         widgetsToResize = query("[widgetId]", node); // Resize all contained widgets, not just immediate children.
+         array.forEach(widgetsToResize, lang.hitch(this, this.resizeWidget, dimensions));
       },
 
       /**
@@ -411,6 +410,12 @@ define(["dojo/_base/declare",
          if (widget && typeof widget.resize === "function")
          {
             widget.resize(dimensions);
+         }
+         else
+         {
+            // See AKU-689 - resize the widgets DOM node and publish an event to indicate that it has been resized...
+            domStyle.set(widget.domNode, "width", dimensions.w);
+            this.alfPublishResizeEvent(widget.domNode, true); // Make sure the event is unthrottled...
          }
       },
 

--- a/aikau/src/test/resources/alfresco/lists/views/GalleryViewFocusTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/GalleryViewFocusTest.js
@@ -41,8 +41,9 @@ define(["intern!object",
             browser.end();
          },
 
+         // See AKU-690...
          "Keyboard focus works": function() {
-            return browser.findDisplayedByCssSelector("#PROPERTY_ITEM_0")
+            return browser.findDisplayedByCssSelector("#VERTICAL_ITEM_0 .alfresco-renderers-Property")
                .click()
             .end()
 
@@ -52,6 +53,16 @@ define(["intern!object",
                .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "Telford and Wrekin Council", "Focus not moved");
+                  });
+         },
+
+         // See AKU-689...
+         // We need to ensure that horizontal widget resize events are correctly handled as the grid cells resize...
+         "Test initial sizing": function() {
+            return browser.findDisplayedByCssSelector("#VERTICAL_ITEM_5 .alfresco-layout-HorizontalWidgets")
+               .getSize()
+                  .then(function(size) {
+                     assert.equal(size.width, 200, "Width not set correctly");
                   });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/GalleryViewFocus.get.js
@@ -30,13 +30,28 @@ model.jsonModel = {
                {
                   name: "alfresco/documentlibrary/views/AlfGalleryView",
                   config: {
-                     columns: 4,
+                     resizeByColumnCount: false,
+                     thumbnailSize: 200,
                      widgets: [
                         {
-                           id: "PROPERTY",
-                           name: "alfresco/renderers/Property",
+                           id: "VERTICAL",
+                           name: "alfresco/layout/VerticalWidgets",
                            config: {
-                              propertyToRender: "displayName"
+                              widgets: [
+                                 {
+                                    name: "alfresco/layout/HorizontalWidgets",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "displayName"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
                            }
                         }
                      ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-689 to ensure that widgets placed within an alfresco/lists/views/layouts/Grid widget are resized appropriately when they do not have a resize function. In particular this addresses the scenario where an alfresco/layout/HorizontalWidgets widget is used within a grid to ensure that the first cell does not consume too much horizontal space before the rest of the cells on the row have been rendered.