### PR TITLE
Fix bug with throttled resize publishes

### DIFF
--- a/aikau/src/main/resources/alfresco/core/ResizeMixin.js
+++ b/aikau/src/main/resources/alfresco/core/ResizeMixin.js
@@ -57,25 +57,16 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} resizedNode The node that has been resized
-       * @param {boolean} [unthrottled] Indicates whether or not the publication should be throttled or not
        * @fires module:alfresco/core/ResizeMixin#alfResizeNodeTopic
        */
-      alfPublishResizeEvent: function alfresco_core_ResizeMixin__alfPublishResizeEvent(resizedNode, unthrottled) {
+      alfPublishResizeEvent: function alfresco_core_ResizeMixin__alfPublishResizeEvent(resizedNode) {
          // Fire a custom event to let contained objects know that the node has been resized.
-         if (!unthrottled)
-         {
-            this.throttledPublish(this.alfResizeNodeTopic, {
-               node: resizedNode
-            }, true, false, {
-               timeoutMs: 100
-            });
-         }
-         else
-         {
-            this.alfPublish(this.alfResizeNodeTopic, {
-               node: resizedNode
-            }, true);
-         }
+         this.throttledPublish(this.alfResizeNodeTopic, {
+            node: resizedNode
+         }, true, false, {
+            timeoutMs: 100,
+            filter: resizedNode
+         });
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -617,7 +617,7 @@ define(["dojo/_base/declare",
          {
             // See AKU-689 - resize the widgets DOM node and publish an event to indicate that it has been resized...
             domStyle.set(widget.domNode, "width", dimensions.w);
-            this.alfPublishResizeEvent(widget.domNode, true); // Make sure the event is unthrottled...
+            this.alfPublishResizeEvent(widget.domNode);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/util/functionUtils.js
+++ b/aikau/src/main/resources/alfresco/util/functionUtils.js
@@ -127,17 +127,19 @@ define([
          },
 
          // Helper to get the value for a name and filter
-         _getFilteredValue: function alfresco_util_functionUtils___getFilteredValue(collection, name, filter) {
+         _getFilteredValue: function alfresco_util_functionUtils___getFilteredValue(collection, name, filter, defaultValue) {
             var items = collection[name] || [],
+               valueFound = false,
                value;
             array.some(items, function(item) {
                if (item.filter === filter) {
                   value = item.value;
-                  return true;
+                  valueFound = true;
                }
-               return false;
+               return valueFound;
             });
-            return value;
+
+            return valueFound ? value : defaultValue;
          },
 
          // Helper to set the value for a name and filter
@@ -151,10 +153,11 @@ define([
                   return false;
                });
             if (!updatedValue) {
-               collection[name] = [{
+               items.push({
                   filter: filter,
                   value: value
-               }];
+               });
+               collection[name] = items;
             }
          },
 
@@ -173,7 +176,7 @@ define([
 
             // Retrieve the specific info using name and filter
             var currentTimeout = this._getFilteredValue(timeouts, name, filter),
-               lastExecutionTime = this._getFilteredValue(lastExecutions, name, filter),
+               lastExecutionTime = this._getFilteredValue(lastExecutions, name, filter, 0),
                timeSinceLastExec = Date.now() - lastExecutionTime,
                lastExecWithinTimePeriod = timeSinceLastExec < timeoutMs;
 
@@ -222,6 +225,7 @@ define([
             }
 
             // Pass back a remove-object for cancelling the queued function
+            currentTimeout = this._getFilteredValue(timeouts, name, filter);
             return {
                remove: function() {
                   clearTimeout(currentTimeout);

--- a/aikau/src/main/resources/alfresco/util/functionUtils.js
+++ b/aikau/src/main/resources/alfresco/util/functionUtils.js
@@ -55,13 +55,35 @@ define([
          // See API below
          defaultThrottleMs: 250,
 
-         // A holder for the debounce-functionality pointers/variables, where the keys are the names provided to the limiting function
+         // A holder for the debounce-functionality pointers/variables
+         // 
+         // EXAMPLE:
+         // debounceVars: {
+         //   lastExecutions: {
+         //     foo: [{
+         //       filter: "", <-- DEFAULT
+         //       value: [Timeout pointer]
+         //     }, {
+         //       filter: [Object],
+         //       value: [Timeout pointer]
+         //     }]
+         //   },
+         //   timeouts: {
+         //     foo: [{
+         //       filter: "", <-- DEFAULT
+         //       value: [Function]
+         //     }, {
+         //       filter: [Object],
+         //       value: [Function]
+         //     }]
+         //   }
+         // }
          debounceVars: {
             lastExecutions: {},
             timeouts: {}
          },
 
-         // A holder for the debounce-functionality pointers/variables, where the keys are the names provided to the limiting function
+         // A holder for the debounce-functionality pointers/variables (format as debounceVars)
          throttleVars: {
             lastExecutions: {},
             timeouts: {}
@@ -104,19 +126,54 @@ define([
             return this._limit("throttle", args);
          },
 
+         // Helper to get the value for a name and filter
+         _getFilteredValue: function alfresco_util_functionUtils___getFilteredValue(collection, name, filter) {
+            var items = collection[name] || [],
+               value;
+            array.some(items, function(item) {
+               if (item.filter === filter) {
+                  value = item.value;
+                  return true;
+               }
+               return false;
+            });
+            return value;
+         },
+
+         // Helper to set the value for a name and filter
+         _setFilteredValue: function alfresco_util_functionUtils___setFilteredValue(collection, name, filter, value) {
+            var items = collection[name] || [],
+               updatedValue = array.some(items, function(item) {
+                  if (item.filter === filter) {
+                     item.value = value;
+                     return true;
+                  }
+                  return false;
+               });
+            if (!updatedValue) {
+               collection[name] = [{
+                  filter: filter,
+                  value: value
+               }];
+            }
+         },
+
          // Implements the functionality of the debounce and throttle methods
          _limit: function alfresco_util_functionUtils___limit(type, args) {
 
             // Setup variables
             var pointers = this[type + "Vars"],
-               timeouts = pointers.timeouts,
                lastExecutions = pointers.lastExecutions,
+               timeouts = pointers.timeouts,
                name = args.name,
-               currentTimeout = timeouts[name],
-               lastExecutionTime = lastExecutions[name] || 0,
+               filter = args.filter || "",
                execFirst = (args.execFirst === true),
                ignoreFirst = (args.ignoreFirst === true),
-               timeoutMs = args.timeoutMs || (type === "throttle" ? this.defaultThrottleMs : this.defaultDebounceMs),
+               timeoutMs = args.timeoutMs || (type === "throttle" ? this.defaultThrottleMs : this.defaultDebounceMs);
+
+            // Retrieve the specific info using name and filter
+            var currentTimeout = this._getFilteredValue(timeouts, name, filter),
+               lastExecutionTime = this._getFilteredValue(lastExecutions, name, filter),
                timeSinceLastExec = Date.now() - lastExecutionTime,
                lastExecWithinTimePeriod = timeSinceLastExec < timeoutMs;
 
@@ -129,32 +186,38 @@ define([
                // Debounce logic
                if (execFirst) { // Should we run at start of debounce
                   !lastExecWithinTimePeriod && args.func(); // If first run then exec now
-                  lastExecutions[name] = Date.now(); // Whether first run or within run-period, update last-exec time
+                  this._setFilteredValue(lastExecutions, name, filter, Date.now()); // Whether first run or within run-period, update last-exec time
                } else {
-                  timeouts[name] = setTimeout(function() { // Not in run-at-start mode, so setTimeout
-                     args.func(); // Execute the function
-                     lastExecutions[name] = 0; // Reset last-exec time
-                  }, timeoutMs); // Defer by defined timeout period
+                  // Not in run-at-start mode, so setTimeout
+                  this._setFilteredValue(timeouts, name, filter, setTimeout(lang.hitch(this, function() {
+                        args.func(); // Execute the function
+                        this._setFilteredValue(lastExecutions, name, filter, 0); // Reset last-exec time
+                     }), timeoutMs) // Defer by defined timeout period
+                  );
                }
 
             } else {
 
                // Throttle logic
                if (lastExecWithinTimePeriod) { // Within a throttle "period"?
-                  timeouts[name] = setTimeout(function() { // Defer execution
-                     args.func(); // Execute the function
-                     lastExecutions[name] = Date.now(); // Update the last-run time
-                  }, (timeoutMs - timeSinceLastExec)); // Defer until this period ends
+                  // Defer execution
+                  this._setFilteredValue(timeouts, name, filter, setTimeout(lang.hitch(this, function() {
+                        args.func(); // Execute the function
+                        this._setFilteredValue(lastExecutions, name, filter, Date.now()); // Update the last-run time
+                     }), (timeoutMs - timeSinceLastExec)) // Defer until this period ends
+                  );
                } else { // Not been run recently
                   if (ignoreFirst) { // Should we ignore the first execution call?
-                     timeouts[name] = setTimeout(function() { // Ignore, so defer execution
-                        args.func(); // Execute the function
-                        lastExecutions[name] = Date.now(); // Update the last-run time
-                     }, timeoutMs); // Defer until period ends
+                     // Ignore, so defer execution
+                     this._setFilteredValue(timeouts, name, filter, setTimeout(lang.hitch(this, function() {
+                           args.func(); // Execute the function
+                           this._setFilteredValue(lastExecutions, name, filter, Date.now()); // Update the last-run time
+                        }), timeoutMs) // Defer until period ends
+                     );
                   } else { // Do not ignore first calling
                      args.func(); // Execute the function
                   }
-                  lastExecutions[name] = Date.now(); // Update the last execution (request) time
+                  this._setFilteredValue(lastExecutions, name, filter, Date.now()); // Update the last execution (request) time
                }
             }
 
@@ -244,6 +307,9 @@ define([
           *                                      function received within that period extending it by the debounce timeout.
           * @param {int} [args.timeoutMs] The length of the debounce, if different from the
           *                               [default]{@link module:alfresco/util/functionUtils#defaultDebounceMs}
+          * @param {*} [args.filter] An optional parameter which is used in conjunction with the name to give further
+          *                          context to the debounce: i.e. will debounce only when name AND filter match. The
+          *                          filter can be any value, and will use a strict-equality check to make the comparison.
           * @return {Object} An object containing a remove() function which will clear any outstanding timeout
           */
          debounce: lang.hitch(util, util.debounce),
@@ -271,6 +337,9 @@ define([
           *                                        be executed.
           * @param {int} [args.timeoutMs] The length of the throttle, if different from the
           *                               [default]{@link module:alfresco/util/functionUtils#defaultThrottleMs}
+          * @param {*} [args.filter] An optional parameter which is used in conjunction with the name to give further
+          *                          context to the throttle: i.e. will throttle only when name AND filter match. The
+          *                          filter can be any value, and will use a strict-equality check to make the comparison.
           * @return {Object} An object containing a remove() function which will clear any outstanding timeout
           */
          throttle: lang.hitch(util, util.throttle)

--- a/aikau/src/test/resources/alfresco/util/functionUtilsTest.js
+++ b/aikau/src/test/resources/alfresco/util/functionUtilsTest.js
@@ -55,7 +55,8 @@ registerSuite(function(){
                                  name: "Throttle Test",
                                  func: function() {
                                     results.push(label);
-                                 }
+                                 },
+                                 timeoutMs: 250
                               });
                            }, delayMs);
                         };
@@ -74,6 +75,45 @@ registerSuite(function(){
                });
          },
 
+         "Filtered throttle works": function() {
+            return browser.setExecuteAsyncTimeout(5000)
+               .executeAsync(function(callback) {
+                  require(["alfresco/util/functionUtils"], function(funcUtils) {
+                     var results = [],
+                        before = Date.now(),
+                        filterObj = {},
+                        invokeThrottle = function(label, delayMs, filter) {
+                           setTimeout(function() {
+                              funcUtils.throttle({
+                                 name: "Throttle Test",
+                                 func: function() {
+                                    results.push(label);
+                                 },
+                                 timeoutMs: 250,
+                                 filter: filter
+                              });
+                           }, delayMs);
+                        };
+                     invokeThrottle("A", 0);
+                     invokeThrottle("B", 50, filterObj);
+                     invokeThrottle("C", 60);
+                     invokeThrottle("D", 110, filterObj);
+                     invokeThrottle("E", 120);
+                     invokeThrottle("F", 170, filterObj);
+                     invokeThrottle("G", 280);
+                     invokeThrottle("H", 330, filterObj);
+                     invokeThrottle("I", 400);
+                     invokeThrottle("J", 450, filterObj);
+                     setTimeout(function() {
+                        callback(results);
+                     }, 1000);
+                  });
+               })
+               .then(function(results) {
+                  assert.equal(results.join(), "A,B,E,F,I,J", "Did not throttle functions correctly");
+               });
+         },
+
          "Throttle option ignoreFirst works": function() {
             return browser.setExecuteAsyncTimeout(5000)
                .executeAsync(function(callback) {
@@ -87,6 +127,7 @@ registerSuite(function(){
                                  func: function() {
                                     results.push(label);
                                  },
+                                 timeoutMs: 250,
                                  ignoreFirst: true
                               });
                            }, delayMs);
@@ -119,7 +160,8 @@ registerSuite(function(){
                                  name: "Debounce Test",
                                  func: function() {
                                     timeOfExecution = Date.now() - before
-                                 }
+                                 },
+                                 timeoutMs: 250
                               });
                            }, delayMs);
                         };
@@ -152,6 +194,7 @@ registerSuite(function(){
                                  func: function() {
                                     timeOfExecution = Date.now() - before
                                  },
+                                 timeoutMs: 250,
                                  execFirst: true
                               });
                            }, delayMs);


### PR DESCRIPTION
Fix bug by "scoping" the resize throttling to the node being resized, so that multiple nodes can be resized simultaneously without messages getting lost. Unit test created and full regression test completed successfully.