### PR TITLE
AKU-717: Add support for TinyMCE editor to auto resize

### DIFF
--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -265,9 +265,16 @@ define(["dojo/_base/declare",
             if (this._editorInitialized)
             {
                // Work our way back up through the current node ancestors to find
-               // the first ancestor that have height and width set on them
+               // the first ancestors that have height and width set on them. Height
+               // and width do not need to come from the same node, but we only want
+               // to take the first values we find of each (i.e. if we find a height but
+               // not a width, don't take the height from the node that we DO find a width
+               // on later)...
                var height, width;
                $(this.domNode).parents().each(function() {
+                  // Check the style attribute returned by the JQuery function to see if
+                  // height/width is set... then get the actual height/width of that
+                  // element.
                   var style = $(this).attr("style");
                   if (!height && style && style.indexOf("height:") !== -1)
                   {
@@ -277,6 +284,7 @@ define(["dojo/_base/declare",
                   {
                      width = $(this).width();
                   }
+                  // When both height and width have been set exit the loop...
                   if (height && width)
                   {
                      return false;

--- a/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
@@ -32,6 +32,17 @@ define(["alfresco/forms/controls/BaseFormControl",
    return declare([BaseFormControl], {
       
       /**
+       * This indicates whether or not the [TinyMCE editor]{@link module:alfresco/editors/TinyMCE}
+       * should automatically resize to consume the available space.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.47
+       */
+      autoResize: false,
+
+      /**
        * Returns the configuration to use for the widget.
        *
        * @instance
@@ -44,7 +55,8 @@ define(["alfresco/forms/controls/BaseFormControl",
             initiallyDisabled: (this.disablementConfig && this.disablementConfig.initialValue === true),
             immediateInit: false,
             contentChangeScope: this,
-            contentChangeHandler: this.onEditorValueChange
+            contentChangeHandler: this.onEditorValueChange,
+            autoResize: this.autoResize
          };
       },
       

--- a/aikau/src/main/resources/alfresco/renderers/CommentsList.js
+++ b/aikau/src/main/resources/alfresco/renderers/CommentsList.js
@@ -72,24 +72,6 @@ define(["dojo/_base/declare",
       addCommentsPadding: 0,
 
       /**
-       * Executed after properties mixed in and before widget created
-       *
-       * @instance
-       * @override
-       * @since 1.0.43
-       */
-      postMixInProperties: function alfresco_renderers_CommentsList__postMixInProperties() {
-         this.inherited(arguments);
-         if (this.addCommentsFullScreen) {
-            var addCommentPayload = lang.getObject("widgets.0.config.widgetsBefore.0.config.publishPayload", false, this);
-            if(addCommentPayload) {
-               addCommentPayload.fullScreenMode = true;
-               addCommentPayload.fullScreenPadding = this.addCommentsPadding;
-            }
-         }
-      },
-      
-      /**
        * Widget has been started, but not necessarily any sub-widgets.
        * 
        * @instance
@@ -131,6 +113,8 @@ define(["dojo/_base/declare",
                               url: "api/node/{node.nodeRef}/comments",
                               pubSubScope: "{pubSubScope}"
                            },
+                           fullScreenMode: "{addCommentsFullScreen}",
+                           fullScreenPadding: "{addCommentsPadding}",
                            additionalCssClasses: "no-padding tinymce-dialog",
                            fixedWidth: true,
                            dialogWidth: "540px",
@@ -138,7 +122,8 @@ define(["dojo/_base/declare",
                               {
                                  name: "alfresco/forms/controls/TinyMCE",
                                  config: {
-                                    name: "content"
+                                    name: "content",
+                                    autoResize: "{addCommentsFullScreen}"
                                  }
                               }
                            ]

--- a/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
@@ -293,6 +293,15 @@ define(["intern!object",
                   assert.equal(dialog.y, 0, "Dialog top was not zero");
                })
 
+            // See AKU-717...
+            .findByCssSelector(".alfresco-editors-TinyMCE")
+               .getSize()
+               .then(function(size) {
+                  assert.isAbove(size.height, 250, "Height of editor did now grow to consume dialog space");
+                  assert.isAbove(size.width, 538, "Height of editor did now grow to consume dialog space");
+               })
+            .end()
+
             .findByCssSelector(".cancellationButton .dijitButtonNode")
                .click()
                .end()


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-717 to make it possible to the TinyMCE editor to automatically grow to take up available space. In particular this is focused around the full screen commenting support for CommentsList.