### PR TITLE
AKU-731: Double encoding in hashUtils

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -468,7 +468,7 @@ define(["dojo/_base/declare",
        */
       updateFilterHash: function alfresco_search_AlfSearchList__updateFilterHash(fullFilter, mode) {
          // Get the existing hash and extract the individual facetFilters into an array
-         var aHash = hashUtils.getHash(true),
+         var aHash = hashUtils.getHash(),
              facetFilters = aHash.facetFilters ? aHash.facetFilters : "",
              facetFiltersArr = facetFilters === "" ? [] : facetFilters.split(",");
 

--- a/aikau/src/main/resources/alfresco/search/FacetFilter.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilter.js
@@ -253,7 +253,7 @@ define(["dojo/_base/declare",
        */
       _updateHash: function alfresco_search_FacetFilter___updateHash(fullFilter, mode) {
          // Get the existing hash and extract the individual facetFilters into an array
-         var aHash = hashUtils.getHash(true),
+         var aHash = hashUtils.getHash(),
              facetFilters = ((aHash.facetFilters) ? aHash.facetFilters : ""),
              facetFiltersArr = (facetFilters === "") ? [] : facetFilters.split(",");
 

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -34,15 +34,9 @@ define(["dojo/_base/array",
    var util = {
 
       // See API below
-      getHash: function alfresco_util_hashUtils__getHash(suppressDecoding) {
+      getHash: function alfresco_util_hashUtils__getHash() {
          var hashString = this.getHashString(),
             hashObj = ioQuery.queryToObject(hashString);
-         if (suppressDecoding !== true)
-         {
-            array.forEach(Object.keys(hashObj), function(hashKey) {
-               hashObj[hashKey] = decodeURIComponent(hashObj[hashKey]);
-            });
-         }
          return hashObj;
       },
 
@@ -52,15 +46,9 @@ define(["dojo/_base/array",
       },
 
       // See API below
-      setHash: function alfresco_util_hashUtils__setHash(hashObj, replace, suppressEncoding) {
-         var hashObjToUse = lang.clone(hashObj);
-         if (suppressEncoding !== true)
-         {
-            array.forEach(Object.keys(hashObjToUse), function(hashKey) {
-               hashObjToUse[hashKey] = encodeURIComponent(hashObjToUse[hashKey]);
-            });
-         }
-         var hashString = ioQuery.objectToQuery(hashObjToUse);
+      setHash: function alfresco_util_hashUtils__setHash(hashObj, replace) {
+         var hashObjToUse = lang.clone(hashObj),
+            hashString = ioQuery.objectToQuery(hashObjToUse);
          this.setHashString(hashString, replace);
       },
 
@@ -114,7 +102,6 @@ define(["dojo/_base/array",
        *
        * @instance
        * @function
-       * @param {boolean} [suppressDecoding] Optionally suppress URI decoding
        * @returns {Object} The hash value as an object
        */
       getHash: lang.hitch(util, util.getHash),
@@ -137,7 +124,6 @@ define(["dojo/_base/array",
        * @param {Object} hashObj The new hash object
        * @param {boolean} [replace] Replace the current hash, rather than changing
        *                            (i.e. do not add to the history)
-       * @param {boolean} [suppressEncoding] Optionally suppress URI encoding
        */
       setHash: lang.hitch(util, util.setHash),
 

--- a/aikau/src/test/resources/alfresco/util/hashUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/util/hashUtilsTest.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define([
+      "alfresco/TestCommon",
+      "intern!object",
+      "intern/chai!assert"
+   ],
+   function(TestCommon, registerSuite, assert) {
+
+      registerSuite(function() {
+         var browser;
+
+         return {
+            name: "URL Utils Test",
+
+            setup: function() {
+               browser = this.remote;
+               return TestCommon.loadTestWebScript(this.remote, "/Index", "Hash Utils Test").end();
+            },
+
+            beforeEach: function() {
+               browser.end();
+            },
+
+            "updateHash doesn't double-encode": function() {
+               return browser.executeAsync(function(callback) {
+                     require(["alfresco/util/hashUtils"], function(hashUtils) {
+                        hashUtils.updateHash({
+                           myvar: "Something with a space in it"
+                        });
+                        callback();
+                     });
+                  })
+                  .getCurrentUrl()
+                  .then(function(currentUrl) {
+                     assert.include(currentUrl, "#myvar=Something%20with%20a%20space%20in%20it");
+                  });
+            }
+         };
+      });
+   });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -285,6 +285,7 @@ define({
       "src/test/resources/alfresco/upload/UploadTargetTest",
 
       "src/test/resources/alfresco/util/functionUtilsTest",
+      "src/test/resources/alfresco/util/hashUtilsTest",
       "src/test/resources/alfresco/util/urlUtilsTest"
    ],
 


### PR DESCRIPTION
This addresses [AKU-731](https://issues.alfresco.com/jira/browse/AKU-731) by removing the double encoding/decoding present because of the explicit encodeURICompoment and the implict one inside Dojo's ioQuery module, and similarly the decode version. Share checked manually without finding any problems. Full suite run successfully.