### PR TITLE
AKU-711: Ensure that TinyMCE editor is given focus on dialog form open

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -814,6 +814,18 @@ define([],function() {
       TAG_QUERY: "ALF_TAG_QUERY",
 
       /**
+       * This topic is fired when a [TinyMCE editor]{@link module:alfresco/editors/TinyMCE} is given focus.
+       * This is primarily used for testing purposes.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.46
+       * @event
+       */
+      TINYMCE_EDITOR_FOCUSED: "ALF_TINYMCE_EDITOR_FOCUSED",
+
+      /**
        * This topic can be used to publish a request to change the title of a page. It is subscribed to by the
        * [Title widget]{@link module:alfresco/header/Title} and published by the 
        * [SetTitle widget]{@link module:alfresco/header/SetTitle}

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -385,6 +385,23 @@ define(["dojo/_base/declare",
 
          // Listen to resize events
          this.resizeListener = this.addResizeListener(this.containerNode, this.domNode.parentNode);
+
+         // See AKU-604 - ensure that first item in dialog is focused...
+         // Moved for AKU-711 because _onFocus was not always being called...
+         if (this._dialogPanel)
+         {
+            when(this._dialogPanel.getProcessedWidgets(), lang.hitch(this, function(children) {
+               array.some(children, function(child) {
+                  var focused = false;
+                  if (typeof child.focus === "function")
+                  {
+                     child.focus();
+                     focused = true;
+                  }
+                  return focused;
+               });
+            }));
+         }
       },
 
       /**
@@ -466,7 +483,15 @@ define(["dojo/_base/declare",
          domClass.add(this.domNode, "dialogDisplayed");
          // TODO: We could optionally reveal the dialog after resizing to prevent any resizing jumping?
          
-         // See AKU-604 - ensure that first item in dialog is focused...
+         // Publish the widgets ready
+         this.alfPublish(topics.PAGE_WIDGETS_READY, {}, true);
+
+         // NOTE: This is duplicated from the onShow function to absolutely be sure that focus 
+         //       is given to child widgets. It was found in development that in particular
+         //       when attempting to focus on the TinyMCE editor that the carat was not being
+         //       displayed for Chrome without this additional code. It was noted that Firefox,
+         //       Chrome and IE all behaved slightly differently with regards to this function
+         //       being called. Although inefficient, it is at least reliable.
          if (this._dialogPanel)
          {
             when(this._dialogPanel.getProcessedWidgets(), lang.hitch(this, function(children) {
@@ -481,9 +506,6 @@ define(["dojo/_base/declare",
                });
             }));
          }
-         
-         // Publish the widgets ready
-         this.alfPublish(topics.PAGE_WIDGETS_READY, {}, true);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -1068,9 +1068,9 @@ define(["dojo/_base/declare",
          if (this._form)
          {
             var children = this._form.getChildren();
-            if (children.length > 0 && children[0].wrappedWidget && typeof children[0].wrappedWidget.focus === "function")
+            if (children.length > 0 && children[0].wrappedWidget && typeof children[0].focus === "function")
             {
-               children[0].wrappedWidget.focus();
+               children[0].focus();
             }
          }
       },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/editors/TinyMCE.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/editors/TinyMCE.get.js
@@ -10,7 +10,8 @@ model.jsonModel = {
                error: true
             }
          }
-      }
+      },
+      "alfresco/services/DialogService"
    ],
    widgets: [
       {
@@ -32,7 +33,30 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "CREATE_FORM_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create Form Dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "FORM",
+               dialogTitle: "Scoped Form Dialog",
+               formSubmissionTopic: "DIALOG_FORM",
+               widgets: [
+                  {
+                     id: "TINY_MCE_2",
+                     name: "alfresco/forms/controls/TinyMCE",
+                     config: {
+                        name: "text",
+                        label: "Enter some text"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       },
       {
          name: "aikauTesting/TestCoverageResults"


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-711 to ensure that the TinyMCE editor is given focus when displayed in a form dialog.