### PR TITLE
AKU-750: Submit form on ENTER

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -64,6 +64,44 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/AlfButton.properties"}],
 
       /**
+       * Additional classes to be applied to the root DOM element.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      additionalCssClasses: "",
+
+      /**
+       * Indicates whether or not the button should disable itself if any controls publish information indicating that
+       * they are in an invalid state.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      disableOnInvalidControls: false,
+
+      /**
+       * This will be instantiated as an array and used to keep track of any controls that report themselves as being
+       * in an invalid state. The button should only be enabled when this list is empty.
+       *
+       * @instance
+       * @type {object[]}
+       * @default
+       */
+      invalidControls: null,
+
+      /**
+       * The topic to listen to to determine when the button should be disabled
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      invalidTopic: "ALF_INVALID_CONTROL",
+
+      /**
        * The topic to publish when the button is clicked
        *
        * @instance
@@ -82,13 +120,14 @@ define(["dojo/_base/declare",
       publishPayload: null,
 
       /**
-       * Additional classes to be applied to the root DOM element.
+       * An optional title attribute to be added to the button.
        *
        * @instance
        * @type {string}
        * @default
+       * @since 1.0.49
        */
-      additionalCssClasses: "",
+      title: null,
 
       /**
        * The topic to listen to to determine when the button should be enabled
@@ -98,25 +137,6 @@ define(["dojo/_base/declare",
        * @default
        */
       validTopic: "ALF_VALID_CONTROL",
-
-      /**
-       * The topic to listen to to determine when the button should be disabled
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      invalidTopic: "ALF_INVALID_CONTROL",
-
-      /**
-       * An optional title attribute to be added to the button.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       * @since 1.0.49
-       */
-      title: null,
 
       /**
        * Extends the default implementation to check that the [publishPayload]{@link module:alfresco/buttons/AlfButton#publishPayload} attribute has been set
@@ -160,24 +180,14 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Indicates whether or not the button should disable itself if any controls publish information indicating that
-       * they are in an invalid state.
+       * Cause this button to respond as if it had been clicked.
        *
        * @instance
-       * @type {boolean}
-       * @default
+       * @since 1.0.49
        */
-      disableOnInvalidControls: false,
-
-      /**
-       * This will be instantiated as an array and used to keep track of any controls that report themselves as being
-       * in an invalid state. The button should only be enabled when this list is empty.
-       *
-       * @instance
-       * @type {object[]}
-       * @default
-       */
-      invalidControls: null,
+      activate: function alfresco_buttons_AlfButton__activate() {
+         this.onClick();
+      },
 
       /**
        * Handles the reporting of an invalid field. This will disable the button to prevent users from clicking it.

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -418,6 +418,18 @@ define([],function() {
       DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS: "ALF_DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS",
 
       /**
+       * This topic can be fired when the enter key is pressed (but normally is not by default).
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.49
+       *
+       * @event
+       */
+      ENTER_KEY_PRESSED: "ALF_ENTER_KEY_PRESSED",
+
+      /**
        * This topic can be used to request Cloud specific paths to use in an
        * [Tree form control]{@link module:alfresco/forms/controls/Tree}.
        *

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -354,6 +354,13 @@ define(["dojo/_base/declare",
          {
             this.pubSubScope = this.generateUuid();
          }
+
+         // When any of these topics are published, submit the form
+         if (this.publishValueSubscriptions && this.publishValueSubscriptions.length) {
+            array.forEach(this.publishValueSubscriptions, function(subscriptionTopic) {
+               this.alfSubscribe(subscriptionTopic, lang.hitch(this, this.submitOkButton));
+            }, this);
+         }
          
          this._form = new Form({
             id: this.generateUuid()
@@ -718,6 +725,19 @@ define(["dojo/_base/declare",
       okButtonEnablementTopics: null,
 
       /**
+       * If any of these topics are published then publish this form using the
+       * [okButtonPublishTopic]{@link module:alfresco/forms/Form#okButtonPublishTopic}.
+       * One may often wish to use [topics.ENTER_KEY_PRESSED]{@link module:alfresco/core/topics#ENTER_KEY_PRESSED}
+       * as a value in this array, to cause the form to submit when ENTER is pressed.
+       *
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.49
+       */
+      publishValueSubscriptions: null,
+
+      /**
        * The label that will be used for the "Cancel" button. This value can either be an explicit
        * localised value or an properties key that will be used to retrieve a localised value.
        *
@@ -961,6 +981,20 @@ define(["dojo/_base/declare",
                button._alfOriginalButtonPayload = lang.clone(button.publishPayload);
             }
          });
+      },
+
+      /**
+       * Execute a form publish as defined by the OK button.
+       *
+       * @instance
+       * @since 1.0.49
+       */
+      submitOkButton: function alfresco_forms_Form__submitOkButton() {
+         if(!this.okButton) {
+            this.alfLog("warn", "Cannot submit OK button as button not defined");
+         } else {
+            this.okButton.activate();
+         }
       },
       
       /**
@@ -1217,15 +1251,15 @@ define(["dojo/_base/declare",
        * @param {string|string[]} [is] The possible value/values that will re-enable the OK button if matching the specified attribute
        * @param {string|string[]} [isNot] The disallowed value/values that will re-enable the OK button if the attribute does not match it/them
        */
