### PR TITLE
AKU-682: Create Aikau Push Button Control

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -54,8 +54,11 @@
  * }
  *
  * @module alfresco/forms/controls/MultiSelect
- * @extends external:dijit/_TemplatedMixin
  * @extends external:dijit/_WidgetBase
+ * @mixes external:dijit/_TemplatedMixin
+ * @mixes external:dijit/_FocusMixin
+ * @mixes alfresco/core/Core
+ * @mixes alfresco/core/ObjectProcessingMixin
  * @author Martin Doyle
  */
 define([

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
@@ -20,8 +20,8 @@
 /**
  * @module alfresco/forms/controls/MultiSelectInput
  * @extends alfresco/forms/controls/BaseFormControl
- * @extends alfresco/forms/controls/utilities/IconMixin
- * @extends alfresco/forms/controls/utilities/UseServiceStoreMixin
+ * @mixes alfresco/forms/controls/utilities/IconMixin
+ * @mixes alfresco/forms/controls/utilities/UseServiceStoreMixin
  * @author Martin Doyle
  */
 define([

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
@@ -36,11 +36,23 @@ define([
       "alfresco/forms/controls/BaseFormControl",
       "dojo/_base/declare",
       "dojo/_base/lang",
+      "dojo/dom-class",
       "alfresco/forms/controls/PushButtonsControl"
    ],
-   function(CoreWidgetProcessing, BaseFormControl, declare, lang) {
+   function(CoreWidgetProcessing, BaseFormControl, declare, lang, domClass) {
 
       return declare([BaseFormControl, CoreWidgetProcessing], {
+
+         /**
+          * Run after widget created.
+          *
+          * @instance
+          * @override
+          */
+         postCreate: function() {
+            this.inherited(arguments);
+            domClass.add(this.domNode, "alfresco-forms-controls-PushButtons");
+         },
 
          /**
           * Construct the config for the wrapped control.
@@ -54,10 +66,12 @@ define([
             // Setup the widget config
             var widgetConfig = {
                id: this.id + "_CONTROL",
-               multiMode: this.multiMode,
-               name: this.name,
-               width: this.width
+               multiMode: !!this.multiMode,
+               name: this.name
             };
+            if (this.width) {
+               widgetConfig.width = this.width;
+            }
 
             // Pass back the config
             return widgetConfig;

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
@@ -67,10 +67,22 @@ define([
             var widgetConfig = {
                id: this.id + "_CONTROL",
                multiMode: !!this.multiMode,
-               name: this.name
+               name: this.name,
+               noWrap: !!this.noWrap
             };
-            if (this.width) {
+
+            // Set config only if available
+            if (!isNaN(this.width)) {
                widgetConfig.width = this.width;
+            }
+            if (!isNaN(this.maxLineLength)) {
+               widgetConfig.maxLineLength = this.maxLineLength;
+            }
+            if (!isNaN(this.percentGap)) {
+               widgetConfig.percentGap = this.percentGap;
+            }
+            if (!isNaN(this.minPadding)) {
+               widgetConfig.minPadding = this.minPadding;
             }
 
             // Pass back the config

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>An input control that offers the functionality of radio-buttons or checkboxes,
+ * rendered as a single control with push-button options.</p>
+ *
+ * <p>For full information about how to use this control and all of the available
+ * options, please see the implementing widget:
+ * [alfresco/forms/controls/PushButtonsControl]{@link module:alfresco/forms/controls/PushButtonsControl}.</p>
+ * 
+ * @module alfresco/forms/controls/PushButtons
+ * @extends alfresco/forms/controls/BaseFormControl
+ * @mixes alfresco/core/CoreWidgetProcessing
+ * @author Martin Doyle
+ * @since 1.0.44
+ */
+define([
+      "alfresco/core/CoreWidgetProcessing",
+      "alfresco/forms/controls/BaseFormControl",
+      "dojo/_base/declare",
+      "dojo/_base/lang",
+      "alfresco/forms/controls/PushButtonsControl"
+   ],
+   function(CoreWidgetProcessing, BaseFormControl, declare, lang) {
+
+      return declare([BaseFormControl, CoreWidgetProcessing], {
+
+         /**
+          * Construct the config for the wrapped control.
+          *
+          * @instance
+          * @override
+          * @returns {object} The configuration for the form control.
+          */
+         getWidgetConfig: function alfresco_forms_controls_PushButtons__getWidgetConfig() {
+
+            // Setup the widget config
+            var widgetConfig = {
+               id: this.id + "_CONTROL",
+               multiMode: this.multiMode,
+               name: this.name,
+               width: this.width
+            };
+
+            // Pass back the config
+            return widgetConfig;
+         },
+
+         /**
+          * Creates a new [ServiceStore]{@link module:alfresco/forms/controls/utilities/ServiceStore} object to use for
+          * retrieving and filtering the available options to be included in the control and then instantiates and returns
+          * the PushButtonsControl widget that is configured to use it.
+          *
+          * @override
+          * @instance
+          * @param    {object} config Configuration for the control
+          * @returns  {object} The new control
+          */
+         createFormControl: function alfresco_forms_controls_PushButtons__createFormControl(config) {
+            return this.createWidget({
+               name: "alfresco/forms/controls/PushButtonsControl",
+               config: config
+            });
+         }
+      });
+   });

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
@@ -64,12 +64,13 @@ define([
       "dojo/_base/array",
       "dojo/_base/declare",
       "dojo/_base/lang",
+      "dojo/dom-class",
       "dojo/dom-construct",
       "dojo/dom-style",
       "dojo/on",
       "dojo/text!./templates/PushButtonsControl.html"
    ],
-   function(Core, ObjectProcessingMixin, _FocusMixin, _TemplatedMixin, _WidgetBase, array, declare, lang, domConstruct, domStyle, on, template) {
+   function(Core, ObjectProcessingMixin, _FocusMixin, _TemplatedMixin, _WidgetBase, array, declare, lang, domClass, domConstruct, domStyle, on, template) {
       /*jshint devel:true*/
 
       return declare([_WidgetBase, _TemplatedMixin, _FocusMixin, Core, ObjectProcessingMixin], {
@@ -101,17 +102,6 @@ define([
           * @type {String}
           */
          templateString: template,
-
-         /**
-          * The height of the control. Can be specified either as a number,
-          * which is assumed to be in pixels, or as a CSS dimension
-          * string.
-          *
-          * @instance
-          * @type {number|string}
-          * @default
-          */
-         height: 50,
 
          /**
           * The ID of this control
@@ -173,13 +163,16 @@ define([
          },
 
          /**
-          * Start up the widget
+          * Widget has been created (but not necessarily sub-widgets)
           *
           * @instance
           * @override
           */
-         startup: function alfresco_forms_controls_PushButtonsControl__startup() {
+         postCreate: function alfresco_forms_controls_PushButtonsControl__postCreate() {
             this.inherited(arguments);
+            if (this.multiMode) {
+               domClass.add(this.domNode, this.rootClass + "--multi-mode");
+            }
             this.resize();
          },
 
@@ -274,7 +267,7 @@ define([
           * @instance
           */
          resize: function alfresco_forms_controls_PushButtonsControl__resize() {
-            domStyle.set(this.domNode, "lineHeight", isNaN(this.height) ? this.height : this.height + "px");
+            domStyle.set(this.domNode, "width", isNaN(this.width) ? this.width : this.width + "px");
          },
 
          /**
@@ -288,17 +281,18 @@ define([
           * @param {*} value The value to be set
           */
          setValue: function alfresco_forms_controls_PushButtonsControl__setValue(value) {
+            this.alfLog("debug", this.name + ": setValue(" + JSON.stringify(value) + ")");
 
             // Discard null, undefined and empty-string values
             if (value === null || typeof value === "undefined") {
-               this.alfLog("warn", "Invalid value passed to PushButtonsControl (" + value + ")");
+               this.alfLog("warn", "setValue() not completed as invalid value passed to PushButtonsControl (" + value + ")");
                return;
             }
 
             // Make sure value is/isn't an array as appropriate
             var valueIsArray = value.constructor === Array;
             if (!this.multiMode && valueIsArray) {
-               this.alfLog("error", "Value for single-value mode must not be array (value=" + JSON.stringify(value) + ")");
+               this.alfLog("warn", "setValue() not completed as value for single-value mode must not be array (value=" + JSON.stringify(value) + ")");
                return;
             }
 
@@ -317,7 +311,7 @@ define([
                return array.indexOf(validValues, nextValue) === -1;
             });
             if (hasInvalidValues) {
-               this.alfLog("error", "Supplied value " + JSON.stringify(value) + " does not match current option values: " + JSON.stringify(validValues));
+               this.alfLog("warn", "setValue() not completed as supplied value " + JSON.stringify(value) + " does not match current option values: " + JSON.stringify(validValues));
                return;
             }
 

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
@@ -1,0 +1,353 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An input control that offers the functionality of radio-buttons or checkboxes (depending
+ * on [the mode]{@link module:alfresco/forms/controls/PushButtonsControl#multiMode}, rendered as a
+ * single control with push-button options.
+ *
+ * @example <caption>Sample configuration:</caption>
+ * {
+ *    name: "alfresco/forms/controls/PushButtons",
+ *    id: "CAN_BUILD",
+ *    config: {
+ *       name: "canbuild",
+ *       label: "Can build",
+ *       description: "Can we build it?",
+ *       width: 500,
+ *       optionsConfig: {
+ *          fixed: [
+ *             {
+ *                label: "Yes",
+ *                value: true
+ *             },
+ *             {
+ *                label: "No",
+ *                value: false
+ *             }
+ *          ]
+ *       }
+ *    }
+ * }
+ *
+ * @module alfresco/forms/controls/PushButtonsControl
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dijit/_TemplatedMixin
+ * @mixes external:dijit/_FocusMixin
+ * @mixes alfresco/core/Core
+ * @mixes alfresco/core/ObjectProcessingMixin
+ * @author Martin Doyle
+ * @since 1.0.44
+ */
+define([
+      "alfresco/core/Core",
+      "alfresco/core/ObjectProcessingMixin",
+      "dijit/_FocusMixin",
+      "dijit/_TemplatedMixin",
+      "dijit/_WidgetBase",
+      "dojo/_base/array",
+      "dojo/_base/declare",
+      "dojo/_base/lang",
+      "dojo/dom-construct",
+      "dojo/dom-style",
+      "dojo/on",
+      "dojo/text!./templates/PushButtonsControl.html"
+   ],
+   function(Core, ObjectProcessingMixin, _FocusMixin, _TemplatedMixin, _WidgetBase, array, declare, lang, domConstruct, domStyle, on, template) {
+      /*jshint devel:true*/
+
+      return declare([_WidgetBase, _TemplatedMixin, _FocusMixin, Core, ObjectProcessingMixin], {
+
+         /**
+          * An array of the CSS files to use with this widget.
+          *
+          * @instance
+          * @type {object[]}
+          * @default [{cssFile:"./css/PushButtonsControl.css"}]
+          */
+         cssRequirements: [{
+            cssFile: "./css/PushButtonsControl.css"
+         }],
+
+         /**
+          * The root class of this widget
+          *
+          * @instance
+          * @type {string}
+          */
+         rootClass: "alfresco-forms-controls-PushButtonsControl",
+
+         /**
+          * The HTML template to use for the widget.
+          *
+          * @override
+          * @instance
+          * @type {String}
+          */
+         templateString: template,
+
+         /**
+          * The height of the control. Can be specified either as a number,
+          * which is assumed to be in pixels, or as a CSS dimension
+          * string.
+          *
+          * @instance
+          * @type {number|string}
+          * @default
+          */
+         height: 50,
+
+         /**
+          * The ID of this control
+          *
+          * @instance
+          * @type {string}
+          * @default
+          */
+         id: null,
+
+         /**
+          * Whether to run the control in multi-value mode (i.e. like a checkbox).
+          *
+          * @instance
+          * @type {boolean}
+          * @default
+          */
+         multiMode: false,
+
+         /**
+          * The name of this control in the form
+          *
+          * @instance
+          * @type {string}
+          * @default
+          */
+         name: null,
+
+         /**
+          * Local store of the current control options, where the generated
+          * UUID of the input element is the key and the value is an object
+          * containing details of the option.
+          *
+          * @instance
+          * @type {object}
+          * @readonly
+          * @default
+          */
+         opts: null,
+
+         /**
+          * The total width of the control. Can be specified either as a
+          * number, which is assumed to be in pixels, or as a CSS dimension
+          * string.
+          *
+          * @instance
+          * @type {number|string}
+          * @default
+          */
+         width: "auto",
+
+         /**
+          * Constructor
+          *
+          * @instance
+          */
+         constructor: function() {
+            this.opts = {};
+         },
+
+         /**
+          * Start up the widget
+          *
+          * @instance
+          * @override
+          */
+         startup: function alfresco_forms_controls_PushButtonsControl__startup() {
+            this.inherited(arguments);
+            this.resize();
+         },
+
+         /**
+          * Add an option to the control.
+          *
+          * @instance
+          * @param {object} option The option to be added
+          */
+         addOption: function alfresco_forms_controls_PushButtonsControl__addOption(option) {
+
+            // Duplicate values are unsupported
+            var optionAlreadyExists = array.some(this._getOpts(), function(opt) {
+               return opt.option.value === option.value;
+            });
+            if (optionAlreadyExists) {
+               this.alfLog("error", "Attempted to add option with duplicate value: ", option);
+               return;
+            }
+
+            // Setup the DOM structure
+            var optionId = this.id + "_" + this.generateUuid(),
+               inputNode = domConstruct.create("input", {
+                  name: this.name,
+                  id: optionId,
+                  className: this.rootClass + "__input",
+                  type: this.multiMode ? "checkbox" : "radio"
+               }, this.domNode),
+               labelNode = domConstruct.create("label", {
+                  "for": optionId, // Quoted because reserved word
+                  className: this.rootClass + "__label"
+               }, this.domNode);
+
+            // Add the label content (just text initially)
+            var labelContent = document.createTextNode(option.label || option.name || option.value);
+            labelNode.appendChild(labelContent);
+
+            // Setup change-listener
+            var changeListener = on(inputNode, "change", lang.hitch(this, this.onValueChanged));
+            this.own(changeListener);
+
+            // Put the new option into the options-map
+            this.opts[optionId] = {
+               id: optionId,
+               inputNode: inputNode,
+               labelNode: labelNode,
+               changeListener: changeListener,
+               option: option
+            };
+         },
+
+         /**
+          * Get the current value(s) of this control
+          *
+          * @instance
+          * @returns {object[]} The currently selected options
+          */
+         getValue: function alfresco_forms_controls_PushButtonsControl__getValue() {
+            var values = [];
+            array.forEach(this._getOpts(), function(opt) {
+               opt.inputNode.checked && values.push(opt.option.value);
+            }, this);
+            return this.multiMode ? values : values[0];
+         },
+
+         /**
+          * Fires when the value is changed.
+          *
+          * @instance
+          */
+         onValueChanged: function alfresco_forms_controls_PushButtonsControl__onValueChanged() {
+            this._changeAttrValue("value", this.getValue());
+         },
+
+         /**
+          * Remove the selected option from the control.
+          *
+          * @instance
+          * @param {object} option The option to be removed
+          */
+         removeOption: function alfresco_forms_controls_PushButtonsControl__removeOption(option) {
+            array.forEach(this._getOpts(), function(opt) {
+               if (opt.option === option) {
+                  delete this.opts[opt.id];
+               }
+            }, this);
+         },
+
+         /**
+          * Resize the control
+          *
+          * @instance
+          */
+         resize: function alfresco_forms_controls_PushButtonsControl__resize() {
+            domStyle.set(this.domNode, "lineHeight", isNaN(this.height) ? this.height : this.height + "px");
+         },
+
+         /**
+          * <p>Set the value of the control. When not in [multi-value mode]{@link module:alfresco/forms/controls/PushButtonControl#multiMode},
+          * the value must should be a single value, rather than an array.</p>
+          * 
+          * <p>All values in the array must be valid values for the control's
+          * current options, or this function will do nothing.</p>
+          *
+          * @instance
+          * @param {*} value The value to be set
+          */
+         setValue: function alfresco_forms_controls_PushButtonsControl__setValue(value) {
+
+            // Discard null, undefined and empty-string values
+            if (value === null || typeof value === "undefined") {
+               this.alfLog("warn", "Invalid value passed to PushButtonsControl (" + value + ")");
+               return;
+            }
+
+            // Make sure value is/isn't an array as appropriate
+            var valueIsArray = value.constructor === Array;
+            if (!this.multiMode && valueIsArray) {
+               this.alfLog("error", "Value for single-value mode must not be array (value=" + JSON.stringify(value) + ")");
+               return;
+            }
+
+            // Get valid values and normalise value to an array
+            var opts = this._getOpts(),
+               validValues = array.map(opts, function(opt) {
+                  return opt.option.value;
+               }, this),
+               valuesToUse = value;
+            if (!valueIsArray) {
+               valuesToUse = [value];
+            }
+
+            // Check that all new values are valid
+            var hasInvalidValues = array.some(valuesToUse, function(nextValue) {
+               return array.indexOf(validValues, nextValue) === -1;
+            });
+            if (hasInvalidValues) {
+               this.alfLog("error", "Supplied value " + JSON.stringify(value) + " does not match current option values: " + JSON.stringify(validValues));
+               return;
+            }
+
+            // Set the values (and if we're in multi-mode then we deselect
+            // the other values)
+            array.forEach(opts, function(opt) {
+               if (this.multiMode) {
+                  opt.inputNode.checked = false;
+               }
+               if (array.indexOf(valuesToUse, opt.option.value) !== -1) {
+                  opt.inputNode.checked = true;
+               }
+            }, this);
+
+            // Fire a value-changed event
+            this.onValueChanged();
+         },
+
+         /**
+          * This internal function is a helper function used to coerce
+          * the options map into an array of options objects.
+          *
+          * @instance
+          * @returns {object[]} The option objects
+          */
+         _getOpts: function alfresco_forms_controls_PushButtonsControl___getOpts() {
+            return array.map(Object.keys(this.opts), function(optionId) {
+               return this.opts[optionId];
+            }, this);
+         }
+      });
+   }
+);

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
@@ -88,7 +88,6 @@ define([
       "dojo/text!./templates/PushButtonsControl.html"
    ],
    function(Core, ObjectProcessingMixin, _FocusMixin, _TemplatedMixin, _WidgetBase, array, declare, lang, domClass, domConstruct, domStyle, on, template) {
-      /*jshint devel:true*/
 
       return declare([_WidgetBase, _TemplatedMixin, _FocusMixin, Core, ObjectProcessingMixin], {
 

--- a/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
@@ -1,12 +1,9 @@
 .alfresco-forms-controls-PushButtonsControl {
    box-sizing: border-box;
-   display: flex;
    line-height: 20px;
+   margin-top: 2px;
    overflow: hidden;
    position: relative;
-   &__input, &__label {
-      box-sizing: inherit;
-   }
    &__input {
       height: 0;
       left: 100%;
@@ -16,24 +13,25 @@
          background: @button-color-default;
          color: #fff;
       }
-      &:focus + label {
-         background: @focused-border-color;
+      &:focus + label, &:hover + label {
+         border-color: @focused-border-color;
+      }
+      &:checked {
+         &:focus + label, &:hover + label {
+            background: @focused-border-color;
+         }
       }
    }
    &__label {
       border: 1px solid @button-color-default;
       border-radius: 10px;
+      box-sizing: inherit;
       color: @primary-font-color;
       cursor: pointer;
       display: inline-block;
-      flex: 1 0 auto;
       font-size: @small-font-size;
-      margin-right: 10px;
       text-align: center;
       transition: background .2s ease-out, color .2s ease-out;
-      &:last-child {
-         margin-right: 0;
-      }
    }
 }
 
@@ -47,14 +45,14 @@
                border-color: #666;
                box-shadow: inset 1px 1px 3px rgba(0, 0, 0, .3);
                color: @primary-font-color;
-               padding: 2px 0 0 2px;
-               transition: all .2s ease-out;
             }
-            &:focus + label {
+            &:focus + label, &:hover + label {
                background: #eee linear-gradient(to bottom, #fff, #ddd);
             }
-            &:checked:focus + label {
-               background: #f8c681 linear-gradient(to bottom, #fdd49d, #f6b65e);
+            &:checked {
+               &:focus + label, &:hover + label {
+                  background: #f8c681 linear-gradient(to bottom, #fdd49d, #f6b65e);
+               }
             }
          }
          &__label {
@@ -62,8 +60,6 @@
             border: 1px solid #aaa;
             border-radius: 0;
             font-size: @normal-font-size;
-            margin-right: 2px;
-            padding: 1px;
             transition: all .1s ease-in;
          }
       }

--- a/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
@@ -1,0 +1,25 @@
+.alfresco-forms-controls-PushButtonsControl {
+   &__input {
+      display: none;
+      &:checked {
+         + label {
+            border-color: #0c0;
+            color: #0c0;
+            opacity: 1;
+         }
+      }
+   }
+   &__label {
+      border: 1px solid #a00;
+      color: #a00;
+      cursor: pointer;
+      display: inline-block;
+      margin-right: 5px;
+      opacity: .2;
+      padding: 0 5px;
+      transition: all .3s ease-out;
+      &:last-child {
+         margin-right: 0;
+      }
+   }
+}

--- a/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
@@ -1,25 +1,71 @@
 .alfresco-forms-controls-PushButtonsControl {
+   box-sizing: border-box;
+   display: flex;
+   line-height: 20px;
+   overflow: hidden;
+   position: relative;
+   &__input, &__label {
+      box-sizing: inherit;
+   }
    &__input {
-      display: none;
-      &:checked {
-         + label {
-            border-color: #0c0;
-            color: #0c0;
-            opacity: 1;
-         }
+      height: 0;
+      left: 100%;
+      position: absolute;
+      width: 0;
+      &:checked + label {
+         background: @button-color-default;
+         color: #fff;
+      }
+      &:focus + label {
+         background: @focused-border-color;
       }
    }
    &__label {
-      border: 1px solid #a00;
-      color: #a00;
+      border: 1px solid @button-color-default;
+      border-radius: 10px;
+      color: @primary-font-color;
       cursor: pointer;
       display: inline-block;
-      margin-right: 5px;
-      opacity: .2;
-      padding: 0 5px;
-      transition: all .3s ease-out;
+      flex: 1 0 auto;
+      font-size: @small-font-size;
+      margin-right: 10px;
+      text-align: center;
+      transition: background .2s ease-out, color .2s ease-out;
       &:last-child {
          margin-right: 0;
+      }
+   }
+}
+
+.alfresco-forms-controls-PushButtons {
+   &.grey-gradient {
+      .alfresco-forms-controls-PushButtonsControl {
+         line-height: 50px;
+         &__input {
+            &:checked + label {
+               background: #e89f57 linear-gradient(to bottom, #f6b65e, #d5975a);
+               border-color: #666;
+               box-shadow: inset 1px 1px 3px rgba(0, 0, 0, .3);
+               color: @primary-font-color;
+               padding: 2px 0 0 2px;
+               transition: all .2s ease-out;
+            }
+            &:focus + label {
+               background: #eee linear-gradient(to bottom, #fff, #ddd);
+            }
+            &:checked:focus + label {
+               background: #f8c681 linear-gradient(to bottom, #fdd49d, #f6b65e);
+            }
+         }
+         &__label {
+            background: #ddd linear-gradient(to bottom, #eee, #ccc);
+            border: 1px solid #aaa;
+            border-radius: 0;
+            font-size: @normal-font-size;
+            margin-right: 2px;
+            padding: 1px;
+            transition: all .1s ease-in;
+         }
       }
    }
 }

--- a/aikau/src/main/resources/alfresco/forms/controls/templates/PushButtonsControl.html
+++ b/aikau/src/main/resources/alfresco/forms/controls/templates/PushButtonsControl.html
@@ -1,0 +1,1 @@
+<div class="${rootClass}"></div>

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -51,7 +51,10 @@ define(["intern!object",
                .getLastPublish("SCOPED_POST_FORM", true)
                   .then(function(payload) {
                      assert.propertyVal(payload, "canbuild", true);
-                     assert.propertyVal(payload, "properfootball", "rugby_football");
+                     assert.lengthOf(payload.properfootball, 2);
+                     assert.deepPropertyVal(payload, "properfootball[0]", "rugby_football");
+                     assert.deepPropertyVal(payload, "properfootball[1]", "union_football");
+                     assert.propertyVal(payload, "bestlanguage", "javascript");
                   });
             },
 
@@ -64,6 +67,10 @@ define(["intern!object",
                   .click()
                   .end()
 
+               .findById("VB_VALUE")
+                  .click()
+                  .end()
+
                .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
                   .clearLog()
                   .click()
@@ -72,15 +79,28 @@ define(["intern!object",
                .getLastPublish("SCOPED_POST_FORM", true)
                   .then(function(payload) {
                      assert.propertyVal(payload, "canbuild", false);
-                     assert.propertyVal(payload, "properfootball", "rugby_union");
+                     assert.lengthOf(payload.properfootball, 1);
+                     assert.deepPropertyVal(payload, "properfootball[0]", "rugby_union");
+                     assert.propertyVal(payload, "bestlanguage", "vb");
                   });
             },
 
-            "Keyboard navigation and selection is supported": function() {
-               return browser.pressKeys([keys.SHIFT, keys.TAB])
-                  .pressKeys(keys.ARROW_UP)
+            "Keyboard navigation and selection is supported on single-value controls": function() {
+               return browser.findById("VB_VALUE") // Focus on last button at top
+                  .click()
+                  .end()
+
+               .pressKeys(keys.TAB) // Tab to "canbuild" control
+                  .pressKeys(keys.ARROW_LEFT)
                   .pressKeys(keys.SPACE)
-                  .pressKeys(keys.NULL) // Cancel modifiers
+                  .end()
+
+               .pressKeys(keys.TAB) // Tab to "properfootball" control, first value
+                  .pressKeys(keys.SPACE)
+                  .end()
+
+               .pressKeys(keys.TAB) // Tab to "properfootball" control, second value
+                  .pressKeys(keys.SPACE)
                   .end()
 
                .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
@@ -90,12 +110,14 @@ define(["intern!object",
 
                .getLastPublish("SCOPED_POST_FORM", true)
                   .then(function(payload) {
-                     assert.propertyVal(payload, "properfootball", "rugby_football");
+                     assert.propertyVal(payload, "canbuild", true);
+                     assert.lengthOf(payload.properfootball, 1);
+                     assert.deepPropertyVal(payload, "properfootball[0]", "rugby_football");
                   });
             },
 
             "Can select push button with mouse": function() {
-               return browser.findByCssSelector("input[value=\"union_football\"]")
+               return browser.findByCssSelector("#BEST_LANGUAGE_CONTROL label:nth-of-type(2)")
                   .click()
                   .end()
 
@@ -106,7 +128,7 @@ define(["intern!object",
 
                .getLastPublish("SCOPED_POST_FORM", true)
                   .then(function(payload) {
-                     assert.propertyVal(payload, "properfootball", "union_football");
+                     assert.propertyVal(payload, "bestlanguage", "javascript");
                   });
             },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "alfresco/TestCommon",
+      "intern/dojo/node!leadfoot/keys"
+   ],
+   function(registerSuite, assert, TestCommon, keys) {
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "PushButtons Tests",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/PushButtons", "PushButtons Control Tests");
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "Initial value is set correctly": function() {
+               return browser.findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "canbuild", true);
+                     assert.propertyVal(payload, "properfootball", "rugby_football");
+                  });
+            },
+
+            "Value can be updated by publish": function() {
+               return browser.findById("CANT_BUILD_VALUE")
+                  .click()
+                  .end()
+
+               .findById("RUGBY_UNION_VALUE")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "canbuild", false);
+                     assert.propertyVal(payload, "properfootball", "rugby_union");
+                  });
+            },
+
+            "Keyboard navigation and selection is supported": function() {
+               return browser.pressKeys([keys.SHIFT, keys.TAB])
+                  .pressKeys(keys.ARROW_UP)
+                  .pressKeys(keys.SPACE)
+                  .pressKeys(keys.NULL) // Cancel modifiers
+                  .end()
+
+               .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "properfootball", "rugby_football");
+                  });
+            },
+
+            "Can select push button with mouse": function() {
+               return browser.findByCssSelector("input[value=\"union_football\"]")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "properfootball", "union_football");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+   });

--- a/aikau/src/test/resources/alfresco/forms/controls/RadioButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/RadioButtonsTest.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "alfresco/TestCommon",
+      "intern/dojo/node!leadfoot/keys"
+   ],
+   function(registerSuite, assert, TestCommon, keys) {
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "RadioButtons Tests",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/RadioButtons", "RadioButtons Control Tests");
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "Initial value is set correctly": function() {
+               return browser.findByCssSelector("#RADIO_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "canbuild", true);
+                     assert.propertyVal(payload, "properfootball", "rugby_football");
+                  });
+            },
+
+            "Value can be updated by publish": function() {
+               return browser.findById("CANT_BUILD_VALUE")
+                  .click()
+                  .end()
+
+               .findById("RUGBY_UNION_VALUE")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#RADIO_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "canbuild", false);
+                     assert.propertyVal(payload, "properfootball", "rugby_union");
+                  });
+            },
+
+            "Keyboard navigation and selection is supported": function() {
+               return browser.pressKeys([keys.SHIFT, keys.TAB])
+                  .pressKeys(keys.ARROW_UP)
+                  .pressKeys(keys.SPACE)
+                  .pressKeys(keys.NULL) // Cancel modifiers
+                  .end()
+
+               .findByCssSelector("#RADIO_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "properfootball", "rugby_football");
+                  });
+            },
+
+            "Can select radio button with mouse": function() {
+               return browser.findByCssSelector("input[value=\"union_football\"]")
+                  .click()
+                  .end()
+
+               .findByCssSelector("#RADIO_FORM .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("SCOPED_POST_FORM", true)
+                  .then(function(payload) {
+                     assert.propertyVal(payload, "properfootball", "union_football");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/layout/FixedHeaderFooterTest"
+      "src/test/resources/alfresco/forms/controls/RadioButtonsTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
@@ -131,6 +131,7 @@ define({
       "src/test/resources/alfresco/forms/controls/MultipleEntryFormControlTest",
       "src/test/resources/alfresco/forms/controls/MultiSelectInputTest",
       "src/test/resources/alfresco/forms/controls/NumberSpinnerTest",
+      "src/test/resources/alfresco/forms/controls/RadioButtonsTest",
       "src/test/resources/alfresco/forms/controls/SelectTest",
       "src/test/resources/alfresco/forms/controls/SimplePickerTest",
       "src/test/resources/alfresco/forms/controls/SitePickerTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/RadioButtonsTest"
+      "src/test/resources/alfresco/forms/controls/PushButtonsTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
@@ -131,6 +131,7 @@ define({
       "src/test/resources/alfresco/forms/controls/MultipleEntryFormControlTest",
       "src/test/resources/alfresco/forms/controls/MultiSelectInputTest",
       "src/test/resources/alfresco/forms/controls/NumberSpinnerTest",
+      "src/test/resources/alfresco/forms/controls/PushButtonsTest",
       "src/test/resources/alfresco/forms/controls/RadioButtonsTest",
       "src/test/resources/alfresco/forms/controls/SelectTest",
       "src/test/resources/alfresco/forms/controls/SimplePickerTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>PushButtons Test</shortname>
+  <description>This is a test page for the alfresco/forms/controls/PushButtons control</description>
+  <family>aikau-unit-tests</family>
+  <url>/PushButtons</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -71,17 +71,18 @@ model.jsonModel = {
                   id: "CAN_BUILD",
                   config: {
                      name: "canbuild",
-                     label: "Can build (single-value, default theme)",
-                     description: "Can we build it?",
-                     width: 200,
+                     label: "Can we build it?",
+                     description: "Config options: noWrap=true, percentGap=5",
+                     noWrap: true,
+                     percentGap: 5,
                      optionsConfig: {
                         fixed: [
                            {
-                              label: "Yes",
+                              label: "Yes we can",
                               value: true
                            },
                            {
-                              label: "No",
+                              label: "No we can't",
                               value: false
                            }
                         ]
@@ -94,8 +95,8 @@ model.jsonModel = {
                   config: {
                      additionalCssClasses: "grey-gradient",
                      name: "properfootball",
-                     label: "Proper football (multi-value, custom theme)",
-                     description: "What are the only proper forms of football?",
+                     label: "Only proper form of football?",
+                     description: "Config options: width=400, multiMode=true",
                      width: 400,
                      multiMode: true,
                      optionsConfig: {
@@ -110,9 +111,10 @@ model.jsonModel = {
                   config: {
                      additionalCssClasses: "grey-gradient",
                      name: "bestlanguage",
-                     label: "Best language (single-value, custom theme)",
-                     description: "Which is the best language?",
+                     label: "What's the best language?",
+                     description: "Config options: width=300, maxLineLength=3",
                      width: 300,
+                     maxLineLength: 3,
                      optionsConfig: {
                         fixed: [
                            {
@@ -126,6 +128,26 @@ model.jsonModel = {
                            {
                               label: "VisualBasic",
                               value: "vb"
+                           },
+                           {
+                              label: "Java",
+                              value: "java"
+                           },
+                           {
+                              label: "C",
+                              value: "c"
+                           },
+                           {
+                              label: "Ruby",
+                              value: "ruby"
+                           },
+                           {
+                              label: "Scala",
+                              value: "scale"
+                           },
+                           {
+                              label: "Go",
+                              value: "go"
                            }
                         ]
                      }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -1,0 +1,107 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "aikauTesting/mockservices/PushButtonsMockService",
+      "alfresco/services/DialogService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "CANT_BUILD_VALUE",
+         config: {
+            label: "No we can't",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               canbuild: false
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "RUGBY_UNION_VALUE",
+         config: {
+            label: "Rugby Union",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               properfootball: "rugby_union"
+            }
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/forms/Form",
+         config: {
+            id: "TEST_FORM",
+            okButtonPublishTopic: "POST_FORM",
+            setValueTopic: "SET_FORM_VALUE",
+            pubSubScope: "SCOPED_",
+            value: {
+               canbuild: true,
+               properfootball: ["rugby_football", "union_football"]
+            },
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/PushButtons",
+                  id: "CAN_BUILD",
+                  config: {
+                     name: "canbuild",
+                     label: "Can build",
+                     description: "Can we build it?",
+                     width: 500,
+                     optionsConfig: {
+                        fixed: [
+                           {
+                              label: "Yes",
+                              value: true
+                           },
+                           {
+                              label: "No",
+                              value: false
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/PushButtons",
+                  id: "PROPER_FOOTBALL",
+                  config: {
+                     name: "properfootball",
+                     label: "Proper football",
+                     description: "What are the only proper forms of football?",
+                     width: 600,
+                     multiMode: true,
+                     optionsConfig: {
+                        publishTopic: "GET_FOOTBALL_OPTIONS",
+                        publishGlobal: true
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -37,6 +37,17 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "VB_VALUE",
+         config: {
+            label: "VisualBasic",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               bestlanguage: "vb"
+            }
+         }
+      },
+      {
          name: "alfresco/html/Spacer",
          config: {
             height: "30px"
@@ -51,7 +62,8 @@ model.jsonModel = {
             pubSubScope: "SCOPED_",
             value: {
                canbuild: true,
-               properfootball: ["rugby_football", "union_football"]
+               properfootball: ["rugby_football", "union_football"],
+               bestlanguage: "javascript"
             },
             widgets: [
                {
@@ -59,9 +71,9 @@ model.jsonModel = {
                   id: "CAN_BUILD",
                   config: {
                      name: "canbuild",
-                     label: "Can build",
+                     label: "Can build (single-value, default theme)",
                      description: "Can we build it?",
-                     width: 500,
+                     width: 200,
                      optionsConfig: {
                         fixed: [
                            {
@@ -80,14 +92,42 @@ model.jsonModel = {
                   name: "alfresco/forms/controls/PushButtons",
                   id: "PROPER_FOOTBALL",
                   config: {
+                     additionalCssClasses: "grey-gradient",
                      name: "properfootball",
-                     label: "Proper football",
+                     label: "Proper football (multi-value, custom theme)",
                      description: "What are the only proper forms of football?",
-                     width: 600,
+                     width: 400,
                      multiMode: true,
                      optionsConfig: {
                         publishTopic: "GET_FOOTBALL_OPTIONS",
                         publishGlobal: true
+                     }
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/PushButtons",
+                  id: "BEST_LANGUAGE",
+                  config: {
+                     additionalCssClasses: "grey-gradient",
+                     name: "bestlanguage",
+                     label: "Best language (single-value, custom theme)",
+                     description: "Which is the best language?",
+                     width: 300,
+                     optionsConfig: {
+                        fixed: [
+                           {
+                              label: "PHP",
+                              value: "php"
+                           },
+                           {
+                              label: "JavaScript",
+                              value: "javascript"
+                           },
+                           {
+                              label: "VisualBasic",
+                              value: "vb"
+                           }
+                        ]
                      }
                   }
                }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>RadioButtons Test</shortname>
+  <description>This is a test page for the alfresco/forms/controls/RadioButtons control</description>
+  <family>aikau-unit-tests</family>
+  <url>/RadioButtons</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.js
@@ -1,0 +1,100 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "aikauTesting/mockservices/RadioButtonsMockService",
+      "alfresco/services/DialogService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "CANT_BUILD_VALUE",
+         config: {
+            label: "No we can't",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               canbuild: false
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "RUGBY_UNION_VALUE",
+         config: {
+            label: "Rugby Union",
+            publishTopic: "SET_FORM_VALUE",
+            publishPayload: {
+               properfootball: "rugby_union"
+            }
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/forms/Form",
+         config: {
+            id: "RADIO_FORM",
+            okButtonPublishTopic: "POST_FORM",
+            setValueTopic: "SET_FORM_VALUE",
+            pubSubScope: "SCOPED_",
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/RadioButtons",
+                  id: "CAN_BUILD",
+                  config: {
+                     name: "canbuild",
+                     label: "Can build",
+                     description: "Can we build it?",
+                     optionsConfig: {
+                        fixed: [
+                           {
+                              label: "Yes",
+                              value: true
+                           },
+                           {
+                              label: "No",
+                              value: false
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/RadioButtons",
+                  id: "PROPER_FOOTBALL",
+                  config: {
+                     name: "properfootball",
+                     label: "Proper football",
+                     description: "What is the only proper form of football?",
+                     optionsConfig: {
+                        publishTopic: "GET_FOOTBALL_OPTIONS",
+                        publishGlobal: true
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PushButtonsMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PushButtonsMockService.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/RadioButtonsMockService
+ * @extends module:alfresco/core/Core
+ * @author Martin Doyle
+ */
+define(["alfresco/core/Core",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(AlfCore, declare, lang) {
+
+      return declare([AlfCore], {
+
+         /**
+          * Constructor
+          *
+          * @instance
+          * @param {array} args The constructor arguments.
+          */
+         constructor: function alfresco_testing_mockservices_AlfListViewMockService__constructor(args) {
+            /*jshint loopfunc:true*/
+            declare.safeMixin(this, args);
+            this.alfSubscribe("GET_FOOTBALL_OPTIONS", lang.hitch(this, function(payload) {
+               this.alfPublish(payload.responseTopic, {
+                  options: [{
+                     label: "Rugby Football",
+                     value: "rugby_football"
+                  }, {
+                     label: "Rugby Union",
+                     value: "rugby_union"
+                  }, {
+                     label: "Union Football",
+                     value: "union_football"
+                  }]
+               }, payload.alfResponseScope);
+            }));
+         }
+      });
+   });

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/RadioButtonsMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/RadioButtonsMockService.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/RadioButtonsMockService
+ * @extends module:alfresco/core/Core
+ * @author Martin Doyle
+ */
+define(["alfresco/core/Core",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(AlfCore, declare, lang) {
+
+      return declare([AlfCore], {
+
+         /**
+          * Constructor
+          *
+          * @instance
+          * @param {array} args The constructor arguments.
+          */
+         constructor: function alfresco_testing_mockservices_AlfListViewMockService__constructor(args) {
+            /*jshint loopfunc:true*/
+            declare.safeMixin(this, args);
+            this.alfSubscribe("GET_FOOTBALL_OPTIONS", lang.hitch(this, function(payload) {
+               this.alfPublish(payload.responseTopic, {
+                  options: [{
+                     label: "Rugby Football",
+                     value: "rugby_football"
+                  }, {
+                     label: "Rugby Union",
+                     value: "rugby_union"
+                  }, {
+                     label: "Union Football",
+                     value: "union_football"
+                  }]
+               }, payload.alfResponseScope);
+            }));
+         }
+      });
+   });


### PR DESCRIPTION
This addresses issue [AKU-682](https://issues.alfresco.com/jira/browse/AKU-682), and creates a new PushButtons control which can act as either radio-buttons (in single-value mode) or checkboxes (in multi-value mode). Tests has been almost duplicated from the RadioButtons tests, in order to try and promoted interoperability between controls. A full test suite has been run successfully. Also, updated some documentation in the MultiSelect controls.