### PR TITLE
AKU-675: Expandable grid

### DIFF
--- a/aikau/src/main/resources/alfresco/core/WidgetsCreator.js
+++ b/aikau/src/main/resources/alfresco/core/WidgetsCreator.js
@@ -68,11 +68,26 @@ define(["dojo/_base/declare",
 
       /**
        * This function is called to create the widgets. An optional rootNode argument can
-       * be passed to provide a destination for the created widgets.
+       * be passed to provide a destination for the created widgets. If a caller argument
+       * is provided then key data from it will be extracted for the creation of the widgets
+       * (such as pubSubScope, dataScope, etc).
        * 
        * @instance
+       * @param {element} rootNode The node to bind the root widgets to
+       * @param {object} [caller] The calling widget or service.
        */
-      buildWidgets: function alfresco_core_WidgetsCreator__buildWidgets(rootNode) {
+      buildWidgets: function alfresco_core_WidgetsCreator__buildWidgets(rootNode, caller) {
+         if (caller)
+         {
+            // If a caller has passed itself then we want to extract all the core data that
+            // would otherwise be extracted in CoreWidgetProcessing...
+            this.pubSubScope = caller.pubSubScope;
+            this.parentPubSubScope = caller.parentPubSubScope;
+            this.dataScope = caller.dataScope;
+            this.currentItem = caller.currentItem;
+            this.currentMetadata = caller.currentMetadata;
+            this.groupMemberships = caller.groupMemberships;
+         }
          this.processWidgets(this.widgets, rootNode);
       },
 

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -69,6 +69,17 @@ define(["dojo/_base/declare",
       columnsPreferenceProperty: "org.alfresco.share.documentList.galleryColumns",
 
       /**
+       * Indicates whether or not highlighting should be enabled. If this is configured to be
+       * true then highlighting of focus and expansion will be handled.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.44
+       */
+      enableHighlighting: false,
+
+      /**
        * This is an array of optional topics that can be subscribed to to create a panel within the 
        * [grid]{@link module:alfresco/lists/views/layouts/Grid} for showing additional data about a 
        * particular cell in the grid. The payload should contain a "widgets" attribute that represents the model 
@@ -388,7 +399,8 @@ define(["dojo/_base/declare",
             nextLinkPublishTopic: this.nextLinkPublishTopic,
             thumbnailSize: this.thumbnailSize,
             itemKeyProperty: this.itemKeyProperty,
-            expandTopics: this.expandTopics
+            expandTopics: this.expandTopics,
+            enableHighlighting: this.enableHighlighting
          });
          return dlr;
       },

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -18,8 +18,27 @@
  */
 
 /**
- * This defines the widget model for rendering the gallery view. This is a grid based layout of thumbnails
- * that can be scaled using a slider control.
+ * <p>This defines the widget model for rendering the gallery view. By default this is a grid based layout 
+ * of thumbnails that can be scaled using a slider control. There are a number of ways in which this can
+ * be configured to obtain alternative rendering.</p>
+ * <p>By default the thumbnail size will be determined by the
+ * available horizontal space for the configured number of 
+ * [columns]{@link module:alfresco/documentlibrary/AlfGalleryView#columns} however it is possible to 
+ * configure [resizeByColumnCount]{@link module:alfresco/documentlibrary/AlfGalleryView#resizeByColumnCount}
+ * to be false such that the thumbnails will have a constant width defined by the configured
+ * [thumbnailSize]{@link module:alfresco/documentlibrary/AlfGalleryView#thumbnailSize}.</p>
+ * <p>When used in a [list]{@link module:alfresco/lists/AlfList} that is configured for
+ * [infinite scrolling]{@link module:alfresco/lists/AlfList#useInfiniteScroll} it is sensible to
+ * configure [showNextLink]{@link module:alfresco/documentlibrary/AlfGalleryView#showNextLink} to be true
+ * such that a link is provided when the scrolling is not available when the thumbnails are so small
+ * that an entire page of data fits within the browser window.</p>
+ * <p>If something other than [thumbnails]{@link module:alfresco/renderers/GalleryThumbnail} needs to be
+ * displayed then it is possible to 
+ * [enable highlighting]{@link module:alfresco/documentlibrary/AlfGalleryView#enableHighlighting} so that
+ * it is clear what item is currently focused - this will help greatly with keyboard navigation.</p>
+ * <p>If more information needs to be displayed for an individual cell then it is possible to configure
+ * one or more [expandTopics]{@link module:alfresco/documentlibrary/AlfGalleryView#expandTopics} that 
+ * when published will reveal a panel in which additional data can be rendered.</p>
  * 
  * @module alfresco/documentlibrary/views/AlfGalleryView
  * @extends module:alfresco/lists/views/AlfListView

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfGalleryView.js
@@ -69,6 +69,36 @@ define(["dojo/_base/declare",
       columnsPreferenceProperty: "org.alfresco.share.documentList.galleryColumns",
 
       /**
+       * This is an array of optional topics that can be subscribed to to create a panel within the 
+       * [grid]{@link module:alfresco/lists/views/layouts/Grid} for showing additional data about a 
+       * particular cell in the grid. The payload should contain a "widgets" attribute that represents the model 
+       * to render within the panel.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.44
+       */
+      expandTopics: null,
+
+      /**
+       * This is the property that is used to uniquely identify each 
+       * [item]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} rendered in the
+       * [grid]{@link module:alfresco/lists/views/layouts/Grid}. It is used
+       * as the key in the [gridCellMapping]{@link module:alfresco/lists/views/layouts/Grid#gridCellMapping}
+       * to map each item to the cell that it is rendered in. This is required in order to know where to 
+       * exand the grid when the 
+       * [expandTopics]{@link module:alfresco/lists/views/layouts/Grid#expandTopics} is
+       * published.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.44
+       */
+      itemKeyProperty: null,
+
+      /**
        * This enables the mixed in [SelectedItemStateMixin]{@link module:alfresco/lists/SelectedItemStateMixin}
        * capabilities to track items as they are selected and deselected. This should only be changed from the
        * default when the view is not used within a [list]{@link module:alfresco/lists/AlfList} (as lists will
@@ -356,7 +386,9 @@ define(["dojo/_base/declare",
             showNextLink: this.showNextLink,
             nextLinkLabel: this.nextLinkLabel,
             nextLinkPublishTopic: this.nextLinkPublishTopic,
-            thumbnailSize: this.thumbnailSize
+            thumbnailSize: this.thumbnailSize,
+            itemKeyProperty: this.itemKeyProperty,
+            expandTopics: this.expandTopics
          });
          return dlr;
       },

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -82,7 +82,9 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_lists_AlfFilteredList__postCreate() {
          domClass.add(this.domNode, "alfresco-lists-AlfFilteredList");
-         this.filtersNode = domConstruct.create("div", {}, this.domNode, "first");
+         this.filtersNode = domConstruct.create("div", {
+            className: "alfresco-lists-AlfFilteredList__filters"
+         }, this.domNode, "first");
 
          // We need a promise here to address the scenario where XHR requests are made for filtering widgets
          // that have not had there dependencies correctly analysed by Surf. This is the case for the ComboBox

--- a/aikau/src/main/resources/alfresco/lists/css/AlfFilteredList.css
+++ b/aikau/src/main/resources/alfresco/lists/css/AlfFilteredList.css
@@ -1,3 +1,9 @@
-.alfresco-lists-AlfFilteredList .alfresco-forms-controls-BaseFormControl {
-   display: inline-block;
+.alfresco-lists-AlfFilteredList {
+
+   .alfresco-lists-AlfFilteredList__filters {
+      
+      .alfresco-forms-controls-BaseFormControl {
+         display: inline-block;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/lists/css/AlfFilteredList.css
+++ b/aikau/src/main/resources/alfresco/lists/css/AlfFilteredList.css
@@ -1,6 +1,6 @@
 .alfresco-lists-AlfFilteredList {
 
-   .alfresco-lists-AlfFilteredList__filters {
+   &__filters {
       
       .alfresco-forms-controls-BaseFormControl {
          display: inline-block;

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/CellContainer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/CellContainer.js
@@ -18,9 +18,12 @@
  */
 
 /**
- *
+ * This widget has been created to be used as a widget container within a
+ * [list view]{@link module:alfresco/lists/views/AlfListView} that uses a 
+ * [grid renderer]{@link module:alfresco/lists/views/layouts/Grid} such as the
+ * [AlfGalleryView]{@link module:alfresco/documentlibrary/AlfGalleryView}.
  * 
- * @module alfresco/lists/views/layouts/Cell
+ * @module alfresco/lists/views/layouts/CellContainer
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
@@ -37,9 +40,10 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "dojo/text!./templates/CellContainer.html",
         "dojo/_base/event",
-        "dojo/_base/lang"], 
+        "dojo/_base/lang",
+        "dojo/dom-style"], 
         function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, Core, 
-                 template, event, lang) {
+                 template, event, lang, domStyle) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, Core], {
       
@@ -60,6 +64,24 @@ define(["dojo/_base/declare",
        */
       templateString: template,
       
+      /**
+       * The minimum height for each container in pixels.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      minHeight: 100,
+
+      /**
+       * The widgets model to render.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default
+       */
+      widgets: null,
+
       /**
        * 
        *
@@ -82,11 +104,13 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
+       * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets} with the
+       * configured [widgets model]{@link module:alfresco/lists/views/layouts/CellContainer#widgets}.
        * 
        * @instance
        */
       postCreate: function alfresco_lists_views_layouts_CellContainer__postCreate() {
+         domStyle.set(this.domNode, "minHeight", this.minHeight + "px");
          if (this.widgets)
          {
             this.processWidgets(this.widgets, this.widgetsNode);

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/CellContainer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/CellContainer.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * 
+ * @module alfresco/lists/views/layouts/Cell
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
+ * @mixes module:alfresco/core/Core
+ * @author Dave Draper
+ * @since 1.0.44
+ */
+define(["dojo/_base/declare",
+        "dijit/_WidgetBase", 
+        "dijit/_TemplatedMixin",
+        "dijit/_OnDijitClickMixin",
+        "alfresco/renderers/_PublishPayloadMixin",
+        "alfresco/lists/views/layouts/_LayoutMixin",
+        "alfresco/core/Core",
+        "dojo/text!./templates/CellContainer.html",
+        "dojo/_base/event",
+        "dojo/_base/lang"], 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, Core, 
+                 template, event, lang) {
+
+   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, Core], {
+      
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/CellContainer.css"}]
+       */
+      cssRequirements: [{cssFile:"./css/CellContainer.css"}],
+      
+      /**
+       * The HTML template to use for the widget.
+       * 
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
+      
+      /**
+       * 
+       *
+       * @instance
+       * @param  {object} evt The click event
+       */
+      onClick: function alfresco_lists_views_layouts_CellContainer__onClick(evt) {
+         event.stop(evt);
+         if (!this.publishTopic || lang.trim(this.publishTopic) === "")
+         {
+            this.alfLog("warn", "No publishTopic provided for CellContainer click", this);
+         }
+         else
+         {
+            var publishGlobal = this.publishGlobal || false;
+            var publishToParent = this.publishToParent || false;
+            var payload = this.generatePayload(this.publishPayload, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
+            this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
+         }
+      },
+
+      /**
+       * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
+       * 
+       * @instance
+       */
+      postCreate: function alfresco_lists_views_layouts_CellContainer__postCreate() {
+         if (this.widgets)
+         {
+            this.processWidgets(this.widgets, this.widgetsNode);
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -97,6 +97,17 @@ define(["dojo/_base/declare",
       emptyCells: null,
 
       /**
+       * Indicates whether or not highlighting should be enabled. If this is configured to be
+       * true then highlighting of focus and expansion will be handled.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.44
+       */
+      enableHighlighting: false,
+
+      /**
        * This is set to the [itemKeyProperty]{@link module:alfresco/lists/views/layouts/Grid#itemKeyProperty}
        * of the item in the grid that has been expanded by the publication of the 
        * [expandTopic]{@link module:alfresco/lists/views/layouts/Grid#expandTopic}
@@ -241,7 +252,10 @@ define(["dojo/_base/declare",
             }, this);
          }
 
-         domClass.add(this.domNode, "alfresco-lists-views-layouts-Grid--showFocus");
+         if (this.enableHighlighting)
+         {
+            domClass.add(this.domNode, "alfresco-lists-views-layouts-Grid--enableHighlighting");
+         }
       },
 
 

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -39,6 +39,7 @@ define(["dojo/_base/declare",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
         "alfresco/lists/views/layouts/_LayoutMixin",
+        "alfresco/core/WidgetsCreator",
         "dojo/keys",
         "dojo/_base/lang",
         "dojo/_base/array",
@@ -51,7 +52,7 @@ define(["dojo/_base/declare",
         "dijit/registry",
         "dijit/focus"],
         function(declare, _WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, template, _MultiItemRendererMixin,
-                 AlfCore, _LayoutMixin, keys, lang, array, domAttr, domClass, domConstruct, domGeom, query, domStyle,
+                 AlfCore, _LayoutMixin, WidgetsCreator, keys, lang, array, domAttr, domClass, domConstruct, domGeom, query, domStyle,
                  registry, focusUtil) {
 
    return declare([_WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, _MultiItemRendererMixin, AlfCore, _LayoutMixin], {
@@ -96,6 +97,44 @@ define(["dojo/_base/declare",
       emptyCells: null,
 
       /**
+       * This is set to the [itemKeyProperty]{@link module:alfresco/lists/views/layouts/Grid#itemKeyProperty}
+       * of the item in the grid that has been expanded by the publication of the 
+       * [expandTopic]{@link module:alfresco/lists/views/layouts/Grid#expandTopic}
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.44
+       */
+      expandedItemKey: null,
+
+      /**
+       * This is set to a reference to a panel expanded within the grid showing more details of one of the
+       * rendered items.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.44
+       */
+      exandedPanel: null,
+
+      /**
+       * This is an array of optional topics that can be subscribed to to create a panel within the grid for
+       * showing additional data about a particular cell in the grid. The payload should contain
+       * a "widgets" attribute that represents the model to render within the panel.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.44
+       * 
+       * @event
+       * @property {objects[]} widgets The widgets to show in the expanded panel.
+       */
+      expandTopics: null,
+
+      /**
        * Indicates whether the number of columns is fixed for resize events. This means that
        * the thumbnail size can change. 
        * 
@@ -105,6 +144,32 @@ define(["dojo/_base/declare",
        * @since 1.0.40
        */
       fixedColumns: true,
+
+      /**
+       * Used to keep track of which cell is mapped to each itemKeyProperty]
+       *
+       * @instance
+       * @type {object}
+       * @default
+       * @since 1.0.44
+       */
+      gridCellMapping: null,
+
+      /**
+       * This is the property that is used to uniquely identify each 
+       * [item]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} rendered in the grid. It is used
+       * as the key in the [gridCellMapping]{@link module:alfresco/lists/views/layouts/Grid#gridCellMapping}
+       * to map each item to the cell that it is rendered in. This is required in order to know where to 
+       * exand the grid when the 
+       * [expandTopics]{@link module:alfresco/lists/views/layouts/Grid#expandTopics} is
+       * published.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.44
+       */
+      itemKeyProperty: null,
 
       /**
        * The label to use for the next link. This defaults to null, so MUST be set for the next link to be displayed.
@@ -150,6 +215,7 @@ define(["dojo/_base/declare",
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        *
        * @instance postCreate
+       * @listens module:alfresco/lists/views/layouts/Grid#expandTopics
        */
       postCreate: function alfresco_lists_views_layouts_Grid__postCreate() {
          this.inherited(arguments);
@@ -165,6 +231,105 @@ define(["dojo/_base/declare",
 
          // Update the grid as the window changes...
          this.alfSetupResizeSubscriptions(this.resizeCells, this);
+
+         // Subscribe to any topics that will trigger the expansion of a panel to display more
+         // information about the related cell...
+         if (this.expandTopics && this.itemKeyProperty)
+         {
+            array.forEach(this.expandTopics, function(topic) {
+               this.alfSubscribe(topic, lang.hitch(this, this.expandPanel));
+            }, this);
+         }
+
+         domClass.add(this.domNode, "alfresco-lists-views-layouts-Grid--showFocus");
+      },
+
+
+      /**
+       * Destroys the [exandedPanel]{@link module:alfresco/lists/views/layouts/Grid#exandedPanel}.
+       * 
+       * @instance
+       * @since 1.0.44
+       */
+      collapsePanel: function alfresco_lists_views_layouts_Grid__collapsePanel() {
+         // If an expanded pane already exists, then destroy it
+         if (this.exandedPanel)
+         {
+            var widgets = registry.findWidgets(this.exandedPanel);
+            array.forEach(widgets, function(widget) {
+               widget.destroy();
+            });
+            domConstruct.destroy(this.exandedPanel);
+         }
+      },
+
+      /**
+       * Creates a new [exandedPanel]{@link module:alfresco/lists/views/layouts/Grid#exandedPanel}
+       * for an item rendered in the grid or 
+       * [collapses]{@link module:alfresco/lists/views/layouts/Grid#collapsePanel} the currently
+       * expanded panel if it represents the requested item.
+       * 
+       * @instance
+       * @param {object} payload The payload containing the details of the item to expand and what to
+       * place in the expanded panel.
+       * @since 1.0.44
+       */
+      expandPanel: function alfresco_lists_views_layouts_Grid__expandPanel(payload) {
+
+         var itemKey = lang.getObject(this.itemKeyProperty, false, payload);
+         if (itemKey && this.gridCellMapping[itemKey])
+         {
+            var cell = this.gridCellMapping[itemKey];
+            if (itemKey === this.expandedItemKey)
+            {
+               // The item is already expanded so collapse it...
+               this.collapsePanel();
+               domClass.remove(cell, "alfresco-lists-views-layouts-Grid__cell--expanded");
+               this.expandedItemKey = null;
+            }
+            else
+            {
+               // Remove the highlight from the previous selected cell...
+               if (this.expandedItemKey)
+               {
+                  domClass.remove(this.gridCellMapping[this.expandedItemKey], "alfresco-lists-views-layouts-Grid__cell--expanded");
+               }
+               
+               // Set the current itemKey as the expanded panel...
+               this.expandedItemKey = itemKey;
+
+               // A new item has been requested to be expanded...
+               var row = cell.parentNode;
+
+               domClass.add(cell, "alfresco-lists-views-layouts-Grid__cell--expanded");
+
+               this.collapsePanel();
+
+               // Create a new row...
+               this.exandedPanel = domConstruct.create("tr", {
+                  className: "alfresco-lists-views-layouts-Grid__expandedPanel"
+               }, row, "after");
+
+               // Add a single cell that spans all the columns in the row...
+               var spanningCell = domConstruct.create("td", {
+                  colspan: this.columns
+               }, this.exandedPanel);
+
+               var forWidgets = domConstruct.create("div", {
+               }, spanningCell);
+
+               if (payload.widgets)
+               {
+                  // TODO: pubSubScopes, currentMetadata, etc -might want to generally improve WidgetsCreator
+                  //       to slurp the required data - maybe by passing "this" as an optional argument?
+                  var wc = new WidgetsCreator({ 
+                     currentItem: this.currentItem,
+                     widgets: payload.widgets
+                  });
+                  wc.buildWidgets(forWidgets);
+               }
+            }
+         }
       },
 
       /**
@@ -193,7 +358,7 @@ define(["dojo/_base/declare",
          {
             focusedChild.blur();
          }
-         domClass.remove(focusedChild.domNode, "alfresco-lists-views-layouts-Grid__cell--focused");
+         domClass.remove(focusedChild.domNode.parentNode, "alfresco-lists-views-layouts-Grid__cell--focused");
       },
 
       /**
@@ -221,7 +386,7 @@ define(["dojo/_base/declare",
                focusUtil.focus(widget.domNode);
             }
          }
-         domClass.add(widget.domNode, "alfresco-lists-views-layouts-Grid__cell--focused");
+         domClass.add(widget.domNode.parentNode, "alfresco-lists-views-layouts-Grid__cell--focused");
       },
 
       /**
@@ -434,17 +599,45 @@ define(["dojo/_base/declare",
          {
             // Create a new row if the maximum number of columns has been exceeded...
             var newRow = domConstruct.create("TR", {}, rootNode);
-            nodeToAdd = domConstruct.create("TD", {}, newRow);
+            nodeToAdd = domConstruct.create("TD", {
+               className: "alfresco-lists-views-layouts-Grid__cell"
+            }, newRow);
          }
          else
          {
             var lastNode = rootNode.children[rootNode.children.length-1];
-            nodeToAdd = domConstruct.create("TD", {}, lastNode);
+            nodeToAdd = domConstruct.create("TD", {
+               className: "alfresco-lists-views-layouts-Grid__cell"
+            }, lastNode);
+         }
+
+         // TODO: Add warnings
+         // TODO: Only do this if subscribing to expansion topics
+         if (this.itemKeyProperty)
+         {
+            var itemKey = lang.getObject(this.itemKeyProperty, false, this.currentItem);
+            if (itemKey)
+            {
+               this.gridCellMapping[itemKey] = nodeToAdd;
+            }
          }
 
          // Add a new cell...
          return domConstruct.create("DIV", {}, nodeToAdd);
       },
+
+      /**
+       * Extends the [mixed in function]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin#renderData}
+       * to reset the [gridCellMapping]{@link module:alfresco/lists/views/layouts/Grid#gridCellMapping} in preparation
+       * for rendering a new data set.
+       * 
+       * @instance
+       * @since 1.0.44
+       */
+      renderData: function alfresco_lists_views_layouts_Grid__renderData() {
+         this.gridCellMapping = {};
+         this.inherited(arguments);
+      }, 
 
       /**
        * Extends the [inherited function]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin#renderNextItem}

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -348,10 +348,7 @@ define(["dojo/_base/declare",
 
                if (payload.widgets)
                {
-                  // TODO: pubSubScopes, currentMetadata, etc -might want to generally improve WidgetsCreator
-                  //       to slurp the required data - maybe by passing "this" as an optional argument?
                   var wc = new WidgetsCreator({ 
-                     currentItem: this.currentItem,
                      widgets: payload.widgets,
 
                      // Add a callback to focus on the first created widget...
@@ -362,7 +359,7 @@ define(["dojo/_base/declare",
                         }
                      })
                   });
-                  wc.buildWidgets(forWidgets);
+                  wc.buildWidgets(forWidgets, this);
                }
             }
          }

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/CellContainer.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/CellContainer.css
@@ -1,0 +1,6 @@
+.alfresco-lists-views-layouts-CellContainer {
+   
+   .alfresco-lists-views-layouts-CellContainer__widgets {
+      overflow: hidden;
+   }
+}

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/CellContainer.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/CellContainer.css
@@ -4,7 +4,7 @@
    box-sizing: border-box;
    outline: none;
 
-   .alfresco-lists-views-layouts-CellContainer__widgets {
+   &__widgets {
       overflow: hidden;
    }
 }

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/CellContainer.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/CellContainer.css
@@ -1,5 +1,9 @@
 .alfresco-lists-views-layouts-CellContainer {
    
+   padding: @standard-column-spacing;
+   box-sizing: border-box;
+   outline: none;
+
    .alfresco-lists-views-layouts-CellContainer__widgets {
       overflow: hidden;
    }

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/Grid.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/Grid.css
@@ -48,3 +48,9 @@
    }
 }
 
+.alfresco-lists-views-layouts-Grid__expandedPanel {
+   .alfresco-lists-views-layouts-Grid__cell--focused {
+      border: none;
+   }
+}
+

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/Grid.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/Grid.css
@@ -2,17 +2,16 @@
    border-collapse: separate;
    border-spacing: 2px;
    width: 100%;
+   outline: none;
 
-   &--showFocus {
+   &--enableHighlighting {
       
       .alfresco-lists-views-layouts-Grid__cell {
          border: @standard-border;
          border-radius: @standard-border-radius;
-         padding: @standard-column-spacing;
-         box-sizing: border-box;
-
+         
          &--focused {
-            border: @thick-border-width solid @focused-border-color;
+            border: @thick-border-width solid @hover-border-color;
          }
 
          &--expanded {

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/Grid.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/Grid.css
@@ -2,4 +2,50 @@
    border-collapse: separate;
    border-spacing: 2px;
    width: 100%;
+
+   &--showFocus {
+      
+      .alfresco-lists-views-layouts-Grid__cell {
+         border: @standard-border;
+         border-radius: @standard-border-radius;
+         padding: @standard-column-spacing;
+         box-sizing: border-box;
+
+         &--focused {
+            border: @thick-border-width solid @focused-border-color;
+         }
+
+         &--expanded {
+            position: relative;
+            background:@primary-background-color;
+            border: @thick-border-width solid @focused-border-color;
+
+            &:after, &:before {
+               top: 100%;
+               left: 50%;
+               border: solid transparent;
+               content: " ";
+               height: 0;
+               width: 0;
+               position: absolute;
+               pointer-events: none;
+            }
+
+            &:after {
+               border-color: rgba(red(@primary-background-color), green(@primary-background-color), blue(@primary-background-color), 0);
+               border-top-color: @primary-background-color;
+               border-width: 10px;
+               margin-left: -10px;
+            }
+
+            &:before {
+               border-color: rgba(red(@focused-border-color), green(@focused-border-color), blue(@focused-border-color), 0);
+               border-top-color: @focused-border-color;
+               border-width: 14px;
+               margin-left: -14px;
+            }
+         }
+      }
+   }
 }
+

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/templates/CellContainer.html
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/templates/CellContainer.html
@@ -1,0 +1,3 @@
+<div class="alfresco-lists-views-layouts-CellContainer" data-dojo-attach-event="ondijitclick:onClick">
+   <div class="alfresco-lists-views-layouts-CellContainer__widgets" data-dojo-attach-point="widgetsNode"></div>
+</div>

--- a/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
@@ -41,24 +41,69 @@ define(["intern!object",
             browser.end();
          },
 
-         "Click on a cell to expand": function() {
+         "There should be no expanded cells": function() {
+            return browser.findDisplayedById("CELL_CONTAINER_ITEM_0")
+            .end()
 
+            .findAllByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Unexpected expanded panel found");
+               });
+         },
+
+         "Click on a cell to expand": function() {
+            return browser.findDisplayedById("CELL_CONTAINER_ITEM_0")
+               .click()
+            .end()
+
+            .findByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel");
+         },
+
+         "Check the expanded panel position": function() {
+            // This verifies that the expanded panel has been inserted in the 2nd row...
+            return browser.findByCssSelector(".alfresco-lists-views-layouts-Grid tr.alfresco-lists-views-layouts-Grid__expandedPanel:nth-child(2)");
          },
 
          "Check that expanded panel has focus": function() {
-
+            return browser.getActiveElement()
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "Monthly HES Summary Data", "The form field in the expanded element was not focused");
+               });
          },
 
          "Use escape key to close panel": function() {
+            return browser.pressKeys(keys.ESCAPE)
+               .waitForDeletedByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel");
+         },
 
+         "The expanded cell should be re-focused": function() {
+            return browser.findByCssSelector(".alfresco-lists-views-layouts-Grid__cell--focused #CELL_CONTAINER_ITEM_0");
          },
 
          "Keyboard navigate to and expand another cell": function() {
+            return browser.pressKeys(keys.ARROW_RIGHT)
+               .findByCssSelector(".alfresco-lists-views-layouts-Grid__cell--focused #CELL_CONTAINER_ITEM_1")
+            .end()
 
+            .pressKeys(keys.RETURN)
+
+            .findByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel")
+            .end()
+
+            .getActiveElement()
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "Telford and Wrekin Council", "The form field in the expanded element was not focused");
+               });
          },
 
          "Use mouse to close expanded cell": function() {
+            return browser.findById("CELL_CONTAINER_ITEM_1")
+               .click()
+            .end()
 
+            .waitForDeletedByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel");
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"], 
+        function (registerSuite, assert, TestCommon, keys) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Expandable Gallery View Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ExandableGallery", "Expandable Gallery View Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Click on a cell to expand": function() {
+
+         },
+
+         "Check that expanded panel has focus": function() {
+
+         },
+
+         "Use escape key to close panel": function() {
+
+         },
+
+         "Keyboard navigate to and expand another cell": function() {
+
+         },
+
+         "Use mouse to close expanded cell": function() {
+
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -172,6 +172,7 @@ define({
       "src/test/resources/alfresco/lists/LocalStorageFallbackTest",
       "src/test/resources/alfresco/lists/PaginatorVisibilityTest",
       "src/test/resources/alfresco/lists/views/AlfListViewTest",
+      "src/test/resources/alfresco/lists/views/ExpandableGalleryTest",
       "src/test/resources/alfresco/lists/views/GalleryViewFocusTest",
       "src/test/resources/alfresco/lists/views/GalleryViewInfiniteScrollTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Expandable Gallery</shortname>
+  <description>This demonstrates how a gallery view can be configured to split to reveal a panel showing more information for a specific cell.</description>
+  <family>aikau-unit-tests</family>
+  <url>/ExandableGallery</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
@@ -30,10 +30,12 @@ model.jsonModel = {
                   name: "alfresco/documentlibrary/views/AlfGalleryView",
                   config: {
                      columns: 10,
+                     enableHighlighting: true,
                      itemKeyProperty: "nodeRef",
                      expandTopics: ["EXPAND"],
                      widgets: [
                         {
+                           id: "CELL_CONTAINER",
                            name: "alfresco/lists/views/layouts/CellContainer",
                            config: {
                               publishTopic: "EXPAND",
@@ -79,6 +81,7 @@ model.jsonModel = {
                               publishPayloadItemMixin: true,
                               widgets: [
                                  {
+                                    id: "PROPERTY",
                                     name: "alfresco/renderers/Property",
                                     config: {
                                        propertyToRender: "node.properties.cm:name"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
@@ -1,0 +1,108 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "TOOLBAR",
+         name: "alfresco/documentlibrary/AlfToolbar"
+      },
+      {
+         id: "DOCLIST",
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            useHash: false,
+            additionalControlsTarget: "TOOLBAR",
+            currentPageSize:40,
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/views/AlfGalleryView",
+                  config: {
+                     columns: 10,
+                     itemKeyProperty: "nodeRef",
+                     expandTopics: ["EXPAND"],
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/CellContainer",
+                           config: {
+                              publishTopic: "EXPAND",
+                              publishPayload: {
+                                 widgets: [
+                                    {
+                                       name: "alfresco/forms/Form",
+                                       config: {
+                                          showOkButton: true,
+                                          okButtonPublishTopic: "POST",
+                                          okButtonLabel: "Update",
+                                          showCancelButton: false,
+                                          value: "{node}",
+                                          widgets: [
+                                             {
+                                                name: "alfresco/forms/controls/TextBox",
+                                                config: {
+                                                   label: "Name",
+                                                   name: "properties.cm:name"
+                                                }
+                                             },
+                                             {
+                                                name: "alfresco/forms/controls/TextBox",
+                                                config: {
+                                                   label: "Title",
+                                                   name: "properties.cm:title"
+                                                }
+                                             },
+                                             {
+                                                name: "alfresco/forms/controls/TextArea",
+                                                config: {
+                                                   label: "Description",
+                                                   name: "properties.cm:description"
+                                                }
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 ]
+                              },
+                              publishPayloadType: "PROCESS",
+                              publishPayloadModifiers: ["processCurrentItemTokens"],
+                              publishPayloadItemMixin: true,
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "node.properties.cm:name"
+                                       
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/NodesMockXhr",
+         config: {
+            totalItems: 40,
+            folderRatio: [100]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-675 to make it possible to expand a grid to reveal a panel for displaying additional information about the selected cell. A new alfresco/lists/views/layouts/CellContainer widget has been added for grids that do not want to use thumbnails and optional highlighting is now supported.