-      setupOkButtonEnablementSubscription: function alfresco_forms_Form__setupOkButtonEnablementSubscription(topics) {
+      setupOkButtonEnablementSubscription: function alfresco_forms_Form__setupOkButtonEnablementSubscription(topic) {
          var topicName,
             rulesObj;
-         if (typeof topics === "string") {
-            topicName = topics;
+         if (typeof topic === "string") {
+            topicName = topic;
             rulesObj = {};
          } else {
-            topicName = topics.topic;
-            rulesObj = lang.clone(topics);
+            topicName = topic.topic;
+            rulesObj = lang.clone(topic);
             delete rulesObj.topic;
          }
          this.alfConditionalSubscribe(topicName, rulesObj, lang.hitch(this, this.reenableOkButton));

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -181,6 +181,31 @@ registerSuite(function(){
             });
       },
 
+      "Enter key can submit form": function() {
+         var firstPublish;
+
+         return browser.findByCssSelector("#ENTER_TEXT_FIELD .dijitInputInner")
+            .clearLog()
+            .type("wibble")
+            .pressKeys(keys.ENTER)
+            .end()
+
+         .getLastPublish("FORM_PUBLISH")
+            .then(function(payload) {
+               firstPublish = payload;
+            })
+
+         .findByCssSelector("#ENTER_FORM .confirmationButton .dijitButtonNode")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("FORM_PUBLISH")
+            .then(function(payload) {
+               assert.deepEqual(payload, firstPublish, "ENTER publish did not match button-click publish");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -32,7 +32,7 @@ define({
     */
    // Uncomment and add specific tests as necessary during development!
    xbaseFunctionalSuites: [
-      "src/test/resources/alfresco/forms/controls/ButtonsTest"
+      "src/test/resources/alfresco/forms/controls/BaseFormTest"
 
       // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -179,6 +179,33 @@ model.jsonModel = {
          }
       },
       {
+         "name": "alfresco/layout/HorizontalWidgets",
+         "config": {
+            "widgets": [
+               {
+                  name: "alfresco/forms/Form",
+                  id: "ENTER_FORM",
+                  config: {
+                     okButtonPublishTopic: "FORM_PUBLISH",
+                     cancelButtonPublishTopic: "FORM_CANCEL",
+                     publishValueSubscriptions: ["ALF_ENTER_KEY_PRESSED"],
+                     widgets: [
+                        {
+                           id: "ENTER_TEXT_FIELD",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              name: "control",
+                              label: "Textbox",
+                              description: "Pressing ENTER will submit this form"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
          name: "alfresco/html/Spacer",
          config: {
             height: "20px"


### PR DESCRIPTION
This addresses [AKU-750](https://issues.alfresco.com/jira/browse/AKU-750) and permits submission of a form when pressing enter, by adding the following config to the Form control in a model:

```javascript
publishValueSubscriptions: ["ALF_ENTER_KEY_PRESSED"],
```

A test has been created. Additionally, the properties in the AlfButton widget have been reordered.
