### PR TITLE
AKU-698 & AKU-701: alfresco/forms/controls/Textbox attributes

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/Password.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Password.js
@@ -1,4 +1,4 @@
-/**
+   /**
  * Copyright (C) 2005-2014 Alfresco Software Limited.
  *
  * This file is part of Alfresco
@@ -18,27 +18,27 @@
  */
 
 /**
- * This is a specialization of the [DojoValidationTextBox]{@link module:alfresco/forms/controls/DojoValidationTextBox}
+ * This is a specialization of the [TextBox]{@link module:alfresco/forms/controls/TextBox}
  * that sets the widget type to be of type "password". It should be used for capturing user password entry where the
  * password entered should not be visible.
  * 
  * @module alfresco/forms/controls/Password
- * @extends module:alfresco/forms/controls/DojoValidationTextBox
+ * @extends module:alfresco/forms/controls/TextBox
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/forms/controls/DojoValidationTextBox"], 
-        function(declare, DojoValidationTextBox) {
+        "alfresco/forms/controls/TextBox"], 
+        function(declare, TextBox) {
    
-   return declare([DojoValidationTextBox], {
+   return declare([TextBox], {
       
       /**
-       * Extends the [inherited function]{@link module:alfresco/forms/controls/DojoValidationTextBox#getWidgetConfig}
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/TextBox#getWidgetConfig}
        * to make the text box of type "password".
        *
        * @instance
        */
