### PR TITLE
AKU-734: Item selection retention on sort

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -179,6 +179,7 @@ define(["dojo/_base/declare",
        * @type {string} 
        * @default [DOCUMENT_SELECTION_UPDATE]{@link module:alfresco/core/topics#DOCUMENT_SELECTION_UPDATE}
        * @event
+       * @property {object[]} selectedItems The selected items
        */
       documentSelectionTopic: topics.DOCUMENT_SELECTION_UPDATE,
       
@@ -199,6 +200,8 @@ define(["dojo/_base/declare",
        * @instance
        * @type {string} 
        * @default
+       * @event
+       * @property {object[]} selectedItems The items selected
        */
       selectedDocumentsChangeTopic: topics.SELECTED_DOCUMENTS_CHANGED,
       

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfDetailedViewItem.js
@@ -114,7 +114,8 @@ define(["alfresco/lists/views/layouts/Row",
             name: "alfresco/renderers/Selector",
             config: {
                publishGlobal: false,
-               publishToParent: true
+               publishToParent: true,
+               itemKey: "node.nodeRef"
             }
          }, {
             _attachPoint: "indicators",

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
@@ -253,7 +253,10 @@ define(["dojo/_base/declare",
                widgets: [
                   {
                      name: "alfresco/renderers/Selector",
-                     align: "left"
+                     align: "left",
+                     config: {
+                        itemKey: "node.nodeRef"
+                     }
                   },
                   {
                      name: "alfresco/renderers/Property",

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfSimpleView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfSimpleView.js
@@ -79,7 +79,10 @@ define(["dojo/_base/declare",
                         widgets: [
                            {
                               id: "SIMPLE_VIEW_SELECTOR",
-                              name: "alfresco/renderers/Selector"
+                              name: "alfresco/renderers/Selector",
+                              config: {
+                                 itemKey: "node.nodeRef"
+                              }
                            }
                         ]
                      }

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
@@ -149,7 +149,10 @@ define(["dojo/_base/declare",
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
-                              name: "alfresco/renderers/Selector"
+                              name: "alfresco/renderers/Selector",
+                              config: {
+                                 itemKey: "node.nodeRef"
+                              }
                            }
                         ]
                      }

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1085,6 +1085,7 @@ define(["dojo/_base/declare",
                this.currentData.filters = payload.requestConfig && this._extractFilters(payload.requestConfig);
                this.processLoadedData(payload.response || this.currentData);
                this.renderView();
+               this.retainPreviousItemSelectionState(items);
             }
 
             // This request has finished, allow another one to be triggered.
@@ -1120,6 +1121,8 @@ define(["dojo/_base/declare",
             this.alfPublish("ALF_RESIZE_SIDEBAR", {});
          }
       },
+
+      
 
       /**
        * Publishes the details of the documents that have been loaded (primarily for multi-selection purposes)

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -854,7 +854,12 @@ function getDocLibSortOptions(options, sortingConfigItems) {
       for (var i = 0; i < xmlSortConfig.size(); i++)
       {
          var xmlSortItem = xmlSortConfig.get(i);
-         sortingConfigItems.push(xmlSortItem.attributes);
+         var label = xmlSortItem.getAttribute("label");
+         var value = xmlSortItem.getValue();
+         sortingConfigItems.push({
+            label: label,
+            value: value
+         });
       }
    }
    else

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -22,11 +22,9 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
-
-   
+        function (registerSuite, assert, TestCommon) {
+   /* global document */
 
    var testClearingDocumentList = function(browser, buttonId, errorMsg) {
       return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
@@ -57,220 +55,220 @@ define(["intern!object",
    };
 
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "AlfSortablePaginatedList Tests",
-      
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedList#currentPage=2&currentPageSize=20", "AlfSortablePaginatedList Tests").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
+      return {
+         name: "AlfSortablePaginatedList Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedList#currentPage=2&currentPageSize=20", "AlfSortablePaginatedList Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Preference names are honoured when retrieving pageSize": function() {
-         return browser.findByCssSelector("body") // Need to create the session
+         "Preference names are honoured when retrieving pageSize": function() {
+            return browser.findByCssSelector("body") // Need to create the session
+               .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "ALF_PREFERENCE_GET",
+                  object: "HASH_LIST",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.propertyVal(payload, "preference", "org.alfresco.share.documentList.documentsPerPage", "Incorrect preference used for HASH_LIST list");
+               })
+
             .getLogEntries({
-               type: "PUBLISH",
-               topic: "ALF_PREFERENCE_GET",
-               object: "HASH_LIST",
-               pos: "last"
-            })
-            .then(function(payload) {
-               assert.propertyVal(payload, "preference", "org.alfresco.share.documentList.documentsPerPage", "Incorrect preference used for HASH_LIST list");
-            })
+                  type: "PUBLISH",
+                  topic: "ALF_PREFERENCE_GET",
+                  object: "DOCUMENT_LIST",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.propertyVal(payload, "preference", "org.alfresco.share.documentList.documentsPerPage", "Incorrect preference used for DOCUMENT_LIST list");
+               })
 
-         .getLogEntries({
-               type: "PUBLISH",
-               topic: "ALF_PREFERENCE_GET",
-               object: "DOCUMENT_LIST",
-               pos: "last"
-            })
-            .then(function(payload) {
-               assert.propertyVal(payload, "preference", "org.alfresco.share.documentList.documentsPerPage", "Incorrect preference used for DOCUMENT_LIST list");
-            })
+            .getLogEntries({
+                  type: "PUBLISH",
+                  topic: "ALF_PREFERENCE_GET",
+                  object: "INFINITE_SCROLL_LIST",
+                  pos: "last"
+               })
+               .then(function(payload) {
+                  assert.propertyVal(payload, "preference", "custom.pageSize.preference", "Incorrect preference used for INFINITE_SCROLL_LIST list");
+               });
+         },
 
-         .getLogEntries({
-               type: "PUBLISH",
-               topic: "ALF_PREFERENCE_GET",
-               object: "INFINITE_SCROLL_LIST",
-               pos: "last"
-            })
-            .then(function(payload) {
-               assert.propertyVal(payload, "preference", "custom.pageSize.preference", "Incorrect preference used for INFINITE_SCROLL_LIST list");
+         "Check URL hash controls displayed page": function() {
+            // See AKU-293
+            return browser.findByCssSelector("#HASH_LIST tr:nth-child(1) .alfresco-renderers-Property .value")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "21", "The currentPage URL hash parameter was ignored on load");
+               });
+         },
+
+         "Check paginator has updated the page size": function() {
+            // See AKU-302
+            return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "20 per page", "Page size menu ignored URL hash parameter");
+               });
+         },
+
+         "Count the rows": function() {
+            return browser.findAllByCssSelector("#HASH_LIST .alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 20, "There should only be twenty rows");
+               });
+         },
+
+         "Scroll to bottom of basic infinite scroll area": function() {
+            // Click on the first row to give it focus...
+            return browser.execute(function() {
+                  document.querySelector("#INFINITE_SCROLL_AREA .alfresco-layout-FixedHeaderFooter__content").scrollTop += 50;
+               })
+            .getLastPublish("INFINITE_SCROLL_AREA_ALF_EVENTS_SCROLL", "List scroll event not registered")
+            .end()
+            .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 20, "Additional rows were not loaded when the bottom of the list was reached");
+               });
+         },
+
+         "Simulate a filter data request": function() {
+            // Clear previous pub/sub log (so that we can detect the next load)...
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+               .click()
+            .end()
+            .findByCssSelector("#SIMULATE_FILTER_label")
+               .click()
+            .end()
+            .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", 1500, "More results not loaded")
+            .end()
+            .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 10, "Old data not cleared when data filter request applied");
+               });
+         },
+
+         "Simulate a reload request": function() {
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+               .click()
+            .end()
+            .findByCssSelector("#SIMULATE_RELOAD_label")
+               .click()
+            .end()
+            .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", "More results not loaded")
+            .end()
+            .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 10, "Old data not cleared when data filter request applied");
+               });
+         },
+
+         "Simulate a path change": function() {
+            return browser.then(function() {
+               return testClearingDocumentList(browser, "#SIMULATE_PATH_CHANGE_label", "Old data not cleared when path change request applied");
             });
-      },
+         },
 
