### PR TITLE
AKU-749: Changed label for search result count to remove <b> tags

### DIFF
--- a/aikau/src/main/resources/alfresco/html/i18n/Label.properties
+++ b/aikau/src/main/resources/alfresco/html/i18n/Label.properties
@@ -1,0 +1,3 @@
+# See AKU-749: This is a workaround for Alfresco 5.0.1 & 5.0.2 using Aikau versions 1.0.46 or greater
+#              This label 
+faceted-search.results-menu.results-found-patch={0} - results found

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -733,7 +733,7 @@ define(["dojo/_base/declare",
             // Publish the number of search results found...
             this.alfPublish("ALF_SEARCH_RESULTS_COUNT", {
                count: resultsCount,
-               label: this.message("faceted-search.results-menu.results-found", {
+               label: this.message("faceted-search.results-menu.results-found-patch", {
                   0: resultsCount
                })
             });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-749 to change the label and remove the bold tags from the search result count