-      getWidgetConfig: function alfresco_forms_controls_DojoValidationTextBox__getWidgetConfig() {
+      getWidgetConfig: function alfresco_forms_controls_Password__getWidgetConfig() {
          var config = this.inherited(arguments);
          config.type = "password";
          return config;

--- a/aikau/src/main/resources/alfresco/forms/controls/TextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TextBox.js
@@ -39,10 +39,10 @@ define(["alfresco/forms/controls/BaseFormControl",
         "alfresco/forms/controls/utilities/TextBoxValueChangeMixin",
         "alfresco/forms/controls/utilities/IconMixin",
         "dojo/_base/declare",
-        "dijit/form/ValidationTextBox",
+        "alfresco/forms/controls/TextBoxControl",
         "dojo/_base/lang",
         "dojo/dom-class"], 
-        function(BaseFormControl, TextBoxValueChangeMixin, IconMixin, declare, ValidationTextBox, lang, domClass) {
+        function(BaseFormControl, TextBoxValueChangeMixin, IconMixin, declare, TextBoxControl, lang, domClass) {
    
    return declare([BaseFormControl, TextBoxValueChangeMixin, IconMixin], {
       
@@ -55,7 +55,25 @@ define(["alfresco/forms/controls/BaseFormControl",
       cssRequirements: [{cssFile:"./css/TextBox.css"}],
 
       /**
+       * <p>Whether to enable autocomplete on the textbox. Be aware that this can cause issues in two ways. Firstly, change events are not
+       * reliably fired by browsers when they autofill fields. Secondly, it may cause problems if set to true on textbox sub-components which
+       * would normally verify user-inputs and control them. The default (null) will leave the autocomplete as "off", as per the Dojo defaults.</p>
        *
+       * <p><strong>NOTE:</strong> Although one would normally override this with a setting of "on", consideration should be given to instead
+       * using a more suitable HTML5-accepted value, such as "username" or "email". A full list of the possible values can be found on
+       * the [WHATWG reference page]{@link https://html.spec.whatwg.org/multipage/forms.html#autofill} and further explanation of many of them
+       * is available on the [MDN input page]{@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input}.</p>
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.45
+       */
+      autocomplete: null,
+
+      /**
+       * The placeholder to be used (will use native HTML5 if available).
+       * 
        * @instance
        * @type {string}
        * @default
@@ -71,6 +89,7 @@ define(["alfresco/forms/controls/BaseFormControl",
          return {
             id : this.generateUuid(),
             name: this.name,
+            autocomplete: this.autocomplete,
             placeHolder: placeHolder,
             iconClass: this.iconClass
          };
@@ -80,7 +99,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        */
       createFormControl: function alfresco_forms_controls_TextBox__createFormControl(config, /*jshint unused:false*/ domNode) {
-         var textBox = new ValidationTextBox(config);
+         var textBox = new TextBoxControl(config);
          // Handle adding classes
          var additionalCssClasses = "";
          if (this.additionalCssClasses)

--- a/aikau/src/main/resources/alfresco/forms/controls/TextBoxControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TextBoxControl.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An extension of the native Dijit control, that permits altering some inherited
+ * code, in order to fix bugs and/or add features.
+ *
+ * @module alfresco/forms/controls/TextBoxControl
+ * @extends external:dijit/form/ValidationTextBox
+ * @author Martin Doyle
+ * @since 1.0.45
+ */
+define([
+      "alfresco/core/Core",
+      "dijit/form/ValidationTextBox",
+      "dojo/_base/declare",
+      "dojo/_base/lang",
+      "dojo/dom-construct",
+      "dojo/on"
+   ],
+   function(Core, ValidationTextBox, declare, lang, domConstruct, on) {
+
+      // We only want to run this once
+      var supportsPlaceholder = document.createElement("input").placeholder === "";
+
+      return declare([ValidationTextBox], {
+
+         /**
+          * Whether to enable autocomplete on the textbox. Further details available against the
+          * [alfresco/forms/controls/TextBox property]{@link module:alfresco/forms/controls/TextBox#autocomplete}.
+          *
+          * @instance
+          * @type {string}
+          * @default
+          */
+         autocomplete: null,
+
+         /**
+          * Run after the widget has been created.
+          *
+          * @instance
+          * @override
+          */
+         postCreate: function alfresco_forms_controls_TextBoxControl__postCreate() {
+            this.inherited(arguments);
+            if(this.autocomplete) {
+               this.textbox && this.textbox.setAttribute("autocomplete", this.autocomplete);
+            }
+         },
+
+         /**
+          * If we can use native placeholder, use it instead of the Dojo one.
+          *
+          * @instance
+          * @override
+          * @param {string} placeholderValue The placeholder value.
+          */
+         _setPlaceHolderAttr: function alfresco_forms_controls_TextBoxControl___setPlaceHolderAttr(placeholderValue) {
+            if (supportsPlaceholder) {
+               this.textbox.placeholder = placeholderValue;
+            } else {
+               this.inherited(arguments);
+            }
+         }
+      });
+   });

--- a/aikau/src/test/resources/alfresco/login/LoginFormTest.js
+++ b/aikau/src/test/resources/alfresco/login/LoginFormTest.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ * @author Martin Doyle
+ */
+define([
+      "alfresco/TestCommon",
+      "intern!object",
+      "intern/chai!assert"
+   ],
+   function(TestCommon, registerSuite, assert) {
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "Login Form Tests",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/Login", "Login Form Tests");
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "Placeholder attribute passed through if supported": function() {
+               var placeholderSupported = false;
+
+               return browser.execute(function() {
+                     return document.createElement('input').placeholder === "";
+                  })
+                  .then(function(supported) {
+                     placeholderSupported = supported;
+                  })
+                  .findByCssSelector("#LOGIN_USERNAME .dijitInputField input")
+                  .getAttribute("placeholder")
+                  .then(function(attrValue) {
+                     assert[placeholderSupported ? "equal" : "notEqual"](attrValue, "Username");
+                  });
+            },
+
+            "Autocomplete attribute passed through": function() {
+               return browser.findByCssSelector("#LOGIN_USERNAME .dijitInputField input")
+                  .getAttribute("autocomplete")
+                  .then(function(attrValue) {
+                     assert.equal(attrValue, "username");
+                  });
+            },
+
+            "Post Coverage Results": function() {
+               TestCommon.alfPostCoverageResults(this, browser);
+            }
+         };
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/DisablingSubmitFormTest"
+      "src/test/resources/alfresco/login/LoginFormTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
@@ -166,6 +166,8 @@ define({
       "src/test/resources/alfresco/layout/StripedContentTest",
       "src/test/resources/alfresco/layout/TwisterTest",
       "src/test/resources/alfresco/layout/VerticalRevealTest",
+
+      "src/test/resources/alfresco/login/LoginFormTest",
 
       "src/test/resources/alfresco/lists/AlfHashListTest",
       "src/test/resources/alfresco/lists/AlfSortablePaginatedListTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/login/Login.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/login/Login.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+   <shortname>Login Test</shortname>
+   <description>A sample login-page for exercising forms/controls/TextBox, forms/controls/Password and alfresco/services/LoginService</description>
+   <family>aikau-unit-tests</family>
+   <url>/Login</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/login/Login.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/login/Login.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/login/Login.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/login/Login.get.js
@@ -1,0 +1,105 @@
+var successUrl = context.properties["alfRedirectUrl"];
+if (successUrl === null)
+{
+   successUrl = url.context;
+}
+successUrl = successUrl.replace("?error=true","");
+successUrl = successUrl.replace("&error=true","");
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      {
+         name: "alfresco/services/LoginService",
+         config: {
+            defaultLoginPage: "tp/ws/Index"
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  widthPx: 400,
+                  config: {
+                     title: "Login",
+                     additionalCssClasses: "bottomBorderRadius shadow",
+                     widgets: [
+                        {
+                           name: "alfresco/forms/Form",
+                           id: "LOGIN_FORM",
+                           config: {
+                              okButtonLabel: "Login",
+                              okButtonPublishTopic: "ALF_DOLOGIN",
+                              okButtonPublishGlobal: true,
+                              okButtonPublishRevertSecs: 2,
+                              okButtonSubmitsToHiddenIframe: true,
+                              showCancelButton: false,
+                              widgets: [
+                                 {
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       name: "successUrl",
+                                       value: successUrl,
+                                       visibilityConfig: {
+                                          initialValue: false
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/controls/TextBox",
+                                    id: "LOGIN_USERNAME",
+                                    config: {
+                                       name: "username",
+                                       label: "Username",
+                                       placeHolder: "Username",
+                                       description: "Your Alfresco user name",
+                                       autocomplete: "username",
+                                       value: context.properties["alfLastUsername"],
+                                       requirementConfig: {
+                                          initialValue: true
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/controls/Password",
+                                    id: "LOGIN_PASSWORD",
+                                    config: {
+                                       name: "password",
+                                       label: "Password",
+                                       placeHolder: "Password",
+                                       autocomplete: "current-password",
+                                       description: "The password associated with your Alfresco user name",
+                                       requirementConfig: {
+                                          initialValue: true
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses [AKU-698](https://issues.alfresco.com/jira/browse/AKU-698) and [AKU-701](https://issues.alfresco.com/jira/browse/AKU-701) together because the major work effort for both is completed by either one of them. Specifically, `autocomplete` can now be specified on `alfresco/forms/controls/TextBox` controls and all its descendants (e.g. Password). Also, the `placeholder` attribute is used instead of Dojo's "visual shim", wherever it's supported. Some simple tests have been added and a full regression suite run successfully.