### PR TITLE
AKU-747: Create non-modal fixed position dialog

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -272,8 +272,29 @@ define([],function() {
        * @instance
        * @type {string}
        * @default
+       *
+       * @event
+       * @property {string} message The message to be displayed in the prompt
+       * @property {string} [title] The title of the prompt
        */
       DISPLAY_PROMPT: "ALF_DISPLAY_PROMPT",
+
+      /**
+       * This topic can be published to request that a [StickyPanel]{@link module:alfresco/layout/StickyPanel} be
+       * displayed. It is subscribed to by the [NotificationService]{@link module:alfresco/services/NotificationService}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.48
+       *
+       * @event
+       * @property {object[]} widgets The widgets to appear in the panel
+       * @property {string} [title=default.title] The title to display (uses i18n)
+       * @property {number} [padding=10] The padding to be applied to the widgets area
+       * @property {string|number} [width=50%] The width of the panel (CSS dimension or number of pixels)
+       */
+      DISPLAY_STICKY_PANEL: "DISPLAY_STICKY_PANEL",
 
       /**
        * Publish this to indicate the de-selection of an individual item
@@ -806,6 +827,36 @@ define([],function() {
        * @property {object[]} nodes The node or nodes to download.
        */
       SMART_DOWNLOAD: "ALF_SMART_DOWNLOAD",
+
+      /**
+       * This can be called to close the StickyPanel.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.48
+       */
+      STICKY_PANEL_CLOSE: "STICKY_PANEL_CLOSE",
+
+      /**
+       * This is fired when the StickyPanel has been closed.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.48
+       */
+      STICKY_PANEL_CLOSED: "STICKY_PANEL_CLOSED",
+
+      /**
+       * This can be called to set the title of the StickyPanel.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.48
+       */
+      STICKY_PANEL_SET_TITLE: "STICKY_PANEL_SET_TITLE",
 
       /**
        * This topic is published in order to make the actual request to sync a node or nodes

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -838,7 +838,7 @@ define([],function() {
        *
        * @event
        */
-      STICKY_PANEL_CLOSE: "STICKY_PANEL_CLOSE",
+      STICKY_PANEL_CLOSE: "ALF_STICKY_PANEL_CLOSE",
 
       /**
        * This is fired when the StickyPanel has been closed.
@@ -850,7 +850,7 @@ define([],function() {
        *
        * @event
        */
-      STICKY_PANEL_CLOSED: "STICKY_PANEL_CLOSED",
+      STICKY_PANEL_CLOSED: "ALF_STICKY_PANEL_CLOSED",
 
       /**
        * This can be called to set the title of the StickyPanel.
@@ -863,7 +863,7 @@ define([],function() {
        * @event
        * @property {string} title The new title to use
        */
-      STICKY_PANEL_SET_TITLE: "STICKY_PANEL_SET_TITLE",
+      STICKY_PANEL_SET_TITLE: "ALF_STICKY_PANEL_SET_TITLE",
 
       /**
        * This topic is published in order to make the actual request to sync a node or nodes

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -294,7 +294,7 @@ define([],function() {
        * @property {number} [padding=10] The padding to be applied to the widgets area
        * @property {string|number} [width=50%] The width of the panel (CSS dimension or number of pixels)
        */
-      DISPLAY_STICKY_PANEL: "DISPLAY_STICKY_PANEL",
+      DISPLAY_STICKY_PANEL: "ALF_DISPLAY_STICKY_PANEL",
 
       /**
        * Publish this to indicate the de-selection of an individual item
@@ -835,6 +835,8 @@ define([],function() {
        * @type {string}
        * @default
        * @since 1.0.48
+       *
+       * @event
        */
       STICKY_PANEL_CLOSE: "STICKY_PANEL_CLOSE",
 
@@ -845,6 +847,8 @@ define([],function() {
        * @type {string}
        * @default
        * @since 1.0.48
+       *
+       * @event
        */
       STICKY_PANEL_CLOSED: "STICKY_PANEL_CLOSED",
 
@@ -855,6 +859,9 @@ define([],function() {
        * @type {string}
        * @default
        * @since 1.0.48
+       *
+       * @event
+       * @property {string} title The new title to use
        */
       STICKY_PANEL_SET_TITLE: "STICKY_PANEL_SET_TITLE",
 

--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module alfresco/layout/StickyPanel
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/core/Core
+ * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @author Martin Doyle
+ */
+define([
+      "alfresco/core/Core",
+      "alfresco/core/CoreWidgetProcessing",
+      "dijit/_WidgetBase",
+      "dijit/_TemplatedMixin",
+      "dojo/_base/declare",
+      "dojo/dom-class",
+      "dojo/text!./templates/StickyPanel.html",
+   ],
+   function(AlfCore, CoreWidgetProcessing, _WidgetBase, _TemplatedMixin, declare, domClass, template) {
+
+      return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
+
+         /**
+          * An array of the CSS files to use with this widget
+          * 
+          * @instance
+          * @type {object[]}
+          * @default [{cssFile:"./css/StickyPanel.css"}]
+          */
+         cssRequirements: [{
+            cssFile: "./css/StickyPanel.css"
+         }],
+
+         /**
+          * The HTML template to use for the widget
+          * 
+          * @instance
+          * @type {string}
+          */
+         templateString: template,
+
+         /**
+          * The main class for this widget
+          *
+          * @instance
+          * @type {string}
+          * @default
+          */
+         baseClass: "alfresco-layout-StickyPanel",
+
+         /**
+          * The title to display in the title-bar of the panel
+          *
+          * @instance
+          * @type {string}
+          * @default
+          */
+         title: "Information panel",
+
+         /**
+          * Run after widget created, but before sub-widgets
+          *
+          * @instance
+          * @override
+          */
+         postCreate: function() {
+
+            // Extend the method
+            this.inherited(arguments);
+
+            // Move the widget to the root node
+            document.body.appendChild(this.domNode);
+
+            // Set the title
+            this.titleNode.appendChild(document.createTextNode(this.title));
+
+            // Add child widgets
+            this.processWidgets(this.widgets, this.widgetsNode);
+         },
+
+         onClickMinimiseRestore: function() {
+            domClass.toggle(this.domNode, this.baseClass + "--minimised");
+         }
+      });
+   });

--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -137,9 +137,11 @@ define(["alfresco/core/Core",
          this.inherited(arguments);
          this.setupSubscriptions();
          document.body.appendChild(this.domNode);
-         this.titleNode.textContent = this.title;
+         this.setTitle();
          this.widgets && this.processWidgets(this.widgets, this.widgetsNode);
-         this.widgetsPadding && domStyle.set(this.widgetsNode, "padding", this.widgetsPadding + "px");
+         if(this.widgetsPadding || this.widgetsPadding === 0) {
+            domStyle.set(this.widgetsNode, "padding", this.widgetsPadding + "px");
+         }
          this.sizePanel();
       },
 
@@ -185,15 +187,16 @@ define(["alfresco/core/Core",
       },
 
       /**
-       * Set the title of the panel.
+       * Set the title of the panel. If no payload or title is provided, then it will use
+       * the [title property]{@link module:alfresco/layout/StickyPanel#title}.
        *
        * @instance
        * @param {object} payload The payload containing the new title
        * @param {string} payload.title The new title
        */
       setTitle: function alfresco_layout_StickyPanel__setTitle(payload) {
-         var newTitle = (payload && payload.title && this.message(payload.title)) || "";
-         this.titleNode.textContent = newTitle;
+         var newTitle = (payload && payload.title) || this.title;
+         this.titleNode.textContent = this.message(newTitle);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -1,0 +1,58 @@
+.alfresco-layout-StickyPanel {
+   background: #fff;
+   border: 1px solid #07c;
+   border-bottom: 0;
+   border-radius: 3px 3px 0 0;
+   bottom: 0;
+   box-sizing: border-box;
+   min-width: 200px;
+   position: fixed;
+   right: 10%;
+   &__title-bar {
+      background: #07c;
+      color: #fff;
+      line-height: 28px;
+      padding: 0 70px 0 7px;
+      position: relative;
+      &__title {
+         font-size: 13px;
+      }
+      &__close, &__restore, &__minimise {
+         cursor: pointer;
+         display: block;
+         font-size: 20px;
+         position: absolute;
+      }
+      &__close {
+         right: 7px;
+         top: 0;
+      }
+      &__restore {
+         display: none;
+         right: 25px;
+         top: -5px;
+      }
+      &__minimise {
+         right: 25px;
+         top: 2px;
+      }
+   }
+   &__widgets {
+      padding: 7px;
+   }
+   &--minimised {
+      .alfresco-layout-StickyPanel {
+         &__title-bar {
+            &__restore {
+               display: block;
+            }
+            &__minimise {
+               display: none;
+            }
+         }
+         &__widgets {
+            display: none;
+         }
+      }
+   }
+}

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -1,21 +1,26 @@
 .alfresco-layout-StickyPanel {
-   background: #fff;
-   border: 1px solid #07c;
-   border-bottom: 0;
-   border-radius: 3px 3px 0 0;
    bottom: 0;
-   box-sizing: border-box;
-   min-width: 200px;
+   left: 50%;
    position: fixed;
-   right: 10%;
+   right: 0;
+   &__panel {
+      background: #fff;
+      border: 1px solid #07c;
+      border-bottom: 0;
+      border-radius: 3px 3px 0 0;
+      box-sizing: border-box;
+      left: -50%;
+      position: relative;
+   }
    &__title-bar {
       background: #07c;
       color: #fff;
       line-height: 28px;
-      padding: 0 70px 0 7px;
+      padding: 0 70px 0 10px;
       position: relative;
       &__title {
          font-size: 13px;
+         text-align: center;
       }
       &__close, &__restore, &__minimise {
          cursor: pointer;
@@ -24,24 +29,27 @@
          position: absolute;
       }
       &__close {
-         right: 7px;
+         right: 10px;
          top: 0;
       }
       &__restore {
          display: none;
-         right: 25px;
+         right: 35px;
          top: -5px;
       }
       &__minimise {
-         right: 25px;
+         right: 35px;
          top: 2px;
       }
    }
    &__widgets {
-      padding: 7px;
+      padding: 0;
    }
    &--minimised {
       .alfresco-layout-StickyPanel {
+         &__panel {
+            opacity: .8;
+         }
          &__title-bar {
             &__restore {
                display: block;

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -43,6 +43,8 @@
       }
    }
    &__widgets {
+      overflow-x: hidden;
+      overflow-y: auto;
       padding: 0;
    }
    &--minimised {

--- a/aikau/src/main/resources/alfresco/layout/i18n/StickyPanel.properties
+++ b/aikau/src/main/resources/alfresco/layout/i18n/StickyPanel.properties
@@ -1,0 +1,1 @@
+default.title=Information Panel

--- a/aikau/src/main/resources/alfresco/layout/templates/StickyPanel.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/StickyPanel.html
@@ -1,0 +1,9 @@
+<div class="${baseClass}">
+   <div class="${baseClass}__title-bar">
+      <div class="${baseClass}__title-bar__title" data-dojo-attach-point="titleNode"></div>
+      <div class="${baseClass}__title-bar__minimise" data-dojo-attach-point="minimiseButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
+      <div class="${baseClass}__title-bar__restore" data-dojo-attach-point="restoreButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
+      <div class="${baseClass}__title-bar__close" data-dojo-attach-point="closeButtonNode">&times;</div>
+   </div>
+   <div class="${baseClass}__widgets" data-dojo-attach-point="widgetsNode"></div>
+</div>

--- a/aikau/src/main/resources/alfresco/layout/templates/StickyPanel.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/StickyPanel.html
@@ -1,9 +1,11 @@
 <div class="${baseClass}">
-   <div class="${baseClass}__title-bar">
-      <div class="${baseClass}__title-bar__title" data-dojo-attach-point="titleNode"></div>
-      <div class="${baseClass}__title-bar__minimise" data-dojo-attach-point="minimiseButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
-      <div class="${baseClass}__title-bar__restore" data-dojo-attach-point="restoreButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
-      <div class="${baseClass}__title-bar__close" data-dojo-attach-point="closeButtonNode">&times;</div>
+   <div class="${baseClass}__panel" data-dojo-attach-point="panelNode">
+      <div class="${baseClass}__title-bar">
+         <div class="${baseClass}__title-bar__title" data-dojo-attach-point="titleNode"></div>
+         <div class="${baseClass}__title-bar__minimise" tabindex="0" data-dojo-attach-point="minimiseButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
+         <div class="${baseClass}__title-bar__restore" tabindex="0" data-dojo-attach-point="restoreButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
+         <div class="${baseClass}__title-bar__close" tabindex="0" data-dojo-attach-point="closeButtonNode" data-dojo-attach-event="dijitClick:onClickClose">&times;</div>
+      </div>
+      <div class="${baseClass}__widgets" data-dojo-attach-point="widgetsNode"></div>
    </div>
-   <div class="${baseClass}__widgets" data-dojo-attach-point="widgetsNode"></div>
 </div>

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -25,9 +25,14 @@
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
         "dojo/_base/lang",
+        "dojo/on",
+        "alfresco/layout/StickyPanel",
         "alfresco/notifications/AlfNotification",
         "alfresco/core/topics"],
-        function(declare, BaseService, lang, AlfNotification, topics) {
+        function(declare, BaseService, lang, on, StickyPanel, AlfNotification, topics) {
+
+   // We only ever allow one sticky panel currently
+   var theStickyPanel = null;
 
    return declare([BaseService], {
 
@@ -75,17 +80,20 @@ define(["dojo/_base/declare",
        * @instance
        * @since 1.0.32
        * @listens module:alfresco/services/NotificationService#displayNotificationTopic
+       * @listens module:alfresco/services/NotificationService#displayPromptTopic
+       * @listens module:alfresco/core/topics#DISPLAY_STICKY_PANEL
        */
       registerSubscriptions: function alfresco_services_NotificationService__registerSubscriptions() {
          this.alfSubscribe(this.displayNotificationTopic, lang.hitch(this, this.onDisplayNotification));
          this.alfSubscribe(this.displayPromptTopic, lang.hitch(this, this.onDisplayPrompt));
+         this.alfSubscribe(topics.DISPLAY_STICKY_PANEL, lang.hitch(this, this.onDisplayStickyPanel));
       },
 
       /**
        * Displays a notification to the user
        *
        * @instance
-       * @param {object} payload The The details of the notification.
+       * @param {object} payload The details of the notification.
        */
       onDisplayNotification: function alfresco_services_NotificationService__onDisplayNotification(payload) {
          var message = lang.getObject("message", false, payload);
@@ -106,10 +114,43 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Displays a sticky panel at the bottom of the screen.
+       *
+       * @instance
+       * @param {object} payload The details of the notification.
+       */
+      onDisplayStickyPanel: function alfresco_services_NotificationService__onDisplayStickyPanel(payload) {
+         if (theStickyPanel) {
+            this.alfLog("warn", "It was not possible to display the StickyPanel because one is already displayed", payload);
+            return;
+         }
+         if (payload.widgets) {
+            var panelOpts = {
+               widgets: payload.widgets
+            };
+            if(payload.title) {
+               panelOpts.title = payload.title;
+            }
+            if(payload.width) {
+               panelOpts.width = payload.width;
+            }
+            if(payload.padding || payload.padding === 0 || payload.padding === "0") {
+               panelOpts.padding = payload.padding;
+            }
+            theStickyPanel = new StickyPanel(panelOpts);
+            on(theStickyPanel, "destroy", function() {
+               theStickyPanel = null;
+            });
+         } else {
+            this.alfLog("warn", "It was not possible to display the StickyPanel because no suitable 'widgets' attribute was provided", payload);
+         }
+      },
+
+      /**
        * Displays a prompt to the user
        *
        * @instance
-       * @param {object} payload The The details of the notification.
+       * @param {object} payload The details of the notification.
        */
       onDisplayPrompt: function alfresco_services_NotificationService__onDisplayPrompt(payload) {
          var message = lang.getObject("message", false, payload);

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -118,29 +118,31 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload The details of the notification.
+       * @since 1.0.48
        */
       onDisplayStickyPanel: function alfresco_services_NotificationService__onDisplayStickyPanel(payload) {
+         var panelOpts = {},
+            closeSubscription;
          if (theStickyPanel) {
-            this.alfLog("warn", "It was not possible to display the StickyPanel because one is already displayed", payload);
+            this.alfLog("warn", "It was not possible to display a StickyPanel because one is already displayed", payload);
             return;
          }
          if (payload.widgets) {
-            var panelOpts = {
-               widgets: payload.widgets
-            };
+            panelOpts.widgets = payload.widgets
             if(payload.title) {
                panelOpts.title = payload.title;
             }
             if(payload.width) {
-               panelOpts.width = payload.width;
+               panelOpts.panelWidth = payload.width;
             }
-            if(payload.padding || payload.padding === 0 || payload.padding === "0") {
-               panelOpts.padding = payload.padding;
+            if(payload.padding || payload.padding === 0) {
+               panelOpts.widgetsPadding = payload.padding;
             }
             theStickyPanel = new StickyPanel(panelOpts);
-            on(theStickyPanel, "destroy", function() {
+            closeSubscription = this.alfSubscribe(topics.STICKY_PANEL_CLOSED, lang.hitch(this, function() {
                theStickyPanel = null;
-            });
+               this.alfUnsubscribe(closeSubscription);
+            }));
          } else {
             this.alfLog("warn", "It was not possible to display the StickyPanel because no suitable 'widgets' attribute was provided", payload);
          }

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -76,6 +76,105 @@ registerSuite(function(){
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification__message");
       },
 
+      "Can display sticky panel": function() {
+         return browser.findById("STICKY_PANEL_BUTTON")
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__title")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "My sticky panel title", "Did not display correct title in panel");
+            })
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel__widgets")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "This is some text to go inside the sticky panel", "Did not display correct content in panel");
+            });
+      },
+
+      "Can minimise and restore panel": function() {
+         return browser.findByCssSelector(".alfresco-layout-StickyPanel__title-bar__minimise")
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel--minimised .alfresco-layout-StickyPanel__widgets")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "", "Did not minimise panel");
+            })
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__restore")
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel .alfresco-layout-StickyPanel__widgets")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "This is some text to go inside the sticky panel", "Did not restore panel");
+            });
+      },
+
+      "Cannot open another panel while one already open": function() {
+         return browser.findById("STICKY_PANEL_BUTTON")
+            .click()
+            .end()
+
+         .findAllByCssSelector(".alfresco-layout-StickyPanel")
+            .then(function(elements) {
+               assert.lengthOf(elements, 1);
+            });
+      },
+
+      "Can close panel": function() {
+         return browser.findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("STICKY_PANEL_CLOSED")
+
+         .findAllByCssSelector(".alfresco-layout-StickyPanel")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            });
+      },
+
+      "Can open panel again": function() {
+         return browser.findById("STICKY_PANEL_BUTTON")
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel__widgets")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "This is some text to go inside the sticky panel");
+            });
+      },
+
+      "Changing panel title does not allow XSS injection": function() {
+         return browser.findById("UPDATE_PANEL_TITLE_BUTTON")
+            .click()
+            .end()
+
+         .execute(function() {
+               return window.hackedPanel ? "injected" : "safe";
+            })
+            .then(function(result) {
+               assert.equal(result, "safe", "XSS injection not prevented");
+            })
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__title")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "<img src=\"1\" onerror=\"window.hackedPanel=true\">");
+            });
+      },
+      
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -135,7 +135,7 @@ registerSuite(function(){
             .click()
             .end()
 
-         .getLastPublish("STICKY_PANEL_CLOSED")
+         .getLastPublish("ALF_STICKY_PANEL_CLOSED")
 
          .findAllByCssSelector(".alfresco-layout-StickyPanel")
             .then(function(elements) {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,8 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/NavigationServiceTest",
-      "src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest"
+      "src/test/resources/alfresco/services/NotificationServiceTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>StickyPanel</shortname>
+  <description>A test-page to exercise the alfresco/layout/StickyPanel widget</description>
+  <family>aikau-unit-tests</family>
+  <url>/StickyPanel</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -1,0 +1,34 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/layout/StickyPanel",
+         id: "STICKY_PANEL",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/html/Heading",
+                  id: "TEST_HEADING",
+                  config: {
+                     level: 3,
+                     label: "This is a heading"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -12,6 +12,14 @@ model.jsonModel = {
    ],
    widgets:[
       {
+         name: "alfresco/html/Heading",
+         id: "PAGE_HEADING",
+         config: {
+            level: 3,
+            label: "Page used for development only. This widget should be instantiated through the NotificationService."
+         }
+      },
+      {
          name: "alfresco/layout/StickyPanel",
          id: "STICKY_PANEL",
          config: {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -107,7 +107,7 @@ model.jsonModel = {
          id: "UPDATE_PANEL_TITLE_BUTTON",
          config: {
             label: "Update panel title (and check XSS)",
-            publishTopic: "STICKY_PANEL_SET_TITLE",
+            publishTopic: "ALF_STICKY_PANEL_SET_TITLE",
             publishPayload: {
                title: "<img src=\"1\" onerror=\"window.hackedPanel=true\">"
             }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -81,6 +81,39 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "STICKY_PANEL_BUTTON",
+         config: {
+            label: "Display sticky panel",
+            publishTopic: "ALF_DISPLAY_STICKY_PANEL",
+            publishPayload: {
+               title: "My sticky panel title",
+               width: 500,
+               padding: 0,
+               widgets: [
+                  {
+                     name: "alfresco/html/Heading",
+                     config: {
+                        label: "This is some text to go inside the sticky panel",
+                        level: 3
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "UPDATE_PANEL_TITLE_BUTTON",
+         config: {
+            label: "Update panel title (and check XSS)",
+            publishTopic: "STICKY_PANEL_SET_TITLE",
+            publishPayload: {
+               title: "<img src=\"1\" onerror=\"window.hackedPanel=true\">"
+            }
+         }
+      },
+      {
          name: "alfresco/html/Spacer",
          config: {
             height: "500px"
@@ -99,9 +132,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/DebugLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };


### PR DESCRIPTION
This addresses [AKU-747](https://issues.alfresco.com/jira/browse/AKU-747) and creates a fixed-position StickyPanel widget. Tests have been created accordingly.

Full suite has been run and only `src/test/resources/alfresco/dnd/NestedConfigurationTest` has any failures, which seems entirely unrelated to any of this work, so should be safe to merge. Would be good to have a look at the failures though, to see if there's a quick fix?