### PR TITLE
AKU-718: Cannot scroll long dialogs in IE9 - CSS updated

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -46,7 +46,6 @@
       .dialog-body {
          height: auto;
          margin-bottom: 0;
-         overflow: hidden;
          padding: 12px;
       }
       .footer {


### PR DESCRIPTION
This addresses [AKU-718](https://issues.alfresco.com/jira/browse/AKU-718), which is about long dialogs not scrolling in IE9 (in fact any dialog that has enough content to require a scrollbar). The change is a single CSS change that has been manually tested in IE9 against all dialogs on the DialogService test page. No regressions were found.