-      "Check URL hash controls displayed page": function() {
-         // See AKU-293
-         return browser.findByCssSelector("#HASH_LIST tr:nth-child(1) .alfresco-renderers-Property .value")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "21", "The currentPage URL hash parameter was ignored on load");
+         "Simulate a category change": function() {
+            return browser.then(function() {
+               return testClearingDocumentList(browser, "#SIMULATE_CATEGORY_CHANGE_label", "Old data not cleared when category change request applied");
             });
-      },
+         },
 
-      "Check paginator has updated the page size": function() {
-         // See AKU-302
-         return browser.findByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "20 per page", "Page size menu ignored URL hash parameter");
+         "Simulate a tag change": function() {
+            return browser.then(function() {
+               return testClearingDocumentList(browser, "#SIMULATE_TAG_CHANGE_label", "Old data not cleared when tag change request applied");
             });
-      },
+         },
 
-      "Count the rows": function() {
-         return browser.findAllByCssSelector("#HASH_LIST .alfresco-lists-views-layouts-Row")
-            .then(function(elements) {
-               assert.lengthOf(elements, 20, "There should only be twenty rows");
+         "Simulate a filter change": function() {
+            return browser.then(function() {
+               return testClearingDocumentList(browser, "#SIMULATE_FILTER_CHANGE_label", "Old data not cleared when filter change request applied");
             });
-      },
+         },
 
-      "Scroll to bottom of basic infinite scroll area": function() {
-         // Click on the first row to give it focus...
-         return browser.execute(function() {
-               document.querySelector("#INFINITE_SCROLL_AREA .alfresco-layout-FixedHeaderFooter__content").scrollTop += 50;
-            })
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_EVENTS_SCROLL", "List scroll event not registered")
-         .end()
-         .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
-            .then(function(elements) {
-               assert.lengthOf(elements, 20, "Additional rows were not loaded when the bottom of the list was reached");
-            });
-      },
-
-      "Simulate a filter data request": function() {
-         // Clear previous pub/sub log (so that we can detect the next load)...
-         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
-            .click()
-         .end()
-         .findByCssSelector("#SIMULATE_FILTER_label")
-            .click()
-         .end()
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", 1500, "More results not loaded")
-         .end()
-         .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
-            .then(function(elements) {
-               assert.lengthOf(elements, 10, "Old data not cleared when data filter request applied");
-            });
-      },
-
-      "Simulate a reload request": function() {
-         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
-            .click()
-         .end()
-         .findByCssSelector("#SIMULATE_RELOAD_label")
-            .click()
-         .end()
-         .getLastPublish("INFINITE_SCROLL_AREA_ALF_DOCLIST_REQUEST_FINISHED", "More results not loaded")
-         .end()
-         .findAllByCssSelector("#INFINITE_SCROLL_LIST tr")
-            .then(function(elements) {
-               assert.lengthOf(elements, 10, "Old data not cleared when data filter request applied");
-            });
-      },
-
-      "Simulate a path change": function() {
-         return browser.then(function() {
-            return testClearingDocumentList(browser, "#SIMULATE_PATH_CHANGE_label", "Old data not cleared when path change request applied");
-         });
-      },
-
-      "Simulate a category change": function() {
-         return browser.then(function() {
-            return testClearingDocumentList(browser, "#SIMULATE_CATEGORY_CHANGE_label", "Old data not cleared when category change request applied");
-         });
-      },
-
-      "Simulate a tag change": function() {
-         return browser.then(function() {
-            return testClearingDocumentList(browser, "#SIMULATE_TAG_CHANGE_label", "Old data not cleared when tag change request applied");
-         });
-      },
-
-      "Simulate a filter change": function() {
-         return browser.then(function() {
-            return testClearingDocumentList(browser, "#SIMULATE_FILTER_CHANGE_label", "Old data not cleared when filter change request applied");
-         });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "AlfSortablePaginatedList Tests (data load failure)",
-      
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
+      return {
+         name: "AlfSortablePaginatedList Tests (data load failure)",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedListDataFail", "AlfSortablePaginatedList Tests (data load failure)").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check data failure message": function() {
-         return browser.findByCssSelector("#LIST .data-failure")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "Loading message not displayed");
-            });
-      },
+         "Check data failure message": function() {
+            return browser.findByCssSelector("#LIST .data-failure")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Loading message not displayed");
+               });
+         },
 
