### PR TITLE
AKU-719: CommentsList preferences

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -122,11 +122,11 @@ define(["dojo/_base/declare",
             this._coreHashVars = ["currentPage","currentPageSize","sortField","sortAscending"];
          }
 
-         this.alfPublish(this.getPreferenceTopic, {
+         this.alfServicePublish(this.getPreferenceTopic, {
             preference: this.pageSizePreferenceName,
             callback: this.setPageSize,
             callbackScope: this
-         }, true);
+         });
       },
 
       /**
@@ -136,12 +136,13 @@ define(["dojo/_base/declare",
        * @param {number} value The number of documents per page.
        */
       setPageSize: function alfresco_lists_AlfSortablePaginatedList__setPageSize(value) {
+         if (value)
+         {
+            this.onItemsPerPageChange({
+               value: value
+            });
+         }
          this.currentPageSize = value || this.currentPageSize || 25;
-         this.alfPublish(this.docsPerpageSelectionTopic, {
-            label: this.message("list.paginator.perPage.label", {0: this.currentPageSize}),
-            value: this.currentPageSize,
-            selected: true
-         });
       },
 
       /**
@@ -329,9 +330,6 @@ define(["dojo/_base/declare",
             // Set the new page size, and log the previous page size for some calculations we'll do in a moment...
             var previousPageSize = this.currentPageSize;
             this.currentPageSize = payload.value;
-            // this.alfPublish(this.docsPerpageSelectionTopic, {
-            //    value: this.currentPageSize
-            // });
 
             if (this._readyToLoad === true)
             {

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -180,6 +180,16 @@ define(["dojo/_base/declare",
       pageSelectorGroup: null,
       
       /**
+       * The name of the property to access in order to retrieve the page-size preference for this widget
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.46
+       */
+      pageSizePreferenceName: "org.alfresco.share.documentList.documentsPerPage",
+
+      /**
        * This can be used to configure an array of page sizes that should be displayed in the paginator.
        * If left as the default of null then an array will automatically created containing page sizes of
        * 25, 50, 75 and 100. The array should be a simple list of numbers.
@@ -309,8 +319,8 @@ define(["dojo/_base/declare",
          if (payload && payload.value && payload.value !== this.documentsPerPage && this.isValidPageSize(payload.value))
          {
             this.documentsPerPage = payload.value;
-            this.alfPublish(this.setPreferenceTopic, {
-               preference: "org.alfresco.share.documentList.documentsPerPage",
+            this.alfServicePublish(this.setPreferenceTopic, {
+               preference: this.pageSizePreferenceName,
                value: this.documentsPerPage
             });
          }

--- a/aikau/src/main/resources/alfresco/renderers/CommentsList.js
+++ b/aikau/src/main/resources/alfresco/renderers/CommentsList.js
@@ -112,6 +112,7 @@ define(["dojo/_base/declare",
             config: {
                documentsLoadedTopic: "ALF_GET_COMMENTS_SUCCESS",
                documentsPerPage: 5,
+               pageSizePreferenceName: "org.alfresco.share.documentList.commentsPerPage",
                pageSizes: [5, 10, 20],
                widgetsBefore: [
                   {
@@ -195,6 +196,7 @@ define(["dojo/_base/declare",
                loadDataPublishPayload: {
                   nodeRef: "{node.nodeRef}"
                },
+               pageSizePreferenceName: "org.alfresco.share.documentList.commentsPerPage",
                currentPageSize: 5,
                documentsLoadedTopic: "ALF_COMMENTS_LOADED",
                widgets: [

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -21,535 +21,534 @@
  * @author Dave Draper
  */
 define(["intern!object",
-        "intern/chai!expect", 
         "intern/chai!assert", 
         "alfresco/TestCommon"], 
-        function(registerSuite, expect, assert, TestCommon) {
+        function(registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Pagination Tests",
+      return {
+         name: "Pagination Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Test page selector drop-down label intialization": function() {
-         return browser.findByCssSelector("body") // Need a session to start checking for a publish
-            .getLastPublish("ALF_WIDGETS_READY")
-            .end()
+         "Test page selector drop-down label intialization": function() {
+            return browser.findByCssSelector("body") // Need a session to start checking for a publish
+               .getLastPublish("ALF_WIDGETS_READY")
+               .end()
 
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "1-25 of 243", "Page selector menu label didn't initialize correctly, expected '1-25 of 243' but saw: " + text);
-            });
-      },
-
-      "Test custom configured page selector drop-down label intialization": function() {
-         return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "1-10 of 243", "Page selector menu label didn't initialize correctly for custom pagination");
-            });
-      },
-
-      "Test custom configured page size selector value": function() {
-         return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "10 per page", "Page size menu label didn't initialize correctly for custom pagination");
-            });
-      },
-
-      "Count custom configured page sizes": function() {
-         return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown .alf-checkable-menu-item")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "The wrong number of custom page sizes was found");
-            });
-      },
-
-      "Test prevous page button is disabled on page load": function() {
-         return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The previous page button should be disabled");
-            });
-      },
-
-      "Test next page button is enabled on page load": function() {
-         return browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The next page button should be enabled");
-            });
-      },
-
-      "Test items loaded correctly (check first row of 25 items)": function() {
-         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "1", "First displayed row should be 1, saw: " + text);
-            });
-      },
-
-      "Test items loaded correctly (check last row of 25 items)": function() {
-         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(25) span.value")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "25", "First displayed row should be 25, saw: " + text);
-            });
-      },
-
-      "Test 50 items per page selection update page selector drop-down label": function() {
-         // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
-         // Switch to 50 results per page...
-         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(2) td:nth-child(3)")
-            .click()
-            .end()
             .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "1-50 of 243", "Page selector label not updated correctly after switching to 50 items per page: " + text);
