### PR TITLE
AKU-675: Fix expanded cell resize bug

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -584,13 +584,16 @@ define(["dojo/_base/declare",
        * @param {number} index The current index of the element in the array
        */
       resizeCell: function alfresco_lists_views_layouts_Grid__resizeCell(containerNodeMarginBox, widthToSet, node, /*jshint unused:false*/ index) {
-         domStyle.set(node, {"width": widthToSet});
-         var dimensions = {
-            w: widthToSet,
-            h: null
-         },
-         widgetsToResize = query("[widgetId]", node); // Resize all contained widgets, not just immediate children.
-         array.forEach(widgetsToResize, lang.hitch(this, this.resizeWidget, dimensions));
+         if (!domClass.contains(node.parentNode, "alfresco-lists-views-layouts-Grid__expandedPanel"))
+         {
+            domStyle.set(node, {"width": widthToSet});
+            var dimensions = {
+               w: widthToSet,
+               h: null
+            },
+            widgetsToResize = query("[widgetId]", node); // Resize all contained widgets, not just immediate children.
+            array.forEach(widgetsToResize, lang.hitch(this, this.resizeWidget, dimensions));
+         }
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
@@ -59,6 +59,22 @@ define(["intern!object",
             .findByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel");
          },
 
+         "Resize window to make sure expanded cell remains the same size": function() {
+            var originalWidth;
+            return browser.findByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel td")
+               .getSize()
+               .then(function(size) {
+                  originalWidth = size.width;
+               })
+
+               .setWindowSize(null, 1500, 768)
+
+               .getSize()
+               .then(function(size) {
+                  assert.isAbove(size.width, originalWidth, "Expanded panel cell should not have got smaller");
+               });
+         },
+
          "Check the expanded panel position": function() {
             // This verifies that the expanded panel has been inserted in the 2nd row...
             return browser.findByCssSelector(".alfresco-lists-views-layouts-Grid tr.alfresco-lists-views-layouts-Grid__expandedPanel:nth-child(2)");


### PR DESCRIPTION
This PR fixes a problem observed in the sprint review when demonstrating https://issues.alfresco.com/jira/browse/AKU-675. This ensures that the the expanded panel cell does not get resized when it is displayed. A unit test has been added to verify the fix.