### PR TITLE
AKU-751: Focus on first field in form

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -1053,6 +1053,8 @@ define(["dojo/_base/declare",
 
             // If configured, focus the first field in the form
             if (this.firstFieldFocusOnLoad) {
+               // Use setTimeout to allow other synchronous processes to complete first, as this
+               // has a much greater chance of successfully focusing on the field
                setTimeout(lang.hitch(this, this.focus));
             }
          }

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -177,7 +177,20 @@ define(["dojo/_base/declare",
        * @default
        */
       convertFormToJsonString: false,
-      
+
+      /**
+       * <p>Should the first field in the form be focused when the form is loaded?</p>
+       *
+       * <p><strong>NOTE:</strong> If more than one form on a page has this setting,
+       * then the order in which the fields are focused cannot be guaranteed.</p>
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.49
+       */
+      firstFieldFocusOnLoad: false,
+
       /**
        * This will be instantiated as an array and used to keep track of any controls that report themselves as being
        * in an invalid state. The "OK" button for submitting the form should only be enabled when this list is empty.
@@ -1037,6 +1050,11 @@ define(["dojo/_base/declare",
                this.publishValidValue();
             }
             this._formSetupComplete = true;
+
+            // If configured, focus the first field in the form
+            if (this.firstFieldFocusOnLoad) {
+               setTimeout(lang.hitch(this, this.focus));
+            }
          }
       },
       

--- a/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormValidationTest.js
@@ -41,6 +41,23 @@ registerSuite(function(){
          browser.end();
       },
 
+      "Check that first field of second form is focused initially": function() {
+         var focusedId;
+
+         return browser.getActiveElement()
+            .getAttribute("id")
+            .then(function(id) {
+               focusedId = id;
+            })
+            .end()
+
+         .findByCssSelector("#TB3 .dijitInputInner")
+            .getAttribute("id")
+            .then(function(id) {
+               assert.equal(focusedId, id);
+            });
+      },
+
       "Check that first form is NOT displayed as invalid on load": function() {
          return browser.findAllByCssSelector("#TB1.alfresco-forms-controls-BaseFormControl--invalid")
             .then(function(elements) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/FormValidation.get.js
@@ -103,6 +103,7 @@ model.jsonModel = {
                   config: {
                      okButtonPublishTopic: "PUBLISH_FORM_DATA",
                      cancelButtonPublishTopic: "CANCEL_FORM_DATA",
+                     firstFieldFocusOnLoad: true,
                      pubSubScope: "FORM2_",
                      showValidationErrorsImmediately: true,
                      widgets: [


### PR DESCRIPTION
This addresses [AKU-751](https://issues.alfresco.com/jira/browse/AKU-751) and will focus on the first field in the form, on page load, if the following is added to the form config:

```javascript
firstFieldFocusOnLoad: true,
```

Unit-test added.