-            });
-      },
-
-      "Test that user page size user preference is updated": function() {
-         return browser.findByCssSelector("body")
-            .end()
-
-         .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
-            .then(function(xhr){
-               assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.documentList.documentsPerPage", 50);
-            });
-      },
-
-      "Test previous page button is still disabled (after increasing page size)": function() {
-         browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The previous page button should still be disabled");
-            });
-      },
-
-      "Test next page button is still enabled (after increasing page size)": function() {
-         browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The next page button should still be enabled");
-            });
-      },
-
-      "Test clicking next page updates page selector drop-down label": function() {
-         return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "51-100 of 243", "Page selector label not correct, expected '51-100 of 243' but saw: " + text);
-            });
-      },
-
-      "Test clicking next page enables previous page button": function() {
-         return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The previous page button should now be enabled");
-            });
-      },
-
-      "Test next page button is still enabled (after using next page button)": function() {
-         return browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The next page button should still be enabled");
-            });
-      },
-
-      "Test previous page button updates page selector drop-down label": function() {
-         return browser.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "1-50 of 243", "Page selector label not correct, expected '1-50 of 243' but saw: " + text);
-            });
-      },
-
-      "Test previous page button is disabled (after previous page action)": function() {
-         return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The previous page button should now be disabled");
-            });
-      },
-
-      "Test page selection updates page selector label correctly": function() {
-         // Select the 4th page, because there are 5 pages and we want to click next page to check that
-         // using the next page button will disable the next page button when the last page is reached...
-         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "151-200 of 243", "Page selector label not correct, expected '151-200 of 243' but saw: " + text);
-            });
-      },
-
-      "Test next page button (to last page) disables next page button": function() {
-         return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The next page button should be disabled when next paging to the last page");
-            });
-      },
-
-      "Test increasing page size adjusts current page (50 to 100 on last page)": function() {
-         // This tests that when we increase the page size on the last page, we don't attempt to load 
-         // a page of data that won't exist... instead, we should load a smaller page number to 
-         // accommodate the larger page size.
-         // Select 100 items per page and the page number should go from 5 to 3...
-         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "201-243 of 243", "Page selector label not correct, expected '201-243 of 243' but saw: " + text);
-            })
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "3", "Page number not correct, expected '3' but saw: " + text);
-            });
-      },
-
-      "Test items loaded correctly for incomplete page(check first row of 100 items": function() {
-         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "201", "First displayed row should be 201, saw: " + text);
-            });
-      },
-
-      "Test items loaded correctly (check last row of 100 items": function() {
-         return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(43) span.value")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "243", "First displayed row should be 243, saw: " + text);
-            });
-      },
-
-      "Test Results Per Page Group": function() {
-         // This tests the external results per page menu, to ensure it picks up changes correctly...
-         return browser.findByCssSelector("#MENU_BAR_POPUP_text")
-            .click()
-            .end()
-
-         .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(4) td.alf-selected-icon")
-            .then(function(elements) {
-               assert(elements.length === 1, "Results per page widget check box not highlighted correctly");
-            });
-      },
-
-      "Test reducing page size adjusts current page (100 to 25 on last page)": function() {
-         // This tests that when we reduce the page size on the last page jump to an 
-         // appropriate page for the smaller page size. Although we're on the last page (201-243) for
-         // 100 items per page, we want to jump to the penultimate page for 25 items per page (201-225)
-         // as this is the most appropriate page for where we were.
-         return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(1) td:nth-child(3)")
-            .click()
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "201-225 of 243", "Page selector label not correct, expected '201-225 of 243' but saw: " + text);
-            })
-            .end()
-
-         .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "9", "Page number not correct, expected '9' but saw: " + text);
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-   });
-
-   // See AKU-330...
-registerSuite(function(){
-   var browser;
-
-   return {
-      name: "Pagination Tests (Custom page sizes)",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests (Custom page sizes)").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Starting page is initialised and working (useHash=false)": function() {
-         return checkPage(browser, "CUSTOM_", 1)()
-            .then(gotoNextPage(browser, "CUSTOM_"))
-            .then(checkPage(browser, "CUSTOM_", 2));
-      },
-
-      "Changing filter changes to page 1 (useHash=false)": function() {
-         return clickButton(browser, "CHANGE_FILTER")
-            .then(checkPage(browser, "CUSTOM_", 1))
-            .then(gotoNextPage(browser, "CUSTOM_"));
-      },
-
-      "Changing tag changes to page 1 (useHash=false)": function() {
-         return clickButton(browser, "CHANGE_TAG")
-            .then(checkPage(browser, "CUSTOM_", 1))
-            .then(gotoNextPage(browser, "CUSTOM_"));
-      },
-
-      "Changing category changes to page 1 (useHash=false)": function() {
-         return clickButton(browser, "CHANGE_CATEGORY")
-            .then(checkPage(browser, "CUSTOM_", 1))
-            .then(gotoNextPage(browser, "CUSTOM_"));
-      },
-
-      "Changing path changes to page 1 (useHash=false)": function() {
-         return clickButton(browser, "CHANGE_PATH")
-            .then(checkPage(browser, "CUSTOM_", 1))
-            .then(gotoNextPage(browser, "CUSTOM_"));
-      },
-
-      "Starting page is initialised and working (useHash=true)": function() {
-         return checkPage(browser, "HASH_CUSTOM_", 1)()
-            .then(gotoNextPage(browser, "HASH_CUSTOM_"))
-            .then(checkPage(browser, "HASH_CUSTOM_", 2));
-      },
-
-      "Changing filter changes to page 1 (useHash=true)": function() {
-         return clickButton(browser, "HASH_CHANGE_FILTER")
-            .then(checkPage(browser, "HASH_CUSTOM_", 1))
-            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
-      },
-
-      "Changing tag changes to page 1 (useHash=true)": function() {
-         return clickButton(browser, "HASH_CHANGE_TAG")
-            .then(checkPage(browser, "HASH_CUSTOM_", 1))
-            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
-      },
-
-      "Changing category changes to page 1 (useHash=true)": function() {
-         return clickButton(browser, "HASH_CHANGE_CATEGORY")
-            .then(checkPage(browser, "HASH_CUSTOM_", 1))
-            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
-      },
-
-      "Changing path changes to page 1 (useHash=true)": function() {
-         return clickButton(browser, "HASH_CHANGE_PATH")
-            .then(checkPage(browser, "HASH_CUSTOM_", 1))
-            .then(gotoNextPage(browser, "HASH_CUSTOM_"));
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-   });
-
-registerSuite(function(){
-   var browser;
-
-   return {
-      name: "Pagination Tests (invalid current page)",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=14&currentPageSize=20", "Pagination Tests (invalid current page)").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Check no data message": function() {
-         return browser.findByCssSelector("#HASH_LIST .rendered-view")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "There is no data to render a view from", "No data message not displayed");
-            });
-      },
-
-      "Check that the pagination controls are all hidden": function() {
-         return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page selector was not hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_BACK")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page back button was not hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page indicator was not hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page forward button was not hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The items per page selector was not hidden");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-   });
-
-registerSuite(function(){
-   var browser;
-
-   return {
-      name: "Pagination Tests (valid current page)",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=13&currentPageSize=20", "Pagination Tests (invalid current page)").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Check results": function() {
-         return browser.findAllByCssSelector("#HASH_LIST tr")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "Unexpected number of results shown");
-            });
-      },
-
-      "Check that the pagination controls are all hidden": function() {
-         return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The page selector was hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_BACK")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The page back button was hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The page indicator was hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The page forward button was hidden");
-            })
-         .end()
-         .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The items per page selector was hidden");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-   });
-
-   // See AKU-330...
-registerSuite(function(){
-   var browser;
-
-   return {
-      name: "Scroll to item test",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=1&currentPageSize=20&currentItem=18", "Pagination Tests").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Check scrollTop": function() {
-         // Interestingly Firefox registers the scrollTop on html and Chrome on body... so we need to check both!
-         function getScrollTops() {
-               /* global document */
-               var html = document.querySelector("html");
-               var body = document.querySelector("body");
-               return {html: html.scrollTop, body:body.scrollTop};
-            }
-            return browser.execute(getScrollTops)
-               .then(function(scrollTops) {
-                  assert((scrollTops.html !== 0 || scrollTops.body !== 0), "Page did not scroll, html scrollTop=" + scrollTops.html + ", body scrollTop=" + scrollTops.body);
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "1-25 of 243", "Page selector menu label didn't initialize correctly, expected '1-25 of 243' but saw: " + text);
                });
-      },
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Test custom configured page selector drop-down label intialization": function() {
+            return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "1-10 of 243", "Page selector menu label didn't initialize correctly for custom pagination");
+               });
+         },
+
+         "Test custom configured page size selector value": function() {
+            return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "10 per page", "Page size menu label didn't initialize correctly for custom pagination");
+               });
+         },
+
+         "Count custom configured page sizes": function() {
+            return browser.findByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown .alf-checkable-menu-item")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "The wrong number of custom page sizes was found");
+               });
+         },
+
+         "Test prevous page button is disabled on page load": function() {
+            return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 1, "The previous page button should be disabled");
+               });
+         },
+
+         "Test next page button is enabled on page load": function() {
+            return browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 0, "The next page button should be enabled");
+               });
+         },
+
+         "Test items loaded correctly (check first row of 25 items)": function() {
+            return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "1", "First displayed row should be 1, saw: " + text);
+               });
+         },
+
+         "Test items loaded correctly (check last row of 25 items)": function() {
+            return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(25) span.value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "25", "First displayed row should be 25, saw: " + text);
+               });
+         },
+
+         "Test 50 items per page selection update page selector drop-down label": function() {
+            // Wait for the data to load and the page to draw - this is currently slow and the rendering needs to be
+            // Switch to 50 results per page...
+            return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(2) td:nth-child(3)")
+               .click()
+               .end()
+               .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "1-50 of 243", "Page selector label not updated correctly after switching to 50 items per page: " + text);
+               });
+         },
+
+         "Test that user page size user preference is updated": function() {
+            return browser.findByCssSelector("body")
+               .end()
+
+            .getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences")
+               .then(function(xhr){
+                  assert.deepPropertyVal(xhr.request.body, "org.alfresco.share.documentList.documentsPerPage", 50);
+               });
+         },
+
+         "Test previous page button is still disabled (after increasing page size)": function() {
+            browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 1, "The previous page button should still be disabled");
+               });
+         },
+
+         "Test next page button is still enabled (after increasing page size)": function() {
+            browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 0, "The next page button should still be enabled");
+               });
+         },
+
+         "Test clicking next page updates page selector drop-down label": function() {
+            return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "51-100 of 243", "Page selector label not correct, expected '51-100 of 243' but saw: " + text);
+               });
+         },
+
+         "Test clicking next page enables previous page button": function() {
+            return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 0, "The previous page button should now be enabled");
+               });
+         },
+
+         "Test next page button is still enabled (after using next page button)": function() {
+            return browser.findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 0, "The next page button should still be enabled");
+               });
+         },
+
+         "Test previous page button updates page selector drop-down label": function() {
+            return browser.findByCssSelector("#PAGINATOR_PAGE_BACK_text")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "1-50 of 243", "Page selector label not correct, expected '1-50 of 243' but saw: " + text);
+               });
+         },
+
+         "Test previous page button is disabled (after previous page action)": function() {
+            return browser.findAllByCssSelector("#PAGINATOR_PAGE_BACK.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 1, "The previous page button should now be disabled");
+               });
+         },
+
+         "Test page selection updates page selector label correctly": function() {
+            // Select the 4th page, because there are 5 pages and we want to click next page to check that
+            // using the next page button will disable the next page button when the last page is reached...
+            return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "151-200 of 243", "Page selector label not correct, expected '151-200 of 243' but saw: " + text);
+               });
+         },
+
+         "Test next page button (to last page) disables next page button": function() {
+            return browser.findByCssSelector("#PAGINATOR_PAGE_FORWARD_text")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#PAGINATOR_PAGE_FORWARD.dijitDisabled")
+               .then(function(elements) {
+                  assert(elements.length === 1, "The next page button should be disabled when next paging to the last page");
+               });
+         },
+
+         "Test increasing page size adjusts current page (50 to 100 on last page)": function() {
+            // This tests that when we increase the page size on the last page, we don't attempt to load 
+            // a page of data that won't exist... instead, we should load a smaller page number to 
+            // accommodate the larger page size.
+            // Select 100 items per page and the page number should go from 5 to 3...
+            return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(4) td:nth-child(3)")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "201-243 of 243", "Page selector label not correct, expected '201-243 of 243' but saw: " + text);
+               })
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "3", "Page number not correct, expected '3' but saw: " + text);
+               });
+         },
+
+         "Test items loaded correctly for incomplete page(check first row of 100 items": function() {
+            return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) span.value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "201", "First displayed row should be 201, saw: " + text);
+               });
+         },
+
+         "Test items loaded correctly (check last row of 100 items": function() {
+            return browser.findByCssSelector(".alfresco-lists-AlfList tr:nth-child(43) span.value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "243", "First displayed row should be 243, saw: " + text);
+               });
+         },
+
+         "Test Results Per Page Group": function() {
+            // This tests the external results per page menu, to ensure it picks up changes correctly...
+            return browser.findByCssSelector("#MENU_BAR_POPUP_text")
+               .click()
+               .end()
+
+            .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(4) td.alf-selected-icon")
+               .then(function(elements) {
+                  assert(elements.length === 1, "Results per page widget check box not highlighted correctly");
+               });
+         },
+
+         "Test reducing page size adjusts current page (100 to 25 on last page)": function() {
+            // This tests that when we reduce the page size on the last page jump to an 
+            // appropriate page for the smaller page size. Although we're on the last page (201-243) for
+            // 100 items per page, we want to jump to the penultimate page for 25 items per page (201-225)
+            // as this is the most appropriate page for where we were.
+            return browser.findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:nth-child(1) td:nth-child(3)")
+               .click()
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "201-225 of 243", "Page selector label not correct, expected '201-225 of 243' but saw: " + text);
+               })
+               .end()
+
+            .findByCssSelector("#PAGINATOR_PAGE_MARKER > span")
+               .getVisibleText()
+               .then(function(text) {
+                  assert(text === "9", "Page number not correct, expected '9' but saw: " + text);
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   // See AKU-330...
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Pagination Tests (Custom page sizes)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests (Custom page sizes)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Starting page is initialised and working (useHash=false)": function() {
+            return checkPage(browser, "CUSTOM_", 1)()
+               .then(gotoNextPage(browser, "CUSTOM_"))
+               .then(checkPage(browser, "CUSTOM_", 2));
+         },
+
+         "Changing filter changes to page 1 (useHash=false)": function() {
+            return clickButton(browser, "CHANGE_FILTER")
+               .then(checkPage(browser, "CUSTOM_", 1))
+               .then(gotoNextPage(browser, "CUSTOM_"));
+         },
+
+         "Changing tag changes to page 1 (useHash=false)": function() {
+            return clickButton(browser, "CHANGE_TAG")
+               .then(checkPage(browser, "CUSTOM_", 1))
+               .then(gotoNextPage(browser, "CUSTOM_"));
+         },
+
+         "Changing category changes to page 1 (useHash=false)": function() {
+            return clickButton(browser, "CHANGE_CATEGORY")
+               .then(checkPage(browser, "CUSTOM_", 1))
+               .then(gotoNextPage(browser, "CUSTOM_"));
+         },
+
+         "Changing path changes to page 1 (useHash=false)": function() {
+            return clickButton(browser, "CHANGE_PATH")
+               .then(checkPage(browser, "CUSTOM_", 1))
+               .then(gotoNextPage(browser, "CUSTOM_"));
+         },
+
+         "Starting page is initialised and working (useHash=true)": function() {
+            return checkPage(browser, "HASH_CUSTOM_", 1)()
+               .then(gotoNextPage(browser, "HASH_CUSTOM_"))
+               .then(checkPage(browser, "HASH_CUSTOM_", 2));
+         },
+
+         "Changing filter changes to page 1 (useHash=true)": function() {
+            return clickButton(browser, "HASH_CHANGE_FILTER")
+               .then(checkPage(browser, "HASH_CUSTOM_", 1))
+               .then(gotoNextPage(browser, "HASH_CUSTOM_"));
+         },
+
+         "Changing tag changes to page 1 (useHash=true)": function() {
+            return clickButton(browser, "HASH_CHANGE_TAG")
+               .then(checkPage(browser, "HASH_CUSTOM_", 1))
+               .then(gotoNextPage(browser, "HASH_CUSTOM_"));
+         },
+
+         "Changing category changes to page 1 (useHash=true)": function() {
+            return clickButton(browser, "HASH_CHANGE_CATEGORY")
+               .then(checkPage(browser, "HASH_CUSTOM_", 1))
+               .then(gotoNextPage(browser, "HASH_CUSTOM_"));
+         },
+
+         "Changing path changes to page 1 (useHash=true)": function() {
+            return clickButton(browser, "HASH_CHANGE_PATH")
+               .then(checkPage(browser, "HASH_CUSTOM_", 1))
+               .then(gotoNextPage(browser, "HASH_CUSTOM_"));
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Pagination Tests (invalid current page)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=14&currentPageSize=20", "Pagination Tests (invalid current page)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check no data message": function() {
+            return browser.findByCssSelector("#HASH_LIST .rendered-view")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "There is no data to render a view from", "No data message not displayed");
+               });
+         },
+
+         "Check that the pagination controls are all hidden": function() {
+            return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page selector was not hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_BACK")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page back button was not hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page indicator was not hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page forward button was not hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The items per page selector was not hidden");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Pagination Tests (valid current page)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=13&currentPageSize=20", "Pagination Tests (invalid current page)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check results": function() {
+            return browser.findAllByCssSelector("#HASH_LIST tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "Unexpected number of results shown");
+               });
+         },
+
+         "Check that the pagination controls are all hidden": function() {
+            return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_SELECTOR")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The page selector was hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_BACK")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The page back button was hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The page indicator was hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The page forward button was hidden");
+               })
+            .end()
+            .findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The items per page selector was hidden");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   // See AKU-330...
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Scroll to item test",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Paginator#currentPage=1&currentPageSize=20&currentItem=18", "Pagination Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check scrollTop": function() {
+            // Interestingly Firefox registers the scrollTop on html and Chrome on body... so we need to check both!
+            function getScrollTops() {
+                  /* global document */
+                  var html = document.querySelector("html");
+                  var body = document.querySelector("body");
+                  return {html: html.scrollTop, body:body.scrollTop};
+               }
+               return browser.execute(getScrollTops)
+                  .then(function(scrollTops) {
+                     assert((scrollTops.html !== 0 || scrollTops.body !== 0), "Page did not scroll, html scrollTop=" + scrollTops.html + ", body scrollTop=" + scrollTops.body);
+                  });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
    /********************/

--- a/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
@@ -55,11 +55,22 @@ define(["intern!object",
                });
          },
 
