### PR TITLE
AKU-765: Add textContent shim for IE8

### DIFF
--- a/aikau/src/main/resources/alfresco/core/shims.js
+++ b/aikau/src/main/resources/alfresco/core/shims.js
@@ -44,6 +44,7 @@ define([], function() {
          }
          this._addObjectKeys();
          this._addDateNow();
+         this._addTextContent();
          _applied = true;
       },
 
@@ -112,6 +113,30 @@ define([], function() {
                   return result;
                };
             }());
+         }
+      },
+
+      /**
+       * Allow setting of textContent on elements in IE8
+       * From https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
+       *
+       * @protected
+       * @instance
+       * @since 1.0.49
+       */
+      _addTextContent: function alfresco_core_shim___addTextContent() {
+         if (Object.defineProperty && Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor(Element.prototype, "textContent") && !Object.getOwnPropertyDescriptor(Element.prototype, "textContent").get) {
+            (function() {
+               var innerText = Object.getOwnPropertyDescriptor(Element.prototype, "innerText");
+               Object.defineProperty(Element.prototype, "textContent", {
+                  get: function() {
+                     return innerText.get.call(this);
+                  },
+                  set: function(s) {
+                     return innerText.set.call(this, s);
+                  }
+               });
+            })();
          }
       }
    };


### PR DESCRIPTION
This addresses [AKU-765](https://issues.alfresco.com/jira/browse/AKU-765) and adds a polyfill for using textContent with IE8 to the shims file in Aikau.