### PR TITLE
AKU-727: Hide IE "X" on input fields

### DIFF
--- a/aikau/src/main/resources/alfresco/core/css/Core.css
+++ b/aikau/src/main/resources/alfresco/core/css/Core.css
@@ -48,3 +48,8 @@ body {
 {
    display: none !important;
 }
+
+/* See AKU-707: Hide the "X" on input fields on IE11 */
+input::-ms-clear {
+   display: none;
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-727 to ensure that the "X" on input fields in IE10/11 is not displayed.