### PR TITLE
AKU-732 & AKU-745: AlfBreadcrumbTrail updates

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -510,6 +510,7 @@ define([],function() {
        * @property {string} url - The URL to navigate to
        * @property {string} [type=module:alfresco/enums/urlTypes#PAGE_RELATIVE] - The [type of navigation]{@link module:alfresco/enums/urlTypes#PAGE_RELATIVE}
        * @property {string} [target=CURRENT"] - Whether to use the current tab ("CURRENT") or open in a new tab ("NEW")
+       * @property {string} [modifyCurrent=false] Whether to modify the current hash (default is to completely replace it)
        */
       NAVIGATE_TO_PAGE: "ALF_NAVIGATE_TO_PAGE",
 

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -379,7 +379,8 @@ define(["dojo/_base/declare",
                config.publishPayload = {
                   url: "path=" + (path || "/"),
                   type: "HASH",
-                  target: "CURRENT"
+                  target: "CURRENT",
+                  modifyCurrent: true
                };
                config.publishGlobal = true;
             }

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -94,7 +94,7 @@ define(["dojo/_base/declare",
        * @param {string} hashString An optional string to use as the hash. If not provided the current hash will be
        */
       initialiseFilter: function alfresco_documentlibrary_AlfHashMixin__intialiseFilter(hashString) {
-         hashString && hashUtils.setHashString(hashString);
+         hashString && hashUtils.setHash(hashString);
          this.onHashChange(hashUtils.getHashString());
       },
       

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -149,7 +149,7 @@ define(["dojo/_base/declare",
 
                if (hashString)
                {
-                  hashUtils.setHashString(hashString);
+                  hashUtils.setHash(hashString);
                }
                else if (this.currentFilter)
                {

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -168,7 +168,7 @@ define(["dojo/_base/declare",
                // Determine the location of the URL...
                if (data.type === urlTypes.HASH)
                {
-                  hashUtils.setHashString(url);
+                  hashUtils[data.modifyCurrent ? "updateHash" : "setHash"](url);
                }
                else if (!data.target || data.target === this.currentTarget)
                {

--- a/aikau/src/main/resources/alfresco/util/hashUtils.js
+++ b/aikau/src/main/resources/alfresco/util/hashUtils.js
@@ -46,14 +46,8 @@ define(["dojo/_base/array",
       },
 
       // See API below
-      setHash: function alfresco_util_hashUtils__setHash(hashObj, replace) {
-         var hashObjToUse = lang.clone(hashObj),
-            hashString = ioQuery.objectToQuery(hashObjToUse);
-         this.setHashString(hashString, replace);
-      },
-
-      // See API below
-      setHashString: function alfresco_util_hashUtils__setHashString(hashString, replace) {
+      setHash: function alfresco_util_hashUtils__setHash(newHash, replace) {
+         var hashString = (typeof newHash === "string") ? newHash : ioQuery.objectToQuery(newHash);
          hash(hashString, replace);
       },
 
@@ -61,13 +55,14 @@ define(["dojo/_base/array",
       updateHash: function alfresco_util_hashUtils__updateHash(newValues, replace, force) {
          var currHash = this.getHash(),
             newHash = lang.mixin({}, currHash),
+            valuesToUse = typeof newValues === "string" ? ioQuery.queryToObject(newValues) : newValues,
             hashName,
             newHashValue,
             currHashValue,
             hashChanged;
-         for (hashName in newValues) {
-            if (newValues.hasOwnProperty(hashName)) {
-               newHashValue = newValues[hashName];
+         for (hashName in valuesToUse) {
+            if (valuesToUse.hasOwnProperty(hashName)) {
+               newHashValue = valuesToUse[hashName];
                currHashValue = currHash[hashName];
                if (typeof newHashValue === "undefined" || newHashValue === null) {
                   delete newHash[hashName];
@@ -121,7 +116,7 @@ define(["dojo/_base/array",
        *
        * @instance
        * @function
-       * @param {Object} hashObj The new hash object
+       * @param {object|string} hash The new hash
        * @param {boolean} [replace] Replace the current hash, rather than changing
        *                            (i.e. do not add to the history)
        */
@@ -135,8 +130,9 @@ define(["dojo/_base/array",
        * @param {string} hashString The new hash string
        * @param {boolean} [replace] Replace the current hash, rather than changing
        *                            (i.e. do not add to the history)
+       * @deprecated Since 1.0.48 - Use [hashUtils.setHash()]@{link module:alfresco/util/hashUtils#setHash} instead
        */
-      setHashString: lang.hitch(util, util.setHashString),
+      setHashString: lang.hitch(util, util.setHash),
 
       /**
        * Update the current hash (by default, this will not do the update if the


### PR DESCRIPTION
This addresses [AKU-745](https://issues.alfresco.com/jira/browse/AKU-745) and [AKU-732](https://issues.alfresco.com/jira/browse/AKU-732) by changing NavigationService to modify rather than replace the current hash when a certain flag is passed. The changes also fix the escaping bug. Have also improved hashUtils slightly. Full regression suite run successfully.