### PR TITLE
AKU-665: Aikau page makes weird call to form processor

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -398,6 +398,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param {object} object The object to remove the attributes from.
+       * @deprecated Since 1.0.45 - Use [alfCleanFrameworkAttributes]{@link module:alfreso/core/Core#alfCleanFrameworkAttributes} instead.
        */
       alfDeleteFrameworkAttributes: function alfresco_core_Core__alfDeleteFrameworkAttributes(object) {
          delete object.alfResponseTopic;
@@ -405,6 +406,54 @@ define(["dojo/_base/declare",
          delete object.alfTopic;
          delete object.alfPublishScope;
          delete object.alfCallerName;
+      },
+
+      /**
+       * By default, clones the passed-in object and then deletes any automatically added attributes from the clone. These attributes
+       * are added automatically by [alfPublish]{@link module:alfresco/core/Core#alfPublish} or are used only by the pub/sub framework
+       * (e.g. "responseScope"). The cleaned object is then returned. By passing in the "modifyOriginal" flag this will behave
+       * identically to the [deprecated method it replaces]{@link module:alfresco/core/Core#alfDeleteFrameworkAttributes}, by removing
+       * the framework attributes directly from the passed-in object.
+       * 
+       * @instance
+       * @param {object} original The object to clean the attributes from.
+       * @param {boolean} [modifyOriginal=false] If true, will modify the original object, not a clone.
+       * @param {string[]} [alsoDelete] An optional array of strings denoting additional properties to remove from the object
+       *                                being cleaned. It's also possible to pass in properties prefixed with an exclamation
+       *                                mark, to denote that that property should NOT be removed by the default cleaning
+       *                                algorithm (e.g. ["url", "!alfTopic"]).
+       * @returns {object} The cloned, cleaned object, or if "modifyOriginal" is true then the original, cleaned object.
+       * @since 1.0.45
+       */
+      alfCleanFrameworkAttributes: function alfresco_core_Core__alfCleanFrameworkAttributes(original, modifyOriginal, alsoDelete) {
+
+         // If we have a falsy object, it cannot be an object we are able to clean
+         if (!original) {
+            this.alfLog("warn", "Requested to clean 'falsy' object: ", original);
+            return original;
+         }
+
+         // Setup variables
+         var objToClean = modifyOriginal ? original : lang.clone(original),
+            propsToClean = ["alfResponseTopic", "alfResponseScope", "responseScope", "alfTopic", "alfPublishScope", "alfCallerName"],
+            additionalProps = (alsoDelete && alsoDelete.length) ? alsoDelete : [];
+
+         // Calculate the properties to clean
+         array.forEach(additionalProps, function(propName) {
+            if (propName.charAt(0) === "!") {
+               propsToClean = array.filter(propsToClean, function(propToClean) {
+                  return propToClean !== propName.substr(1);
+               });
+            } else {
+               propsToClean.push(propName);
+            }
+         });
+
+         // Clean and return the properties from the object
+         array.forEach(propsToClean, function(propName) {
+            delete objToClean[propName];
+         });
+         return objToClean;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -106,6 +106,7 @@ define(["dojo/_base/declare",
        * @property {String} url - Where should we send the request to.
        * @property {Object} [headers] headers - Request headers to send (replaces [the default headers]{@link module:alfresco/core/CoreXhr#getDefaultHeaders} if specified)
        * @property {Object} [data=null] - data for the request body
+       * @property {boolean} [doNotCleanData=false] Pass true to SUPPRESS cleaning of the "data" object to [remove framework attributes]{@link module:alfresco/core/Core#alfCleanFrameworkAttributes} from it.
        * @property {String} [query=null] - data for the query string
        * @property {String} [handleAs=text] - TODO - document this feature.
        * @property {String} [method=POST] - HTTP method to use for XHR
@@ -158,6 +159,11 @@ define(["dojo/_base/declare",
                else
                {
                   data = config.data;
+               }
+
+               // Clean the data prior to sending, unless specifically told not to
+               if(data && !config.doNotCleanData) {
+                  data = this.alfCleanFrameworkAttributes(data);
                }
 
                var options = {

--- a/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
@@ -418,7 +418,7 @@ define(["dojo/_base/declare",
             this.alfUnsubscribe(payload.subscriptionHandle);
             delete payload.subscriptionHandle;
          }
-         this.alfDeleteFrameworkAttributes(payload);
+         this.alfCleanFrameworkAttributes(payload, true);
 
          // We should consider whether we actually want to mixin in the updated value
          // or just override it completely. It depends on whether or not we want to be

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -853,7 +853,7 @@ define(["dojo/_base/declare",
       setHashFragment: function alfresco_forms_Form__setHashFragment(payload) {
          // Make sure to remove the alfTopic from the payload (this will always be assigned on publications
          // but is not actually part of the form data)...
-         this.alfDeleteFrameworkAttributes(payload);
+         this.alfCleanFrameworkAttributes(payload, true);
          
          // Make sure that only the controls with names listed in hashVarsForUpdate are set on the URL hash...
          var updatedHash = {};

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -639,7 +639,7 @@ define(["dojo/_base/declare",
 
                if (this.query)
                {
-                  this.alfDeleteFrameworkAttributes(this.query);
+                  this.alfCleanFrameworkAttributes(this.query, true);
 
                   if(typeof this.query === "string")
                   {

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -96,9 +96,10 @@ define(["dojo/_base/declare",
          {
             type = payload.type;
          }
-         var url = AlfConstants.PROXY_URI + "api/type/" + type + "/formprocessor";
+         var url = AlfConstants.PROXY_URI + "api/type/" + type + "/formprocessor",
+            data = this.alfCleanFrameworkAttributes(payload, false, ["currentNode", "type"]);
          this.serviceXhr({url : url,
-                          data: payload,
+                          data: data,
                           method: "POST",
                           successCallback: this.onContentCreationSuccess,
                           callbackScope: this});

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -138,10 +138,7 @@ define(["dojo/_base/declare",
        * @returns {object} The cloned payload
        */
       clonePayload: function alfresco_services_CrudService__clonePayload(payload) {
-         var data = lang.clone(payload);
-         delete data.url;
-         this.alfDeleteFrameworkAttributes(data);
-         return data;
+         return this.alfCleanFrameworkAttributes(payload, false, ["url"]);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -228,7 +228,28 @@ define(["intern!object",
             .findAllByCssSelector(".alfresco-dialog-AlfDialog.dialogDisplayed") // Wait for dialog
             .end()
 
-            .findByCssSelector("#ALF_UPLOAD_DIALOG .confirmationButton.dijitDisabled");
+            .findByCssSelector("#ALF_UPLOAD_DIALOG .confirmationButton.dijitDisabled")
+            .end()
+
+            .findById("ALF_UPLOAD_DIALOG_CANCEL")
+               .click()
+               .end()
+
+            .findByCssSelector("#ALF_UPLOAD_DIALOG.dialogHidden");
+         },
+
+         "Create new content strips framework attributes from POST body": function() {
+            return browser.findById("CREATE_CONTENT")
+               .click()
+               .end()
+ 
+            .getLastXhr("cm:folder/formprocessor")
+               .then(function(xhrEntry){
+                  assert.notDeepProperty(xhrEntry, "request.body.alfPublishScope");
+                  assert.notDeepProperty(xhrEntry, "request.body.alfTopic");
+                  assert.notDeepProperty(xhrEntry, "request.body.type");
+                  assert.notDeepProperty(xhrEntry, "request.body.currentNode");
+               });
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
@@ -137,6 +137,22 @@ model.jsonModel = {
          }
       },
       {
+         id: "CREATE_CONTENT",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create new content",
+            publishTopic: "ALF_CREATE_CONTENT_REQUEST",
+            publishPayload: {
+               currentNode: {
+                  parent: {
+                     nodeRef: "workspace/SpacesStore/f3aefe19-4436-44f1-9733-d22ffede037d"
+                  }
+               },
+               type: "cm:folder"
+            }
+         }
+      },
+      {
          name: "aikauTesting/mockservices/CreateContentMockXhr"
       },
       {


### PR DESCRIPTION
This addresses [AKU-665](https://issues.alfresco.com/jira/browse/AKU-665) by creating a new alfCleanFrameworkAttributes() method in Core.js and deprecating alfDeleteFrameworkAttributes(). References to the old method have been removed and the bug has been addresses by updating ContentService as per the ticket and also including cleaning-by-default in CoreXhr.serviceXhr() method. A full test suite has been run successfully.