### PR TITLE
AKU-739: Tree refresh on add or delete content

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -126,6 +126,33 @@ define([],function() {
        */
       CLOUD_AUTHENTICATION_SUCCESS: "ALF_CLOUD_AUTHENTICATION_SUCCESS",
 
+
+      /**
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.48
+       *
+       * @event
+       */
+      CONTENT_CREATED: "ALF_CONTENT_CREATED",
+
+      /**
+       * This is fired when content is deleted (typically by the [ContentService]{@link module:alfresco/services/ContentService})
+       * and was added to that [trees]{@link module:alfresco/navigation/PathTree} would be able to refresh themselves
+       * following content deletion.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.48
+       *
+       * @event
+       * @property {string[]} nodeRef The nodeRefs of the content that has been deleted.
+       */
+      CONTENT_DELETED: "ALF_CONTENT_DELETED",
+
       /**
        * This topic is published to launch the copying or moving of a node (or nodes) to another location.
        *

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -126,8 +126,10 @@ define([],function() {
        */
       CLOUD_AUTHENTICATION_SUCCESS: "ALF_CLOUD_AUTHENTICATION_SUCCESS",
 
-
       /**
+       * This is fired when content is created (typically by the [ContentService]{@link module:alfresco/services/ContentService})
+       * and was added to that [trees]{@link module:alfresco/navigation/PathTree} would be able to refresh themselves
+       * following content creation.
        * 
        * @instance
        * @type {string}
@@ -135,6 +137,8 @@ define([],function() {
        * @since 1.0.48
        *
        * @event
+       * @property {string} parentNodeRef The nodeRef of the parent that the content was created within
+       * @property {string} nodeRef The nodeRef of the created content
        */
       CONTENT_CREATED: "ALF_CONTENT_CREATED",
 

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -114,9 +114,17 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response The response from the request
        * @param {object} originalRequestConfig The configuration passed on the original request
+       *
+       * @fires module:alfresco/core/topics#CONTENT_CREATED
+       * @fires module:alfresco/core/topics#RELOAD_DATA_TOPIC
        */
       onContentCreationSuccess: function alfresco_services_ContentService__onContentCreationSuccess(/*jshint unused:false*/ response, originalRequestConfig) {
          var responseScope = lang.getObject("data.alfResponseScope", false, originalRequestConfig) || "";
+
+         this.alfPublish(topics.CONTENT_CREATED, {
+            parentNodeRef: originalRequestConfig.data.alf_destination,
+            nodeRef: response.persistedObject
+         }, false, false, responseScope);
          this.alfPublish(this.reloadDataTopic, {}, false, false, responseScope);
       },
 

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -279,6 +279,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload
        * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
+       * @fires module:alfresco/core/topics#CONTENT_DELETED
+       * @fires module:alfresco/core/topics#RELOAD_DATA_TOPIC
        */
       onActionDeleteSuccess: function alfresco_services_ContentService__onActionDeleteSuccess(payload) {
          var subscriptionHandle = lang.getObject("requestConfig.subscriptionHandle", false, payload);
@@ -289,7 +291,10 @@ define(["dojo/_base/declare",
          this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
             message: this.message("contentService.delete.success.message")
          });
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {}, false, false, payload.requestConfig.responseScope);
+         this.alfPublish(topics.CONTENT_DELETED, {
+            nodeRefs: lang.getObject("requestConfig.data.nodeRefs", false, payload)
+         }, false, false, payload.requestConfig.responseScope);
+         this.alfPublish(topics.RELOAD_DATA_TOPIC, {}, false, false, payload.requestConfig.responseScope);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -159,6 +159,34 @@ define(["intern!object",
             return browser.findByCssSelector("#TREE2_TREE_workspace_SpacesStore_d56afdc3-0174-4f8c-bce8-977cafd712ab > .dijitTreeRowSelected");
          },
 
+         // See AKU-739 - Updates have been made to ensure that tree nodes can be refreshed on folder creation/deletion
+         //               The thing is to check that XHR requests are made to get the latest data
+         "Check tree node refresh on folder add": function() {
+            return browser.findById("ADD_FOLDER_label")
+                  .clearXhrLog()
+                  .click()
+               .end()
+
+               .getLastXhr()
+                  .then(function(xhr) {
+                     /* jshint maxlen:500*/
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                  });
+         },
+
+         "Check tree node refresh on folder delete": function() {
+            return browser.findById("DELETE_FOLDER_label")
+                  .clearXhrLog()
+                  .click()
+               .end()
+
+               .getLastXhr()
+                  .then(function(xhr) {
+                     /* jshint maxlen:500*/
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                  });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
@@ -51,6 +51,28 @@ model.jsonModel = {
                                           path: "/documentLibrary/Budget Files/Invoices/"
                                        }
                                     }
+                                 },
+                                 {
+                                    id: "ADD_FOLDER",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Add Folder",
+                                       publishTopic: "ALF_CONTENT_CREATED",
+                                       publishPayload: {
+                                          parentNodeRef: "workspace://SpacesStore/8ab12916-4897-47fb-94eb-1ab699822ecb"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "DELETE_FOLDER",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Delete Folder",
+                                       publishTopic: "ALF_CONTENT_DELETED",
+                                       publishPayload: {
+                                          nodeRefs: ["workspace://SpacesStore/d56afdc3-0174-4f8c-bce8-977cafd712ab"] 
+                                       }
+                                    }
                                  }
                               ]
                            }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-739 to ensure that the alfresco/navigation/PathTree will refresh nodes when content related to them is added or deleted.