### PR TITLE
AKU-737: NavigationService site handling

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -28,6 +28,7 @@
  */
 define(["dojo/_base/declare",
         "module",
+        "alfresco/core/ObjectTypeUtils",
         "alfresco/enums/urlTypes",
         "alfresco/services/BaseService",
         "alfresco/services/_NavigationServiceTopicMixin",
@@ -36,7 +37,7 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-construct"],
-        function(declare, module, urlTypes, BaseService, _NavigationServiceTopicMixin, hashUtils, urlUtils, array, lang, domConstruct) {
+        function(declare, module, ObjectTypeUtils, urlTypes, BaseService, _NavigationServiceTopicMixin, hashUtils, urlUtils, array, lang, domConstruct) {
 
    return declare([BaseService, _NavigationServiceTopicMixin], {
 
@@ -103,11 +104,24 @@ define(["dojo/_base/declare",
          // jshint maxcomplexity:false
 
          // Update the URL based on the site and type properties of the data object
-         var url = data.url,
-            urlType = data.type,
-            siteStem = "site/" + data.site + "/";
-         if(data.site && url.indexOf(siteStem) === -1) {
-            url = siteStem + url;
+         var url = data.url;
+         var urlType = data.type;
+         if (urlType === urlTypes.PAGE_RELATIVE)
+         {
+            var site = lang.getObject("site", false, data);
+            if (!site || !ObjectTypeUtils.isString(site))
+            {
+               site = lang.getObject("site.shortName", false, data);
+            }
+
+            if (site && ObjectTypeUtils.isString(site))
+            {
+               var siteStem = "/site/" + site + "/";
+               if (url.indexOf(siteStem) === -1)
+               {
+                  url = siteStem + url;
+               }
+            }
          }
          url = urlUtils.convertUrl(url, urlType);
 

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -22,135 +22,241 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"],
-        function(registerSuite, assert, require, TestCommon) {
+        function(registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "NavigationService Tests",
+      return {
+         name: "NavigationService Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/NavigationService", "NavigationService Tests")
-            .end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NavigationService", "NavigationService Tests")
+               .end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Set a hash": function() {
-         return browser.findByCssSelector("#SET_HASH_label")
-            .click()
-            .execute("return window.location.hash.toString()")
-            .then(function(hash) {
-               assert.equal(hash, "#hash1=bob&hash2=ted", "Setting a hash didn't work");
-            });
-      },
+         "Set a hash": function() {
+            return browser.findByCssSelector("#SET_HASH_label")
+               .click()
+               .execute("return window.location.hash.toString()")
+               .then(function(hash) {
+                  assert.equal(hash, "#hash1=bob&hash2=ted", "Setting a hash didn't work");
+               });
+         },
 
-      "Post to current page": function() {
-         return browser.findAllByCssSelector("#NOTHING_POSTED")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Loaded a page with request parameters");
-               })
-            .end()
-            .getCurrentUrl()
+         "Post to current page": function() {
+            return browser.findAllByCssSelector("#NOTHING_POSTED")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Loaded a page with request parameters");
+                  })
+               .end()
+               .getCurrentUrl()
+                  .then(function(url) {
+                     assert.include(url, "page/tp/ws/NavigationService", "Unexpected URL fragment (before POST)");
+                     assert.notInclude(url, "page/tp/ws/NavigationService?same=true", "Unexpected URL fragment (before POST)");
+                  })
+               .findByCssSelector("#POST_TO_CURRENT_PAGE_label")
+                  .click()
+               .end()
+               .sleep(1000)
+               .findAllByCssSelector("#POSTED")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Navigation POST didn't occur");
+                  })
+               .end()
+               .getCurrentUrl()
                .then(function(url) {
-                  assert.include(url, "page/tp/ws/NavigationService", "Unexpected URL fragment (before POST)");
-                  assert.notInclude(url, "page/tp/ws/NavigationService?same=true", "Unexpected URL fragment (before POST)");
-               })
-            .findByCssSelector("#POST_TO_CURRENT_PAGE_label")
+                  assert.include(url, "page/tp/ws/NavigationService?same=true", "Unexpected URL fragment (after POST)");
+               });
+         },
+
+         "Back to original page": function() {
+            // Clear the current browser log...
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+               .click()
+            .end()
+            .findByCssSelector("#BACK_TO_ORIGINAL_URL_label")
                .click()
             .end()
             .sleep(1000)
-            .findAllByCssSelector("#POSTED")
+            // Wait for page load
+            .getLastPublish("ALF_WIDGET_PROCESSING_COMPLETE")
+            .findAllByCssSelector("#NOTHING_POSTED")
                .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Navigation POST didn't occur");
+                  assert.lengthOf(elements, 1, "Original URL not reloaded");
                })
+            .end();
+         },
+
+         "Post to new page": function() {
+            // Clear the current browser log...
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+               .click()
             .end()
             .getCurrentUrl()
             .then(function(url) {
-               assert.include(url, "page/tp/ws/NavigationService?same=true", "Unexpected URL fragment (after POST)");
-            });
-      },
-
-      "Back to original page": function() {
-         // Clear the current browser log...
-         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
-            .click()
-         .end()
-         .findByCssSelector("#BACK_TO_ORIGINAL_URL_label")
-            .click()
-         .end()
-         .sleep(1000)
-         // Wait for page load
-         .getLastPublish("ALF_WIDGET_PROCESSING_COMPLETE")
-         .findAllByCssSelector("#NOTHING_POSTED")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Original URL not reloaded");
+               assert.notInclude(url, "page/tp/ws/NavigationService?same=true", "Not on the expected page (before POST to new page");
             })
