### PR TITLE
AKU-761: Get showValidationErrorsImmediately setting working in ControlRow

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/ControlRow.js
+++ b/aikau/src/main/resources/alfresco/forms/ControlRow.js
@@ -101,6 +101,15 @@ define(["alfresco/layout/HorizontalWidgets",
        * @instance
        */
       postCreate: function alfresco_forms_ControlRow__postCreate() {
+         // Before calling inherited (which will process the widgets), ensure
+         // they are populated with the showValidationErrorsImmediately value
+         if (this.widgets) {
+            array.forEach(this.widgets, function(widget) {
+               if (widget && widget.config) {
+                  widget.config.showValidationErrorsImmediately = this.showValidationErrorsImmediately;
+               }
+            }, this);
+         }
          this.inherited(arguments);
          domClass.add(this.domNode, "alfresco-forms-ControlRow");
          var hasDescription = false;

--- a/aikau/src/main/resources/alfresco/forms/css/ControlRow.css
+++ b/aikau/src/main/resources/alfresco/forms/css/ControlRow.css
@@ -1,18 +1,20 @@
-.alfresco-forms-ControlRow > div.title {
-   font-family: @bold-font;
-   font-size: @large-font-size;
-   margin-bottom: @standard-line-height/2;
-}
-
-.alfresco-forms-ControlRow > div.title.border {
-   border-bottom: @standard-border;
-   margin-bottom: @standard-line-height;
-}
-
-.alfresco-forms-ControlRow > div.description {
-   color: @de-emphasized-font-color;
-   font-family: @standard-font;
-   font-size: @normal-font-size;
-   margin-bottom: @standard-line-height;
-   border-bottom: @standard-border;
+.alfresco-forms-ControlRow {
+   > div {
+      &.title {
+         font-family: @bold-font;
+         font-size: @large-font-size;
+         margin-bottom: @standard-line-height/2;
+         &.border {
+            border-bottom: @standard-border;
+            margin-bottom: @standard-line-height;
+         }
+      }
+      &.description {
+         border-bottom: @standard-border;
+         color: @de-emphasized-font-color;
+         font-family: @standard-font;
+         font-size: @normal-font-size;
+         margin-bottom: @standard-line-height;
+      }
+   }
 }

--- a/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
+++ b/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
@@ -59,6 +59,14 @@ registerSuite(function(){
             });
       },
 
+      "Ensure showValidationErrorsImmediately is respected": function() {
+         return browser.findByCssSelector("#TB1 .validation-message")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "");
+            });
+      },
+
       "Post Coverage Results": function() {
          TestCommon.alfPostCoverageResults(this, browser);
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
@@ -58,6 +58,12 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "10px"
+         }
+      },
+      {
          id: "DB1",
          name: "alfresco/buttons/AlfDynamicPayloadButton",
          config: {
@@ -69,6 +75,47 @@ model.jsonModel = {
                   topic: "_valueChangeOf_SELECT1",
                   dataMapping: {
                      value: "selected"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         id: "FORM2",
+         name: "alfresco/forms/Form",
+         config: {
+            pubSubScope: "FORM2_",
+            showValidationErrorsImmediately: false,
+            widgets: [
+               {
+                  id: "CR1",
+                  name: "alfresco/forms/ControlRow",
+                  config: {
+                     widgets: [
+                        {
+                           id: "TB1",
+                           name: "alfresco/forms/controls/DojoValidationTextBox",
+                           config: {
+                              label: "Field 1",
+                              name: "field1",
+                              description: "Needs to be 3 characters or more",
+                              value: "a",
+                              validationConfig: [
+                                 {
+                                    validation: "minLength",
+                                    length: 3,
+                                    errorMessage: "Too short"
+                                 }
+                              ]
+                           }
+                        }
+                     ]
                   }
                }
             ]


### PR DESCRIPTION
This addresses [AKU-761](https://issues.alfresco.com/jira/browse/AKU-761) and makes showValidationErrorsImmediately setting work in ControlRow. Tests have been updated accordingly.