### PR TITLE
AKU-696: Scrolling in dialog scrolls in window

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -408,7 +408,6 @@ define(["dojo/_base/declare",
        */
       onHide: function alfresco_dialogs_AlfDialog__onHide() {
          this.inherited(arguments);
-         domStyle.set(document.documentElement, "overflow", "");
          domClass.remove(this.domNode, "dialogDisplayed");
          domClass.add(this.domNode, "dialogHidden");
          if (this.resizeListener) {
@@ -504,11 +503,6 @@ define(["dojo/_base/declare",
                w: $(window).width() - dimensionAdjustment,
                h: $(window).height() - dimensionAdjustment
             }]);
-
-            // NOTE: Need to set this on the element (rather than using CSS because the underlying 
-            //       Dojo code sets position, the only CSS option would be to use !important which
-            //       we'd prefer to avoid).
-            domStyle.set(this.domNode, "position", "fixed");
 
             // When in full screen mode it is also necessary to take care of the inner dimensions
             // of the dialog...

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -116,6 +116,12 @@
    &--textcontent .dialog-body {
       text-align: center;
    }
+   &--dialogs-visible {
+      &, body, .alfresco-core-Page {
+         height: 100%;
+         overflow: hidden;
+      }
+   }
 }
 
 .dialog-body .control {

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -119,6 +119,8 @@
    &--dialogs-visible {
       &, body, .alfresco-core-Page {
          height: 100%;
+      }
+      body, .alfresco-core-Page {
          overflow: hidden;
       }
    }

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -179,11 +179,12 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/aspect",
+        "dojo/dom-class",
         "dojo/on",
         "dojo/keys",
         "dojo/when",
         "jquery"],
-        function(declare, BaseService, topics, AlfDialog, AlfForm, lang, array, aspect, on, keys, when, $) {
+        function(declare, BaseService, topics, AlfDialog, AlfForm, lang, array, aspect, domClass, on, keys, when, $) {
 
    return declare([BaseService], {
 
@@ -817,6 +818,10 @@ define(["dojo/_base/declare",
          // Add to the stack of active dialogs
          this._activeDialogs.push(dialog);
 
+         // Ensure the dialogs-showing CSS state is "true"
+         // NOTE: This selector is used in AlfDialog.css as this service has no CSS file itself
+         domClass.add(document.documentElement, "alfresco-dialog-AlfDialog--dialogs-visible");
+
          // Handle cancelling
          this._handleCancellation(payload, dialog);
 
@@ -833,6 +838,11 @@ define(["dojo/_base/declare",
             this._activeDialogs = array.filter(this._activeDialogs, function(activeDialog) {
                return activeDialog !== dialog;
             });
+
+            // If there are no dialogs "left" then set the dialogs-showing CSS state to "false"
+            if(this._activeDialogs.length === 0) {
+               domClass.remove(document.documentElement, "alfresco-dialog-AlfDialog--dialogs-visible");
+            }
          }));
       },
 


### PR DESCRIPTION
This addresses [AKU-696](https://issues.alfresco.com/jira/browse/AKU-696) by setting overflow:hidden on a 100% height top-container when dialogs are visible. Also removed some older attempts to fix this. No unit-tests applicable for this change, but have tested manually using the DialogService test page in Chrome, FF and IE9.