### PR TITLE
AKU-670: Auto twister width

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfSideBarContainer.js
@@ -368,6 +368,7 @@ define(["dojo/_base/declare",
          
          // Fire a custom event to let contained objects know that the node has been resized.
          this.alfPublishResizeEvent(this.mainNode);
+         this.alfPublishResizeEvent(this.sidebarNode);
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -87,12 +87,11 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class",
-        "dojo/dom-geometry",
         "dojo/dom-style",
         "dojo/dom-attr",
         "dojo/_base/event"], 
         function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PreferenceServiceTopicMixin, AlfCore, CoreWidgetProcessing, 
-                 template, lang, array, domConstruct, domClass, domGeom, domStyle, domAttr, event) {
+                 template, lang, array, domConstruct, domClass, domStyle, domAttr, event) {
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, AlfCore, CoreWidgetProcessing, _PreferenceServiceTopicMixin], {
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -79,6 +79,7 @@ define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
         "dijit/_TemplatedMixin",
         "dijit/_OnDijitClickMixin",
+        "alfresco/core/ResizeMixin",
         "alfresco/services/_PreferenceServiceTopicMixin",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
@@ -87,12 +88,13 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class",
+        "dojo/dom-geometry",
         "dojo/dom-style",
         "dojo/dom-attr",
         "dojo/_base/event"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PreferenceServiceTopicMixin, AlfCore, CoreWidgetProcessing, 
-                 template, lang, array, domConstruct, domClass, domStyle, domAttr, event) {
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, AlfCore, CoreWidgetProcessing, _PreferenceServiceTopicMixin], {
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ResizeMixin, _PreferenceServiceTopicMixin, AlfCore, CoreWidgetProcessing, 
+                 template, lang, array, domConstruct, domClass, domGeom, domStyle, domAttr, event) {
+   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ResizeMixin, AlfCore, CoreWidgetProcessing, _PreferenceServiceTopicMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -197,7 +199,11 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_layout_Twister__postCreate() {
-         if (this.width)
+         if (this.width === "AUTO")
+         {
+            this.alfSetupResizeSubscriptions(this.resize, this);
+         }
+         else if (this.width)
          {
             domStyle.set(this.domNode, "width", this.width);
          }
@@ -320,6 +326,17 @@ define(["dojo/_base/declare",
 
          // Stop the event propogating any further (ie into the parent element)
          event.stop(evt);
+      },
+
+      /**
+       * 
+       * @instance
+       * @since 1.0.44
+       */
+      resize: function alfresco_layout_Twister__resize() {
+         var computedStyle = domStyle.getComputedStyle(this.domNode.parentNode);
+         var output = domGeom.getMarginBox(this.domNode.parentNode, computedStyle);
+         domStyle.set(this.domNode, "width", output.w + "px");
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -22,10 +22,6 @@
  * open or closed state is indicated by a "twister" icon. The widget can be configured to render any other widget
  * model as its contents. The twister can be configured to be intially open or closed by setting the 
  * [initiallyOpen]{@link module:alfresco/layout/Twister#initiallyOpen} attribute to true (for open) or false (for closed).</p>
- *
- * <p>The [width]{@link module:alfresco/layout/Twister#width} of the twister is determined by the 
- * @sidebar-component-width LESS variable unless otherwise specified. If a value of "AUTO" is configured then 
- * the twister will automatically grow and shrink horizontally to use up the available space.</p>
  * 
  * <p>It is also possible for the open or closed state to be stored to a users personal preferences. This can be done 
  * by configuring a [preferenceName]{@link module:alfresco/layout/Twister#preferenceName} attribute
@@ -83,7 +79,6 @@ define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
         "dijit/_TemplatedMixin",
         "dijit/_OnDijitClickMixin",
-        "alfresco/core/ResizeMixin",
         "alfresco/services/_PreferenceServiceTopicMixin",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
@@ -96,9 +91,9 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dojo/dom-attr",
         "dojo/_base/event"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ResizeMixin, _PreferenceServiceTopicMixin, AlfCore, CoreWidgetProcessing, 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PreferenceServiceTopicMixin, AlfCore, CoreWidgetProcessing, 
                  template, lang, array, domConstruct, domClass, domGeom, domStyle, domAttr, event) {
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ResizeMixin, AlfCore, CoreWidgetProcessing, _PreferenceServiceTopicMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, AlfCore, CoreWidgetProcessing, _PreferenceServiceTopicMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -177,16 +172,14 @@ define(["dojo/_base/declare",
       preferencePrefix: "org.alfresco.share.twisters.",
       
       /**
-       * The width to make the twister. This is null by default and the standard width of a twister is controlled
-       * by the "@sidebar-component-width" LESS variable. However, this can be overridden by configuring this
-       * attribute to be a specific width. Units such as "px" should be included. A value of "AUTO" can be configured
-       * to make the twister use all the available horizontal space.
+       * The width to make the twister. Units such as "px" should be included. By default all available
+       * horizontal width will be used.
        *
        * @instance
        * @type {string}
        * @default
        */
-      width: null,
+      width: "auto",
 
       /**
        * @instance
@@ -204,11 +197,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_layout_Twister__postCreate() {
-         if (this.width === "AUTO")
-         {
-            this.alfSetupResizeSubscriptions(this.resize, this);
-         }
-         else if (this.width)
+         if (this.width)
          {
             domStyle.set(this.domNode, "width", this.width);
          }
@@ -331,17 +320,6 @@ define(["dojo/_base/declare",
 
          // Stop the event propogating any further (ie into the parent element)
          event.stop(evt);
-      },
-
-      /**
-       * 
-       * @instance
-       * @since 1.0.44
-       */
-      resize: function alfresco_layout_Twister__resize() {
-         var computedStyle = domStyle.getComputedStyle(this.domNode.parentNode);
-         var output = domGeom.getMarginBox(this.domNode.parentNode, computedStyle);
-         domStyle.set(this.domNode, "width", output.w + "px");
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/layout/Twister.js
+++ b/aikau/src/main/resources/alfresco/layout/Twister.js
@@ -22,6 +22,10 @@
  * open or closed state is indicated by a "twister" icon. The widget can be configured to render any other widget
  * model as its contents. The twister can be configured to be intially open or closed by setting the 
  * [initiallyOpen]{@link module:alfresco/layout/Twister#initiallyOpen} attribute to true (for open) or false (for closed).</p>
+ *
+ * <p>The [width]{@link module:alfresco/layout/Twister#width} of the twister is determined by the 
+ * @sidebar-component-width LESS variable unless otherwise specified. If a value of "AUTO" is configured then 
+ * the twister will automatically grow and shrink horizontally to use up the available space.</p>
  * 
  * <p>It is also possible for the open or closed state to be stored to a users personal preferences. This can be done 
  * by configuring a [preferenceName]{@link module:alfresco/layout/Twister#preferenceName} attribute
@@ -175,7 +179,8 @@ define(["dojo/_base/declare",
       /**
        * The width to make the twister. This is null by default and the standard width of a twister is controlled
        * by the "@sidebar-component-width" LESS variable. However, this can be overridden by configuring this
-       * attribute to be a specific width. Units such as "px" should be included.
+       * attribute to be a specific width. Units such as "px" should be included. A value of "AUTO" can be configured
+       * to make the twister use all the available horizontal space.
        *
        * @instance
        * @type {string}

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -485,6 +485,7 @@ function getDocLibFilters(options) {
       config: {
          label: "filter.label.documents",
          additionalCssClasses: "no-borders",
+         width: "AUTO",
          widgets: [
             {
                name: "alfresco/documentlibrary/AlfDocumentFilter",
@@ -571,6 +572,7 @@ function getDocLibTree(options) {
       config: {
          label: "twister.library.label",
          additionalCssClasses: "no-borders",
+         width: "AUTO",
          widgets: [
             {
                name: "alfresco/navigation/PathTree",
@@ -594,6 +596,7 @@ function getDocLibTags(options) {
       name: "alfresco/documentlibrary/AlfTagFilters",
       config: {
          label: "filter.label.tags",
+         width: "AUTO",
          additionalCssClasses: "no-borders",
          siteId: options.siteId,
          containerId: options.containerId,
@@ -609,6 +612,7 @@ function getDocLibCategories(options) {
       name: "alfresco/layout/Twister",
       config: {
          label: "twister.categories.label",
+         width: "AUTO",
          additionalCssClasses: "no-borders",
          widgets: [
             {

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -22,218 +22,217 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Twister Tests",
+      return {
+         name: "Twister Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Twister", "Twister Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Twister", "Twister Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check the first twister gets H3 element": function () {
-         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with heading level", "The 1st twister did not render an H3 element");
-            });
-      },
+         "Check the first twister gets H3 element": function () {
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text,"Twister with heading level", "The 1st twister did not render an H3 element");
+               });
+         },
 
-      "Check the second twister renders without header element": function () {
-         return browser.findByCssSelector("#TWISTER_NO_HEADING_LEVEL > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with no heading level", "The 2n twister label was rendered incorrectly");
-            });
-      },
+         "Check the second twister renders without header element": function () {
+            return browser.findByCssSelector("#TWISTER_NO_HEADING_LEVEL > div.label")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text,"Twister with no heading level", "The 2nd twister label was rendered incorrectly");
+               });
+         },
 
-      "Check that invalid heading level 'a' does not render invalid element": function () {
-         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with faulty heading level 'a'", "The 3rd twister did not render correctly");
-            });
-      },
+         "Check that invalid heading level 'a' does not render invalid element": function () {
+            return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text,"Twister with faulty heading level 'a'", "The 3rd twister did not render correctly");
+               });
+         },
 
-      "Check that invalid heading level '0' does not render invalid element": function () {
-         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with heading level 0", "The 4th twister did not render correctly");
-            });
-      },
+         "Check that invalid heading level '0' does not render invalid element": function () {
+            return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO > div.label")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text,"Twister with heading level 0", "The 4th twister did not render correctly");
+               });
+         },
 
-      "Check that invalid heading level '7' does not render invalid element": function () {
-         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_THREE > div.label")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with heading level 7", "The 5th twister did not render correctly");
-            });
-      },
+         "Check that invalid heading level '7' does not render invalid element": function () {
+            return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_THREE > div.label")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text,"Twister with heading level 7", "The 5th twister did not render correctly");
+               });
+         },
 
-      "Check that null label twister is not displayed": function () {
-         return browser.findByCssSelector("#TWISTER_NULL_LABEL")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isFalse(result, "Twister with null label was unexpectedly displayed");
-            });
-      },
+         "Check that null label twister is not displayed": function () {
+            return browser.findByCssSelector("#TWISTER_NULL_LABEL")
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result, "Twister with null label was unexpectedly displayed");
+               });
+         },
 
-      "Check that empty string label twister is not displayed": function () {
-         return browser.findByCssSelector("#TWISTER_EMPTY_LABEL")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isFalse(result, "Twister with empty string label was unexpectedly displayed");
-            });
-      },
+         "Check that empty string label twister is not displayed": function () {
+            return browser.findByCssSelector("#TWISTER_EMPTY_LABEL")
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result, "Twister with empty string label was unexpectedly displayed");
+               });
+         },
 
-      "Check that first twister is open": function() {
-         return browser.findAllByCssSelector("#TWISTER_HEADING_LEVEL .alfresco-layout-Twister--open")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Twister configured to be open, was closed");
-            })
-         .end()
-         .findByCssSelector("#TWISTER_HEADING_LEVEL .content")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "Twister configured to be open is NOT displaying its contents");
-            });
-      },
-
-      "Check that second twister is closed": function() {
-         return browser.findAllByCssSelector("#TWISTER_NO_HEADING_LEVEL .alfresco-layout-Twister--closed")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Twister configured to be closed, was open");
-            })
-         .end()
-         .findByCssSelector("#TWISTER_NO_HEADING_LEVEL .content")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "Twister configured to be closed is displaying its contents");
-            });
-      },
-
-      "Check that third twister is open (using preferences)": function() {
-         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL .alfresco-layout-Twister--open")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Twister preferred to be open, was closed");
-            })
-         .end()
-         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL .content")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "Twister preferred to be open is NOT displaying its contents");
-            });
-      },
-
-      "Check that fourth twister is closed (using preferences)": function() {
-         return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .alfresco-layout-Twister--closed")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Twister preferred to be closed, was open");
-            })
-         .end()
-         .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .content")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "Twister preferred to be closed is displaying its contents");
-            });
-      },
-
-      "Check the first twister title is still visible": function () {
-         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
-            .click()
-         .end()
-
-         // Title should still be visible
-         .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with heading level", "The first twister title is not visible");
-            });
-      },
-
-      "Check that logo in the first twister is hidden when the twister is clicked": function() {
-         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isFalse(result, "The logo was unexpectedly shown");
-            });
-      },
-      
-      "Check the first twister title is still visible (2)": function() {
-         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
-            .click()
-         .end()
-
-         // Title should still be visible
-         .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
-            .getVisibleText()
-            .then(function (text) {
-               assert.equal(text,"Twister with heading level", "The first twister title is not visible");
-            });
-      },
-      
-      "Check that logo in the first twister is hidden when the twister is clicked (2)": function() {
-         return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "The logo was unexpectedly hidden");
-            });
-      },
-
-      "Check that closing a twister updates its preferences": function() {
-         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
-            .click()
+         "Check that first twister is open": function() {
+            return browser.findAllByCssSelector("#TWISTER_HEADING_LEVEL .alfresco-layout-Twister--open")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Twister configured to be open, was closed");
+               })
             .end()
+            .findByCssSelector("#TWISTER_HEADING_LEVEL .content")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Twister configured to be open is NOT displaying its contents");
+               });
+         },
 
-         .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
-            .then(function(xhr){
-               assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.twisters.twister1", false);
-            });
-      },
-
-      "Check that opening a twister updates its preferences": function() {
-         return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
-            .click()
+         "Check that second twister is closed": function() {
+            return browser.findAllByCssSelector("#TWISTER_NO_HEADING_LEVEL .alfresco-layout-Twister--closed")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Twister configured to be closed, was open");
+               })
             .end()
+            .findByCssSelector("#TWISTER_NO_HEADING_LEVEL .content")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Twister configured to be closed is displaying its contents");
+               });
+         },
 
-         .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
-            .then(function(xhr){
-               assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.twisters.twister1", true);
-            });
-      },
+         "Check that third twister is open (using preferences)": function() {
+            return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL .alfresco-layout-Twister--open")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Twister preferred to be open, was closed");
+               })
+            .end()
+            .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL .content")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Twister preferred to be open is NOT displaying its contents");
+               });
+         },
 
-      // NOTE: Called because the next test does a refresh...
-      "Post Coverage Results Before Page Refresh": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      },
+         "Check that fourth twister is closed (using preferences)": function() {
+            return browser.findAllByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .alfresco-layout-Twister--closed")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Twister preferred to be closed, was open");
+               })
+            .end()
+            .findByCssSelector("#TWISTER_BAD_HEADING_LEVEL_TWO .content")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Twister preferred to be closed is displaying its contents");
+               });
+         },
 
-      "Check the first twister title is visible after keyboard [RETURN]": function () {
-         return browser.refresh()
-
-            // Focus the title of twister 1
-            .pressKeys(keys.TAB)
-            
-            // 'Click' the title with the return key
-            .pressKeys(keys.RETURN)
+         "Check the first twister title is still visible": function () {
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
+               .click()
+            .end()
 
             // Title should still be visible
             .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
                .getVisibleText()
                .then(function (text) {
-                  assert.equal(text,"Twister with heading level", "The first twister title is not visible after keyboard [RETURN]");
+                  assert.equal(text,"Twister with heading level", "The first twister title is not visible");
                });
+         },
+
+         "Check that logo in the first twister is hidden when the twister is clicked": function() {
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result, "The logo was unexpectedly shown");
+               });
+         },
+         
+         "Check the first twister title is still visible (2)": function() {
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
+               .click()
+            .end()
+
+            // Title should still be visible
+            .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
+               .getVisibleText()
+               .then(function (text) {
+                  assert.equal(text,"Twister with heading level", "The first twister title is not visible");
+               });
+         },
+         
+         "Check that logo in the first twister is hidden when the twister is clicked (2)": function() {
+            return browser.findByCssSelector("#TWISTER_HEADING_LEVEL #LOGO1")
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isTrue(result, "The logo was unexpectedly hidden");
+               });
+         },
+
+         "Check that closing a twister updates its preferences": function() {
+            return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
+               .click()
+               .end()
+
+            .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
+               .then(function(xhr){
+                  assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.twisters.twister1", false);
+               });
+         },
+
+         "Check that opening a twister updates its preferences": function() {
+            return browser.findByCssSelector("#TWISTER_BAD_HEADING_LEVEL > div.label")
+               .click()
+               .end()
+
+            .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
+               .then(function(xhr){
+                  assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.twisters.twister1", true);
+               });
+         },
+
+         // NOTE: Called because the next test does a refresh...
+         "Post Coverage Results Before Page Refresh": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         },
+
+         "Check the first twister title is visible after keyboard [RETURN]": function () {
+            return browser.refresh()
+
+               // Focus the title of twister 1
+               .pressKeys(keys.TAB)
+               
+               // 'Click' the title with the return key
+               .pressKeys(keys.RETURN)
+
+               // Title should still be visible
+               .findByCssSelector("#TWISTER_HEADING_LEVEL > div.label > h3")
+                  .getVisibleText()
+                  .then(function (text) {
+                     assert.equal(text,"Twister with heading level", "The first twister title is not visible after keyboard [RETURN]");
+                  });
          },
 
          "Check that logo in the first twister is hidden after keyboard [RETURN]": function() {
@@ -262,11 +261,11 @@ registerSuite(function(){
                .then(function(result) {
                   assert.isTrue(result, "The logo was unexpectedly hidden");
                });
-      },
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -263,6 +263,46 @@ define(["intern!object",
                });
          },
 
+         "Check fixed width": function() {
+            return browser.findById("FIXED_WIDTH_TWISTER")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.width, 500, "The fixed width twister was not the correct size");
+               });
+         },
+
+         "Check dynamic resizing": function() {
+            var lastWidth;
+            return browser.findById("AUTO_WIDTH_TWISTER")
+               .getSize()
+               .then(function(size) {
+                  lastWidth = size.width;
+               })
+            .end()
+
+            .findById("HIDE_BUTTON_label")
+               .click()
+            .end()
+
+            .findById("AUTO_WIDTH_TWISTER")
+               .getSize()
+               .then(function(size) {
+                  assert.isAbove(size.width, lastWidth, "Twister did not get bigger");
+                  lastWidth = size.width;
+               })
+            .end()
+
+            .findById("SHOW_BUTTON_label")
+               .click()
+            .end()
+
+            .findById("AUTO_WIDTH_TWISTER")
+               .getSize()
+               .then(function(size) {
+                  assert.isBelow(size.width, lastWidth, "Twister did not get smaller");
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/alfresco/layout/TwisterTest.js
+++ b/aikau/src/test/resources/alfresco/layout/TwisterTest.js
@@ -280,9 +280,13 @@ define(["intern!object",
                })
             .end()
 
+            .clearLog()
+
             .findById("HIDE_BUTTON_label")
                .click()
             .end()
+
+            .getLastPublish("ALF_PREFERENCE_SET_SUCCESS")
 
             .findById("AUTO_WIDTH_TWISTER")
                .getSize()
@@ -292,14 +296,45 @@ define(["intern!object",
                })
             .end()
 
+            .clearLog()
+
             .findById("SHOW_BUTTON_label")
                .click()
             .end()
+
+            .getLastPublish("ALF_PREFERENCE_SET_SUCCESS")
 
             .findById("AUTO_WIDTH_TWISTER")
                .getSize()
                .then(function(size) {
                   assert.isBelow(size.width, lastWidth, "Twister did not get smaller");
+               });
+         },
+
+         // NOTE: During development it was noticed that the sidebar was not publishing
+         //       to indicate that the sidebar had resized as well as the main node
+         "Check sidebar dynamic resizing": function() {
+            var lastWidth;
+            return browser.findById("TWISTER_HEADING_LEVEL")
+               .getSize()
+               .then(function(size) {
+                  lastWidth = size.width;
+               })
+            .end()
+
+            .clearLog()
+
+            .findById("HIDE_BUTTON_label")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_PREFERENCE_SET_SUCCESS")
+
+            .findById("TWISTER_HEADING_LEVEL")
+               .getSize()
+               .then(function(size) {
+                  assert.isBelow(size.width, lastWidth, "Twister in sidebar did not get bigger");
+                  lastWidth = size.width;
                });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -35,6 +35,7 @@ model.jsonModel = {
                                     config: {
                                        label: "Twister with heading level",
                                        headingLevel: 3,
+                                       width: "AUTO",
                                        initiallyOpen: true,
                                        widgets: [
                                           {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -35,7 +35,6 @@ model.jsonModel = {
                                     config: {
                                        label: "Twister with heading level",
                                        headingLevel: 3,
-                                       width: "AUTO",
                                        initiallyOpen: true,
                                        widgets: [
                                           {
@@ -168,7 +167,7 @@ model.jsonModel = {
                                        label: "Resizing Twister",
                                        initiallyOpen: true,
                                        headingLevel: 3,
-                                       width: "AUTO",
+                                       width: "auto",
                                        widgets: [
                                           {
                                              id: "HORIZONTAL1",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/Twister.get.js
@@ -19,107 +19,198 @@ model.jsonModel = {
          config: {
             widgets: [
                {
-                  id: "FACETS",
-                  name: "alfresco/layout/VerticalWidgets",
+                  id: "SIDBAR",
+                  name: "alfresco/layout/AlfSideBarContainer",
                   config: {
                      widgets: [
                         {
-                           id: "TWISTER_HEADING_LEVEL",
-                           name: "alfresco/layout/Twister",
+                           id: "FACETS",
+                           name: "alfresco/layout/VerticalWidgets",
+                           align: "sidebar",
                            config: {
-                              label: "Twister with heading level",
-                              headingLevel: 3,
-                              initiallyOpen: true,
                               widgets: [
                                  {
-                                    id: "LOGO1",
-                                    name: "alfresco/logo/Logo"
+                                    id: "TWISTER_HEADING_LEVEL",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Twister with heading level",
+                                       headingLevel: 3,
+                                       initiallyOpen: true,
+                                       widgets: [
+                                          {
+                                             id: "LOGO1",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "TWISTER_NO_HEADING_LEVEL",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Twister with no heading level",
+                                       initiallyOpen: false,
+                                       widgets: [
+                                          {
+                                             id: "LOGO2",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "TWISTER_BAD_HEADING_LEVEL",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Twister with faulty heading level 'a'",
+                                       initiallyOpen: false,
+                                       preferenceName: "twister1",
+                                       headingLevel: "a",
+                                       widgets: [
+                                          {
+                                             id: "LOGO3",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "TWISTER_BAD_HEADING_LEVEL_TWO",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Twister with heading level 0",
+                                       headingLevel: 0,
+                                       initiallyOpen: true,
+                                       preferenceName: "twister2",
+                                       widgets: [
+                                          {
+                                             id: "LOGO4",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "TWISTER_BAD_HEADING_LEVEL_THREE",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Twister with heading level 7",
+                                       headingLevel: 7,
+                                       widgets: [
+                                          {
+                                             id: "LOGO5",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "TWISTER_NULL_LABEL",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: null,
+                                       widgets: [
+                                          {
+                                             id: "LOGO6",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "TWISTER_EMPTY_LABEL",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "",
+                                       widgets: [
+                                          {
+                                             id: "LOGO7",
+                                             name: "alfresco/logo/Logo"
+                                          }
+                                       ]
+                                    }
                                  }
                               ]
                            }
                         },
                         {
-                           id: "TWISTER_NO_HEADING_LEVEL",
-                           name: "alfresco/layout/Twister",
+                           id: "MAIN",
+                           name: "alfresco/layout/VerticalWidgets",
                            config: {
-                              label: "Twister with no heading level",
-                              initiallyOpen: false,
                               widgets: [
                                  {
-                                    id: "LOGO2",
-                                    name: "alfresco/logo/Logo"
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           id: "TWISTER_BAD_HEADING_LEVEL",
-                           name: "alfresco/layout/Twister",
-                           config: {
-                              label: "Twister with faulty heading level 'a'",
-                              initiallyOpen: false,
-                              preferenceName: "twister1",
-                              headingLevel: "a",
-                              widgets: [
+                                    id: "SHOW_BUTTON",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Show Sidebar",
+                                       publishTopic: "ALF_DOCLIST_SHOW_SIDEBAR",
+                                       publishPayload: {
+                                          selected: true
+                                       }
+                                    }
+                                 },
                                  {
-                                    id: "LOGO3",
-                                    name: "alfresco/logo/Logo"
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           id: "TWISTER_BAD_HEADING_LEVEL_TWO",
-                           name: "alfresco/layout/Twister",
-                           config: {
-                              label: "Twister with heading level 0",
-                              headingLevel: 0,
-                              initiallyOpen: true,
-                              preferenceName: "twister2",
-                              widgets: [
+                                    id: "HIDE_BUTTON",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Hide Sidebar",
+                                       publishTopic: "ALF_DOCLIST_SHOW_SIDEBAR",
+                                       publishPayload: {
+                                          selected: false
+                                       }
+                                    }
+                                 },
                                  {
-                                    id: "LOGO4",
-                                    name: "alfresco/logo/Logo"
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           id: "TWISTER_BAD_HEADING_LEVEL_THREE",
-                           name: "alfresco/layout/Twister",
-                           config: {
-                              label: "Twister with heading level 7",
-                              headingLevel: 7,
-                              widgets: [
+                                    id: "AUTO_WIDTH_TWISTER",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Resizing Twister",
+                                       initiallyOpen: true,
+                                       headingLevel: 3,
+                                       width: "AUTO",
+                                       widgets: [
+                                          {
+                                             id: "HORIZONTAL1",
+                                             name: "alfresco/layout/HorizontalWidgets",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/layout/ClassicWindow",
+                                                      config: {
+                                                         title: "Watch me grow and shrink!"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
                                  {
-                                    id: "LOGO5",
-                                    name: "alfresco/logo/Logo"
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           id: "TWISTER_NULL_LABEL",
-                           name: "alfresco/layout/Twister",
-                           config: {
-                              label: null,
-                              widgets: [
-                                 {
-                                    id: "LOGO6",
-                                    name: "alfresco/logo/Logo"
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           id: "TWISTER_EMPTY_LABEL",
-                           name: "alfresco/layout/Twister",
-                           config: {
-                              label: "",
-                              widgets: [
-                                 {
-                                    id: "LOGO7",
-                                    name: "alfresco/logo/Logo"
+                                    id: "FIXED_WIDTH_TWISTER",
+                                    name: "alfresco/layout/Twister",
+                                    config: {
+                                       label: "Fixed Width Twister",
+                                       initiallyOpen: true,
+                                       headingLevel: 3,
+                                       width: "500px",
+                                       widgets: [
+                                          {
+                                             id: "HORIZONTAL1",
+                                             name: "alfresco/layout/HorizontalWidgets",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/layout/ClassicWindow",
+                                                      config: {
+                                                         title: "Watch me stay the same size!"
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
                                  }
                               ]
                            }

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -21,8 +21,8 @@
          @link-title-font-color-hover: @button-color-default;
          @link-title-text-decoration-hover: underline;
 
-         @sidebar-container-sidebar-background-color: #FDFAA4;
-         @sidebar-container-main-background-color: #CCFCA5;
+         @sidebar-container-sidebar-background-color: #eee;
+         @sidebar-container-main-background-color: #f8f8f8;
       </less-variables>
    </css-tokens>
 </theme>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-670 to add a new configuration option for the alfresco/layout/Twister so that it can be configured with a width of "AUTO" to automatically grow and shrink to the available width.