-      "Check that the pagination controls are all hidden": function() {
-         return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page selector was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_PAGE_BACK")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page back button was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_PAGE_MARKER")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page indicator was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The page forward button was NOT hidden");
-            })
-         .end()
-         .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The items per page selector was NOT hidden");
-            });
-      },
-
-      "Resize and check that controls are all still hidden": function() {
-         return browser.setWindowSize(null, 1024, 300)
+         "Check that the pagination controls are all hidden": function() {
+            return browser.findByCssSelector("#PAGINATOR_PAGE_SELECTOR")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page selector was NOT hidden");
+               })
+            .end()
+            .findByCssSelector("#PAGINATOR_PAGE_BACK")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page back button was NOT hidden");
+               })
+            .end()
+            .findByCssSelector("#PAGINATOR_PAGE_MARKER")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page indicator was NOT hidden");
+               })
+            .end()
+            .findByCssSelector("#PAGINATOR_PAGE_FORWARD")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The page forward button was NOT hidden");
+               })
+            .end()
             .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The items per page selector was revealed on resize");
-            });
-      },
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The items per page selector was NOT hidden");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Resize and check that controls are all still hidden": function() {
+            return browser.setWindowSize(null, 1024, 300)
+               .findByCssSelector("#PAGINATOR_RESULTS_PER_PAGE_SELECTOR")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The items per page selector was revealed on resize");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfSortablePaginatedListTest.js
@@ -206,6 +206,75 @@ define(["intern!object",
       var browser;
 
       return {
+         name: "AlfSortablePaginatedList Tests (item selection retention)",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfSortablePaginatedList", "AlfSortablePaginatedList Tests (item selection retention)").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Select items": function() {
+            return browser.findDisplayedById("SELECTOR_ITEM_2")
+               .click()
+            .end()
+
+            .getLastPublish("HASH_CUSTOM_ALF_DOCLIST_FILE_SELECTION", "Selection data not published (1)")
+            .clearLog()
+
+            .findDisplayedById("SELECTOR_ITEM_4")
+               .click()
+            .end()
+
+            .getLastPublish("HASH_CUSTOM_ALF_DOCLIST_FILE_SELECTION", "Selection data not published (2)")
+            .clearLog();
+         },
+
+         "Switch order and check items are still selected": function() {
+            return browser.findById("DESCENDING_text")
+               .click()
+            .end()
+
+            .getLastPublish("HASH_CUSTOM_ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS", "Data not reloaded")
+            .clearLog()
+
+            .findByCssSelector("#SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--selected")
+            .end()
+
+            .findByCssSelector("#SELECTOR_ITEM_4.alfresco-lists-ItemSelectionMixin--selected");
+         },
+
+         "Change the page size and check items are still selected": function() {
+            return browser.findById("HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_text")
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector("#HASH_CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown tr:first-child .dijitMenuItemLabel")
+               .click()
+            .end()
+
+            .getLastPublish("HASH_CUSTOM_ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS", "Data not reloaded")
+            .clearLog()
+
+            .findByCssSelector("#SELECTOR_ITEM_2.alfresco-lists-ItemSelectionMixin--selected")
+            .end()
+
+            .findByCssSelector("#SELECTOR_ITEM_4.alfresco-lists-ItemSelectionMixin--selected");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
          name: "AlfSortablePaginatedList Tests (data load failure)",
          
          setup: function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfSortablePaginatedList.get.js
@@ -26,6 +26,52 @@ var view = {
    }
 };
 
+var view2 = {
+   name: "alfresco/lists/views/AlfListView",
+   config: {
+      widgets: [
+         {
+            id: "ROW",
+            name: "alfresco/lists/views/layouts/Row",
+            config: {
+               widgets: [
+                  {
+                     id: "SELECTOR_CELL",
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              id: "SELECTOR",
+                              name: "alfresco/renderers/Selector",
+                              config: {
+                                 itemKey: "index"
+                              }
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     id: "PROPERTY_CELL",
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              id: "PROPERTY",
+                              name: "alfresco/renderers/Property",
+                              config: {
+                                 propertyToRender: "index"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ]
+   }
+};
+
 model.jsonModel = {
    services: [
       {
@@ -60,17 +106,33 @@ model.jsonModel = {
                      pubSubScope: "HASH_CUSTOM_",
                      widgets: [
                         {
-                           id: "HASH_MENU_BAR",
-                           name: "alfresco/menus/AlfMenuBar",
+                           id: "HASH_CUSTOM_PAGE_SIZE_PAGINATOR",
+                           name: "alfresco/lists/Paginator",
                            config: {
-                              widgets: [
+                              useHash: true,
+                              documentsPerPage: 10,
+                              pageSizes: [5,10,20],
+                              widgetsAfter: [
                                  {
-                                    id: "HASH_CUSTOM_PAGE_SIZE_PAGINATOR",
-                                    name: "alfresco/lists/Paginator",
+                                    id: "ASCENDING",
+                                    name: "alfresco/menus/AlfMenuBarItem",
                                     config: {
-                                       useHash: true,
-                                       documentsPerPage: 10,
-                                       pageSizes: [5,10,20]
+                                       label: "Ascending",
+                                       publishTopic: "ALF_DOCLIST_SORT",
+                                       publishPayload: {
+                                          direction: "ascending"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "DESCENDING",
+                                    name: "alfresco/menus/AlfMenuBarItem",
+                                    config: {
+                                       label: "Descending",
+                                       publishTopic: "ALF_DOCLIST_SORT",
+                                       publishPayload: {
+                                          direction: "descending"
+                                       }
                                     }
                                  }
                               ]
@@ -80,9 +142,10 @@ model.jsonModel = {
                            id: "HASH_LIST",
                            name: "alfresco/lists/AlfSortablePaginatedList",
                            config: {
+                              itemKeyProperty: "index",
                               useHash: true,
                               currentPageSize: 10,
-                              widgets: [view]
+                              widgets: [view2]
                            }
                         }
                      ]

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginationService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PaginationService.js
@@ -67,11 +67,25 @@ define(["dojo/_base/declare",
          var startIndex = (page - 1) * pageSize;
          var stopIndex = startIndex + pageSize;
          stopIndex = stopIndex > totalRecords ? totalRecords : stopIndex;
-         for (var i=startIndex; i<stopIndex; i++)
+         
+         var i;
+         if (payload.sortAscending === "false")
          {
-            items.push({
-               index: i+1
-            });
+            for (i=stopIndex; i>startIndex; i--)
+            {
+               items.push({
+                  index: i
+               });
+            }
+         }
+         else
+         {
+            for (i=startIndex; i<stopIndex; i++)
+            {
+               items.push({
+                  index: i+1
+               });
+            }
          }
          var responsePayload = {
             response: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-734 to ensure that selected items retain selection when the sort order is changed. I went further than just this though to fix up some general issues whilst investigating sort issues.... the Document Library lib file now ensures sort menu derived from Share XML config renders correctly, the OOTB views configure the Selector widgets appropriately for both data accessed via the Share tier and from the Repository directly. I've also ensured that changing page size retains selection as well.