### PR TITLE
AKU-679: Aikau Form elements are producing some Wave accessibility alerts

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -948,6 +948,26 @@ define(["dojo/_base/declare",
       validationInProgressAltText: "validation.inprogress.alttext",
 
       /**
+       * The local image to use for a validation-error indicator.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.47
+       */
+      validationErrorImg: "error-16.png",
+
+      /**
+       * The alt-text label to use for the validation-error indicator.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.47
+       */
+      validationErrorAltText: "validation.error.alttext",
+
+      /**
        * The local image to use for the inline help indicator.
        *
        * @instance
@@ -989,7 +1009,17 @@ define(["dojo/_base/declare",
          {
             this.validationInProgressImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.validationInProgressImg;
          }
-         this.validationInProgressAltText = this.message(this.validationInProgressAltText);
+         this.validationInProgressAltText = this.message(this.validationInProgressAltText, {
+            0: this.message(this.label)
+         });
+
+         if (!this.validationErrorImgSrc)
+         {
+            this.validationErrorImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.validationErrorImg;
+         }
+         this.validationErrorAltText = this.message(this.validationErrorAltText, {
+            0: this.message(this.label)
+         });
 
          if (!this.inlineHelpImgSrc)
          {
@@ -1647,8 +1677,7 @@ define(["dojo/_base/declare",
       showValidationFailure: function alfresco_forms_controls_BaseFormControl__showValidationFailure() {
          if (this.showValidationErrorsImmediately || this._hadFocus)
          {
-            domClass.add(this._validationIndicator, "validation-error");
-            domClass.add(this._validationMessage, "display");
+            domClass.add(this.domNode, "alfresco-forms-controls-BaseFormControl--invalid");
          }
          else
          {
@@ -1665,8 +1694,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       hideValidationFailure: function alfresco_forms_controls_BaseFormControl__hideValidationFailure() {
-         domClass.remove(this._validationIndicator, "validation-error");
-         domClass.remove(this._validationMessage, "display");
+         domClass.remove(this.domNode, "alfresco-forms-controls-BaseFormControl--invalid");
          this._pendingValidationFailureDisplay = false;
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -1,180 +1,158 @@
-.claro .dijitMenu {
-   border-color: @standard-border-color;
+// Override base Dojo styles
+.claro {
+   .dijitMenu {
+      border-color: @standard-border-color;
+   }
+   .dijitSelect .dijitInputField, .dijitTextBox .dijitInputField {
+      padding: 2px 4px;
+   }
 }
 
-.claro .dijitSelect .dijitInputField,
-.claro .dijitTextBox .dijitInputField {
-   padding: 2px 4px;
-}
-
+// Main CSS
 .alfresco-forms-controls-BaseFormControl {
    margin-bottom: @standard-line-height;
+   > .description-row {
+      max-width: @dialog-control-section;
+      > .description {
+         color: @de-emphasized-font-color;
+         font-size: @small-font-size;
+         line-height: ceil(@small-font-size/@standard-line-height) * @standard-line-height;
+         margin: 0 0 @standard-line-height 0;
+      }
+   }
+   &.hiddenlabel > .title-row {
+      height: 0;
+      left: -999em;
+      position: absolute;
+   }
+   > .control-row {
+      display: inline-block;
+   }
+   > .control-row > .control {
+      display: inline-block;
+      margin-right: 5px;
+   }
+   > .title-row {
+      display: block;
+      > label {
+         display: inline-block;
+         font-size: @normal-font-size;
+         line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
+      }
+      > .requirementIndicator {
+         display: none;
+         &.required {
+            display: inline-block;
+         }
+      }
+      > .validation {
+         display: none;
+      }
+      > img.validationInProgress {
+         height: 16px;
+         margin: 2px 0;
+         vertical-align: top;
+         width: 16px;
+         &.hidden {
+            display: none;
+         }
+      }
+      > img.inlineHelp {
+         cursor: pointer;
+         height: 16px;
+         margin: 2px 0;
+         vertical-align: top;
+         width: 16px;
+         &.hidden {
+            display: none;
+         }
+      }
+      > .validation-error {
+         background: url("./images/error-16.png");
+         background-repeat: no-repeat;
+         display: inline-block;
+         height: 16px;
+         margin: 0 4px;
+         width: 16px;
+      }
+      > .validation-message {
+         color: #ed2525;
+         display: none;
+         font-size: @normal-font-size - 3;
+         margin: 0;
+         width: @dialog-label-section;
+         &.display {
+            display: inline-block;
+         }
+      }
+   }
+   > .units {
+      margin-top: 5px;
+   }
+   > .clear-both {
+      clear: both;
+   }
+   &.long > .control-row > div.control > div {
+      width: 472px;
+   }
+   div.control {
+      div.dijitComboBox.dijitTextBoxHover, .dijitTextBoxHover, .dijitTextAreaHover, .dijitTextBoxFocused, .dijitTextAreaFocused, .dijitTextBoxActive, .dijitTextAreaActive {
+         background-color: inherit;
+         background-image: none;
+         border-color: @hover-border-color;
+      }
+      .dijitPlaceHolder {
+         color: @de-emphasized-font-color;
+         font-style: normal;
+      }
+      div.dijitComboBox {
+         border-color: @standard-border-color;
+      }
+      div.dijitComboBox.dijitTextBoxFocused, .dijitActive, .dijitFocused {
+         border-color: @focused-border-color;
+      }
+   }
 }
 
-.alfresco-forms-controls-BaseFormControl > .description-row {
-   max-width: @dialog-control-section;
+// Special layout
+.unmargined {
+   .alfresco-forms-controls-BaseFormControl {
+      margin-bottom: 0;
+      > .clear-both {
+         height: 0;
+      }
+   }
 }
 
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl {
-   min-width: @dialog-control-section + 2;
-}
-
-.alfresco-forms-controls-BaseFormControl > .description-row > .description {
-   font-size: @small-font-size;
-   line-height: ceil(@small-font-size/@standard-line-height) * @standard-line-height;
-   margin: 0 0 @standard-line-height 0;
-   color: @de-emphasized-font-color;
-}
-
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .description-row > .description {
-   margin: 0 0 @standard-line-height @dialog-label-section + 4;
-}
-
-.alfresco-forms-controls-BaseFormControl > .control-row {
-   display: inline-block;
-}
-
-.alfresco-forms-controls-BaseFormControl > .control-row > .control {
-   margin-right: 5px;
-   display: inline-block;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row {
-   display: block;
-}
-
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .title-row {
-   display: inline;
-   float: left;
-   width: @dialog-label-section - 4;
-   text-align: right;
-   margin-right: 8px;
-   margin-top: 2px;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > label {
-   font-size: @normal-font-size;
-   line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
-   display: inline-block;
-}
-
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form > .alfresco-forms-controls-BaseFormControl > .title-row > label:after {
-   content: ":";
-}
-
-.alfresco-forms-controls-BaseFormControl.hiddenlabel > .title-row {
-   position: absolute;
-   left: -999em;
-   height: 0;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > .requirementIndicator {
-   display: none;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > .requirementIndicator.required {
-   display: inline-block;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > .validation {
-   display: none;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > img.validationInProgress {
-   width: 16px;
-   height: 16px;
-   margin: 2px 0;
-   vertical-align: top;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > img.validationInProgress.hidden {
-   display: none;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > img.inlineHelp {
-   width: 16px;
-   height: 16px;
-   margin: 2px 0;
-   vertical-align: top;
-   cursor: pointer;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > img.inlineHelp.hidden {
-   display: none;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > .validation-error {
-   background: url("./images/error-16.png");
-   display: inline-block;
-   height: 16px;
-   width: 16px;
-   background-repeat: no-repeat;
-   margin: 0 4px;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > .validation-message {
-   display: none;
-   width: @dialog-label-section;
-   color: #ED2525;
-   font-size: @normal-font-size - 3;
-   margin: 0;
-}
-
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .title-row > .validation-message {
-   margin: 7px 0 0 -5px;
-}
-
-.alfresco-forms-controls-BaseFormControl > .title-row > .validation-message.display {
-   display: inline-block;
-}
-
-.alfresco-dialog-AlfDialog .dialog-body .alfresco-forms-Form.root-dialog-form > form >  .alfresco-forms-controls-BaseFormControl > .title-row > .validation-message.display {
-   display: block;
-}
-
-.alfresco-forms-controls-BaseFormControl > .units {
-   margin-top: 5px;
-}
-
-.alfresco-forms-controls-BaseFormControl > .clear-both {
-   clear: both;
-}
-
-.unmargined .alfresco-forms-controls-BaseFormControl{
-   margin-bottom: 0;
-}
-
-.unmargined .alfresco-forms-controls-BaseFormControl > .clear-both {
-   height: 0;
-}
-
-.alfresco-forms-controls-BaseFormControl.long > .control-row > div.control > div {
-   width: 472px;
-}
-
-.alfresco-forms-controls-BaseFormControl div.control div.dijitComboBox.dijitTextBoxHover,
-.alfresco-forms-controls-BaseFormControl div.control .dijitTextBoxHover,
-.alfresco-forms-controls-BaseFormControl div.control .dijitTextAreaHover,
-.alfresco-forms-controls-BaseFormControl div.control .dijitTextBoxFocused,
-.alfresco-forms-controls-BaseFormControl div.control .dijitTextAreaFocused,
-.alfresco-forms-controls-BaseFormControl div.control .dijitTextBoxActive,
-.alfresco-forms-controls-BaseFormControl div.control .dijitTextAreaActive {
-   border-color: @hover-border-color;
-   background-image: none;
-   background-color: inherit;
-}
-
-.alfresco-forms-controls-BaseFormControl div.control .dijitPlaceHolder {
-   font-style: normal;
-   color: @de-emphasized-font-color;
-}
-
-.alfresco-forms-controls-BaseFormControl div.control div.dijitComboBox {
-   border-color: @standard-border-color;
-}
-
-.alfresco-forms-controls-BaseFormControl div.control div.dijitComboBox.dijitTextBoxFocused,
-.alfresco-forms-controls-BaseFormControl div.control .dijitActive,
-.alfresco-forms-controls-BaseFormControl div.control .dijitFocused {
-   border-color: @focused-border-color;
+// Customised layout within dialog
+.alfresco-dialog-AlfDialog {
+   .dialog-body {
+      .alfresco-forms-Form.root-dialog-form {
+         > form {
+            > .alfresco-forms-controls-BaseFormControl {
+               min-width: @dialog-control-section + 2;
+               > .description-row > .description {
+                  margin: 0 0 @standard-line-height @dialog-label-section + 4;
+               }
+               > .title-row {
+                  display: inline;
+                  float: left;
+                  margin-right: 8px;
+                  margin-top: 2px;
+                  text-align: right;
+                  width: @dialog-label-section - 4;
+                  > label:after {
+                     content: ":";
+                  }
+                  > .validation-message {
+                     margin: 7px 0 0 -5px;
+                     &.display {
+                        display: block;
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -11,6 +11,24 @@
 // Main CSS
 .alfresco-forms-controls-BaseFormControl {
    margin-bottom: @standard-line-height;
+   // BEM CSS
+   &__validation-error {
+      display: none;
+      height: 16px;
+      margin: 0 4px;
+      width: 16px;
+   }
+   &--invalid {
+      > .title-row {
+         > .alfresco-forms-controls-BaseFormControl__validation-error {
+            display: inline-block;
+         }
+         > span.validation-message {
+            display: inline-block;
+         }
+      }
+   }
+   // Legacy CSS
    > .description-row {
       max-width: @dialog-control-section;
       > .description {
@@ -45,9 +63,6 @@
             display: inline-block;
          }
       }
-      > .validation {
-         display: none;
-      }
       > img.validationInProgress {
          height: 16px;
          margin: 2px 0;
@@ -67,23 +82,12 @@
             display: none;
          }
       }
-      > .validation-error {
-         background: url("./images/error-16.png");
-         background-repeat: no-repeat;
-         display: inline-block;
-         height: 16px;
-         margin: 0 4px;
-         width: 16px;
-      }
       > .validation-message {
          color: #ed2525;
          display: none;
          font-size: @normal-font-size - 3;
          margin: 0;
          width: @dialog-label-section;
-         &.display {
-            display: inline-block;
-         }
       }
    }
    > .units {
@@ -131,6 +135,13 @@
          > form {
             > .alfresco-forms-controls-BaseFormControl {
                min-width: @dialog-control-section + 2;
+               &--invalid {
+                  > .title-row {
+                     > span.validation-message {
+                        display: block;
+                     }
+                  }
+               }
                > .description-row > .description {
                   margin: 0 0 @standard-line-height @dialog-label-section + 4;
                }
@@ -146,9 +157,6 @@
                   }
                   > .validation-message {
                      margin: 7px 0 0 -5px;
-                     &.display {
-                        display: block;
-                     }
                   }
                }
             }

--- a/aikau/src/main/resources/alfresco/forms/controls/i18n/BaseFormControl.properties
+++ b/aikau/src/main/resources/alfresco/forms/controls/i18n/BaseFormControl.properties
@@ -1,3 +1,4 @@
 validation.control.invalid=invalid
-validation.inprogress.alttext=Validating
+validation.error.alttext=Error validating '{0}'
+validation.inprogress.alttext=Validating '{0}'
 inlinehelp.alttext=Click for more information about {0}.

--- a/aikau/src/main/resources/alfresco/forms/controls/templates/BaseFormControl.html
+++ b/aikau/src/main/resources/alfresco/forms/controls/templates/BaseFormControl.html
@@ -1,7 +1,7 @@
 <div class="alfresco-forms-controls-BaseFormControl wipe" data-dojo-attach-point="containerNode">
    <div data-dojo-attach-point="_titleRowNode" class="title-row">
       <img class="validationInProgress hidden" src="${validationInProgressImgSrc}" alt="${validationInProgressAltText}" data-dojo-attach-point="_validationInProgressIndicator">
-      <span class="validation" data-dojo-attach-point="_validationIndicator">&nbsp;</span>
+      <img class="alfresco-forms-controls-BaseFormControl__validation-error" src="${validationErrorImgSrc}" alt="${validationErrorAltText}" data-dojo-attach-point="_validationErrorIndicator">
       <img class="inlineHelp hidden" src="${inlineHelpImgSrc}" alt="${inlineHelpAltText}" data-dojo-attach-point="_inlineHelpIndicator" data-dojo-attach-event="ondijitclick:showInlineHelp">
       <label class="label" data-dojo-attach-point="_labelNode"></label>
       <span class="requirementIndicator" data-dojo-attach-point="_requirementIndicator">*</span>

--- a/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
@@ -41,28 +41,17 @@ registerSuite(function(){
          browser.end();
       },
 
-      "Check that first form does NOT show validation errors on load": function() {
-         return browser.findAllByCssSelector("#TB1 .validation-error")
+      "Check that first form is NOT displayed as invalid on load": function() {
+         return browser.findAllByCssSelector("#TB1.alfresco-forms-controls-BaseFormControl--invalid")
             .then(function(elements) {
-               assert.lengthOf(elements, 0, "The error icon should not have been displayed (TB1)");
+               assert.lengthOf(elements, 0, "The form control should not be marked as invalid (TB1)");
             })
          .end()
-         .findByCssSelector("#TB1 .validation-message")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The error message should not have been displayed (TB1)");
-            })
-         .end()
-         .findAllByCssSelector("#TB2 .validation-error")
+         .findAllByCssSelector("#TB2.alfresco-forms-controls-BaseFormControl--invalid")
             .then(function(elements) {
-               assert.lengthOf(elements, 0, "The error icon should not have been displayed (TB1)");
+               assert.lengthOf(elements, 0, "The form control should not be marked as invalid (TB2)");
             })
          .end()
-         .findByCssSelector("#TB2 .validation-message")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The error message should not have been displayed (TB2)");
-            });
       },
 
       "Check that first form confirmation button is disabled": function() {
@@ -72,70 +61,59 @@ registerSuite(function(){
             });
       },
 
-      "Check that seoond form DOES show validation errors on load": function() {
-         return browser.findByCssSelector("#TB3 .validation-error")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB3)");
-            })
+      "Check that second form IS displayed as invalid on load": function() {
+         return browser.findByCssSelector("#TB3.alfresco-forms-controls-BaseFormControl--invalid")
          .end()
+         .findByCssSelector("#TB4.alfresco-forms-controls-BaseFormControl--invalid");
+      },
+
+      "Error indicators are only shown when form is invalid": function() {
+         return browser.findByCssSelector("#TB1 .alfresco-forms-controls-BaseFormControl__validation-error")
+            .isDisplayed()
+            .then(function(isDisplayed) {
+               assert.isFalse(isDisplayed, "Error image was shown on valid form control");
+            })
+            .end()
+            
+         .findByCssSelector("#TB1 .validation-message")
+            .isDisplayed()
+            .then(function(isDisplayed) {
+               assert.isFalse(isDisplayed, "Error message was shown on valid form control");
+            })
+            .end()
+
+         .findByCssSelector("#TB3 .alfresco-forms-controls-BaseFormControl__validation-error")
+            .isDisplayed()
+            .then(function(isDisplayed) {
+               assert.isTrue(isDisplayed, "Error image was not shown on invalid form control");
+            })
+            .end()
+            
          .findByCssSelector("#TB3 .validation-message")
             .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB3)");
-            })
-         .end()
-         .findByCssSelector("#TB4 .validation-error")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB4)");
-            })
-         .end()
-         .findByCssSelector("#TB4 .validation-message")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB4)");
+            .then(function(isDisplayed) {
+               assert.isTrue(isDisplayed, "Error message was not shown on invalid form control");
             });
       },
 
-      "Give and remove focus to first text field and verify error message is displayed": function() {
+      "Give and remove focus to first text field and verify control is marked as invalid": function() {
          return browser.findByCssSelector("#TB1 .dijitInputContainer input")
             .click()
          .end()
          .findByCssSelector("#TB2 .dijitInputContainer input")
             .click()
          .end()
-         .findByCssSelector("#TB1 .validation-error")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB1)");
-            })
-         .end()
-         .findByCssSelector("#TB1 .validation-message")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB1)");
-            });
+         .findByCssSelector("#TB1.alfresco-forms-controls-BaseFormControl--invalid");
       },
 
-      "Remove focus from second text field and verify error message is displayed": function() {
+      "Remove focus from second text field and verify control is marked as invalid": function() {
          return browser.findByCssSelector("#TB3 .dijitInputContainer input")
             .click()
          .end()
-         .findByCssSelector("#TB2 .validation-error")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error icon SHOULD have been displayed (TB2)");
-            })
-         .end()
-         .findByCssSelector("#TB2 .validation-message")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "The error message SHOULD have been displayed (TB2)");
-            });
+         .findByCssSelector("#TB2.alfresco-forms-controls-BaseFormControl--invalid");
       },
 
-      "Make third text field valid and then remove focus and verify that error indicator is not displayed": function() {
+      "Make third text field valid and then remove focus and verify that control is not marked as invalid": function() {
          return browser.findByCssSelector("#TB5 .dijitInputContainer input")
             .clearValue()
             .type("abcde")
@@ -143,15 +121,9 @@ registerSuite(function(){
          .findByCssSelector("#TB3 .dijitInputContainer input")
             .click()
          .end()
-         .findAllByCssSelector("#TB5 .validation-error")
+         .findAllByCssSelector("#TB5.alfresco-forms-controls-BaseFormControl--invalid")
             .then(function(elements) {
-               assert.lengthOf(elements, 0, "The error icon should NOT have been displayed (TB5)");
-            })
-         .end()
-         .findByCssSelector("#TB5 .validation-message")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The error message should NOT have been displayed (TB5)");
+               assert.lengthOf(elements, 0, "The control should not be marked as invalid (TB5)");
             });
       },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
@@ -167,17 +167,14 @@ registerSuite(function(){
             .clearValue()
             .end()
 
-         .findAllByCssSelector("#NS1 .validation-error")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Standard number spinner should not permit empty values");
-            })
+         .findByCssSelector("#NS1.alfresco-forms-controls-BaseFormControl--invalid")
             .end()
 
          .findByCssSelector("#NS7 .dijitInputContainer input")
             .clearValue()
             .end()
 
-         .findAllByCssSelector("#NS7 .validation-error")
+         .findAllByCssSelector("#NS7.alfresco-forms-controls-BaseFormControl--invalid")
             .then(function(elements) {
                assert.lengthOf(elements, 0, "'permitEmpty' number spinner should allow empty values");
             });

--- a/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
@@ -305,11 +305,7 @@ registerSuite(function(){
       },
 
       "Check validation error indicator": function() {
-         return browser.findByCssSelector("#HAS_VALIDATION_CONFIG span.validation")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Validation error indicator should be displayed");
-            });
+         return browser.findByCssSelector("#HAS_VALIDATION_CONFIG.alfresco-forms-controls-BaseFormControl--invalid");
       },
 
       "Check validation error message": function() {
@@ -328,11 +324,7 @@ registerSuite(function(){
          return browser.findByCssSelector("#HAS_VALIDATION_CONFIG .dijitInputContainer input")
             .type("x")
          .end()
-         .findByCssSelector("#HAS_VALIDATION_CONFIG span.validation")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Validation error indicator should be displayed for non-numeric");
-            });
+         .findByCssSelector("#HAS_VALIDATION_CONFIG.alfresco-forms-controls-BaseFormControl--invalid");
       },
 
       "Check validation indicator is hidden (non-numeric)": function() {
@@ -340,10 +332,9 @@ registerSuite(function(){
             .type(keys.BACKSPACE)
             .type("1234")
          .end()
-         .findByCssSelector("#HAS_VALIDATION_CONFIG span.validation")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Validation error indicator should be hidden for numeric entry");
+         .findAllByCssSelector("#HAS_VALIDATION_CONFIG.alfresco-forms-controls-BaseFormControl--invalid")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -17,6 +17,7 @@ model.jsonModel = {
    widgets: [
       {
          name: "alfresco/forms/Form",
+         id: "TEST_FORM",
          config: {
             widgets: [
                {
@@ -140,9 +141,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };


### PR DESCRIPTION
This pull-request addresses [AKU-679](https://issues.alfresco.com/jira/browse/AKU-679) by adjusting the template of the BaseFormControl to customise the alt-text for images by control. A full regression suite has been run successfully.

It may be easier to view CSS changes by looking at the second commit below individually, as the first commit makes no changes to the CSS directly, but does reformat it all to "LESSify" it.