### PR TITLE
AKU-715: Tag renderer customization

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -187,7 +187,18 @@ define(["dojo/_base/declare",
        */
       saveLabel: "inline-edit.save.label",
 
-       /**
+      /**
+       * If configured to be false then "Save" and "Cancel" actions will not be displayed when editing
+       * the property. It will still be possible to save changes by using the ENTER key.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.47
+       */
+      showOkCancelActions: true,
+
+      /**
        * The topic to publish when a property edit should be persisted. For convenience it is assumed that document
        * or folder properties are being edited so this function is called whenever a 'publishTopic' attribute
        * has not been set. The defaults are to publish on the "ALF_CRUD_CREATE" topic which will publish a payload
@@ -266,6 +277,12 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_renderers_InlineEditProperty__postCreate() {
          this.inherited(arguments);
+
+         if (!this.showOkCancelActions)
+         {
+            domClass.add(this.domNode, "alfresco-renderers-InlineEditProperty--hide-save-cancel-actions");
+         }
+
          if (this.permissionProperty)
          {
             var hasEditPermission = lang.getObject(this.permissionProperty, false, this.currentItem);

--- a/aikau/src/main/resources/alfresco/renderers/css/EditTag.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/EditTag.css
@@ -1,9 +1,11 @@
 .alfresco-renderers-EditTag {
    font-size: 93%;
    margin-right: 0.5em;
-   padding: 2px 8px;
+   padding: 1px 8px 3px 8px;
    background-color: @primary-theme-color;
    color: @general-font-color;
+   display: inline-block;
+   line-height: 22px;
 }
 
 .alfresco-renderers-EditTag.highlight {

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -50,9 +50,16 @@
    > .editor {
       display: inline-block;
       height: 40px;
+      line-height: 40px;
       > .alfresco-forms-Form {
          display: inline-block;
-         vertical-align: bottom;
+      }
+   }
+   &--hide-save-cancel-actions {
+      > .editor {
+         > .action {
+            display: none;
+         }
       }
    }
 }

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -151,9 +151,8 @@ define(["intern!object",
          "Navigate to a node with no tags and edit it": function() {
             // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
             // An immediate request for existing tags should be made
-            return browser.pressKeys([keys.TAB])
-               .pressKeys([keys.TAB])
-               .pressKeys([keys.TAB])
+            return browser.findByCssSelector("body")
+               .tabToElement("#TAGS_3 .inlineEditValue")
                .pressKeys([keys.CONTROL, "e"])
                .pressKeys(keys.NULL)
                .end()
@@ -220,8 +219,8 @@ define(["intern!object",
          "Navigate to a node with no tags and edit it": function() {
             // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
             // An immediate request for existing tags should be made
-            return browser.pressKeys([keys.TAB])
-               .pressKeys([keys.TAB])
+            return browser.findByCssSelector("body")
+               .tabToElement("#TAGS_2 .inlineEditValue")
                .pressKeys([keys.CONTROL, "e"])
                .pressKeys(keys.NULL)
             .end()

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -24,182 +24,229 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Tags Tests",
+      return {
+         name: "Tags Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Tags", "Tags Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Tags", "Tags Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-     "Check there are the expected number of tag controls successfully rendered": function () {
-         return browser.findAllByCssSelector("span.alfresco-renderers-InlineEditProperty.alfresco-renderers-Property")
-            .then(function (tagcontrols){
-               assert.lengthOf(tagcontrols, 4, "There should be 4 tag controls successfully rendered");
-            });
-      },
+        "Check there are the expected number of tag controls successfully rendered": function () {
+            return browser.findAllByCssSelector("span.alfresco-renderers-InlineEditProperty.alfresco-renderers-Property")
+               .then(function (tagcontrols){
+                  assert.lengthOf(tagcontrols, 4, "There should be 4 tag controls successfully rendered");
+               });
+         },
 
-      "Check there are the expected number of readonlytags successfully rendered": function() {
-         return browser.findAllByCssSelector("#TAGS_4 span.alfresco-renderers-ReadOnlyTag")
-            .then(function (readonlytags){
-               assert.lengthOf(readonlytags, 3, "There should be 3 readonlytags successfully rendered");
-            });
-      },
+         "Check there are the expected number of readonlytags successfully rendered": function() {
+            return browser.findAllByCssSelector("#TAGS_4 span.alfresco-renderers-ReadOnlyTag")
+               .then(function (readonlytags){
+                  assert.lengthOf(readonlytags, 3, "There should be 3 readonlytags successfully rendered");
+               });
+         },
 
-      "Check there are no edittags shown": function() {
-         return browser.findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
-            .then(function (edittags){
-               assert.lengthOf(edittags, 0, "There should be 0 edittags shown");
-            });
-      },
+         "Check there are no edittags shown": function() {
+            return browser.findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
+               .then(function (edittags){
+                  assert.lengthOf(edittags, 0, "There should be 0 edittags shown");
+               });
+         },
 
-      "Check the link click published as expected": function() {
-         return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-ReadOnlyTag:first-of-type a")
-            .click()
-         .end()
-         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
-            .then(function(payload) {
-               assert.propertyVal(payload, "type", "HASH", "The link did not publish the payload with 'type' as 'HASH'");
-               assert.propertyVal(payload, "url", "tag=Test1", "The link did not publish the payload with 'url' as 'tag=Test1'");
-            });
-      },
+         "Check the link click published as expected": function() {
+            return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-ReadOnlyTag:first-of-type a")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "type", "HASH", "The link did not publish the payload with 'type' as 'HASH'");
+                  assert.propertyVal(payload, "url", "tag=Test1", "The link did not publish the payload with 'url' as 'tag=Test1'");
+               });
+         },
 
-      "Check there are 3 edit tags now shown": function() {
-         return browser.findByCssSelector("#TAGS_4 > img.editIcon")
-            .click()
-         .end()
+         "Check there are 3 edit tags now shown": function() {
+            return browser.findByCssSelector("#TAGS_4 > img.editIcon")
+               .click()
+            .end()
 
-         .findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
-            .then(function (edittags){
-               assert.lengthOf(edittags, 3, "There should be 3 edittags now shown");
-            });
-      },
+            .findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
+               .then(function (edittags){
+                  assert.lengthOf(edittags, 3, "There should be 3 edittags now shown");
+               });
+         },
 
-      "Check the first edit tag reads 'Test1'": function() {
-         return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type")
-            .getVisibleText()
-            .then(function (edittagtext){
-               assert.include(edittagtext, "Test1", "Edit tag 1 should read 'Test1'");
-            });
-      },
+         "Check the first edit tag reads 'Test1'": function() {
+            return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type")
+               .getVisibleText()
+               .then(function (edittagtext){
+                  assert.include(edittagtext, "Test1", "Edit tag 1 should read 'Test1'");
+               });
+         },
 
-      "Check there are 2 edit tags now shown": function() {
-         return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type span.tagDelete")
-            .click()
-         .end()
+         "Check there are 2 edit tags now shown": function() {
+            return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type span.tagDelete")
+               .click()
+            .end()
 
-         .findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
-            .then(function (edittags){
-               assert.lengthOf(edittags, 2, "There should be 2 edittags now shown");
-            });
-      },
+            .findAllByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag")
+               .then(function (edittags){
+                  assert.lengthOf(edittags, 2, "There should be 2 edittags now shown");
+               });
+         },
 
-      "Check the first edit tag now reads 'Test2'": function() {
-         return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type")
-            .getVisibleText()
-            .then(function (edittagtext){
-               assert.include(edittagtext, "Test2", "Edit tag 1 should now read 'Test2'");
-            })
-         .end()
+         "Check the first edit tag now reads 'Test2'": function() {
+            return browser.findByCssSelector("#TAGS_4 span.alfresco-renderers-EditTag:first-of-type")
+               .getVisibleText()
+               .then(function (edittagtext){
+                  assert.include(edittagtext, "Test2", "Edit tag 1 should now read 'Test2'");
+               })
+            .end()
 
-         // Click the cancel button
-         .findByCssSelector("#TAGS_4 span.action:nth-of-type(2)")
-            .click()
-         .end();
-      },
+            // Click the cancel button
+            .findByCssSelector("#TAGS_4 span.action:nth-of-type(2)")
+               .click()
+            .end();
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Tags Tests (inline creation and save)",
+      return {
+         name: "Tags Tests (inline creation and save)",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Tags", "Tags Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Tags", "Tags Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "There should be no read only tags initially": function() {
-         return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-ReadOnlyTag")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "There should be no tags initially");
-            })
-            .clearLog();
-      },
+         "There should be no read only tags initially": function() {
+            return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-ReadOnlyTag")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "There should be no tags initially");
+               })
+               .clearLog();
+         },
 
-      "Navigate to a node with no tags and edit it": function() {
-         // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
-         // An immediate request for existing tags should be made
-         return browser.pressKeys([keys.TAB])
-            .pressKeys([keys.TAB])
-            .pressKeys([keys.TAB])
-            .pressKeys([keys.CONTROL, "e"])
-            .pressKeys(keys.NULL)
+         "Navigate to a node with no tags and edit it": function() {
+            // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
+            // An immediate request for existing tags should be made
+            return browser.pressKeys([keys.TAB])
+               .pressKeys([keys.TAB])
+               .pressKeys([keys.TAB])
+               .pressKeys([keys.CONTROL, "e"])
+               .pressKeys(keys.NULL)
+               .end()
+               .getLastPublish("ALF_RETRIEVE_CURRENT_TAGS", "No request made for existing tag data");
+         },
+
+         "Type a new tag name and hit enter to create it": function() {
+            return browser.pressKeys("tag1")
+               .pressKeys(keys.ENTER)
+               .getLastXhr("aikau/proxy/alfresco/api/tag/workspace/SpacesStore")
+               .then(function(xhr){
+                  assert.propertyVal(xhr.request.body, "name", "tag1");
+               });
+         },
+
+         "New tag should be displayed": function() {
+            return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-EditTag")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Should be displaying the tag just created");
+               });
+         },
+
+         "Hit return to save the node with the new tag": function() {
+            return browser.pressKeys([keys.ENTER])
+               .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/d91128af-3b99-4710-95b6-a858eb090418/formprocessor")
+               .then(function(xhr){
+                  assert.propertyVal(xhr.request.body, "node.properties.cm:taggable", "workspace://SpacesStore/6619a771-5e35-40be-8c08-2f4791d9a056");
+               });
+         },
+
+         "The updated tag should be displayed in read-only mode": function() {
+            return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-ReadOnlyTag")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Should be displaying the tag just created");
+               });
+         },
+
+         "The document-tagged event should have fired": function() {
+            return browser.findByCssSelector("body")
+               .getLastPublish("ALF_DOCUMENT_TAGGED");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Tags Tests (hidden actions)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Tags", "Tags Tests (hidden actions)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Navigate to a node with no tags and edit it": function() {
+            // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
+            // An immediate request for existing tags should be made
+            return browser.pressKeys([keys.TAB])
+               .pressKeys([keys.TAB])
+               .pressKeys([keys.CONTROL, "e"])
+               .pressKeys(keys.NULL)
             .end()
-            .getLastPublish("ALF_RETRIEVE_CURRENT_TAGS", "No request made for existing tag data");
-      },
 
-      "Type a new tag name and hit enter to create it": function() {
-         return browser.pressKeys("tag1")
-            .pressKeys(keys.ENTER)
-            .getLastXhr("aikau/proxy/alfresco/api/tag/workspace/SpacesStore")
-            .then(function(xhr){
-               assert.propertyVal(xhr.request.body, "name", "tag1");
-            });
-      },
+            .findDisplayedById("TAGS_2_EDIT_TAGS_CONTROL");
+         },
 
-      "New tag should be displayed": function() {
-         return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-EditTag")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Should be displaying the tag just created");
-            });
-      },
+         "Check that actions are not displayed": function() {
+            return browser.findByCssSelector("#TAGS_2 .action.save")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Save action should not be shown");
+               })
+            .end()
 
-      "Hit return to save the node with the new tag": function() {
-         return browser.pressKeys([keys.ENTER])
-            .getLastXhr("aikau/proxy/alfresco/api/node/workspace/SpacesStore/d91128af-3b99-4710-95b6-a858eb090418/formprocessor")
-            .then(function(xhr){
-               assert.propertyVal(xhr.request.body, "node.properties.cm:taggable", "workspace://SpacesStore/6619a771-5e35-40be-8c08-2f4791d9a056");
-            });
-      },
+            .findByCssSelector("#TAGS_2 .action.cancel")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "Save action should not be shown");
+               });
+         },
 
-      "The updated tag should be displayed in read-only mode": function() {
-         return browser.findAllByCssSelector("#TAGS_3 .alfresco-renderers-ReadOnlyTag")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Should be displaying the tag just created");
-            });
-      },
-
-      "The document-tagged event should have fired": function() {
-         return browser.findByCssSelector("body")
-            .getLastPublish("ALF_DOCUMENT_TAGGED");
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Tags.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Tags.get.js
@@ -26,7 +26,8 @@ model.jsonModel = {
          name: "alfresco/renderers/Tags",
          config: {
             propertyToRender: "node.properties.cm:taggable",
-            permissionProperty: null
+            permissionProperty: null,
+            showOkCancelActions: false
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-715 to make it possible to configure the alfresco/renderers/Tags widget hide the "Save" and "Cancel" actions displayed in edit mode.