### PR TITLE
AKU-683: Optionally disable the submit button on a Form when it is submitted

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -29,6 +29,7 @@
 define(["dojo/_base/declare",
         "alfresco/core/CoreData",
         "alfresco/core/PubSubLog",
+        "alfresco/util/objectUtils",
         "service/constants/Default",
         "dojo/topic",
         "alfresco/core/PubQueue",
@@ -37,7 +38,7 @@ define(["dojo/_base/declare",
         "dojox/uuid/generateRandomUuid", 
         "dojox/html/entities", 
         "dojo/Deferred"], 
-        function(declare, CoreData, PubSubLog, AlfConstants, pubSub, PubQueue, array, lang, uuid, htmlEntities, Deferred) {
+        function(declare, CoreData, PubSubLog, objUtils, AlfConstants, pubSub, PubQueue, array, lang, uuid, htmlEntities, Deferred) {
 
    return declare(null, {
 
@@ -561,6 +562,29 @@ define(["dojo/_base/declare",
          handle.scopedTopic = scopedTopic;
          this.alfSubscriptions.push(handle);
          return handle;
+      },
+
+      /**
+       * Subscribe to a publication and then analyse the payload. Depending on whether it
+       * matches the provided [rules object]{@link module:alfresco/util/objectUtils#Rules},
+       * apply the success or failure callback as appropriate. Please see the
+       * [underlying method]{@link module:alfresco/util/objectUtils#evaluateRules} for more
+       * information.
+       *
+       * @instance
+       * @param {string} topic The topic on which to subscribe
+       * @param {module:alfresco/util/objectUtils#Rules} rules The rules object to apply
+       * @param {function} success The function to run if successful
+       * @param {function} [failure] The function to run if unsuccessful
+       * @param {boolean} [global] Indicates that the pub/sub scope should not be applied
+       * @param {boolean} [parentScope] Indicates that the pub/sub scope inherited from the parent should be applied
+       * @returns {object} A handle to the subscription
+       * @since 1.0.44
+       */
+      alfConditionalSubscribe: function alfresco_core_CoreWidgetProcessing__alfConditionalSubscribe(topic, rules, success, failure, global, parentScope) {
+         return this.alfSubscribe(topic, lang.hitch(this, function(payload) {
+            objUtils.evaluateRules(lang.mixin({testObject: payload}, rules), success, failure);
+         }), global, parentScope);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -342,7 +342,7 @@ define(["dojo/_base/declare",
                   if (topic && attribute && (is || isNot))
                   {
                      var rulesObj = {
-                           attributePath: attribute,
+                           attribute: attribute,
                            lookupObject: useCurrentItem && widget.currentItem,
                            is: is,
                            isNot: isNot,

--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -341,11 +341,47 @@ define(["dojo/_base/declare",
                       useCurrentItem = rule.useCurrentItem != null ? rule.useCurrentItem : false;
                   if (topic && attribute && (is || isNot))
                   {
-                     widget.alfSubscribe(topic, lang.hitch(this, "processVisibility", widget, is, isNot, attribute, negate, strict, useCurrentItem));
+                     var rulesObj = {
+                           attributePath: attribute,
+                           lookupObject: useCurrentItem && widget.currentItem,
+                           is: is,
+                           isNot: isNot,
+                           negate: negate,
+                           strict: strict
+                        },
+                        successCallback = lang.hitch(this, this.onVisibilityProcessedSuccess, widget),
+                        failureCallback = lang.hitch(this, this.onVisibilityProcessedFailure, widget);
+                     widget.alfConditionalSubscribe(topic, rulesObj, successCallback, failureCallback);
                   }
                }, this);
             }
          }
+      },
+
+      /**
+       * Called when visibility config on a widget has passed rule-evaluation.
+       *
+       * @instance
+       * @param {object} widget The widget under test
+       * @since 1.0.44
+       */
+      onVisibilityProcessedSuccess: function alfresco_core_CoreWidgetProcessing__onVisibilityProcessedSuccess(widget) {
+         domStyle.set(widget.domNode, "display", "");
+         if (typeof widget.alfPublishResizeEvent === "function")
+         {
+            widget.alfPublishResizeEvent(widget.domNode);
+         }
+      },
+
+      /**
+       * Called when visibility config on a widget has failed rule-evaluation.
+       *
+       * @instance
+       * @param {object} widget The widget under test
+       * @since 1.0.44
+       */
+      onVisibilityProcessedFailure: function alfresco_core_CoreWidgetProcessing__onVisibilityProcessedFailure(widget) {
+         domStyle.set(widget.domNode, "display", "none");
       },
 
       /**
@@ -360,6 +396,7 @@ define(["dojo/_base/declare",
        * @param {string} attribute The dot-notation attribute to retrieve from the payload
        * @param {boolean} negate Whether or not the to negate the evaluated rule (e.g evaluated visible become invisible)
        * @param {object} payload The publication payload triggering the visibility processing
+       * @deprecated Since 1.0.44 - See [setupVisibilityConfigProcessing]{@link module:alfresco/core/CoreWidgetProcessing#setupVisibilityConfigProcessing} source code for current technique for evaluating visibility
        */
       processVisibility: function alfresco_core_CoreWidgetProcessing__processVisibility(widget, is, isNot, attribute, negate, strict, useCurrentItem, payload) {
          var target = lang.getObject(attribute, false, payload);
@@ -430,6 +467,7 @@ define(["dojo/_base/declare",
        * @param {boolean} useCurrentItem Indicates whether or not the values to check are attributes of the "currentItem"
        * @param {string} currValue The value from the current rule being processed
        * @returns {boolean} true if the values match and false otherwise
+       * @deprecated Since 1.0.44 - See [setupVisibilityConfigProcessing]{@link module:alfresco/core/CoreWidgetProcessing#setupVisibilityConfigProcessing} source code for current technique for evaluating visibility
        */
       visibilityRuleComparator: function alfresco_core_CoreWidgetProcessing__visibilityRuleComparator(targetValue, widget, useCurrentItem, currValue) {
          if (targetValue == null && currValue == null)

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -218,6 +218,33 @@ define([],function() {
       DELETE_SITE: "ALF_DELETE_SITE",
 
       /**
+       * This topic can be published to request that a notification be displayed. It is subscribed to 
+       * by the [NotificationService]{@link module:alfresco/services/NotificationService}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       *
+       * @event
+       * @property {string} message The message to be displayed
+       * @property {string} [publishTopic] A topic to be published after the notification has closed
+       * @property {object} [publishPayload] The payload to be published after the notification has closed
+       * @property {boolean} [publishGlobal] Whether to publish the topic globally
+       * @property {boolean} [publishToParent] Whether to publish the topic on the parent scope
+       */
+      DISPLAY_NOTIFICATION: "ALF_DISPLAY_NOTIFICATION",
+
+      /**
+       * This topic can be published to request that a prompt be displayed. It is subscribed to 
+       * by the [NotificationService]{@link module:alfresco/services/NotificationService}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      DISPLAY_PROMPT: "ALF_DISPLAY_PROMPT",
+
+      /**
        * Publish this to indicate the de-selection of an individual item
        * 
        * @instance
@@ -337,33 +364,6 @@ define([],function() {
        * @property {object} response.item The metadata for the requested node
        */
       DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS",
-
-      /**
-       * This topic can be published to request that a notification be displayed. It is subscribed to 
-       * by the [NotificationService]{@link module:alfresco/services/NotificationService}.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       *
-       * @event
-       * @property {string} message The message to be displayed
-       * @property {string} [publishTopic] A topic to be published after the notification has closed
-       * @property {object} [publishPayload] The payload to be published after the notification has closed
-       * @property {boolean} [publishGlobal] Whether to publish the topic globally
-       * @property {boolean} [publishToParent] Whether to publish the topic on the parent scope
-       */
-      DISPLAY_NOTIFICATION: "ALF_DISPLAY_NOTIFICATION",
-
-      /**
-       * This topic can be published to request that a prompt be displayed. It is subscribed to 
-       * by the [NotificationService]{@link module:alfresco/services/NotificationService}.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      DISPLAY_PROMPT: "ALF_DISPLAY_PROMPT",
 
       /**
        * This topic can be used to request Cloud specific paths to use in an

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -1192,8 +1192,10 @@ define(["dojo/_base/declare",
             this.setHashFragment(payload);
          }
 
-         // Change the button label
-         this.okButton.set("label", this.message(this.okButtonPublishedLabel));
+         // Change the button label if auto-revert or disable-on-publish are set
+         if (this.okButtonPublishRevertSecs > 0 || this.okButtonDisableOnPublish) {
+            this.okButton.set("label", this.message(this.okButtonPublishedLabel));
+         }
 
          // If we should disable on publish then do so
          if (this.okButtonDisableOnPublish) {
@@ -1201,12 +1203,8 @@ define(["dojo/_base/declare",
          }
 
          // Unless there are enablement topics, automatically revert changes to the OK button
-         if (!this.okButtonEnablementTopics || !this.okButtonEnablementTopics.length) {
-            if (this.okButtonPublishRevertSecs > 0) {
-               setTimeout(lang.hitch(this, this.reenableOkButton), this.okButtonPublishRevertSecs * 1000);
-            } else {
-               this.reenableOkButton();
-            }
+         if ((!this.okButtonEnablementTopics || !this.okButtonEnablementTopics.length) && this.okButtonPublishRevertSecs > 0) {
+            setTimeout(lang.hitch(this, this.reenableOkButton), this.okButtonPublishRevertSecs * 1000);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -309,7 +309,7 @@ define(["dojo/_base/declare",
        * @since 1.0.32
        */
       warningsPosition: "top",
-      
+
       /**
        * @instance
        */
@@ -383,6 +383,13 @@ define(["dojo/_base/declare",
             }, this);
 
             this.processWidgets(this.widgets, this._form.domNode, "FIELDS");
+         }
+
+         // Setup subscriptions for the re-enablement of the OK button if necessary
+         if(this.okButton && this.okButtonDisableOnPublish && this.okButtonEnablementTopics && this.okButtonEnablementTopics.length) {
+            array.forEach(this.okButtonEnablementTopics, function(topic) {
+               this.setupOkButtonEnablementSubscription(topic);
+            }, this);
          }
       },
 
@@ -655,6 +662,62 @@ define(["dojo/_base/declare",
       okButtonPublishGlobal: null,
 
       /**
+       * The label that will be used for the "OK" button after a publish. It will return to the configured label
+       * after [okButtonPublishRevertSecs]{@link module:alfresco/forms/Form#okButtonPublishRevertSecs} seconds
+       * (but also see [okButtonDisableOnPublish]{@link module:alfresco/forms/Form#okButtonDisableOnPublish}).
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.44
+       */
+      okButtonPublishedLabel: "form.button.ok.label.published",
+
+      /**
+       * <p>When the OK button has been pushed, the label will changed to the [published-label]{@link module:alfresco/forms/Form#okButtonPublishedLabel}
+       * and will also disable if [okButtonDisableOnPublish]{@link module:alfresco/forms/Form#okButtonDisableOnPublish} is set to true. Unless the
+       * [okButtonEnablementTopics property]{@link module:alfresco/alfresco/forms/Form#okButtonEnablementTopics} has been provided, both changes will
+       * automatically be reverted after this property's value in seconds has passed.</p>
+       *
+       * <p>See [this comment from UX]{link https://issues.alfresco.com/jira/browse/AKU-683?focusedCommentId=425326&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-425326} for the reason for this property.</p>
+       *
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.44
+       */
+      okButtonPublishRevertSecs: 0,
+
+      /**
+       * Whether to disable the OK button after a publish. If this is set to true then the
+       * [published-label]{@link module:alfresco/forms/Form#okButtonPublishedLabel} will
+       * remain in-place until the button is re-enabled by use of either the
+       * [okButtonEnablementTopics]{@link module:alfresco/alfresco/forms/Form#okButtonEnablementTopics}
+       * or [okButtonReenableSecs]{@link module:alfresco/alfresco/forms/Form#okButtonReenableSecs}
+       * properties.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.44
+       */
+      okButtonDisableOnPublish: false,
+
+      /**
+       * If [okButtonDisableOnPublish]{@link module:alfresco/forms/Form#okButtonDisableOnPublish} has been set to true
+       * and this property is provided then the button will remain disabled until one of these topics has been published
+       * (scoped as necessary). The array should contain either strings for unconditional re-enablement if that topic
+       * is published or [rule objects]{@link module:alfresco/util/objectUtils#Rules} with an additional topic attribute
+       * that defines the topic aname to conditionally subscribe to.
+       *
+       * @instance
+       * @type {string[]|object[]}
+       * @default
+       * @since 1.0.44
+       */
+      okButtonEnablementTopics: null,
+
+      /**
        * The label that will be used for the "Cancel" button. This value can either be an explicit
        * localised value or an properties key that will be used to retrieve a localised value.
        *
@@ -844,19 +907,14 @@ define(["dojo/_base/declare",
                iconClass: this.okButtonIconClass
             }, this.okButtonNode);
 
-            // If useHash is set to true then set up a subcription on the publish topic for the OK button which will
-            // set the hash fragment with the form contents...
-            if (this.useHash === true && this.setHash === true)
+            // Handle any post-publish actions
+            if (this.okButtonPublishTopic && lang.trim(this.okButtonPublishTopic))
             {
-               if (this.okButtonPublishTopic &&
-                   lang.trim(this.okButtonPublishTopic) !== "")
-               {
-                  this.alfSubscribe(this.okButtonPublishTopic, lang.hitch(this, this.setHashFragment), this.okButtonPublishGlobal);
-               }
-               else
-               {
-                  this.alfLog("warn", "A form is configured to use the browser hash fragment, but has no okButtonPublishTopic set", this);
-               }
+               this.alfSubscribe(this.okButtonPublishTopic, lang.hitch(this, this.onOkButtonPublish), this.okButtonPublishGlobal);
+            }
+            else if (this.useHash === true && this.setHash === true)
+            {
+               this.alfLog("warn", "A form is configured to use the browser hash fragment, but has no okButtonPublishTopic set", this);
             }
          }
          else
@@ -1117,6 +1175,74 @@ define(["dojo/_base/declare",
             lang.mixin(clonedPayload, currentValue);
             this.alfServicePublish(payload.publishTopic, clonedPayload);
          }
+      },
+
+      /**
+       * If an [okButtonPublishTopic]{@link module:alfresco/forms/Form#okButtonPublishTopic} has been provided
+       * then this function will be run after it has been published.
+       *
+       * @instance
+       * @param {object} payload The published payload
+       * @since 1.0.44
+       */
+      onOkButtonPublish: function alfresco_forms_Form__onOkButtonPublish(payload) {
+
+         // Set the hash fragment with the form contents...
+         if (this.useHash === true && this.setHash === true) {
+            this.setHashFragment(payload);
+         }
+
+         // Change the button label
+         this.okButton.set("label", this.message(this.okButtonPublishedLabel));
+
+         // If we should disable on publish then do so
+         if (this.okButtonDisableOnPublish) {
+            this.okButton.set("disabled", true);
+         }
+
+         // Unless there are enablement topics, automatically revert changes to the OK button
+         if (!this.okButtonEnablementTopics || !this.okButtonEnablementTopics.length) {
+            if (this.okButtonPublishRevertSecs > 0) {
+               setTimeout(lang.hitch(this, this.reenableOkButton), this.okButtonPublishRevertSecs * 1000);
+            } else {
+               this.reenableOkButton();
+            }
+         }
+      },
+
+      /**
+       * Setup the subscription(s) to re-enable the OK button after it's been disabled on submission.
+       *
+       * @instance
+       * @param {string|module:alfresco/util/objectUtils#Rules} topic The raw topic name to subscribe to, or a Rules object with an additional
+       *                                                              topic attribute that defines the name of the topic to subscribe to
+       * @param {string|string[]} [is] The possible value/values that will re-enable the OK button if matching the specified attribute
+       * @param {string|string[]} [isNot] The disallowed value/values that will re-enable the OK button if the attribute does not match it/them
+       */
+      setupOkButtonEnablementSubscription: function alfresco_forms_Form__setupOkButtonEnablementSubscription(topics) {
+         var topicName,
+            rulesObj;
+         if (typeof topics === "string") {
+            topicName = topics;
+            rulesObj = {};
+         } else {
+            topicName = topics.topic;
+            rulesObj = lang.clone(topics);
+            delete rulesObj.topic;
+         }
+         this.alfConditionalSubscribe(topicName, rulesObj, lang.hitch(this, this.reenableOkButton));
+      },
+
+      /**
+       * Re-enable the OK button after it's been [disabled by publishing]{@link module:alfresco/forms/Form#okButtonDisableOnPublish}.
+       * Calls the [onValidField]{@link module:alfresco/forms/Form#onValidField} method to ensure that validation rules are maintained.
+       *
+       * @instance
+       * @since 1.0.44
+       */
+      reenableOkButton: function alfresco_forms_Form__reenableOkButton() {
+         this.okButton.set("label", this.message(this.okButtonLabel));
+         this.onValidField();
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/i18n/Form.properties
+++ b/aikau/src/main/resources/alfresco/forms/i18n/Form.properties
@@ -1,2 +1,3 @@
 form.button.ok.label=OK
+form.button.ok.label.published=Submitted!
 form.button.cancel.label=Cancel

--- a/aikau/src/main/resources/alfresco/util/objectUtils.js
+++ b/aikau/src/main/resources/alfresco/util/objectUtils.js
@@ -39,9 +39,17 @@ define([
          evaluateRules: function alfresco_util_objectUtils__evaluateRules(rules, successHandler, failureHandler) {
 
             // Setup variables
-            var testValue = lang.getObject(rules.attributePath, false, rules.testObject),
-               hasIsRules = typeof rules.is !== "undefined" && rules.is.length > 0,
-               hasIsNotRules = typeof rules.isNot !== "undefined" && rules.isNot.length > 0;
+            var testValue = lang.getObject(rules.attribute, false, rules.testObject),
+               hasIsRules = rules.is && rules.is.constructor === Array && rules.is.length,
+               hasIsNotRules = rules.isNot && rules.isNot.constructor === Array && rules.isNot.length;
+
+            // Log a warning if rules are not valid
+            if (rules.is !== null && typeof rules.is !== "undefined" && rules.is.constructor !== Array) {
+               console.warn("alfresco_util_objectUtils__evaluateRules() - \"is\" rules provided but not an array: " + JSON.stringify(rules.is));
+            }
+            if (rules.isNot !== null && typeof rules.isNot !== "undefined" && rules.isNot.constructor !== Array) {
+               console.warn("alfresco_util_objectUtils__evaluateRules() - \"isNot\" rules provided but not an array: " + JSON.stringify(rules.isNot));
+            }
 
             // Test the validity
             var comparatorFunc = rules.useLegacyProcessing === false ? this._ruleComparator : this._legacyRuleComparator,
@@ -100,7 +108,7 @@ define([
          /**
           * <p>The Rules object (as used in [evaluateRules]{@link module:alfresco/util/objectUtils#evaluateRules}).</p>
           *
-          * <p>The value under test (test-value) is retrieved from the "testObject" property using the path defined in "attributePath". The rules are then evaluated as follows:</p>
+          * <p>The value under test (test-value) is retrieved from the "testObject" property using the path defined in "attribute". The rules are then evaluated as follows:</p>
           *
           * <ul>
           *    <li>If neither "is" nor "isNot" are specified then the test-value is valid and the success callback will be executed</li>
@@ -113,12 +121,12 @@ define([
           *
           * @instance
           * @typedef {object} Rules
-          * @property {string} attributePath The dot-notation path to the value retrieve from the object under test
+          * @property {string} attribute The dot-notation path to the value retrieve from the object under test
           * @property {object} testObject The object under test
           * @property {object} [lookupObject] If this is supplied then treat the values contained in the rules as paths
           *                                   to the true comparison value within this lookupObject
-          * @property {string|string[]} [is] The tested value MUST be equal to at least one of these values if provided
-          * @property {string|string[]} [isNot] The tested value must NOT be equal to any of these values if provided
+          * @property {*} [is] The tested value MUST be equal to at least one of these values if provided (must be array)
+          * @property {*} [isNot] The tested value must NOT be equal to any of these values if provided (must be array)
           * @property {boolean} [negate] Invert the final result
           * @property {boolean} [strict] See description above
           * @property {boolean} [useLegacyProcessing=true] Use the legacy algorithms for evaluating matches

--- a/aikau/src/main/resources/alfresco/util/objectUtils.js
+++ b/aikau/src/main/resources/alfresco/util/objectUtils.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Utility object for object-related utilities. Note that this is not a Class, and so does
+ * not need to be instantiated before use.
+ *
+ * @module alfresco/util/objectUtils
+ * @author Martin Doyle
+ * @since 1.0.44
+ */
+define([
+      "dojo/_base/array",
+      "dojo/_base/lang"
+   ],
+   function(array, lang) {
+      /*jshint maxlen:false*/
+
+      // The private container for the functionality and properties of the util
+      var util = {
+
+         // See API below
+         evaluateRules: function alfresco_util_objectUtils__evaluateRules(rules, successHandler, failureHandler) {
+
+            // Setup variables
+            var testValue = lang.getObject(rules.attributePath, false, rules.testObject),
+               hasIsRules = typeof rules.is !== "undefined" && rules.is.length > 0,
+               hasIsNotRules = typeof rules.isNot !== "undefined" && rules.isNot.length > 0;
+
+            // Test the validity
+            var comparatorFunc = rules.useLegacyProcessing === false ? this._ruleComparator : this._legacyRuleComparator,
+               ruleEvaluator = lang.partial(comparatorFunc, testValue, rules.lookupObject),
+               isInvalid = hasIsNotRules && array.some(rules.isNot, ruleEvaluator),
+               isValid = !isInvalid && (!hasIsRules || array.some(rules.is, ruleEvaluator));
+
+            // Deal with the results
+            if (isValid && !isInvalid) {
+               if (rules.negate) {
+                  failureHandler && failureHandler();
+               } else {
+                  successHandler();
+               }
+            } else if (rules.strict) {
+               if (rules.negate) {
+                  successHandler();
+               } else {
+                  failureHandler && failureHandler();
+               }
+            }
+         },
+
+         // The legacy rule comparator
+         _legacyRuleComparator: function alfresco_util_objectUtils___legacyRuleComparator(actualValue, lookupObject, expectedValue) {
+            /*jshint eqnull:true*/
+            if (actualValue == null && expectedValue == null) {
+               return true;
+            } else if (actualValue != null && typeof actualValue.toString === "function" && expectedValue != null && typeof expectedValue.toString === "function") {
+               if (lookupObject) {
+                  expectedValue = lang.getObject(expectedValue.toString(), false, lookupObject);
+                  return expectedValue === actualValue.toString();
+               } else {
+                  return expectedValue.toString() === actualValue.toString();
+               }
+            } else {
+               return false;
+            }
+         },
+
+         // The updated rule comparator
+         _ruleComparator: function alfresco_util_objectUtils___ruleComparator(actualValue, lookupObject, expectedValue) {
+            var expected = lookupObject ? lang.getObject(expectedValue, false, lookupObject) : expectedValue;
+            return (actualValue === expected);
+         }
+
+      };
+
+      /**
+       * The public API for this utility class
+       *
+       * @alias module:alfresco/util/objectUtils
+       */
+      return {
+
+         /**
+          * <p>The Rules object (as used in [evaluateRules]{@link module:alfresco/util/objectUtils#evaluateRules}).</p>
+          *
+          * <p>The value under test (test-value) is retrieved from the "testObject" property using the path defined in "attributePath". The rules are then evaluated as follows:</p>
+          *
+          * <ul>
+          *    <li>If neither "is" nor "isNot" are specified then the test-value is valid and the success callback will be executed</li>
+          *    <li>If only "is" is provided then the success callback will be executed if the test-value is within the "is" values</li>
+          *    <li>If only "isNot" is provided then the success callback will be executed if the test-value is not within the "isNot" values</li>
+          *    <li>If both "is" and "isNot" are provided then the test-value must NOT be in the "isNot" values. If that test passes then it will then be checked to ensure it is present in the "is" values. If both these tests pass then the success callback will be executed</li>
+          *    <li>The failure callback is NOT normally executed. In order for it to execute, the test-value must be invalid according to the above rules and the "strict" flag should be set to true<li>
+          *    <li>If the "negate" flag is set to true then it will directly inverse the above logic. If a success callback would have been executed then a failure callback will now be, and vice versa</li>
+          * </ul>
+          *
+          * @instance
+          * @typedef {object} Rules
+          * @property {string} attributePath The dot-notation path to the value retrieve from the object under test
+          * @property {object} testObject The object under test
+          * @property {object} [lookupObject] If this is supplied then treat the values contained in the rules as paths
+          *                                   to the true comparison value within this lookupObject
+          * @property {string|string[]} [is] The tested value MUST be equal to at least one of these values if provided
+          * @property {string|string[]} [isNot] The tested value must NOT be equal to any of these values if provided
+          * @property {boolean} [negate] Invert the final result
+          * @property {boolean} [strict] See description above
+          * @property {boolean} [useLegacyProcessing=true] Use the legacy algorithms for evaluating matches
+          */
+
+         /**
+          * Evaluate the supplied [rules object]{@link module:alfresco/util/objectUtils#Rules}, and then
+          * apply the success or failure callback as appropriate.
+          *
+          * @instance
+          * @param {string} topic The topic on which to subscribe
+          * @param {module:alfresco/util/objectUtils#Rules} rules The rules object to apply to the published payload
+          * @param {function} successHandler The function to run if the rules match the payload
+          * @param {function} [failureHandler] The function to run if the rules do not match the payload (or )
+          * @param {boolean} [global] Indicates that the pub/sub scope should not be applied
+          * @param {boolean} [parentScope] Indicates that the pub/sub scope inherited from the parent should be applied
+          * @returns {object} A handle to the subscription
+          */
+         evaluateRules: lang.hitch(util, util.evaluateRules)
+      };
+   });

--- a/aikau/src/test/resources/alfresco/forms/controls/DisablingSubmitFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DisablingSubmitFormTest.js
@@ -1,0 +1,199 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a unit test for the disabling-submit functionality of the alfresco/forms/Form control
+ * 
+ * @author Martin Doyle
+ */
+define([
+      "alfresco/TestCommon",
+      "intern!object",
+      "intern/chai!assert",
+      "intern/dojo/node!leadfoot/keys"
+   ],
+   function(TestCommon, registerSuite, assert, keys) {
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "Disabling-submit Form control Tests",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/DisablingSubmitForm", "Disabling-submit Form control Tests");
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "OK button disables and label changes, and both are re-enabled by publication": function() {
+               return browser.findByCssSelector("#NAME_TEXTBOX .dijitInputField input")
+                  .type("Fred")
+                  .end()
+
+               .findByCssSelector("#FORM_WITH_REENABLE_TOPICS .confirmationButton .dijitButtonNode")
+                  .click()
+                  .end()
+
+               .getLastPublish("MY_NAME_IS", true)
+
+               .findByCssSelector("#FORM_WITH_REENABLE_TOPICS .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "true", "OK button not disabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Submitted!", "OK button label not changed");
+                  })
+                  .end()
+
+               .getLastPublish("ENABLE_OK_BUTTON", 5000)
+
+               .findByCssSelector("#FORM_WITH_REENABLE_TOPICS .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "false", "OK button not re-enabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "OK", "OK button label not reset");
+                  });
+            },
+
+            "Forcing a publication which fails a conditional check will NOT re-enable the OK button": function() {
+               return browser.findByCssSelector("#FORM_WITH_CONDITIONAL_REENABLEMENT .confirmationButton .dijitButtonNode")
+                  .clearLog()
+                  .click()
+                  .end()
+
+               .getLastPublish("ODD_OR_EVEN", true)
+
+               .findByCssSelector("#FORM_WITH_CONDITIONAL_REENABLEMENT .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "true", "OK button not disabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Submitted!", "OK button label not changed");
+                  })
+                  .end()
+
+               .getLastPublish("ENABLE_OK_BUTTON_IF", 5000)
+
+               .findByCssSelector("#FORM_WITH_CONDITIONAL_REENABLEMENT .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "true", "OK button incorrectly re-enabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Submitted!", "OK button label incorrectly reset");
+                  })
+                  .end()
+
+               .findById("REENABLE_OK_BUTTON_BUTTON")
+                  .click();
+            },
+
+            "Forcing a publication which passes a conditional check WILL re-enable the OK button": function() {
+               // Function from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+               // Returns a random integer between min (included) and max (excluded)
+               // Using Math.round() will give you a non-uniform distribution!
+               function getRandomInt(min, max) {
+                  return Math.floor(Math.random() * (max - min)) + min;
+               }
+
+               return browser.findByCssSelector("#CONDITIONAL_REENABLE_INPUT .dijitInputField input")
+                  .clearLog()
+                  .type("" + (getRandomInt(0, 100) * 2))
+                  .end()
+
+               .findByCssSelector("#FORM_WITH_CONDITIONAL_REENABLEMENT .confirmationButton .dijitButtonNode")
+                  .click()
+                  .end()
+
+               .getLastPublish("ODD_OR_EVEN", true)
+
+               .findByCssSelector("#FORM_WITH_CONDITIONAL_REENABLEMENT .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "true", "OK button not disabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Submitted!", "OK button label not changed");
+                  })
+                  .end()
+
+               .getLastPublish("ENABLE_OK_BUTTON_IF", 5000)
+
+               .findByCssSelector("#FORM_WITH_CONDITIONAL_REENABLEMENT .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "false", "OK button not re-enabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "OK", "OK button label not reset");
+                  })
+                  .end();
+            },
+
+            "OK button can just change label on submit and reverts automatically": function() {
+               return browser.findByCssSelector("#DEFAULT_FORM .confirmationButton .dijitButtonNode")
+                  .click()
+                  .end()
+
+               .getLastPublish("HERES_A_SECRET")
+
+               .findByCssSelector("#DEFAULT_FORM .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "false", "OK button incorrectly disabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "Submitted!", "OK button label not changed");
+                  })
+                  .end()
+
+               .sleep(3000)
+
+               .findByCssSelector("#DEFAULT_FORM .confirmationButton .dijitButtonContents")
+                  .getAttribute("aria-disabled")
+                  .then(function(isDisabled) {
+                     assert.equal(isDisabled, "false", "OK button incorrectly disabled");
+                  })
+                  .getVisibleText()
+                  .then(function(visibleText) {
+                     assert.equal(visibleText, "OK", "OK button label not reset");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/PushButtonsTest"
+      "src/test/resources/alfresco/forms/controls/DisablingSubmitFormTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
@@ -125,6 +125,7 @@ define({
       "src/test/resources/alfresco/forms/controls/ComboBoxTest",
       "src/test/resources/alfresco/forms/controls/ContainerPickerTest",
       "src/test/resources/alfresco/forms/controls/DateTextBoxTest",
+      "src/test/resources/alfresco/forms/controls/DisablingSubmitFormTest",
       "src/test/resources/alfresco/forms/controls/DocumentPickerTest",
       "src/test/resources/alfresco/forms/controls/DocumentPickerSingleItemTest",
       "src/test/resources/alfresco/forms/controls/FormButtonDialogTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/DisablingSubmitForm.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/DisablingSubmitForm.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Disabling submit button Form Test</shortname>
+  <description>This WebScript exercises the auto-disabling of the submit button in the alfresco/forms/Form control</description>
+  <family>aikau-unit-tests</family>
+  <url>/DisablingSubmitForm</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/DisablingSubmitForm.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/DisablingSubmitForm.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/DisablingSubmitForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/DisablingSubmitForm.get.js
@@ -1,0 +1,114 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NotificationService",
+      "aikauTesting/mockservices/DisablingSubmitMockService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/forms/Form",
+                  id: "FORM_WITH_REENABLE_TOPICS",
+                  config: {
+                     okButtonPublishTopic: "MY_NAME_IS",
+                     okButtonPublishGlobal: true,
+                     okButtonDisableOnPublish: true,
+                     okButtonEnablementTopics: ["ENABLE_OK_BUTTON"],
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/TextBox",
+                           id: "NAME_TEXTBOX",
+                           config: {
+                              name: "name",
+                              label: "What's your name?",
+                              description: "Uses topic to re-enable",
+                              requirementConfig: {
+                                 initialValue: true
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/Form",
+                  id: "FORM_WITH_CONDITIONAL_REENABLEMENT",
+                  config: {
+                     okButtonPublishTopic: "ODD_OR_EVEN",
+                     okButtonPublishGlobal: true,
+                     okButtonDisableOnPublish: true,
+                     okButtonEnablementTopics: [
+                        {
+                           topic: "ENABLE_OK_BUTTON_IF",
+                           attribute: "enable",
+                           is: [true]
+                        },
+                        "ENABLE_OK_BUTTON_ALWAYS"
+                     ],
+                     widgets: [
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           id: "REENABLE_OK_BUTTON_BUTTON",
+                           config: {
+                              label: "Re-enable OK button",
+                              publishTopic: "ENABLE_OK_BUTTON_ALWAYS"
+                           }
+                        },
+                        {
+                           name: "alfresco/html/Spacer",
+                           config: {
+                              height: "20px"
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/controls/TextBox",
+                           id: "CONDITIONAL_REENABLE_INPUT",
+                           config: {
+                              name: "testValue",
+                              label: "Supply even number to re-enable",
+                              description: "Uses topic to conditionally re-enable"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/forms/Form",
+                  id: "DEFAULT_FORM",
+                  config: {
+                     okButtonPublishTopic: "HERES_A_SECRET",
+                     okButtonPublishRevertSecs: 2,
+                     widgets: [
+                        {
+                           name: "alfresco/forms/controls/TextBox",
+                           id: "TEXTBOX",
+                           config: {
+                              name: "secret",
+                              label: "Tell me a secret",
+                              description: "OK button with auto-revert"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/DisablingSubmitMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/DisablingSubmitMockService.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/DisablingSubmitMockService
+ * @author Martin Doyle
+ */
+define([
+      "alfresco/core/Core",
+      "alfresco/core/topics",
+      "dojo/_base/declare",
+      "dojo/_base/lang"
+   ],
+   function(AlfCore, topics, declare, lang) {
+
+      return declare([AlfCore], {
+
+         /**
+          * Constructor.
+          * 
+          * @instance
+          * @param {object[]} args Constructor arguments
+          */
+         constructor: function alfresco_testing_mockservices_DisablingSubmitMockService__constructor(args) {
+            declare.safeMixin(this, args);
+            this.alfSubscribe("MY_NAME_IS", lang.hitch(this, this.onNameReceived));
+            this.alfSubscribe("ODD_OR_EVEN", lang.hitch(this, this.onOddOrEvenReceived));
+         },
+
+         /**
+          * Handles the name being sent.
+          * 
+          * @instance
+          * @param {object} payload The payload.
+          */
+         onNameReceived: function alfresco_testing_mockservices_DisablingSubmitMockService__onNameReceived(payload) {
+            this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
+               message: "Hello " + payload.name + "!",
+               publishTopic: payload.alfResponseScope + "ENABLE_OK_BUTTON" // Hacky, but no time to refactor NotificationService right now
+            });
+         },
+
+         /**
+          * Handles the name being sent.
+          * 
+          * @instance
+          * @param {object} payload The payload.
+          */
+         onOddOrEvenReceived: function alfresco_testing_mockservices_DisablingSubmitMockService__onOddOrEvenReceived(payload) {
+            var reenable = false,
+               parsedNum;
+            try {
+               parsedNum = parseInt(payload.testValue, 10);
+               reenable = !isNaN(parsedNum) && (parsedNum % 2 === 0);
+            } catch (e) {
+               // Ignore errors
+            }
+            this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
+               message: reenable ? "Received even number. Will re-enable!" : "Did not receive even number. Will not re-enable!",
+               publishTopic: payload.alfResponseScope + "ENABLE_OK_BUTTON_IF", // Hacky, but no time to refactor NotificationService right now
+               publishPayload: {
+                  enable: reenable
+               }
+            });
+         }
+      });
+   });


### PR DESCRIPTION
This addresses [AKU-683](https://issues.alfresco.com/jira/browse/AKU-683), and permits optionally disabling the OK button and updating the OK button label on a Form when it is submitted. Additionally it extracts out the algorithms behind visibilityConfig into a new objectUtils module and then reuses them to provide conditional re-enablement via topics and rules.