### PR TITLE
AKU-738: ContentService not responding in correct scope

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -143,27 +143,24 @@ define(["dojo/_base/declare",
                }
 
                // Attempt to parse the data, but reset to null if not possible...
-               var data;
+               var data = config.data;
+
+               // Clean the data prior to sending, unless specifically told not to
+               if (data && !config.doNotCleanData) {
+                  data = this.alfCleanFrameworkAttributes(data);
+               }
+
                if (headers["Content-Type"] === "application/json")
                {
                   try
                   {
-                     data = (config.data && JSON.stringify(config.data)) || null;
+                     data = (data && JSON.stringify(data)) || null;
                   }
                   catch (e)
                   {
                      this.alfLog("warn", "Could not stringify XHR JSON data", data);
                      data = null;
                   }
-               }
-               else
-               {
-                  data = config.data;
-               }
-
-               // Clean the data prior to sending, unless specifically told not to
-               if(data && !config.doNotCleanData) {
-                  data = this.alfCleanFrameworkAttributes(data);
                }
 
                var options = {

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -97,7 +97,9 @@ define(["dojo/_base/declare",
             type = payload.type;
          }
          var url = AlfConstants.PROXY_URI + "api/type/" + type + "/formprocessor",
-            data = this.alfCleanFrameworkAttributes(payload, false, ["currentNode", "type"]);
+            data = lang.clone(payload);
+         delete data.currentNode;
+         delete data.type;
          this.serviceXhr({url : url,
                           data: data,
                           method: "POST",

--- a/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/ContentServiceTest.js
@@ -239,7 +239,7 @@ define(["intern!object",
          },
 
          "Create new content strips framework attributes from POST body": function() {
-            return browser.findById("CREATE_CONTENT")
+            return browser.findById("CREATE_CONTENT_label")
                .click()
                .end()
  
@@ -250,6 +250,15 @@ define(["intern!object",
                   assert.notDeepProperty(xhrEntry, "request.body.type");
                   assert.notDeepProperty(xhrEntry, "request.body.currentNode");
                });
+         },
+
+         "Create new content scopes the success response correctly": function() {
+            return browser.findById("CREATE_CONTENT_SCOPED_label")
+               .clearLog()
+               .click()
+               .end()
+ 
+            .getLastPublish("SCOPED_ALF_DOCLIST_RELOAD_DATA", true);
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -35,10 +35,10 @@ define({
       "src/test/resources/alfresco/login/LoginFormTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
+      // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",
+      // "src/test/resources/alfresco/dnd/NestedConfigurationTest",
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
-      // "src/test/resources/alfresco/layout/HeightMixinTest",
       // "src/test/resources/alfresco/preview/PdfJsPreviewTest"
-      // "src/test/resources/alfresco/services/CloudSyncServiceTest",
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/ContentService.get.js
@@ -153,6 +153,24 @@ model.jsonModel = {
          }
       },
       {
+         id: "CREATE_CONTENT_SCOPED",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create new content (scoped)",
+            publishTopic: "ALF_CREATE_CONTENT_REQUEST",
+            publishPayload: {
+               currentNode: {
+                  parent: {
+                     nodeRef: "workspace/SpacesStore/f3aefe19-4436-44f1-9733-d22ffede037d"
+                  }
+               },
+               type: "cm:folder"
+            },
+            publishGlobal: true,
+            pubSubScope: "SCOPED_"
+         }
+      },
+      {
          name: "aikauTesting/mockservices/CreateContentMockXhr"
       },
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CreateContentMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/CreateContentMockXhr.js
@@ -65,12 +65,17 @@ define(["dojo/_base/declare",
                                     /\/aikau\/proxy\/alfresco\/slingshot\/doclib\/node-templates/,
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
-                                     "{'name':'FAKE_NODE_NAME','success':true}"]);
+                                     "{\"name\":\"FAKE_NODE_NAME\",\"success\":true}"]);
             this.server.respondWith("POST",
                                     /\/aikau\/proxy\/alfresco\/slingshot\/doclib\/folder-templates/,
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
-                                     "{'name':'FAKE_FOLDER_NAME','success':true}"]);
+                                     "{\"name\":\"FAKE_FOLDER_NAME\",\"success\":true}"]);
+            this.server.respondWith("POST",
+                                    /\/aikau\/proxy\/alfresco\/api\/type\/cm:folder\/formprocessor/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     "{\"success\":true}"]);
          }
          catch(e)
          {


### PR DESCRIPTION
This update for [AKU-738](https://issues.alfresco.com/jira/browse/AKU-738) fixes the scoping regression introduced while fixing [AKU-665](https://issues.alfresco.com/jira/browse/AKU-665) and updates tests accordingly. Regression suite run.