### PR TITLE
Feature/aikau and dojo cachebust

### DIFF
--- a/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
+++ b/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
@@ -71,7 +71,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_debug_WidgetInfo__postMixInProperties() {
-         this.imgSrc = require.toUrl("alfresco/debug") + "/css/images/info-16.png";
+         this.imgSrc = require.toUrl("alfresco/debug/css/images/info-16.png");
          if (this.displayId)
          {
             this.altText = this.message("widgetInfo.alt.text", {

--- a/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/dnd/DroppedItemWrapper.js
@@ -185,10 +185,10 @@ define(["dojo/_base/declare",
          this.downAltText = this.encodeHTML(this.message(this.downAltText));
          this.deleteAltText = this.encodeHTML(this.message(this.deleteAltText));
          this.editAltText = this.encodeHTML(this.message(this.editAltText));
-         this.upImageSrc = require.toUrl("alfresco/dnd") + "/css/images/" + this.upImg;
-         this.downImageSrc = require.toUrl("alfresco/dnd") + "/css/images/" + this.downImg;
-         this.editImageSrc = require.toUrl("alfresco/dnd") + "/css/images/" + this.editImg;
-         this.deleteImageSrc = require.toUrl("alfresco/dnd") + "/css/images/" + this.deleteImg;
+         this.upImageSrc = require.toUrl("alfresco/dnd/css/images/" + this.upImg);
+         this.downImageSrc = require.toUrl("alfresco/dnd/css/images/" + this.downImg);
+         this.editImageSrc = require.toUrl("alfresco/dnd/css/images/" + this.editImg);
+         this.deleteImageSrc = require.toUrl("alfresco/dnd/css/images/" + this.deleteImg);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -520,7 +520,7 @@ define(["dojo/_base/declare",
                }
                domConstruct.create("img", {
                   className: "alfresco-documentlibrary-_AlfDndDocumentUploadMixin__overlay__info__icon",
-                  src: require.toUrl("alfresco/documentlibrary/css/images/") + this.dndUploadHighlightImage
+                  src: require.toUrl("alfresco/documentlibrary/css/images/" + this.dndUploadHighlightImage)
                }, pNode);
             }
             

--- a/aikau/src/main/resources/alfresco/footer/AlfShareFooter.js
+++ b/aikau/src/main/resources/alfresco/footer/AlfShareFooter.js
@@ -133,7 +133,7 @@ define(["dojo/_base/declare",
              this.logoImageSrc == "alfresco-share-logo-team.png" ||
              this.logoImageSrc == "alfresco-share-logo.png")
          {
-            this.logoImageSrc = require.toUrl("alfresco/footer") + "/css/images/" + this.logoImageSrc;
+            this.logoImageSrc = require.toUrl("alfresco/footer/css/images/" + this.logoImageSrc);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1007,7 +1007,7 @@ define(["dojo/_base/declare",
 
          if (!this.validationInProgressImgSrc)
          {
-            this.validationInProgressImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.validationInProgressImg;
+            this.validationInProgressImgSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.validationInProgressImg);
          }
          this.validationInProgressAltText = this.message(this.validationInProgressAltText, {
             0: this.message(this.label)
@@ -1015,7 +1015,7 @@ define(["dojo/_base/declare",
 
          if (!this.validationErrorImgSrc)
          {
-            this.validationErrorImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.validationErrorImg;
+            this.validationErrorImgSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.validationErrorImg);
          }
          this.validationErrorAltText = this.message(this.validationErrorAltText, {
             0: this.message(this.label)
@@ -1023,7 +1023,7 @@ define(["dojo/_base/declare",
 
          if (!this.inlineHelpImgSrc)
          {
-            this.inlineHelpImgSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.inlineHelpImg;
+            this.inlineHelpImgSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.inlineHelpImg);
          }
          this.inlineHelpAltText = this.message(this.inlineHelpAltText, {
             0: this.message(this.label)

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryCreator.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryCreator.js
@@ -242,7 +242,7 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_forms_controls_MultipleEntryCreator__postMixInProperties() {
          if (this.addEntryImageSrc == null || this.addEntryImageSrc == "")
          {
-            this.addEntryImageSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.addEntryImage;
+            this.addEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.addEntryImage);
          }
          this.addEntryAltText = this.message(this.addEntryAltText);
       },

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElementWrapper.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElementWrapper.js
@@ -203,22 +203,22 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_forms_controls_MultipleEntryElementWrapper__postMixInProperties() {
          if (this.saveEntryImageSrc == null || this.saveEntryImageSrc == "")
          {
-            this.saveEntryImageSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.saveEntryImage;
+            this.saveEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.saveEntryImage);
          }
          this.saveEntryAltText = this.message(this.saveEntryAltText);
          if (this.cancelEditImageSrc == null || this.cancelEditImageSrc == "")
          {
-            this.cancelEditImageSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.cancelEditImage;
+            this.cancelEditImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.cancelEditImage);
          }
          this.cancelEditAltText = this.message(this.cancelEditAltText);
          if (this.deleteEntryImageSrc == null || this.deleteEntryImageSrc == "")
          {
-            this.deleteEntryImageSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.deleteEntryImage;
+            this.deleteEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.deleteEntryImage);
          }
          this.deleteEntryAltText = this.message(this.deleteEntryAltText);
          if (this.editEntryImageSrc == null || this.editEntryImageSrc == "")
          {
-            this.editEntryImageSrc = require.toUrl("alfresco/forms/controls") + "/css/images/" + this.editEntryImage;
+            this.editEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.editEntryImage);
          }
          this.editEntryAltText = this.message(this.editEntryAltText);
       },

--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -725,7 +725,7 @@ define(["dojo/_base/declare",
                         id: this.id + "_DROPDOWN_MENU",
                         showArrow: false,
                         label: "",
-                        iconSrc: require.toUrl("alfresco/header") + "/css/images/search-16-gray.png",
+                        iconSrc: require.toUrl("alfresco/header/css/images/search-16-gray.png"),
                         iconClass: "alf-search-icon",
                         widgets: [
                            {

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarItem.js
@@ -63,7 +63,7 @@ define(["dojo/_base/declare",
          {
             this.iconNode = domConstruct.create("img", {
                className: this.iconClass,
-               src: require.toUrl("alfresco/menus") + "/css/images/transparent-20.png",
+               src: require.toUrl("alfresco/menus/css/images/transparent-20.png"),
                alt: this.message(this.iconAltText),
                title: this.message(this.iconAltText),
                tabIndex: 0,

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
@@ -123,9 +123,9 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_menus_AlfMenuBarPopup__postCreate() {
          if (this.iconClass && this.iconClass !== "dijitNoIcon")
          {
-            this.iconNode = domConstruct.create("img", { 
-               className: this.iconClass, 
-               src: (this.iconSrc ? this.iconSrc : require.toUrl("alfresco/menus") + "/css/images/transparent-20.png"),
+            this.iconNode = domConstruct.create("img", {
+               className: this.iconClass,
+               src: (this.iconSrc ? this.iconSrc : require.toUrl("alfresco/menus/css/images/transparent-20.png")),
                title: this.message(this.iconAltText),
                alt: this.message(this.iconAltText),
                tabIndex: 0

--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -216,7 +216,7 @@ define(["dojo/_base/declare",
             this.iconNode = domConstruct.create("img", {
                role:"presentation",
                className: "dijitInline dijitIcon dijitMenuItemIcon " + this.iconClass,
-               src: require.toUrl("alfresco/menus") + "/css/images/transparent-20.png",
+               src: require.toUrl("alfresco/menus/css/images/transparent-20.png"),
                title: this.message(this.iconAltText),
                alt: this.message(this.iconAltText),
                tabIndex: 0

--- a/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
@@ -100,7 +100,7 @@ define(["dojo/_base/declare",
        * @returns {boolean}
        */
       getFolderImage: function alfresco_renderers_GalleryThumbnail__getDefaultFolderImage() {
-         return require.toUrl("alfresco/renderers") + "/css/images/folder-256.png";
+         return require.toUrl("alfresco/renderers/css/images/folder-256.png");
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/renderers/Indicators.js
+++ b/aikau/src/main/resources/alfresco/renderers/Indicators.js
@@ -207,7 +207,7 @@ define(["dojo/_base/declare",
             classes.push("has-action");
          }
          var img = domConstruct.create("img", {
-            "src": require.toUrl("alfresco/renderers") + "/css/images/indicators/" + indicator.icon,
+            "src": require.toUrl("alfresco/renderers/css/images/indicators/" + indicator.icon),
             "title": label,
             "alt": indicator.id,
             "class": classes.join(" ")

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -248,7 +248,7 @@ define(["dojo/_base/declare",
 
          if (!this.editIconImageSrc)
          {
-            this.editIconImageSrc = require.toUrl("alfresco/renderers") + "/css/images/edit-16.png";
+            this.editIconImageSrc = require.toUrl("alfresco/renderers/css/images/edit-16.png");
          }
 
          // Localize the labels and alt-text...

--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -93,11 +93,11 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_renderers_PublishAction__postMixInProperties() {
          if (this.iconClass)
          {
-            this.imageSrc = require.toUrl("alfresco/renderers") + "/css/images/" + this.iconClass + ".png";
+            this.imageSrc = require.toUrl("alfresco/renderers/css/images/" + this.iconClass + ".png");
          }
          else
          {
-            this.imageSrc = require.toUrl("alfresco/renderers") + "/css/images/add-icon-16.png";
+            this.imageSrc = require.toUrl("alfresco/renderers/css/images/add-icon-16.png");
          }
 
          // Localize the alt text...

--- a/aikau/src/main/resources/alfresco/renderers/Reorder.js
+++ b/aikau/src/main/resources/alfresco/renderers/Reorder.js
@@ -170,11 +170,11 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_renderers_Reorder__postMixInProperties() {
          if (this.upArrowImageSrc == null || this.upArrowImageSrc == "")
          {
-            this.upArrowImageSrc = require.toUrl("alfresco/renderers") + "/css/images/" + this.upArrowImg;
+            this.upArrowImageSrc = require.toUrl("alfresco/renderers/css/images/" + this.upArrowImg);
          }
          if (this.downArrowImageSrc == null || this.downArrowImageSrc == "")
          {
-            this.downArrowImageSrc = require.toUrl("alfresco/renderers") + "/css/images/" + this.downArrowImg;
+            this.downArrowImageSrc = require.toUrl("alfresco/renderers/css/images/" + this.downArrowImg);
          }
 
          // Localize the alt text...

--- a/aikau/src/main/resources/alfresco/renderers/SmallThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/SmallThumbnail.js
@@ -59,13 +59,13 @@ define(["dojo/_base/declare",
              jsNode = this.currentItem.jsNode;
          if (jsNode.isContainer || (jsNode.isLink && jsNode.linkedNode.isContainer))
          {
-            url = require.toUrl("alfresco/renderers") + "/css/images/filetypes/generic-folder-32.png";
+            url = require.toUrl("alfresco/renderers/css/images/filetypes/generic-folder-32.png");
             // TODO: DnD
          }
          else
          {
             var fileIcon = FileIconUtils.getFileIconByMimetype(this.currentItem.node.mimetype);
-            url = require.toUrl("alfresco/renderers") + "/css/images/filetypes/" + fileIcon;
+            url = require.toUrl("alfresco/renderers/css/images/filetypes/" + fileIcon);
             // TODO: Preview
          }
          return url;

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -532,7 +532,7 @@ define(["dojo/_base/declare",
             var nodeRef = NodeUtils.processNodeRef(this.currentItem.nodeRef);
             if (this.currentItem.type === "folder")
             {
-               this.thumbnailUrl = require.toUrl("alfresco/renderers") + "/css/images/" + this.folderImage;
+               this.thumbnailUrl = require.toUrl("alfresco/renderers/css/images/" + this.folderImage);
             }
             else if (this.currentItem.type === "document" && nodeRef.uri)
             {

--- a/aikau/src/main/resources/alfresco/search/FacetFilter.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilter.js
@@ -166,7 +166,7 @@ define(["dojo/_base/declare",
             this.appliedFilterAltText = this.message(this.appliedFilterAltText, {0: this.label});
 
             // Set the source for the image to use to indicate that a filter is applied...
-            this.appliedFilterImageSrc = require.toUrl("alfresco/search") + "/css/images/" + this.appliedFilterImageSrc;
+            this.appliedFilterImageSrc = require.toUrl("alfresco/search/css/images/" + this.appliedFilterImageSrc);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
@@ -94,35 +94,35 @@ define(["dojo/_base/declare",
          switch (this.currentItem.type)
          {
             case "blogpost":
-               url = require.toUrl("alfresco/search") + "/css/images/blog-post.png";
+               url = require.toUrl("alfresco/search/css/images/blog-post.png");
                break;
-   
+
             case "forumpost":
-               url = require.toUrl("alfresco/search") + "/css/images/topic-post.png";
+               url = require.toUrl("alfresco/search/css/images/topic-post.png");
                break;
-   
+
             case "calendarevent":
-               url = require.toUrl("alfresco/search") + "/css/images/calendar-event.png";
+               url = require.toUrl("alfresco/search/css/images/calendar-event.png");
                break;
-   
+
             case "wikipage":
-               url = require.toUrl("alfresco/search") + "/css/images/wiki-page.png";
+               url = require.toUrl("alfresco/search/css/images/wiki-page.png");
                break;
-   
+
             case "link":
-               url = require.toUrl("alfresco/search") + "/css/images/link.png";
+               url = require.toUrl("alfresco/search/css/images/link.png");
                break;
-   
+
             case "datalist":
-               url = require.toUrl("alfresco/search") + "/css/images/datalist.png";
+               url = require.toUrl("alfresco/search/css/images/datalist.png");
                break;
-   
+
             case "datalistitem":
-               url = require.toUrl("alfresco/search") + "/css/images/datalistitem.png";
+               url = require.toUrl("alfresco/search/css/images/datalistitem.png");
                break;
-   
+
             default:
-               url = require.toUrl("alfresco/search") + "/css/images/generic-result.png";
+               url = require.toUrl("alfresco/search/css/images/generic-result.png");
                break;
          }
          return url;

--- a/aikau/src/main/resources/alfresco/services/LightboxService.js
+++ b/aikau/src/main/resources/alfresco/services/LightboxService.js
@@ -75,8 +75,8 @@ define(["dojo/_base/declare",
             Alfresco.AikauLightbox.show({
                src: src,
                title: title,
-               loadingImage: require.toUrl("alfresco/services") + "/css/images/loading.gif",
-               closeButton: require.toUrl("alfresco/services") + "/css/images/close.gif"
+               loadingImage: require.toUrl("alfresco/services/css/images/loading.gif"),
+               closeButton: require.toUrl("alfresco/services/css/images/close.gif")
             });
          }
       }


### PR DESCRIPTION
Using Aikau with [Dojo's cache bust feature](https://dojotoolkit.org/documentation/tutorials/1.10/dojo_config) leads to invalid URLs to some static resources.

I was not able to open an issue on the Alfresco Jira against the Aikau project, hence description and code over here on GitHub.

###### Description

In many Aikau widgets the path to resources is appended to an URL generated by `require.toUrl`. However, when using cache bust Dojo already adds a query parameter to this URL. This leads to broken URLs such as:
`/aikau/res/js/aikau/1.0.48-SNAPSHOT/alfresco/footer?1450127564788/css/images/alfresco-share-logo.png`

I have added an extension JAR which enables cache busting for the test app to demonstrate the problem and fix, but I am not aware of an easy way to selectively load it for certain tests suites only.

###### License

(c) by Catalyst.net Ltd, submitted under the Apache License v2.