### PR TITLE
AKU-736: Double-encoding of HTML

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -160,6 +160,23 @@ define(["dojo/_base/declare",
        * @type {string}
        */
       templateString: LiveSearchItemTemplate,
+
+      /**
+       * Run after widget created
+       *
+       * @instance
+       * @override
+       * @since 1.0.47
+       */
+      postCreate: function alfresco_header_LiveSearchItem__postCreate() {
+         this.inherited(arguments);
+
+         // Do safe insertion of user data
+         this.linkNode.appendChild(document.createTextNode(this.label));
+         this.linkNode.setAttribute("title", this.title);
+         this.previewImgNode.setAttribute("alt", this.alt);
+         this.previewLinkNode.setAttribute("title", this.label);
+      },
       
       /**
        * Handle storing of a "last" user search in local storage list
@@ -1062,10 +1079,10 @@ define(["dojo/_base/declare",
          info += this.getRelativeTime(item.modifiedOn) + " | ";
          info += this.formatFileSize(item.size);
 
-         var desc = this.encodeHTML(item.title);
+         var desc = item.title;
          if (item.description)
          {
-            desc += (desc.length !== 0 ? "\r\n" : "") + this.encodeHTML(item.description);
+            desc += (desc.length !== 0 ? "\r\n" : "") + item.description;
          }
          // build the widget for the item - including the thumbnail url for the document
          var link;
@@ -1088,10 +1105,10 @@ define(["dojo/_base/declare",
             searchBox: this,
             cssClass: "alf-livesearch-thumbnail",
             title: desc,
-            label: this.encodeHTML(item.name),
+            label: item.name,
             link: urlUtils.convertUrl(site + link, urlTypes.PAGE_RELATIVE),
             icon: AlfConstants.PROXY_URI + "api/node/" + item.nodeRef.replace(":/", "") + "/content/thumbnails/doclib?c=queue&ph=true&lastModified=" + lastModified,
-            alt: this.encodeHTML(item.name),
+            alt: item.name,
             meta: info,
             currentItem: lang.clone(item),
             publishTopic: this.publishTopic,
@@ -1177,11 +1194,11 @@ define(["dojo/_base/declare",
          return this.createLiveSearchSite({
             searchBox: this,
             cssClass: "alf-livesearch-icon",
-            title: this.encodeHTML(item.description),
-            label: this.encodeHTML(item.title),
+            title: item.description,
+            label: item.title,
             link: urlUtils.convertUrl("site/" + item.shortName + "/" + this.sitePage, urlTypes.PAGE_RELATIVE),
             icon: AlfConstants.URL_RESCONTEXT + "components/images/filetypes/generic-site-32.png",
-            alt: this.encodeHTML(item.title),
+            alt: item.title,
             meta: item.description ? this.encodeHTML(item.description) : "&nbsp;",
             currentItem: lang.clone(item),
             publishTopic: this.publishTopic,
@@ -1252,11 +1269,11 @@ define(["dojo/_base/declare",
          return this.createLiveSearchPerson({
             searchBox: this,
             cssClass: "alf-livesearch-icon",
-            title: this.encodeHTML(item.jobtitle || ""),
-            label: this.encodeHTML(fullName + " (" + item.userName + ")"),
+            title: item.jobtitle || "",
+            label: fullName + " (" + item.userName + ")",
             link: urlUtils.convertUrl("user/" + encodeURIComponent(item.userName) + "/" + this.peoplePage, urlTypes.PAGE_RELATIVE),
             icon: AlfConstants.PROXY_URI + "slingshot/profile/avatar/" + encodeURIComponent(item.userName) + "/thumbnail/avatar32",
-            alt: this.encodeHTML(fullName),
+            alt: fullName,
             meta: meta ? meta : "&nbsp;",
             currentItem: lang.clone(item),
             publishTopic: this.publishTopic,

--- a/aikau/src/main/resources/alfresco/header/templates/LiveSearchItem.html
+++ b/aikau/src/main/resources/alfresco/header/templates/LiveSearchItem.html
@@ -1,7 +1,7 @@
 <div>
-   <div class="${cssClass}"><a data-dojo-attach-event="onclick:onResultClick" title="${label}" href="${link}" tabindex="0"><img src="${icon}" alt="${alt}" width="32" border="0"></a></div>
+   <div class="${cssClass}"><a data-dojo-attach-event="onclick:onResultClick" data-dojo-attach-point="previewLinkNode" href="${link}" tabindex="0"><img src="${icon}" width="32" border="0" data-dojo-attach-point="previewImgNode"></a></div>
    <div class="alf-livesearch-item">
-      <a data-dojo-attach-event="onclick:onResultClick" title="${title}" href="${link}" tabindex="0">${label}</a><br>
+      <a data-dojo-attach-event="onclick:onResultClick" data-dojo-attach-point="linkNode" href="${link}" tabindex="0"></a><br>
       <span data-dojo-attach-event="onclick:onMetaClick">${!meta}</span>
    </div>
 </div>

--- a/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
+++ b/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
@@ -74,7 +74,7 @@ define(["intern!object",
          "Count the documents": function() {
             return browser.findAllByCssSelector(".alf-live-search-documents-list .alf-livesearch-item")
                .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Unexpected number of documents found");
+                  assert.lengthOf(elements, 3, "Unexpected number of documents found");
                });
          },
 
@@ -89,6 +89,41 @@ define(["intern!object",
             return browser.findAllByCssSelector(".alf-live-search-people-list .alf-livesearch-item")
                .then(function(elements) {
                   assert.lengthOf(elements, 0, "There shouldn't have been any people displayed");
+               });
+         },
+
+         "Text isn't erroneously escaped": function() {
+            return browser.findByCssSelector("#SB1 .alf-live-search-documents-list > div:nth-child(2)")
+               .findByCssSelector(".alf-livesearch-thumbnail a")
+               .getAttribute("title")
+               .then(function(attr) {
+                  assert.equal(attr, "Terms & Conditions.pdf", "Preview link title attribute not set correctly");
+               })
+               .end()
+
+            .findByCssSelector(".alf-livesearch-thumbnail a img")
+               .getAttribute("alt")
+               .then(function(attr) {
+                  assert.equal(attr, "Terms & Conditions.pdf", "Preview image alt attribute not set correctly");
+               })
+               .end()
+
+            .findByCssSelector(".alf-livesearch-item a")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "Terms & Conditions.pdf", "Link content not set correctly");
+               })
+               .end(); // Necessary to break out of inner context - suite will break out of outer automatically
+         },
+
+         "Code cannot be injected maliciously": function() {
+            return browser.execute(function() {
+                  return ["Name", "Title", "Description"].filter(function(hackedProp) {
+                     return !!window[hackedProp];
+                  });
+               })
+               .then(function(hackedItems) {
+                  assert.lengthOf(hackedItems, 0);
                });
          },
 

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchBox/pdf_docs_search.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SearchBox/pdf_docs_search.json
@@ -1,5 +1,5 @@
 {
-   "totalRecords": 1,
+   "totalRecords": 3,
    "startIndex": 0,
    "hasMoreRecords": false,
    "items":
@@ -18,6 +18,38 @@
          },
          "container": "documentLibrary",
          "size": 381778,
+         "mimetype": "application\/pdf"
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/1a0b110f-1e09-4ca2-b367-fe25e4964a4f",
+         "name": "Terms & Conditions.pdf",
+         "title": "Terms & Conditions for Green Enery",
+         "description": "Terms & Conditions for the Green Energy project",
+         "modifiedOn": "2011-06-14T11:28:55.714+01:00",
+         "modifiedBy": "admin",
+         "site":
+         {
+            "shortName": "swsdp",
+            "title": "Sample: Web Site Design Project"
+         },
+         "container": "documentLibrary",
+         "size": 381779,
+         "mimetype": "application\/pdf"
+      },
+      {
+         "nodeRef": "workspace:\/\/SpacesStore\/1a0b110f-1e09-4ca2-b367-fe25e4964a4d",
+         "name": "Test\u0053\u00f6\u006b<img src=\"1\" onerror=\"window.hackedName=true\">",
+         "title": "Test\u0053\u00f6\u006b<img src=\"1\" onerror=\"window.hackedTitle=true\">",
+         "description": "Test\u0053\u00f6\u006b<img src=\"1\" onerror=\"window.hackedDescription=true\">",
+         "modifiedOn": "2011-06-14T11:18:55.714+01:00",
+         "modifiedBy": "admin",
+         "site":
+         {
+            "shortName": "swsdp",
+            "title": "Sample: Web Site Design Project"
+         },
+         "container": "documentLibrary",
+         "size": 381479,
          "mimetype": "application\/pdf"
       }
    ]


### PR DESCRIPTION
This addresses [AKU-736](https://issues.alfresco.com/jira/browse/AKU-736), which is about double-encoding of HTML, by removing this.encodeHTML and replacing with setAttribute() and appendChild(createTextNode()). Tests updated and full suite run successfully.

__~~NOTE: Please do not merge yet ... awaiting completion of regression suite~~__
__Ready to merge__