### PR TITLE
AKU-752: Add title attribute to button - Update control and tests

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -109,6 +109,16 @@ define(["dojo/_base/declare",
       invalidTopic: "ALF_INVALID_CONTROL",
 
       /**
+       * An optional title attribute to be added to the button.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.49
+       */
+      title: null,
+
+      /**
        * Extends the default implementation to check that the [publishPayload]{@link module:alfresco/buttons/AlfButton#publishPayload} attribute has been set
        * to something other null and if it hasn't initialises it to a new (empty) object.
        *
@@ -142,6 +152,10 @@ define(["dojo/_base/declare",
 
          if (!this.value && this.publishTopic) {
             this.valueNode.setAttribute("value", this.publishTopic);
+         }
+
+         if (this.title) {
+            this.focusNode.setAttribute("title", this.message(this.title));
          }
       },
 

--- a/aikau/src/test/resources/alfresco/forms/controls/ButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ButtonsTest.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+        "intern/chai!assert", 
+        "alfresco/TestCommon", 
+        "intern/dojo/node!leadfoot/keys"],
+        function(registerSuite, assert, TestCommon, keys) {
+
+   registerSuite(function() {
+      var browser;
+
+      return {
+         name: "Buttons Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Buttons", "Buttons Tests");
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Title attribute is set correctly": function() {
+            return browser.findById("DEFAULT_BUTTON")
+               .getAttribute("title")
+               .then(function(title) {
+                  assert.equal(title, "Custom title");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/services/NotificationServiceTest"
+      "src/test/resources/alfresco/forms/controls/ButtonsTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",
@@ -121,6 +121,7 @@ define({
       "src/test/resources/alfresco/forms/controls/AsyncFormControlLoadingTest",
       "src/test/resources/alfresco/forms/controls/AutoSetTest",
       "src/test/resources/alfresco/forms/controls/BaseFormTest",
+      "src/test/resources/alfresco/forms/controls/ButtonsTest",
       "src/test/resources/alfresco/forms/controls/CheckBoxTest",
       "src/test/resources/alfresco/forms/controls/CodeMirrorTest",
       "src/test/resources/alfresco/forms/controls/ComboBoxTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/Buttons.get.js
@@ -22,8 +22,10 @@ model.jsonModel = {
                      widgets: [
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "DEFAULT_BUTTON",
                            config: {
                               label: "Default",
+                              title: "Custom title",
                               publishTopic: "BUTTON_TOPIC",
                               publishPayload: {
                                  foo: "bar"
@@ -32,6 +34,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "DEFAULT_BUTTON_HOVER",
                            config: {
                               additionalCssClasses: "dijitButtonHover",
                               label: "Hover",
@@ -43,6 +46,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "DEFAULT_BUTTON_ACTIVE",
                            config: {
                               additionalCssClasses: "dijitButtonActive",
                               label: "Pressed",
@@ -54,6 +58,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "DEFAULT_BUTTON_DISABLED",
                            config: {
                               label: "Disabled",
                               disabled: true,
@@ -72,6 +77,7 @@ model.jsonModel = {
                      widgets: [
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "CALL_TO_ACTION_BUTTON",
                            config: {
                               additionalCssClasses: "call-to-action",
                               label: "Default",
@@ -83,6 +89,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "CALL_TO_ACTION_BUTTON_HOVER",
                            config: {
                               additionalCssClasses: "call-to-action dijitButtonHover",
                               label: "Hover",
@@ -94,6 +101,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "CALL_TO_ACTION_BUTTON_ACTIVE",
                            config: {
                               additionalCssClasses: "call-to-action dijitButtonActive",
                               label: "Pressed",
@@ -105,6 +113,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "CALL_TO_ACTION_BUTTON_DISABLED",
                            config: {
                               additionalCssClasses: "call-to-action",
                               label: "Disabled",
@@ -124,6 +133,7 @@ model.jsonModel = {
                      widgets: [
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "PRIMARY_CALL_TO_ACTION_BUTTON",
                            config: {
                               additionalCssClasses: "primary-call-to-action",
                               label: "Default",
@@ -135,6 +145,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "PRIMARY_CALL_TO_ACTION_BUTTON_HOVER",
                            config: {
                               additionalCssClasses: "primary-call-to-action dijitButtonHover",
                               label: "Hover",
@@ -146,6 +157,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "PRIMARY_CALL_TO_ACTION_BUTTON_ACTIVE",
                            config: {
                               additionalCssClasses: "primary-call-to-action dijitButtonActive",
                               label: "Pressed",
@@ -157,6 +169,7 @@ model.jsonModel = {
                         },
                         {
                            name: "alfresco/buttons/AlfButton",
+                           id: "PRIMARY_CALL_TO_ACTION_BUTTON_DISABLED",
                            config: {
                               additionalCssClasses: "primary-call-to-action",
                               label: "Disabled",


### PR DESCRIPTION
This addresses [AKU-752](https://issues.alfresco.com/jira/browse/AKU-752) and updates the button control to pass through a title attribute. Test created. Full suite run.