-         .end();
-      },
-
-      "Post to new page": function() {
-         // Clear the current browser log...
-         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
-            .click()
-         .end()
-         .getCurrentUrl()
-         .then(function(url) {
-            assert.notInclude(url, "page/tp/ws/NavigationService?same=true", "Not on the expected page (before POST to new page");
-         })
-         .findByCssSelector("#POST_TO_NEW_PAGE_label")
-            .click()
-         .end()
-         .sleep(1000) // Wait for the page to open
-         .getAllWindowHandles()
-         .then(function(handles) {
-            assert.lengthOf(handles, 2, "A new page wasn't opened");
-            return browser.switchToWindow(handles[1])
-               .getCurrentUrl()
-               .then(function(url) {
-                  // UNCOMMENT THIS FOR DEBUGGING
-                  // console.log("Current URL: " + url);
-                  assert.include(url, "page/tp/ws/NavigationService?new=true", "Not on new page (after POST to new page");
-               })
-               .findAllByCssSelector("#POSTED")
-                  .then(function(elements) {
-                     // UNCOMMENT THIS FOR DEBUGGING
-                     // console.log("Counting posted");
-                     assert.lengthOf(elements, 1, "Navigation POST didn't occur");
-                  })
-               .end();
-         });
-      },
-
-      "Post to new page using params": function() {
-         // Clear the current browser log...
-         return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
-            .click()
-            .end()
-            .getCurrentUrl()
-            .then(function (url) {
-               assert.notInclude(url, "page/tp/ws/NavigationService?bar=scndqryprm&foo=qryprm#baz=hshprm", "Not on the expected page (before nav to new page");
-            })
-            .findByCssSelector("#NAV_TO_PAGE_WITH_PARAMS_label")
-            .click()
+            .findByCssSelector("#POST_TO_NEW_PAGE_label")
+               .click()
             .end()
             .sleep(1000) // Wait for the page to open
+            .getAllWindowHandles()
+            .then(function(handles) {
+               assert.lengthOf(handles, 2, "A new page wasn't opened");
+               return browser.switchToWindow(handles[1])
+                  .getCurrentUrl()
+                  .then(function(url) {
+                     // UNCOMMENT THIS FOR DEBUGGING
+                     // console.log("Current URL: " + url);
+                     assert.include(url, "page/tp/ws/NavigationService?new=true", "Not on new page (after POST to new page");
+                  })
+                  .findAllByCssSelector("#POSTED")
+                     .then(function(elements) {
+                        // UNCOMMENT THIS FOR DEBUGGING
+                        // console.log("Counting posted");
+                        assert.lengthOf(elements, 1, "Navigation POST didn't occur");
+                     })
+                  .end();
+            });
+         },
+
+         "Post to new page using params": function() {
+            // Clear the current browser log...
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__clear-button")
+               .click()
+               .end()
+               .getCurrentUrl()
+               .then(function (url) {
+                  assert.notInclude(url, "page/tp/ws/NavigationService?bar=scndqryprm&foo=qryprm#baz=hshprm", "Not on the expected page (before nav to new page");
+               })
+               .findByCssSelector("#NAV_TO_PAGE_WITH_PARAMS_label")
+               .click()
+               .end()
+               .sleep(1000) // Wait for the page to open
+               .getCurrentUrl()
+               .then(function (url) {
+                  assert.include(url, "page/tp/ws/NavigationService?bar=scndqryprm&foo=qryprm#baz=hshprm", "Not on new page (after nav to new page");
+               })
+               .end();
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "NavigationService Tests (site stemming)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NavigationService", "NavigationService Tests (site stemming)")
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         // See AKU-737 - Full path URLs should ignore any site data (because it's not possible to add a site prefix)
+         "Full path with site data": function() {
+            return browser.findDisplayedById("FULL_PATH_SITE_STRING_text")
+               .clearLog()
+               .click()
+            .end()
+
+            .sleep(1000) // Wait for page load, can't figure out a way around this sleep!
+
+            .getLastPublish("ALF_WIDGETS_READY", "Page loaded")
+
             .getCurrentUrl()
             .then(function (url) {
-               assert.include(url, "page/tp/ws/NavigationService?bar=scndqryprm&foo=qryprm#baz=hshprm", "Not on new page (after nav to new page");
-            })
-            .end();
-      },
+                  assert.include(url, "page/tp/ws/NavigationService", "Loaded URL incorrect");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         // See AKU-737 - A page relative path can make use of a site object...
+         "Page relative path with site object": function() {
+            return browser.findDisplayedById("PAGE_RELATIVE_SITE_OBJECT_text")
+               .clearLog()
+               .click()
+            .end()
+
+            .sleep(1000) // Wait for page load, can't figure out a way around this sleep!
+
+            .getLastPublish("ALF_WIDGETS_READY", "Page loaded")
+
+            .getCurrentUrl()
+            .then(function (url) {
+                  assert.include(url, "page/site/bob/tp/ws/NavigationService", "Loaded URL incorrect");
+               });
+         },
+
+         // See AKU-737 - A page relative path can make use of a site string...
+         "Page relative path with site string": function() {
+            return browser.findDisplayedById("PAGE_RELATIVE_SITE_STRING_text")
+               .clearLog()
+               .click()
+            .end()
+
+            .sleep(1000) // Wait for page load, can't figure out a way around this sleep!
+
+            .getLastPublish("ALF_WIDGETS_READY", "Page loaded")
+
+            .getCurrentUrl()
+            .then(function (url) {
+                  assert.include(url, "page/site/gwen/tp/ws/NavigationService", "Loaded URL incorrect");
+               });
+         },
+
+         // See AKU-737 - A page relative path will ignore invalid site object data...
+         "Page relative path with invalid site object": function() {
+            return browser.findDisplayedById("PAGE_RELATIVE_INVALID_SITE_text")
+               .clearLog()
+               .click()
+            .end()
+
+            .sleep(1000) // Wait for page load, can't figure out a way around this sleep!
+
+            .getLastPublish("ALF_WIDGETS_READY", "Page loaded")
+
+            .getCurrentUrl()
+            .then(function (url) {
+                  assert.include(url, "page/tp/ws/NavigationService", "Loaded URL incorrect");
+               });
+         },
+
+         // See AKU-737 - A page relative path no site data should just be processed as normal...
+         "Page relative path with no site data": function() {
+            return browser.findDisplayedById("PAGE_RELATIVE_NO_SITE_text")
+               .clearLog()
+               .click()
+            .end()
+
+            .sleep(1000) // Wait for page load, can't figure out a way around this sleep!
+
+            .getLastPublish("ALF_WIDGETS_READY", "Page loaded")
+
+            .getCurrentUrl()
+            .then(function (url) {
+                  assert.include(url, "page/tp/ws/NavigationService", "Loaded URL incorrect");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
@@ -95,6 +95,32 @@ model.jsonModel = {
             advancedSearch: false
          }
       },
+      // See AKU-737
+      {
+         id: "SB6",
+         name: "alfresco/header/SearchBox",
+         config: {
+            alignment: "left",
+            placeholder: "Search me!",
+            advancedSearch: false,
+            width: "250",
+            suppressRedirect: true,
+            showSiteResults: false,
+            showPeopleResults: false,
+            hiddenSearchTerms: null,
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayloadType: "PROCESS",
+            publishPayloadModifiers: ["processCurrentItemTokens"],
+            publishPayload: {
+               target: "NEW",
+               type: "FULL_PATH",
+               url: "/share/page/sfdc-document-details?nodeRef={nodeRef}"
+            },
+            publishPayloadItemMixin: false,
+            publishGlobal: true,
+            publishToParent: false
+         }
+      },
       {
          name: "aikauTesting/mockservices/SearchBoxMockXhr"
       },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
@@ -116,6 +116,114 @@ model.jsonModel = {
          }
       },
       {
+         id: "MENU_BAR",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "FULL_PATH_SITE_STRING",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Full path site string",
+                     publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                     publishPayload: {
+                        url: "/aikau/page/tp/ws/NavigationService",
+                        type: "FULL_PATH",
+                        target: "CURRENT"
+                     },
+                     publishPayloadType: "PROCESS",
+                     publishPayloadModifiers: ["processCurrentItemTokens"],
+                     publishPayloadItemMixin: true,
+                     currentItem: {
+                        site: "gwen"
+                     }
+                  }
+               },
+               {
+                  id: "PAGE_RELATIVE_SITE_OBJECT",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Page relative site object",
+                     publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                     publishPayload: {
+                        url: "tp/ws/NavigationService",
+                        type: "PAGE_RELATIVE",
+                        target: "CURRENT"
+                     },
+                     publishPayloadType: "PROCESS",
+                     publishPayloadModifiers: ["processCurrentItemTokens"],
+                     publishPayloadItemMixin: true,
+                     currentItem: {
+                        site: {
+                           shortName: "bob",
+                           title: "Bob"
+                        }
+                     }
+                  }
+               },
+               {
+                  id: "PAGE_RELATIVE_SITE_STRING",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Page relative site string",
+                     publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                     publishPayload: {
+                        url: "tp/ws/NavigationService",
+                        type: "PAGE_RELATIVE",
+                        target: "CURRENT"
+                     },
+                     publishPayloadType: "PROCESS",
+                     publishPayloadModifiers: ["processCurrentItemTokens"],
+                     publishPayloadItemMixin: true,
+                     currentItem: {
+                        site: "gwen"
+                     }
+                  }
+               },
+               {
+                  id: "PAGE_RELATIVE_INVALID_SITE",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Page relative invalid site object",
+                     publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                     publishPayload: {
+                        url: "tp/ws/NavigationService",
+                        type: "PAGE_RELATIVE",
+                        target: "CURRENT"
+                     },
+                     publishPayloadType: "PROCESS",
+                     publishPayloadModifiers: ["processCurrentItemTokens"],
+                     publishPayloadItemMixin: true,
+                     currentItem: {
+                        site: {
+                           wrong: "tony"
+                        }
+                     }
+                  }
+               },
+               {
+                  id: "PAGE_RELATIVE_NO_SITE",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Page relative no site",
+                     publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                     publishPayload: {
+                        url: "tp/ws/NavigationService",
+                        type: "PAGE_RELATIVE",
+                        target: "CURRENT"
+                     },
+                     publishPayloadType: "PROCESS",
+                     publishPayloadModifiers: ["processCurrentItemTokens"],
+                     publishPayloadItemMixin: true,
+                     currentItem: {
+                        
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
          name: "aikauTesting/mockservices/NavigationServiceMockXhr"
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-737. Although the issue reported problems with SearchBox ("live search")... the actual issue was with the underlying NavigationService and how it attempted to make use of site data. I've resolved the issue and added new unit tests to verify the behaviour and prevent future regressions.