### PR TITLE
AKU-713, AKU-714: Fix thumbnail aspect ratio and margin

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -737,8 +737,8 @@ define(["dojo/_base/declare",
 
             // Calcuate the image dimensions...
             var borderThickness = parseInt(domStyle.get(this.imgNode, "borderWidth"), 10);
-            this.imageNodeHeight = thumbnailHeight - (margin + borderThickness);
-            this.imageNodeWidth = thumbnailHeight - (margin + borderThickness);
+            this.imageNodeHeight = thumbnailHeight - ((margin * 2) + borderThickness);
+            this.imageNodeWidth = thumbnailWidth - ((margin * 2) + borderThickness);
             
             // Update the thumbnail nodes...
             domStyle.set(this.thumbnailNode, {

--- a/aikau/src/test/resources/alfresco/renderers/ThumbnailAspectAndSizeTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ThumbnailAspectAndSizeTest.js
@@ -126,6 +126,27 @@ define(["intern!object",
                });
          },
 
+         // NOTE: The following two tests address both AKU-713 and AKU-714...
+         //       The height and width of the landscape and portrait take into account the 
+         //       5px margin - e.g. the *thumbnail* width and height should be 300px and 200px
+         "Non-square thumbnail landscape renders correctly": function() {
+            return browser.findByCssSelector("#THUMB9_ITEM_0 .alfresco-renderers-Thumbnail__image")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.width, 290, 1, "Non-square landscape width is wrong");
+                  assert.closeTo(size.height, 163, 1, "Non-square landscape height is wrong");
+               });
+         },
+
+         "Non-square thumbnail portrait renders correctly": function() {
+            return browser.findByCssSelector("#THUMB9_ITEM_1 .alfresco-renderers-Thumbnail__image")
+               .getSize()
+               .then(function(size) {
+                  assert.closeTo(size.height, 190, 1, "Non-square portrait height is wrong");
+                  assert.closeTo(size.width, 143, 1, "Non-square portrait width is wrong");
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/ThumbnailAspectAndSize.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/ThumbnailAspectAndSize.get.js
@@ -94,6 +94,12 @@ model.jsonModel = {
                            config: {
                               label: "Gallery view (cropped to fit)"
                            }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              label: "Gallery view (non-square with margin)"
+                           }
                         }
                      ],
                      widgets: [
@@ -236,6 +242,28 @@ model.jsonModel = {
                                                 dimensions: {
                                                    w: "250px"
                                                 }
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "COL9",
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "THUMB9",
+                                             name: "alfresco/renderers/GalleryThumbnail",
+                                             config: {
+                                                dimensions: {
+                                                   w: "300px",
+                                                   h: "200px",
+                                                   margin: "5px"
+                                                },
+                                                horizontalAlignment: "MIDDLE",
+                                                verticalAlignment: "BOTTOM",
+                                                cropToFit: false
                                              }
                                           }
                                        ]


### PR DESCRIPTION
This PR addresses both https://issues.alfresco.com/jira/browse/AKU-713 and https://issues.alfresco.com/jira/browse/AKU-714 to ensure that landscape and portrait images are rendered correctly in a non-square thumbnail. This fixes one bug and adds the unit tests to verify both that fix and that margins can be set correctly on GalleryThumbnails.