### PR TITLE
AKU-723: Double-encoding in InlineEditPropertyLink

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
@@ -1,5 +1,5 @@
 <span class="alfresco-renderers-InlineEditProperty ${renderedValueClass}">
-   <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${renderedValue}</span>
+   <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${!renderedValue}</span>
    <span data-dojo-attach-point="editNode" class="editor hidden" data-dojo-attach-event="onkeypress:onValueEntryKeyPress,onclick:suppressFocusRequest">
       <span data-dojo-attach-point="formWidgetNode"></span>
       <span class="action save" data-dojo-attach-point="saveLinkNode" data-dojo-attach-event="ondijitclick:onSave" tabindex="0">${saveLabel}</span>

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -316,6 +316,23 @@ registerSuite(function(){
                });
          },
 
+         "Rendered value is not double-encoded": function() {
+            return browser.findById("LIST_UMLAUTS_ITEMS")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "test äöü test");
+               });
+         },
+
+         "Cannot inject XSS code": function() {
+            return browser.execute(function() {
+                  return !!window.hackedProperty;
+               })
+               .then(function(isHacked) {
+                  assert.isFalse(isHacked);
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
@@ -139,6 +139,34 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/lists/views/AlfListView",
+         id: "LIST_UMLAUTS",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     name: "test äöü test"
+                  }
+               ]
+            },
+            widgets: propertyLinkWidgets
+         }
+      },
+      {
+         name: "alfresco/lists/views/AlfListView",
+         id: "LIST_XSS",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     name: "<img src=\"1\" onerror=\"window.hackedProperty=true\">"
+                  }
+               ]
+            },
+            widgets: propertyLinkWidgets
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This request fixes [AKU-723](https://issues.alfresco.com/jira/browse/AKU-723) by copying the "unescaping" of the rendered value from superclass templates. Tests updated to confirm fix and check for XSS. Full regression test completed.