### PR TITLE
AKU-687: Add "primary-call-to-action" CSS class for button

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -25,6 +25,7 @@
  * <p>The following additionalCssClasses are built in and can be included if required:</p>
  * <ul>
  * <li><strong>call-to-action</strong>: The AlfButton is rendered in call-to-action colours</li>
+ * <li><strong>primary-call-to-action</strong>: The AlfButton is rendered in primary-call-to-action colours</li>
  * <li><strong>biggerBolder</strong>: The AlfButton is rendered with a bigger, bold font</li>
  * </ul>
  *

--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -56,7 +56,7 @@
          opacity: .5;
       }
    }
-   &.call-to-action {
+   &.call-to-action, &.primary-call-to-action {
       background: @call-to-action-button-background;
       border: @call-to-action-button-border;
       border-radius: @call-to-action-button-border-radius;
@@ -93,9 +93,21 @@
          }
       }
    }
+   &.primary-call-to-action {
+      background: @primary-call-to-action-button-background;
+      border: @primary-call-to-action-button-border;
+      &.dijitButtonFocused, &.dijitButtonHover {
+         background: @primary-call-to-action-button-background-focus;
+         border: @primary-call-to-action-button-border-focus;
+      }
+      &.dijitButtonActive {
+         background: @primary-call-to-action-button-background-active;
+         border: @primary-call-to-action-button-border-active;
+      }
+   }
    &.biggerBolder .dijitButtonText {
       font-family: @bold-font;
-      font-weight: @standard-button-font-weight;
       font-size: @large-font-size;
+      font-weight: @standard-button-font-weight;
    }
 }

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -120,7 +120,7 @@
 @hover-border-color: #d3d3d3;
 @focused-border-color: #8dc63f;
 @thick-border-width: 3px;
-@upload-highlight-border: 3px dashed #6BA969;
+@upload-highlight-border: 3px dashed #6ba969;
 
 // Button (colours)
 @button-color-background: #fff;
@@ -128,6 +128,9 @@
 @button-color-hover: #135fa3;
 @button-color-active: #125380;
 @button-color-disabled: #b8b8b8;
+@primary-call-to-action-default: #47aa42;
+@primary-call-to-action-hover: #358032;
+@primary-call-to-action-active: #2c6a29;
 @legacy-button-color: #ccc;
 @legacy-button-color-text: @general-font-color;
 @legacy-action-button-color: #8dc63f;
@@ -184,6 +187,14 @@
 @call-to-action-button-padding: @call-to-action-button-padding-vertical @call-to-action-button-padding-horizontal;
 @call-to-action-button-margin: @standard-button-margin;
 
+// "Primary call-to-action" buttons are first among equals
+@primary-call-to-action-button-background: @primary-call-to-action-default;
+@primary-call-to-action-button-background-focus: @primary-call-to-action-hover;
+@primary-call-to-action-button-background-active: @primary-call-to-action-active;
+@primary-call-to-action-button-border: @call-to-action-button-border-width @call-to-action-button-border-style @primary-call-to-action-default;
+@primary-call-to-action-button-border-focus: @call-to-action-button-border-width @call-to-action-button-border-style @primary-call-to-action-hover;
+@primary-call-to-action-button-border-active: @call-to-action-button-border-width @call-to-action-button-border-style @primary-call-to-action-active;
+
 // The radius textbox is a modifier to the standard textbox
 @radius-textbox-border-radius: 3px;
 
@@ -208,7 +219,7 @@
 // Shadows
 @standard-box-shadow: .33px 2px 8px rgba(0, 0, 0, .3);
 @inset-box-shadow: 1px 1px 3px #ccc inset;
-@selection-box-shadow: 0px 0px 25px 5px #ffaa00;
+@selection-box-shadow: 0px 0px 25px 5px #fa0;
 
 // Thumbnails
 @thumbnail-width: 100px;

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
@@ -119,6 +119,58 @@ model.jsonModel = {
                   }
                },
                {
+                  name: "alfresco/layout/HorizontalWidgets",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "primary-call-to-action",
+                              label: "Default",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "primary-call-to-action dijitButtonHover",
+                              label: "Hover",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "primary-call-to-action dijitButtonActive",
+                              label: "Pressed",
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        },
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              additionalCssClasses: "primary-call-to-action",
+                              label: "Disabled",
+                              disabled: true,
+                              publishTopic: "BUTTON_TOPIC",
+                              publishPayload: {
+                                 foo: "bar"
+                              }
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
                   name: "alfresco/forms/SingleTextFieldForm",
                   config: {
                      okButtonLabel: "Search",


### PR DESCRIPTION
This addresses [AKU-687](https://issues.alfresco.com/jira/browse/AKU-687) by adding a new primary-call-to-action class which mirrors the call-to-action class but with altered background/border colors. Test page updated. No automated tests required.

__Please do not merge yet. Waiting for review of changes__