### PR TITLE
AKU-697: Ensure search previews are same height in film strip

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/css/Carousel.css
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/css/Carousel.css
@@ -12,6 +12,7 @@
       li {
          display: inline-block;
          margin-top: 6px;
+         vertical-align: top;
       }
    }
    .prev, .next {

--- a/aikau/src/test/resources/alfresco/search/SearchFilmStripViewTest.js
+++ b/aikau/src/test/resources/alfresco/search/SearchFilmStripViewTest.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+   function(registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "SearchFilmStripView Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/SearchFilmStripView", "SearchFilmStripView Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         // See AKU-697...
+         "Previews are same height": function() {
+            var firstPreviewHeight;
+
+            return browser.findByCssSelector("body")
+
+               // Last publish on page render completion...
+               .getLastPublish("ALF_PDFJS_ZOOM_SELECTION")
+               
+               // Get the height of the first preview...
+               .findByCssSelector("#SEARCH_RESULTS_PREVIEWS .items li:nth-child(1) .alfresco-preview-PdfJs")
+                  .getSize()
+                  .then(function(size) {
+                     firstPreviewHeight = size.height;
+                  })
+               .end()
+
+               // Show the next preview...
+               .clearLog()
+
+               .findByCssSelector("#SEARCH_RESULTS_PREVIEWS .controls .next .alfresco-html-Image")
+                  .click()
+               .end()
+
+               // Last publish after second preview render...
+               .getLastPublish("ALF_PDFJS_ZOOM_SELECTION")
+
+               // Check the heights are equal...
+               .findByCssSelector("#SEARCH_RESULTS_PREVIEWS .items li:nth-child(2) .alfresco-preview-PdfJs")
+                  .getSize()
+                  .then(function(size) {
+                     assert.equal(firstPreviewHeight, size.height, "The preview heights were not equal");
+                  });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -246,6 +246,7 @@ define({
       "src/test/resources/alfresco/search/CustomSearchResultTest",
       "src/test/resources/alfresco/search/FacetFiltersTest",
       "src/test/resources/alfresco/search/NoHashSearchingTest",
+      "src/test/resources/alfresco/search/SearchFilmStripViewTest",
       "src/test/resources/alfresco/search/SearchSuggestionsTest",
 
       "src/test/resources/alfresco/services/ActionServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Filmstrip View for Search</shortname>
+  <description>This demonstrates the film strip view for search pages.</description>
+  <family>aikau-unit-tests</family>
+  <url>/SearchFilmStripView</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.js
@@ -1,0 +1,64 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets:[
+      {
+         name: "alfresco/search/SearchFilmStripView",
+         config: {
+            id: "SEARCH_RESULTS",
+            currentData: {
+               items: [
+                  {
+                     nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
+                     type: "document",
+                     displayName: "Normal result",
+                     title: "Normal result title",
+                     modifiedBy: "Barry Smith",
+                     modifiedOn: "13th December 2010",
+                     modifiedByUser: "bsmith",
+                     description: "Normal result description",
+                     site: {
+                        title: "Normal result site title",
+                        shortName: "normalResult"
+                     },
+                     path: "/one/two/three/four",
+                     size: 283746
+                  },
+                  {
+                     nodeRef: "workspace://SpacesStore/f8394454-0651-48a5-b583-d067c7d03339",
+                     type: "document",
+                     displayName: "Normal result",
+                     title: "Normal result title",
+                     modifiedBy: "Barry Smith",
+                     modifiedOn: "13th December 2010",
+                     modifiedByUser: "bsmith",
+                     description: "Normal result description",
+                     site: {
+                        title: "Normal result site title",
+                        shortName: "normalResult"
+                     },
+                     path: "/one/two/three/four",
+                     size: 283746
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PdfJsMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-697. The change ensures that height calculations are correct, a full regression suite has been run and no tests failed.