### PR TITLE
AKU-694: Download Cancel is not canceling download

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Progress.js
+++ b/aikau/src/main/resources/alfresco/renderers/Progress.js
@@ -68,13 +68,13 @@ define(["dojo/_base/declare",
       templateString: template,
 
       /**
-       * renderProgressUI
+       * The message to display when progress is complete.
        *
        * @instance
-       * @type {String}
+       * @type {string}
        * @default
        */
-      renderProgressUITopic: "ALF_PROGRESS_RENDER",
+      completedMessage: "renderer.progress.complete",
 
       /**
        * The message to display when progress is being initialized. By default this includes a message
@@ -88,14 +88,14 @@ define(["dojo/_base/declare",
       creatingMessage: "renderer.progress.creating",
 
       /**
-       * The message to display that reports the current status. This message will be provided two tokens
-       * that indicate the number of items processed and the total number of items to process.
+       * The dot-notation address of the property in the progress publication that contains the
+       * amount "done". This is expected to be an integer.
        *
        * @instance
        * @type {string}
        * @default
        */
-      statusMessage: "renderer.progress.status",
+      doneProperty: "response.done",
 
       /**
        * The message to display when an error occurs reporting progress.
@@ -107,13 +107,105 @@ define(["dojo/_base/declare",
       errorMessage: "renderer.progress.error",
 
       /**
-       * The message to display when progress is complete.
+       * The dot-notation address of the property in the progress publication that contains the
+       * number of items completed towards the target.
        *
        * @instance
        * @type {string}
        * @default
        */
-      completedMessage: "renderer.progress.complete",
+      itemsAddedProperty: "response.filesAdded",
+
+      /**
+       * renderProgressUI
+       *
+       * @instance
+       * @type {String}
+       * @default
+       */
+      renderProgressUITopic: "ALF_PROGRESS_RENDER",
+
+      /**
+       * This is the topic that will be published to request the start of progress updates. It will publish
+       * a payload on this topic containing scoped topics that should be used to provide 
+       * [update]{@link module:alfresco/renderers/Progress#progressUpdateTopic}, 
+       * [completion]{@link module:alfresco/renderers/Progress#progressCompleteTopic},
+       * [cancellation]{@link module:alfresco/renderers/Progress#progressCancelledTopic} and
+       * [error]{@link module:alfresco/renderers/Progress#progressErrorTopic} events.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      requestProgressTopic: null,
+
+      /**
+       * The topic to publish on to indicate that the task has been cancelled
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressCancelledTopic: "ALF_PROGRESS_CANCELLED",
+
+      /**
+       * The topic to publish on to indicate the task has completed.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressCompleteTopic: "ALF_PROGRESS_COMPLETED",
+
+      /**
+       * The topic to publish on to indicate that there has been an error processing the task
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressErrorTopic: "ALF_PROGRESS_ERROR",
+
+      /**
+       * The topic to publish on to provide progress updates.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressUpdateTopic: "ALF_PROGRESS_UPDATED",
+
+      /**
+       * The message to display that reports the current status. This message will be provided two tokens
+       * that indicate the number of items processed and the total number of items to process.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      statusMessage: "renderer.progress.status",
+
+      /**
+       * The dot-notation address of the property in the progress publication that contains the
+       * total number of items to process.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      totalItemsProperty: "response.totalFiles",
+
+      /**
+       * The dot-notation address of the property in the progress publication that contains the
+       * total amount "to do". This is expected to be an integer. The percentage complete will be
+       * measured by the value of the [doneProperty]{@link module:alfresco/renderers/Progress} divided 
+       * by the value represented by this property.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      totalProperty: "response.total",
 
       /**
        * Sets up the form specific configuration for the dialog.
@@ -131,56 +223,6 @@ define(["dojo/_base/declare",
          // Kick off the initial progress request
          this.onRequestProgress();
       },
-
-      /**
-       * This is the topic that will be published to request the start of progress updates. It will publish
-       * a payload on this topic containing scoped topics that should be used to provide 
-       * [update]{@link module:alfresco/renderers/Progress#progressUpdateTopic}, 
-       * [completion]{@link module:alfresco/renderers/Progress#progressCompleteTopic},
-       * [cancellation]{@link module:alfresco/renderers/Progress#progressCancelledTopic} and
-       * [error]{@link module:alfresco/renderers/Progress#progressErrorTopic} events.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      requestProgressTopic: null,
-
-      /**
-       * The topic to publish on to provide progress updates.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressUpdateTopic: "ALF_PROGRESS_UPDATED",
-
-      /**
-       * The topic to publish on to indicate the task has completed.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressCompleteTopic: "ALF_PROGRESS_COMPLETED",
-
-      /**
-       * The topic to publish on to indicate that the task has been cancelled
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressCancelledTopic: "ALF_PROGRESS_CANCELLED",
-
-      /**
-       * The topic to publish on to indicate that there has been an error processing the task
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressErrorTopic: "ALF_PROGRESS_ERROR",
 
       /**
        * Called when progress returns & updates progress dialog.
@@ -268,48 +310,6 @@ define(["dojo/_base/declare",
          this.alfLog("log", "Progress Dialog Error: " + payload);
          this.displayUIMessage(this.message(this.errorMessage));
       },
-
-      /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * amount "done". This is expected to be an integer.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      doneProperty: "response.done",
-
-      /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * total amount "to do". This is expected to be an integer. The percentage complete will be
-       * measured by the value of the [doneProperty]{@link module:alfresco/renderers/Progress} divided 
-       * by the value represented by this property.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      totalProperty: "response.total",
-
-      /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * number of items completed towards the target.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      itemsAddedProperty: "response.filesAdded",
-
-      /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * total number of items to process.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      totalItemsProperty: "response.totalFiles",
 
       /**
        * Called to update the UI with the data.

--- a/aikau/src/main/resources/alfresco/renderers/Progress.js
+++ b/aikau/src/main/resources/alfresco/renderers/Progress.js
@@ -68,13 +68,13 @@ define(["dojo/_base/declare",
       templateString: template,
 
       /**
-       * The message to display when progress is complete.
+       * renderProgressUI
        *
        * @instance
-       * @type {string}
+       * @type {String}
        * @default
        */
-      completedMessage: "renderer.progress.complete",
+      renderProgressUITopic: "ALF_PROGRESS_RENDER",
 
       /**
        * The message to display when progress is being initialized. By default this includes a message
@@ -88,102 +88,15 @@ define(["dojo/_base/declare",
       creatingMessage: "renderer.progress.creating",
 
       /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * amount "done". This is expected to be an integer.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      doneProperty: "response.done",
-
-      /**
-       * The message to display when an error occurs reporting progress.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      errorMessage: "renderer.progress.error",
-
-      /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * number of items completed towards the target.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      itemsAddedProperty: "response.filesAdded",
-
-      /**
        * Whether the task(s) have been cancelled
        *
        * @instance
        * @readonly
        * @type {boolean}
        * @default
+       * @since 1.0.44
        */
       isCancelled: false,
-
-      /**
-       * renderProgressUI
-       *
-       * @instance
-       * @type {String}
-       * @default
-       */
-      renderProgressUITopic: "ALF_PROGRESS_RENDER",
-
-      /**
-       * This is the topic that will be published to request the start of progress updates. It will publish
-       * a payload on this topic containing scoped topics that should be used to provide 
-       * [update]{@link module:alfresco/renderers/Progress#progressUpdateTopic}, 
-       * [completion]{@link module:alfresco/renderers/Progress#progressCompleteTopic},
-       * [cancellation]{@link module:alfresco/renderers/Progress#progressCancelledTopic} and
-       * [error]{@link module:alfresco/renderers/Progress#progressErrorTopic} events.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      requestProgressTopic: null,
-
-      /**
-       * The topic to publish on to indicate that the task has been cancelled
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressCancelledTopic: "ALF_PROGRESS_CANCELLED",
-
-      /**
-       * The topic to publish on to indicate the task has completed.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressCompleteTopic: "ALF_PROGRESS_COMPLETED",
-
-      /**
-       * The topic to publish on to indicate that there has been an error processing the task
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressErrorTopic: "ALF_PROGRESS_ERROR",
-
-      /**
-       * The topic to publish on to provide progress updates.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      progressUpdateTopic: "ALF_PROGRESS_UPDATED",
 
       /**
        * The message to display that reports the current status. This message will be provided two tokens
@@ -196,26 +109,22 @@ define(["dojo/_base/declare",
       statusMessage: "renderer.progress.status",
 
       /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * total number of items to process.
+       * The message to display when an error occurs reporting progress.
        *
        * @instance
        * @type {string}
        * @default
        */
-      totalItemsProperty: "response.totalFiles",
+      errorMessage: "renderer.progress.error",
 
       /**
-       * The dot-notation address of the property in the progress publication that contains the
-       * total amount "to do". This is expected to be an integer. The percentage complete will be
-       * measured by the value of the [doneProperty]{@link module:alfresco/renderers/Progress} divided 
-       * by the value represented by this property.
+       * The message to display when progress is complete.
        *
        * @instance
        * @type {string}
        * @default
        */
-      totalProperty: "response.total",
+      completedMessage: "renderer.progress.complete",
 
       /**
        * Sets up the form specific configuration for the dialog.
@@ -233,6 +142,56 @@ define(["dojo/_base/declare",
          // Kick off the initial progress request
          this.onRequestProgress();
       },
+
+      /**
+       * This is the topic that will be published to request the start of progress updates. It will publish
+       * a payload on this topic containing scoped topics that should be used to provide 
+       * [update]{@link module:alfresco/renderers/Progress#progressUpdateTopic}, 
+       * [completion]{@link module:alfresco/renderers/Progress#progressCompleteTopic},
+       * [cancellation]{@link module:alfresco/renderers/Progress#progressCancelledTopic} and
+       * [error]{@link module:alfresco/renderers/Progress#progressErrorTopic} events.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      requestProgressTopic: null,
+
+      /**
+       * The topic to publish on to provide progress updates.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressUpdateTopic: "ALF_PROGRESS_UPDATED",
+
+      /**
+       * The topic to publish on to indicate the task has completed.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressCompleteTopic: "ALF_PROGRESS_COMPLETED",
+
+      /**
+       * The topic to publish on to indicate that the task has been cancelled
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressCancelledTopic: "ALF_PROGRESS_CANCELLED",
+
+      /**
+       * The topic to publish on to indicate that there has been an error processing the task
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      progressErrorTopic: "ALF_PROGRESS_ERROR",
 
       /**
        * Called when progress returns & updates progress dialog.
@@ -323,6 +282,48 @@ define(["dojo/_base/declare",
          this.alfLog("log", "Progress Dialog Error: " + payload);
          this.displayUIMessage(this.message(this.errorMessage));
       },
+
+      /**
+       * The dot-notation address of the property in the progress publication that contains the
+       * amount "done". This is expected to be an integer.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      doneProperty: "response.done",
+
+      /**
+       * The dot-notation address of the property in the progress publication that contains the
+       * total amount "to do". This is expected to be an integer. The percentage complete will be
+       * measured by the value of the [doneProperty]{@link module:alfresco/renderers/Progress} divided 
+       * by the value represented by this property.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      totalProperty: "response.total",
+
+      /**
+       * The dot-notation address of the property in the progress publication that contains the
+       * number of items completed towards the target.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      itemsAddedProperty: "response.filesAdded",
+
+      /**
+       * The dot-notation address of the property in the progress publication that contains the
+       * total number of items to process.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      totalItemsProperty: "response.totalFiles",
 
       /**
        * Called to update the UI with the data.

--- a/aikau/src/main/resources/alfresco/renderers/Progress.js
+++ b/aikau/src/main/resources/alfresco/renderers/Progress.js
@@ -117,6 +117,16 @@ define(["dojo/_base/declare",
       itemsAddedProperty: "response.filesAdded",
 
       /**
+       * Whether the task(s) have been cancelled
+       *
+       * @instance
+       * @readonly
+       * @type {boolean}
+       * @default
+       */
+      isCancelled: false,
+
+      /**
        * renderProgressUI
        *
        * @instance
@@ -274,18 +284,20 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onProgressComplete: function alfresco_renderers_Progress__onProgressComplete(payload) {
-         this.alfLog("log", "Progress Dialog Complete: " + payload);
+         if(!this.isCancelled) {
+            this.alfLog("log", "Progress Dialog Complete: " + payload);
 
-         // Update the UI:
-         this.displayUIMessage(this.message(this.completedMessage));
-         this.updateProgressBar(0);
+            // Update the UI:
+            this.displayUIMessage(this.message(this.completedMessage));
+            this.updateProgressBar(0);
 
-         // Trigger the progressFinishedTopic
-         if (this.progressFinishedTopic) {
-            this.alfPublish(this.progressFinishedTopic, payload);
+            // Trigger the progressFinishedTopic
+            if (this.progressFinishedTopic) {
+               this.alfPublish(this.progressFinishedTopic, payload);
+            }
+
+            this.alfPublish("ALF_CLOSE_DIALOG", payload, true);
          }
-
-         this.alfPublish("ALF_CLOSE_DIALOG", payload, true);
       },
 
       /**
@@ -295,6 +307,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onProgressCancelled: function alfresco_renderers_Progress__onProgressCancelled(payload) {
+         this.isCancelled = true;
          this.alfLog("log", "Progress Dialog Cancelled: " + payload);
          this.alfPublish("ALF_CLOSE_DIALOG", payload, true);
       },

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -483,7 +483,7 @@ define(["dojo/_base/declare",
                   config: {
                      label: this.message("services.ActionService.button.cancel"),
                      additionalCssClasses: "alfresco-dialogs-AlfProgress cancellation call-to-action",
-                     publishTopic: "ALF_CLOSE_DIALOG"
+                     publishTopic: "ALF_PROGRESS_CANCELLED"
                   }
                }
             ],

--- a/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
@@ -132,6 +132,25 @@ registerSuite(function(){
          .clearLog();
       },
 
+      "Cancel will prevent the download occurring": function() {
+         return browser.findById("MULTIPLE_DOWNLOAD_VIA_ACTION_SERVICE")
+            .clearLog()
+            .click()
+            .end()
+
+         .findByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed .dijitButtonNode")
+            .click()
+            .end()
+
+         .findByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
+            .end()
+
+         .getAllPublishes("ALF_DOWNLOAD_FILE")
+            .then(function(publishes) {
+               assert.lengthOf(publishes, 0);
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }


### PR DESCRIPTION
This addresses [AKU-694](https://issues.alfresco.com/jira/browse/AKU-694) by changing the cancel-button publish from `ALF_CLOSE_DIALOG` to `ALF_PROGRESS_CANCELLED`. This automatically closes the dialog. Additionally, the cancel handler-function sets a flag to say that the task(s) have been cancelled and for the completion actions not to be run.