+         // See AKU-719 - The CommentsList should not use the standard Document Library page size (25) 
+         // and instead use it's own preference. CommentsList by default will show 5 items per page unlike
+         // with the next test suite there is no mock preference service so this default should remain.
          "Check paginator page selector text": function() {
             return browser.findByCssSelector(".dijitMenuBar .dijitMenuItem:nth-child(2) > span")
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "1-5 of 6", "The page selector label was incorrect");
+               });
+         },
+
+         "Check comments pagination (results per page)": function() {
+            return browser.findByCssSelector("#COMMENT_LIST .alfresco-lists-Paginator__results-per-page")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.include(text, "5 per page", "Wrong initial page information");
                });
          },
 
@@ -211,6 +222,7 @@ define(["intern!object",
    });
 
    registerSuite(function(){
+      /* global document, window */
       var browser;
 
       return {
@@ -223,6 +235,25 @@ define(["intern!object",
 
          beforeEach: function() {
             browser.end();
+         },
+
+         // See AKU-719 - The CommentsList should not use the standard Document Library page size (25) 
+         // and instead use it's own preference. CommentsList by default will show 5 items per page, however
+         // the mock preference service will override that with a preference of 10...
+         "Check comments pagination (page selector)": function() {
+            return browser.findDisplayedByCssSelector("#FS_COMMENT_LIST .alfresco-lists-Paginator__page-selector")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.include(text, "1-6 of 6", "Wrong initial page information");
+               });
+         },
+
+         "Check comments pagination (results per page)": function() {
+            return browser.findDisplayedByCssSelector("#FS_COMMENT_LIST .alfresco-lists-Paginator__results-per-page")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.include(text, "10 per page", "Wrong initial page information");
+               });
          },
 
          "Add-comment opens in full-screen mode": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -169,6 +169,7 @@ model.jsonModel = {
                                              id: "CUSTOM_PAGE_SIZE_PAGINATOR",
                                              name: "alfresco/lists/Paginator",
                                              config: {
+                                                pageSizePreferenceName: "test.pagesize.name",
                                                 documentsPerPage: 10,
                                                 pageSizes: [5,10,20]
                                              }
@@ -294,6 +295,7 @@ model.jsonModel = {
                                              id: "HASH_CUSTOM_PAGE_SIZE_PAGINATOR",
                                              name: "alfresco/lists/Paginator",
                                              config: {
+                                                pageSizePreferenceName: "test.pagesize.name",
                                                 documentsPerPage: 10,
                                                 pageSizes: [5,10,20]
                                              }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/FullScreenCommentsList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/FullScreenCommentsList.get.js
@@ -17,7 +17,7 @@ model.jsonModel = {
    widgets: [
       {
          name: "alfresco/renderers/CommentsList",
-         id: "COMMENT_LIST",
+         id: "FS_COMMENT_LIST",
          config: {
             addCommentsFullScreen: true,
             addCommentsPadding: 0,
@@ -33,6 +33,9 @@ model.jsonModel = {
                }
             }
          }
+      },
+      {
+         name: "aikauTesting/mockservices/PreferenceServiceMockXhr"
       },
       {
          name: "alfresco/logging/DebugLog"

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Preferences/Preferences.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/Preferences/Preferences.json
@@ -28,7 +28,8 @@
                "hideNavBar": false,
                "showFolders": true,
                "showSidebar": true,
-               "viewRendererName": "simple"
+               "viewRendererName": "simple",
+               "commentsPerPage": 10
             },
             "documents": {
                "favourites": "workspace:\/\/SpacesStore\/5fa74ad3-9b5b-461b-9df5-de407f1f4fe7,workspace:\/\/SpacesStore\/8fe12e94-f092-4d41-9823-cb94507b44d9,workspace:\/\/SpacesStore\/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-719 to initially make sure that the AlfSortablePaginatedList configured within the CommentsList uses an alternative preference for the number of items per page to show. However, on top of this the pagination code has generally been reviewed to ensure that preferences are handled appropriately.