### PR TITLE
AKU-769: Search result middle and control clicks

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2005-2015 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p>This mixin can be used to wrap HTML elements in a widget with an anchor element that allows users
+ * to use the browser context-menu to copy or open the link in a new tab or window. This works around
+ * the fact that all Aikau navigation is achieved via publishing requests to be handled by the 
+ * [Navigation Service]{@link module:alfresco/services/NavigationService}.</p>
+ * <p>This should be mixed into a widget and then the [makeAnchor]{@link module:alfresco/navigation/_HtmlAnchorMixin#makeAnchor}
+ * function should be called by the postCreate function (or any function called after the widgets DOM
+ * has been created). In order for this to work the [getAnchorTargetSelectors]{@link module:alfresco/navigation/_HtmlAnchorMixin#getAnchorTargetSelectors}
+ * should be overridden to return an array of the CSS selectors needed to identify the elements to be wrapped
+ * with an anchor element.</p>
+ *
+ * @module alfresco/navigation/LinkClickMixin
+ * @extends module:alfresco/core/Core
+ * @mixes module:alfresco/services/_NavigationServiceTopicMixin
+ * @author Dave Draper
+ * @since 1.0.50
+ */
+define(["dojo/_base/declare",
+        "alfresco/services/_NavigationServiceTopicMixin"], 
+        function(declare, _NavigationServiceTopicMixin) {
+   
+   return declare([_NavigationServiceTopicMixin], {
+
+      /**
+       * Indicates whether or not a middle-button mouse click on the link should result in the link
+       * being opened in a new browser tab. If this is configured to be true then the a "target" attribute
+       * of "NEW" will be configured on the payload.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.50
+       */
+      newTabOnMiddleMouseClick: false,
+
+      /**
+       * For [navigation topics]{@link module:alfresco/services/_NavigationServiceTopicMixin#navigateToPageTopic}
+       * the click action is checked for a middle mouse click action if the payload does not request that the
+       * navigation target is a new browser tab then it will be added. No change will be made if 
+       * [newTabOnMiddleMouseClick]{@link module:alfresco/navigation/LinkClickMixin#newTabOnMiddleMouseClick}
+       * is not configured to be true.
+       * 
+       * @instance
+       * @param {object} evt The link click event
+       * @param {string} publishTopic The topic to be published as a result of the click
+       * @param {object} publishPayload The payload to be published as a result of the click
+       * @since 1.0.50
+       */
+      checkForMiddleClick: function alfresco_navigation_LinkClickMixin__checkForMiddleClick(evt, publishTopic, publishPayload) {
+         if (this.newTabOnMiddleMouseClick && publishTopic === this.navigateToPageTopic) 
+         {
+            if ((evt.which === 2 || (evt.which === 1 && evt.ctrlKey)) && publishPayload.target !== this.newTarget)
+            {
+               publishPayload.target = this.newTarget;
+            }
+            else if (evt.which === 1 && publishPayload.target !== this.currentTarget)
+            {
+               publishPayload.target = this.currentTarget;
+            }
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
@@ -18,15 +18,9 @@
  */
 
 /**
- * <p>This mixin can be used to wrap HTML elements in a widget with an anchor element that allows users
- * to use the browser context-menu to copy or open the link in a new tab or window. This works around
- * the fact that all Aikau navigation is achieved via publishing requests to be handled by the 
- * [Navigation Service]{@link module:alfresco/services/NavigationService}.</p>
- * <p>This should be mixed into a widget and then the [makeAnchor]{@link module:alfresco/navigation/_HtmlAnchorMixin#makeAnchor}
- * function should be called by the postCreate function (or any function called after the widgets DOM
- * has been created). In order for this to work the [getAnchorTargetSelectors]{@link module:alfresco/navigation/_HtmlAnchorMixin#getAnchorTargetSelectors}
- * should be overridden to return an array of the CSS selectors needed to identify the elements to be wrapped
- * with an anchor element.</p>
+ * This mixin can be used for widgets that support mouse clicks and provides the ability to support 
+ * clicks with the middle mouse button or the control key depressed to open navigation requests
+ * in a new browser tab.
  *
  * @module alfresco/navigation/LinkClickMixin
  * @extends module:alfresco/core/Core
@@ -41,32 +35,41 @@ define(["dojo/_base/declare",
    return declare([_NavigationServiceTopicMixin], {
 
       /**
-       * Indicates whether or not a middle-button mouse click on the link should result in the link
-       * being opened in a new browser tab. If this is configured to be true then the a "target" attribute
-       * of "NEW" will be configured on the payload.
+       * Indicates whether or not a middle-button or control key depresssed mouse click on the link should 
+       * result in the link being opened in a new browser tab. If this is configured to be true then the a "target" 
+       * attribute of "NEW" will be configured on the payload.
        * 
        * @instance
        * @type {boolean}
        * @default
-       * @since 1.0.50
        */
-      newTabOnMiddleMouseClick: false,
+      newTabOnMiddleOrCtrlClick: false,
+
+      /**
+       * The default navigation target to use in 
+       * [processMiddleOrCtrlClick]{@link module:alfresco/navigation/LinkClickMixin#processMiddleOrCtrlClick}
+       * if a middle click or control-click is not detected.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      defaultNavigationTarget: "CURRENT",
 
       /**
        * For [navigation topics]{@link module:alfresco/services/_NavigationServiceTopicMixin#navigateToPageTopic}
-       * the click action is checked for a middle mouse click action if the payload does not request that the
-       * navigation target is a new browser tab then it will be added. No change will be made if 
-       * [newTabOnMiddleMouseClick]{@link module:alfresco/navigation/LinkClickMixin#newTabOnMiddleMouseClick}
+       * the click action is checked for a middle mouse click or control key depressed mouse click if the payload 
+       * does not request that the navigation target is a new browser tab then it will be added. No change will be 
+       * made if [newTabOnMiddleOrCtrlClick]{@link module:alfresco/navigation/LinkClickMixin#newTabOnMiddleOrCtrlClick}
        * is not configured to be true.
        * 
        * @instance
        * @param {object} evt The link click event
        * @param {string} publishTopic The topic to be published as a result of the click
        * @param {object} publishPayload The payload to be published as a result of the click
-       * @since 1.0.50
        */
-      checkForMiddleClick: function alfresco_navigation_LinkClickMixin__checkForMiddleClick(evt, publishTopic, publishPayload) {
-         if (this.newTabOnMiddleMouseClick && publishTopic === this.navigateToPageTopic) 
+      processMiddleOrCtrlClick: function alfresco_navigation_LinkClickMixin__processMiddleOrCtrlClick(evt, publishTopic, publishPayload) {
+         if (this.newTabOnMiddleOrCtrlClick && publishTopic === this.navigateToPageTopic) 
          {
             if ((evt.which === 2 || (evt.which === 1 && evt.ctrlKey)) && publishPayload.target !== this.newTarget)
             {
@@ -74,7 +77,7 @@ define(["dojo/_base/declare",
             }
             else if (evt.which === 1 && publishPayload.target !== this.currentTarget)
             {
-               publishPayload.target = this.currentTarget;
+               publishPayload.target = this.defaultNavigationTarget || this.currentTarget;
             }
          }
       }

--- a/aikau/src/main/resources/alfresco/renderers/DateLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/DateLink.js
@@ -28,12 +28,13 @@ define(["dojo/_base/declare",
         "alfresco/renderers/Date",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_PublishPayloadMixin",
+        "alfresco/navigation/LinkClickMixin",
         "dojo/text!./templates/DateLink.html",
         "dojo/_base/event",
         "dojo/_base/lang"], 
-        function(declare, Date, _OnDijitClickMixin, _PublishPayloadMixin, template, event, lang) {
+        function(declare, Date, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin, template, event, lang) {
 
-   return declare([Date, _OnDijitClickMixin, _PublishPayloadMixin], {
+   return declare([Date, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin], {
 
       /**
        * Overriddes the default HTML template to use for the widget.
@@ -69,9 +70,11 @@ define(["dojo/_base/declare",
          }
          else
          {
+            var payload = this.getPublishPayload();
+            this.checkForMiddleClick(evt, publishTopic, payload);
             var publishGlobal = this.publishGlobal || false;
             var publishToParent = this.publishToParent || false;
-            this.alfPublish(publishTopic, this.getPublishPayload(), publishGlobal, publishToParent);
+            this.alfPublish(publishTopic, payload, publishGlobal, publishToParent);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/DateLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/DateLink.js
@@ -71,7 +71,7 @@ define(["dojo/_base/declare",
          else
          {
             var payload = this.getPublishPayload();
-            this.checkForMiddleClick(evt, publishTopic, payload);
+            this.processMiddleOrCtrlClick(evt, publishTopic, payload);
             var publishGlobal = this.publishGlobal || false;
             var publishToParent = this.publishToParent || false;
             this.alfPublish(publishTopic, payload, publishGlobal, publishToParent);

--- a/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
@@ -84,7 +84,7 @@ define(["dojo/_base/declare",
          else
          {
             var payload = this.getPublishPayload();
-            this.checkForMiddleClick(evt, publishTopic, payload);
+            this.processMiddleOrCtrlClick(evt, publishTopic, payload);
             var publishGlobal = this.publishGlobal || false;
             var publishToParent = this.publishToParent || false;
             this.alfPublish(publishTopic, payload, publishGlobal, publishToParent);

--- a/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
@@ -24,6 +24,7 @@
  * @extends alfresco/renderers/Property
  * @mixes external:dijit/_OnDijitClickMixin
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
+ * @mixes module:alfresco/services/_NavigationServiceTopicMixin
  * @author Dave Draper
  * @author Richard Smith
  */
@@ -31,12 +32,13 @@ define(["dojo/_base/declare",
         "alfresco/renderers/Property",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_PublishPayloadMixin",
+        "alfresco/navigation/LinkClickMixin",
         "dojo/text!./templates/PropertyLink.html",
         "dojo/_base/event",
         "dojo/_base/lang"], 
-        function(declare, Property, _OnDijitClickMixin, _PublishPayloadMixin, template, event, lang) {
+        function(declare, Property, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin, template, event, lang) {
 
-   return declare([Property, _OnDijitClickMixin, _PublishPayloadMixin], {
+   return declare([Property, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -81,9 +83,11 @@ define(["dojo/_base/declare",
          }
          else
          {
+            var payload = this.getPublishPayload();
+            this.checkForMiddleClick(evt, publishTopic, payload);
             var publishGlobal = this.publishGlobal || false;
             var publishToParent = this.publishToParent || false;
-            this.alfPublish(publishTopic, this.getPublishPayload(), publishGlobal, publishToParent);
+            this.alfPublish(publishTopic, payload, publishGlobal, publishToParent);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -930,7 +930,7 @@ define(["dojo/_base/declare",
          {
             var publishGlobal = this.publishGlobal || false;
             var publishToParent = this.publishToParent || false;
-            this.checkForMiddleClick(evt, this.publishTopic, this.publishPayload);
+            this.processMiddleOrCtrlClick(evt, this.publishTopic, this.publishPayload);
             this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
          }
       },

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -102,6 +102,7 @@ define(["dojo/_base/declare",
         "alfresco/renderers/_PublishPayloadMixin",
         "dijit/_OnDijitClickMixin",
         "alfresco/lists/ItemSelectionMixin",
+        "alfresco/navigation/LinkClickMixin",
         "dojo/text!./templates/Thumbnail.html",
         "alfresco/core/Core",
         "alfresco/renderers/_ItemLinkMixin",
@@ -115,11 +116,11 @@ define(["dojo/_base/declare",
         "dojo/Deferred",
         "dojo/when"], 
         function(declare, _WidgetBase, _TemplatedMixin, _JsNodeMixin, DraggableNodeMixin, NodeDropTargetMixin, 
-                 _PublishPayloadMixin, _OnDijitClickMixin, ItemSelectionMixin, template, AlfCore, _ItemLinkMixin,
+                 _PublishPayloadMixin, _OnDijitClickMixin, ItemSelectionMixin, LinkClickMixin, template, AlfCore, _ItemLinkMixin,
                  AlfConstants, lang, event, domClass, domStyle, NodeUtils, win, Deferred, when) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, DraggableNodeMixin, NodeDropTargetMixin, 
-                   AlfCore, _ItemLinkMixin, _PublishPayloadMixin, ItemSelectionMixin], {
+                   AlfCore, _ItemLinkMixin, _PublishPayloadMixin, ItemSelectionMixin, LinkClickMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -893,7 +894,7 @@ define(["dojo/_base/declare",
             }
             else
             {
-               this.onNonPreviewAction();
+               this.onNonPreviewAction(evt);
             }
          }
       },
@@ -904,8 +905,9 @@ define(["dojo/_base/declare",
        * full node data reveals that a preview cannot be supported.
        *
        * @instance
+       * @param {object} evt The click event
        */
-      onNonPreviewAction: function alfresco_renderers_Thumbnail__onNonPreviewAction() {
+      onNonPreviewAction: function alfresco_renderers_Thumbnail__onNonPreviewAction(evt) {
          if (!this.publishTopic)
          {
             // If no topic has been provided then set up a default one (presumed to be for use
@@ -916,7 +918,7 @@ define(["dojo/_base/declare",
          else if (this.publishPayload)
          {
             // If a payload has been provided then use it...
-            this.publishPayload = this.getGeneratedPayload(false, null);
+            this.publishPayload = this.getGeneratedPayload(true, null);
          }
 
          // ...then do it.
@@ -928,6 +930,7 @@ define(["dojo/_base/declare",
          {
             var publishGlobal = this.publishGlobal || false;
             var publishToParent = this.publishToParent || false;
+            this.checkForMiddleClick(evt, this.publishTopic, this.publishPayload);
             this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
          }
       },

--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -157,6 +157,18 @@ define(["dojo/_base/declare",
       navigationTarget: "CURRENT",
 
       /**
+       * Indicates whether or not a middle-button mouse click on the link should result in links
+       * being opened in a new browser tab. If this is configured to be true then the a "target" attribute
+       * of "NEW" will be configured on the payload.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.50
+       */
+      newTabOnMiddleMouseClick: true,
+
+      /**
        * This can be configured to override the default filter for the actions that are applicable to 
        * all nodes that are neither folders nor documents. Actions need to be filtered as Aikau does not 
        * currently support all of the actions that can be configured in Alfresco Share. However, if custom 
@@ -356,7 +368,8 @@ define(["dojo/_base/declare",
                url: "user/{modifiedByUser}/profile",
                type: urlTypes.PAGE_RELATIVE,
                target: this.navigationTarget
-            }
+            },
+            newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
          }, this.dateNode);
       },
 
@@ -375,7 +388,8 @@ define(["dojo/_base/declare",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
             propertyToRender: "displayName",
-            renderSize: "large"
+            renderSize: "large",
+            newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
          };
          if (this.navigationTarget)
          {
@@ -455,7 +469,8 @@ define(["dojo/_base/declare",
                   url: isRepo ? "repository?path={pathLink}" : "site/{site.shortName}/documentlibrary?path={pathLink}",
                   type: urlTypes.PAGE_RELATIVE,
                   target: this.navigationTarget
-               }
+               },
+               newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
             }, this.pathNode);
          }
       },
@@ -520,7 +535,8 @@ define(["dojo/_base/declare",
                   url: "site/{site.shortName}" + this.siteLandingPage.replace(/^\/*/, "/"),
                   type: urlTypes.PAGE_RELATIVE,
                   target: this.navigationTarget
-               }
+               },
+               newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
             }, this.siteNode);
          }
       },
@@ -563,7 +579,8 @@ define(["dojo/_base/declare",
             id: this.id + "_THUMBNAIL",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
-            showDocumentPreview: true
+            showDocumentPreview: true,
+            newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
          };
          if (this.navigationTarget)
          {

--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -157,16 +157,16 @@ define(["dojo/_base/declare",
       navigationTarget: "CURRENT",
 
       /**
-       * Indicates whether or not a middle-button mouse click on the link should result in links
-       * being opened in a new browser tab. If this is configured to be true then the a "target" attribute
-       * of "NEW" will be configured on the payload.
+       * Indicates whether or not a middle-button mouse click (or left click with the control key depressed)
+       * on the link should result in links being opened in a new browser tab. If this is configured to be true 
+       * then the a "target" attribute of "NEW" will be configured on the payload.
        * 
        * @instance
        * @type {boolean}
        * @default
        * @since 1.0.50
        */
-      newTabOnMiddleMouseClick: true,
+      newTabOnMiddleOrCtrlClick: true,
 
       /**
        * This can be configured to override the default filter for the actions that are applicable to 
@@ -369,7 +369,8 @@ define(["dojo/_base/declare",
                type: urlTypes.PAGE_RELATIVE,
                target: this.navigationTarget
             },
-            newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
+            newTabOnMiddleOrCtrlClick: this.newTabOnMiddleOrCtrlClick,
+            defaultNavigationTarget: this.navigationTarget
          }, this.dateNode);
       },
 
@@ -389,7 +390,8 @@ define(["dojo/_base/declare",
             pubSubScope: this.pubSubScope,
             propertyToRender: "displayName",
             renderSize: "large",
-            newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
+            newTabOnMiddleOrCtrlClick: this.newTabOnMiddleOrCtrlClick,
+            defaultNavigationTarget: this.navigationTarget
          };
          if (this.navigationTarget)
          {
@@ -470,7 +472,8 @@ define(["dojo/_base/declare",
                   type: urlTypes.PAGE_RELATIVE,
                   target: this.navigationTarget
                },
-               newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
+               newTabOnMiddleOrCtrlClick: this.newTabOnMiddleOrCtrlClick,
+               defaultNavigationTarget: this.navigationTarget
             }, this.pathNode);
          }
       },
@@ -536,7 +539,8 @@ define(["dojo/_base/declare",
                   type: urlTypes.PAGE_RELATIVE,
                   target: this.navigationTarget
                },
-               newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
+               newTabOnMiddleOrCtrlClick: this.newTabOnMiddleOrCtrlClick,
+               defaultNavigationTarget: this.navigationTarget
             }, this.siteNode);
          }
       },
@@ -580,7 +584,8 @@ define(["dojo/_base/declare",
             currentItem: this.currentItem,
             pubSubScope: this.pubSubScope,
             showDocumentPreview: true,
-            newTabOnMiddleMouseClick: this.newTabOnMiddleMouseClick
+            newTabOnMiddleOrCtrlClick: this.newTabOnMiddleOrCtrlClick,
+            defaultNavigationTarget: this.navigationTarget
          };
          if (this.navigationTarget)
          {

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -24,8 +24,9 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "alfresco/TestCommon"],
-   function(registerSuite, assert, TestCommon) {
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"],
+   function(registerSuite, assert, TestCommon, keys) {
 
    registerSuite(function(){
       var browser;
@@ -123,6 +124,106 @@ define(["intern!object",
                .end()
 
             .findById("SR_ACTIONS_MANAGE_ASPECTS");
+         },
+
+         // See AKU-769 - Need to check left mouse clicks and left mouse clicks with control key depressed...
+         // Middle button clicks SHOULD be tested but Leadfoot API is failing to generate correct event (manually
+         // verified testing shows it working though)...
+
+         "Left click name goes to current target": function() {
+            return browser.findByCssSelector("#SR_DISPLAY_NAME .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "CURRENT", "Name link should use CURRENT target");
+               })
+            .clearLog();
+         },
+
+         "Left click site goes to current target": function() {
+            return browser.findByCssSelector("#SR_SITE .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "CURRENT", "Site link should use CURRENT target");
+               })
+            .clearLog();
+         },
+
+         "Left click path goes to current target": function() {
+            return browser.findByCssSelector("#SR_PATH .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "CURRENT", "Path link should use CURRENT target");
+               })
+            .clearLog();
+         },
+
+         "Left click date goes to current target": function() {
+            return browser.findByCssSelector("#SR_DATE .value")
+               .click()
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "CURRENT", "Date link should use CURRENT target");
+               })
+            .clearLog();
+         },
+
+         "Control click name goes to new target": function() {
+            return browser.findByCssSelector("#SR_DISPLAY_NAME .value")
+               .pressKeys([keys.CONTROL])
+               .click()
+               .pressKeys(keys.NULL)
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Control click name link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Control click site goes to new target": function() {
+            return browser.findByCssSelector("#SR_SITE .value")
+               .pressKeys([keys.CONTROL])
+               .click()
+               .pressKeys(keys.NULL)
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Control click site link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Control click path goes to new target": function() {
+            return browser.findByCssSelector("#SR_PATH .value")
+               .pressKeys([keys.CONTROL])
+               .click()
+               .pressKeys(keys.NULL)
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Control click path link should use NEW target");
+               })
+            .clearLog();
+         },
+
+         "Control click date goes to new target": function() {
+            return browser.findByCssSelector("#SR_DATE .value")
+               .pressKeys([keys.CONTROL])
+               .click()
+               .pressKeys(keys.NULL)
+            .end()
+            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "target", "NEW", "Control click date link should use NEW target");
+               })
+            .clearLog();
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -31,6 +31,7 @@ function getSearchResult() {
    if (page.url.args["override"])
    {
       searchResult.config.navigationTarget = "NEW";
+      searchResult.config.newTabOnMiddleMouseClick = false;
    }
 
    return searchResult;

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/AlfSearchResult.get.js
@@ -31,7 +31,7 @@ function getSearchResult() {
    if (page.url.args["override"])
    {
       searchResult.config.navigationTarget = "NEW";
-      searchResult.config.newTabOnMiddleMouseClick = false;
+      searchResult.config.newTabOnMiddleOrCtrlClick = false;
    }
 
    return searchResult;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-769 to add support for middle mouse clicks and left mouse clicks with the control key depressed resulting in navigation requests opening in a new browser tab. This has been applied to the AlfSearchResult widget to ensure that these types of clicks are supported in the faceted search page in Share. The unit tests have been updated.