### PR TITLE
AKU-704: Ensure grid resizing only impacts immediate children

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -590,9 +590,11 @@ define(["dojo/_base/declare",
             var dimensions = {
                w: widthToSet,
                h: null
-            },
-            widgetsToResize = query("[widgetId]", node); // Resize all contained widgets, not just immediate children.
-            array.forEach(widgetsToResize, lang.hitch(this, this.resizeWidget, dimensions));
+            };
+
+            // See AKU-704 - if you review the change history here you'll see that this has now gone back
+            //               to the original implementation of only resizing direct children
+            array.forEach(node.children, lang.hitch(this, this.resizeWidget, dimensions));
          }
       },
 

--- a/aikau/src/test/resources/alfresco/lists/views/AddableViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/AddableViewTest.js
@@ -52,7 +52,7 @@ define(["alfresco/TestCommon",
             .findDisplayedByCssSelector("#GRID #CREATE_BUTTON_3_ITEM_0");
          },
 
-         "Check that add button is not as wide as it's parent": function() {
+         "Check that add button is not as wide as its parent": function() {
             var containerSize;
             return browser.findById("CELL_CONTAINER_ITEM_0")
                .getSize()

--- a/aikau/src/test/resources/alfresco/lists/views/AddableViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/AddableViewTest.js
@@ -52,6 +52,29 @@ define(["alfresco/TestCommon",
             .findDisplayedByCssSelector("#GRID #CREATE_BUTTON_3_ITEM_0");
          },
 
+         "Check that add button is not as wide as it's parent": function() {
+            var containerSize;
+            return browser.findById("CELL_CONTAINER_ITEM_0")
+               .getSize()
+               .then(function(size) {
+                  containerSize = size.width;
+               })
+            .end()
+
+            .findById("CREATE_BUTTON_3_ITEM_0")
+               .getSize()
+               .then(function(size) {
+                  assert.isBelow(size.width, containerSize, "The button was resized");
+               });
+         },
+
+         "Empty cells should be created when there are no items": function() {
+            return browser.findAllByCssSelector("#GRID_ITEMS .alfresco-lists-views-layouts-Grid__emptyCell")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "No empty cells created");
+               });
+         },
+
          "Create a new item from the grid view": function() {
             // Click the add button...
             return browser.findById("CREATE_BUTTON_3_ITEM_0_label")


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-704 to ensure that only the immediate child widgets of a cell in a grid are resized. It also ensures that empty cells are added as appropriate when no data is available. Unit tests have been added for both fixes.