### PR TITLE
AKU-721: Address double encoding issues in AlfDocumentFilters

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentFilter.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentFilter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2013 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -38,9 +38,8 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
-        "dojo/dom-class",
-        "dojo/on"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, template,  AlfCore, _AlfDocumentListTopicMixin, lang, array, domConstruct, domClass, on) {
+        "dojo/dom-class"], 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, template,  AlfCore, _AlfDocumentListTopicMixin, lang, array, domConstruct, domClass) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, AlfCore, _AlfDocumentListTopicMixin], {
       
@@ -101,12 +100,12 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_documentlibrary_AlfDocumentFilter__postMixInProperties() {
-         if (this.label != null && this.filter != null)
+         if (this.label && this.filter)
          {
-            this.label = this.encodeHTML(this.message(this.label));
-            if (this.description != null)
+            this.label = this.message(this.label);
+            if (this.description)
             {
-               this.description = this.encodeHTML(this.message(this.description));
+               this.description = this.message(this.description);
             }
          }
          else
@@ -122,7 +121,7 @@ define(["dojo/_base/declare",
        * @listens hashChangeTopic
        */
       postCreate: function alfresco_documentlibrary_AlfDocumentFilter__postCreate() {
-         if (this.hide == true)
+         if (this.hide)
          {
             domClass.add(this.domNode, "hidden");
          }
@@ -130,9 +129,9 @@ define(["dojo/_base/declare",
          // Only do this when useHash is set to true. This means that when hashing is used the 
          // description will be published (this is done for the benefit of breadcrumb trails or other
          // widgets that indicate currently selected filters)...
-         if (this.description != null && this.useHash === true)
+         if (this.description && this.useHash === true)
          {
-            this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, "onClick"));
+            this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onClick));
          }
       },
 
@@ -142,7 +141,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onClick: function alfresco_documentlibrary_AlfDocumentFilter__onClick(evt) {
+      onClick: function alfresco_documentlibrary_AlfDocumentFilter__onClick(/*jshint unused:false*/ evt) {
          this.alfPublish(this.filterSelectionTopic, {
             value: this.filter,
             description: this.description

--- a/aikau/src/main/resources/alfresco/html/Label.js
+++ b/aikau/src/main/resources/alfresco/html/Label.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2014 Alfresco Software Limited.
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
  *
  * This file is part of Alfresco
  *
@@ -18,7 +18,30 @@
  */
 
 /**
+ * This module has been somewhat unfortunately named as it creates an HTML <span> element rather than
+ * an HTML <label> element. The name is intended to reflect the intended use within a page rather than
+ * the underlying implementation. This widget can be used to "label" other widgets on the page. It can
+ * also be configured with a [subscriptionTopic]{@link module:alfresco/html/Label#subscriptionTopic}
+ * to dynamically update its displayed value as events occur on the page.
  *
+ * @example <caption>Basic configuration:</caption>
+ * {
+ *   name: "alfresco/html/Label",
+ *   config: {
+ *     label: "Look at this!"
+ *   }
+ * }
+ *
+ * @example <caption>Dynamic configuration (updates the label to show the "display.me" property from the published payload):</caption>
+ * {
+ *   name: "alfresco/html/Label",
+ *   config: {
+ *     label: "Look at this!"
+ *     subscriptionTopic: "UPDATE_LABEL",
+ *     subscriptionPayloadProperty: "display.me"
+ *   }
+ * }
+ * 
  * @module alfresco/html/Label
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
@@ -31,8 +54,8 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Label.html",
         "alfresco/core/Core",
         "dojo/_base/lang",
-        "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, lang, domClass) {
+        "dojo/dom-construct"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, lang, domConstruct) {
    
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
 
@@ -71,47 +94,59 @@ define(["dojo/_base/declare",
       label: "",
 
       /**
-       * Any additional classes to add.
+       * This is an optional topic that can be subscribed that when published will update the
+       * displayed label.
        * 
        * @instance
        * @type {string}
        * @default
+       * @since 1.0.2
        */
-      additionalCssClasses: null,
+      subscriptionTopic: null,
 
       /**
+       * This is the property in any payload published on the 
+       * [subscriptionTopic]{@link module:alfresco/html/Label#subscriptionTopic} to be
+       * used for the updated display.
        * 
        * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.46
        */
-      postCreate: function alfresco_html_Label__postCreate() {
-         if (this.additionalCssClasses != null)
-         {
-            domClass.add(this.domNode, this.additionalCssClasses);
-         }
-      },
+      subscriptionPayloadProperty: "label",
 
       /**
        * @instance
        */
       postMixInProperties: function alfresco_html_Label__postMixInProperties() {
          this.label = this.message(this.label);
-
-         if (this.subscriptionTopic != null && lang.trim(this.subscriptionTopic) !== "")
+         if (this.subscriptionTopic && lang.trim(this.subscriptionTopic) !== "")
          {
-            this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, "onLabelUpdate"));
+            this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.onLabelUpdate));
          }
       },
 
       /**
+       * This function is called when the [subscriptionTopic]{@link module:alfresco/html/Label#subscriptionTopic}
+       * is published. It will then set the 
+       * [subscriptionPayloadProperty]{@link module:alfresco/html/Label#subscriptionPayloadProperty} from the
+       * payload as the new label.
        * 
        * @instance
        * @param {object} payload The details of the label update
        */
       onLabelUpdate: function alfresco_html_Label__onLabelUpdate(payload) {
-         var update = lang.getObject("label", false, payload);
-         if (update != null)
+         var update = lang.getObject(this.subscriptionPayloadProperty, false, payload);
+         if (update !== null && typeof update !== "undefined")
          {
-            this.labelNode.innerHTML = update;
+            // NOTE: It's not safe to simply set the innerHTML attribute here, and it is also
+            //       not possible to simply encode the update (because it might contain characters
+            //       that we do not want to encode). However, we do want to prevent XSS style attacks
+            //       so the following mechanism allows us to do this.
+            domConstruct.empty(this.labelNode);
+            var textNode = document.createTextNode(update);
+            this.labelNode.appendChild(textNode);
          }
       }
    });

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -485,7 +485,7 @@ function getDocLibFilters(options) {
       config: {
          label: "filter.label.documents",
          additionalCssClasses: "no-borders",
-         width: "AUTO",
+         width: "auto",
          widgets: [
             {
                name: "alfresco/documentlibrary/AlfDocumentFilter",
@@ -572,7 +572,7 @@ function getDocLibTree(options) {
       config: {
          label: "twister.library.label",
          additionalCssClasses: "no-borders",
-         width: "AUTO",
+         width: "auto",
          widgets: [
             {
                name: "alfresco/navigation/PathTree",
@@ -596,7 +596,7 @@ function getDocLibTags(options) {
       name: "alfresco/documentlibrary/AlfTagFilters",
       config: {
          label: "filter.label.tags",
-         width: "AUTO",
+         width: "auto",
          additionalCssClasses: "no-borders",
          siteId: options.siteId,
          containerId: options.containerId,
@@ -612,7 +612,7 @@ function getDocLibCategories(options) {
       name: "alfresco/layout/Twister",
       config: {
          label: "twister.categories.label",
-         width: "AUTO",
+         width: "auto",
          additionalCssClasses: "no-borders",
          widgets: [
             {

--- a/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentFiltersTest.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfDocumentFilters Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfDocumentFilters", "AlfDocumentFilters Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Filters label is displayed correctly": function() {
+            return browser.findByCssSelector("#FILTERS > .label")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "TestSök<img src=\"1\" onerror=\"window.hacked=true\">", "Not the expected text");
+               });
+         },
+
+         "Filter label is displayed correctly": function() {
+            return browser.findByCssSelector("#FILTERS .alfresco-documentlibrary-AlfDocumentFilter span")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "TestSök<img src=\"1\" onerror=\"window.hacked=true\">", "Not the expected text");
+               });
+         },
+
+         "Initial subscribing label is correct": function() {
+            return browser.findById("FILTER_DESCRIPTION")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Filter Not SetSök<img src=\"1\" onerror=\"window.hacked=true\">", "Not the expected text");
+               });
+         },
+
+         "Click on filter to publish": function() {
+            return browser.findByCssSelector("#FILTERS .alfresco-documentlibrary-AlfDocumentFilter span")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_DOCLIST_FILTER_SELECTION")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", "all", "Payload not published correctly");
+               });
+         },
+
+         "Subscribing label has been updated": function() {
+            return browser.findById("FILTER_DESCRIPTION")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "TestSök<img src=\"1\" onerror=\"window.hacked=true\">", "Not the expected text");
+               });
+         },
+
+         "No XSS attacks were successful": function() {
+            var notHacked = browser.execute("!window.hacked");
+            assert(notHacked, "XSS attack in setting title succeeded");
+            return browser;
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -83,6 +83,7 @@ define({
       "src/test/resources/alfresco/dnd/NestedReorderTest",
 
       "src/test/resources/alfresco/documentlibrary/AlfDocumentTest",
+      "src/test/resources/alfresco/documentlibrary/AlfDocumentFiltersTest",
       "src/test/resources/alfresco/documentlibrary/AlfGalleryViewSliderTest",
       "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest",
       "src/test/resources/alfresco/documentlibrary/CreateContentTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfDocumentFilters</shortname>
+  <description>This page is used to test the alfresco/documentlibrary/AlfDocumentFilters widget.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfDocumentFilters</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.js
@@ -1,0 +1,48 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "FILTERS",
+         name: "alfresco/documentlibrary/AlfDocumentFilters",
+         config: {
+            label: "first.dodgy.label",
+            additionalCssClasses: "no-borders",
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/AlfDocumentFilter",
+                  config: {
+                     label: "first.dodgy.label",
+                     filter: "all",
+                     description: "first.dodgy.label"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "FILTER_DESCRIPTION",
+         name: "alfresco/html/Label",
+         config: {
+            additionalCssClasses: "large",
+            subscriptionTopic: "ALF_DOCLIST_FILTER_SELECTION",
+            subscriptionPayloadProperty: "description",
+            label: "second.dodgy.label"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentFilters.get.properties
@@ -1,0 +1,2 @@
+first.dodgy.label=Test\u0053\u00f6\u006b<img src="1" onerror="window.hacked=true"> 
+second.dodgy.label=Filter Not Set\u0053\u00f6\u006b<img src="1" onerror="window.hacked=true"> 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-721 to ensure that the alfresco/documentlibrary/AlfDocumentFilters widget does not create HTML encoded values in it's  alfresco/documentlibrary/AlfDocumentFilter children. Unit tests have been updated to ensure that XSS attacks are not possible and this PR also includes some general updates to the alfresco/html/Label attribute that is used in the unit tests to improve its JSDoc and make it more configurable.