### PR TITLE
AKU-743: Delegate resize calls to child widgets

### DIFF
--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewThumbnailSizingTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewThumbnailSizingTest.js
@@ -51,6 +51,16 @@ define(["intern!object",
                });
          },
 
+         // See AKU-743 - The thumbnail is wrapped in a tooltip and we need to ensure that the tooltip
+         //               delegates resize calls onto its child widgets...
+         "Check the thumbnail size": function() {
+            return browser.findByCssSelector("#TOOLIP_ITEM_0 .alfresco-renderers-Thumbnail")
+               .getSize()
+               .then(function(size) {
+                  assert.equal(size.width, 400, "Thumbnail was not sized by outer tooltip widget");
+               });
+         },
+
          "Increase thumbnail size to decrease columns": function() {
             // Increasing the thumbnail size (using the slider) should re-render the grid
             // so that there is only a single column of thumbnails

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/GalleryViewThumbnailSizing.get.js
@@ -26,9 +26,32 @@ model.jsonModel = {
             additionalControlsTarget: "TOOLBAR",
             widgets: [
                {
+                  id: "VIEW",
                   name: "alfresco/documentlibrary/views/AlfGalleryView",
                   config: {
-                     resizeByColumnCount: false
+                     resizeByColumnCount: false,
+                     widgets: [
+                        {
+                           id: "TOOLIP",
+                           name: "alfresco/misc/AlfTooltip",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "THUMBNAIL",
+                                    name: "alfresco/renderers/GalleryThumbnail"
+                                 }
+                              ],
+                              widgetsForTooltip: [
+                                 {
+                                    name: "alfresco/html/Label",
+                                    config: {
+                                       label: "This is the tooltip content"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
                   }
                }
             ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-743 to ensure that the alfresco/misc/AlfTooltip widget will delegate any resize functions to the widgets that it wraps. This ensures that when widgets in a grid are wrapped by a tooltip that they can be resized correctly. An existing unit test has been updated to verify this fix and prevent future regressions.