### PR TITLE
AKU-741: Added widgetsForDataFailureDisplay attribute to AlfList

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -36,6 +36,7 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/core/topics",
+        "alfresco/core/WidgetsCreator",
         "alfresco/lists/SelectedItemStateMixin",
         "alfresco/core/DynamicWidgetProcessingTopics",
         "alfresco/lists/views/AlfListView",
@@ -46,7 +47,7 @@ define(["dojo/_base/declare",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/io-query"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, topics, SelectedItemStateMixin,
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, topics, WidgetsCreator, SelectedItemStateMixin,
                  DynamicWidgetProcessingTopics, AlfDocumentListView, AlfCheckableMenuItem, aspect, array, lang, domConstruct, 
                  domClass, ioQuery) {
 
@@ -360,6 +361,17 @@ define(["dojo/_base/declare",
       widgets: null,
 
       /**
+       * An optional JSON model defining the widgets to display when an error occurs attempting to
+       * load data to display.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.48
+       */
+      widgetsForDataFailureDisplay: null,
+
+      /**
        * Use to keeps track of the [view]{@link module:alfresco/lists/views/AlfListView} that is currently selected.
        *
        * @instance
@@ -367,6 +379,19 @@ define(["dojo/_base/declare",
        * @default
        */
       _currentlySelectedView: null,
+
+      /**
+       * A flag to indicate whether or not the 
+       * [widgetsForDataFailureDisplay]{@link module:alfresco/lists/AlfList#widgetsForDataFailureDisplay}
+       * have been rendered. This prevents them from being repeatedly set. It should not be explicitly
+       * configured in the list - it is for internal use only.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.48
+       */
+      _dataFailureWidgetsRendered: false,
 
       /**
        * @instance
@@ -968,6 +993,16 @@ define(["dojo/_base/declare",
       showDataLoadFailure: function alfresco_lists_AlfList__showDataLoadFailure() {
          this.hideChildren(this.domNode);
          domClass.remove(this.dataFailureNode, "share-hidden");
+
+         if (this.widgetsForDataFailureDisplay && !this._dataFailureWidgetsRendered)
+         {
+            var wc = new WidgetsCreator({
+               widgets: this.widgetsForDataFailureDisplay
+            });
+            domConstruct.empty(this.dataFailureNode);
+            wc.buildWidgets(this.dataFailureNode);
+            this._dataFailureWidgetsRendered = true;
+         }
       },
 
       /**
@@ -1206,8 +1241,6 @@ define(["dojo/_base/declare",
          // Hide any messages
          this.hideLoadingMessage();
       },
-
-      
 
       /**
        * Publishes the details of the documents that have been loaded (primarily for multi-selection purposes)

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -109,7 +109,9 @@ define(["dojo/_base/declare",
 
       /**
        * This can be set to be a custom message that is displayed when there are no items to
-       * be displayed in the current view.
+       * be displayed in the current view. This will not be used if 
+       * [widgetsForNoDataDisplay]{@link module alfresco/lists/views/ListRenderer#widgetsForNoDataDisplay}
+       * is configured.
        *
        * @instance
        * @type {string}

--- a/aikau/src/test/resources/alfresco/lists/views/HtmlListViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/HtmlListViewTest.js
@@ -22,86 +22,85 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "HtmlListView Tests",
-      
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/HtmlListView", "HtmlListView Tests").end();
-      },
-      
-      beforeEach: function() {
-         browser.end();
-      },
+      return {
+         name: "HtmlListView Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/HtmlListView", "HtmlListView Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Count the list elements (DEFAULTS)": function() {
-         return browser.findAllByCssSelector("#DEFAULTS.alfresco-lists-AlfList li")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "Unexpected number of li elements found");
-            });
-      },
+         "Count the list elements (DEFAULTS)": function() {
+            return browser.findAllByCssSelector("#DEFAULTS.alfresco-lists-AlfList li")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "Unexpected number of li elements found");
+               });
+         },
 
-      "Check the properties have been rendered correctly (DEFAULTS)": function() {
-         // Just check a couple...
-         return browser.findByCssSelector("#DEFAULTS.alfresco-lists-AlfList li:nth-child(1)")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "bob", "First item rendered incorrectly");
-            })
-         .end()
-         .findByCssSelector("#DEFAULTS.alfresco-lists-AlfList li:nth-child(4)")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "trevor", "Last item rendered incorrectly");
-            });
-      },
+         "Check the properties have been rendered correctly (DEFAULTS)": function() {
+            // Just check a couple...
+            return browser.findByCssSelector("#DEFAULTS.alfresco-lists-AlfList li:nth-child(1)")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "bob", "First item rendered incorrectly");
+               })
+            .end()
+            .findByCssSelector("#DEFAULTS.alfresco-lists-AlfList li:nth-child(4)")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "trevor", "Last item rendered incorrectly");
+               });
+         },
 
-      "Check that the list style is overridden (DEFAULTS)": function() {
-         return browser.findAllByCssSelector(".alfresco-lists-AlfList li[style=\"list-style-type:none\"]")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "List style type not overridden");
-            });
-      },
+         "Check that the list style is overridden (DEFAULTS)": function() {
+            return browser.findAllByCssSelector(".alfresco-lists-AlfList li[style=\"list-style-type:none\"]")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "List style type not overridden");
+               });
+         },
 
-      "Count the list elements (OVERRIDES)": function() {
-         return browser.findAllByCssSelector("#OVERRIDES.alfresco-lists-AlfList li")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "Unexpected number of li elements found");
-            });
-      },
+         "Count the list elements (OVERRIDES)": function() {
+            return browser.findAllByCssSelector("#OVERRIDES.alfresco-lists-AlfList li")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "Unexpected number of li elements found");
+               });
+         },
 
-      "Check the properties have been rendered correctly (OVERRIDES)": function() {
-         // Just check a couple...
-         return browser.findByCssSelector("#OVERRIDES.alfresco-lists-AlfList li:nth-child(1)")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "one", "First item rendered incorrectly");
-            })
-         .end()
-         .findByCssSelector("#OVERRIDES.alfresco-lists-AlfList li:nth-child(4)")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "four", "Last item rendered incorrectly");
-            });
-      },
+         "Check the properties have been rendered correctly (OVERRIDES)": function() {
+            // Just check a couple...
+            return browser.findByCssSelector("#OVERRIDES.alfresco-lists-AlfList li:nth-child(1)")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "one", "First item rendered incorrectly");
+               })
+            .end()
+            .findByCssSelector("#OVERRIDES.alfresco-lists-AlfList li:nth-child(4)")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "four", "Last item rendered incorrectly");
+               });
+         },
 
-      "Check that the list style is overridden (OVERRIDES)": function() {
-         return browser.findAllByCssSelector(".alfresco-lists-AlfList li[style=\"list-style-type:square\"]")
-            .then(function(elements) {
-               assert.lengthOf(elements, 4, "List style type not overridden");
-            });
-      },
+         "Check that the list style is overridden (OVERRIDES)": function() {
+            return browser.findAllByCssSelector(".alfresco-lists-AlfList li[style=\"list-style-type:square\"]")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4, "List style type not overridden");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/lists/views/ViewNoDataWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/ViewNoDataWidgetsTest.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "View With No Data Widgets Tests",
+         
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ViewNoDataWidgets", "View With No Data Widgets Tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "No data widgets displayed": function() {
+            return browser.findDisplayedById("NO_DATA_WARNING");
+         },
+
+         "Data failure widgets displayed": function() {
+            return browser.findDisplayedById("DATA_FAIL_WARNING");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -185,6 +185,7 @@ define({
       "src/test/resources/alfresco/lists/views/GalleryViewFocusTest",
       "src/test/resources/alfresco/lists/views/GalleryViewInfiniteScrollTest",
       "src/test/resources/alfresco/lists/views/HtmlListViewTest",
+      "src/test/resources/alfresco/lists/views/ViewNoDataWidgetsTest",
       "src/test/resources/alfresco/lists/views/layouts/EditableRowTest",
       "src/test/resources/alfresco/lists/views/layouts/RowTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfListView (widgetsForNoDataDisplay)</shortname>
+  <description>This shows how a view can include a custom model to render when there is no data</description>
+  <family>aikau-unit-tests</family>
+  <url>/ViewNoDataWidgets</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.js
@@ -1,0 +1,99 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "A list with no data",
+            widgets: [
+               {
+                  id: "LIST_NO_DATA",
+                  name: "alfresco/lists/AlfList",
+                  config: {
+                     pubSubScope: "NO_DATA_",
+                     currentData: {
+                        items: []
+                     },
+                     widgets: [
+                        {
+                           id: "VIEW1",
+                           name: "alfresco/lists/views/AlfListView",
+                           config: {
+                              widgetsForNoDataDisplay: [
+                                 {
+                                    id: "NO_DATA_WARNING",
+                                    name: "alfresco/header/Warning",
+                                    config: {
+                                       warnings: [
+                                          {
+                                             message: "No data to display!",
+                                             level: 1
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "A list that fails to get data",
+            widgets: [
+               {
+                  id: "LIST_FAILED_DATA",
+                  name: "alfresco/lists/AlfSortablePaginatedList",
+                  config: {
+                     pubSubScope: "DATA_FAIL_",
+                     currentPageSize: 10,
+                     widgets: [
+                        {
+                           id: "VIEW2",
+                           name: "alfresco/lists/views/AlfListView"
+                        }
+                     ],
+                     widgetsForDataFailureDisplay: [
+                        {
+                           id: "DATA_FAIL_WARNING",
+                           name: "alfresco/header/Warning",
+                           config: {
+                              warnings: [
+                                 {
+                                    message: "Data could not be loaded!",
+                                    level: 1
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         // Note: just using any mock xhr service that will fail...
+         name: "aikauTesting/mockservices/DocumentLibraryMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-741 to add a new widgetsForDataFailureDisplay attribute to AlfList to render a custom widget model when data cannot be retrieved.