### PR TITLE
AKU-766: Ensure selected tab is displayed

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -558,6 +558,12 @@ define(["dojo/_base/declare",
          else if (this.tabContainerWidget && typeof this.tabContainerWidget.resize === "function")
          {
             this.tabContainerWidget.resize();
+
+            // See AKU-766 - absolutely make sure that the selected child really is selected!
+            if (this.tabContainerWidget.selectedChildWidget)
+            {
+               this.tabContainerWidget._showChild(this.tabContainerWidget.selectedChildWidget);
+            }
          }
       },
 

--- a/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
+++ b/aikau/src/test/resources/alfresco/layout/AlfTabContainerTest.js
@@ -709,12 +709,13 @@ define(["intern!object",
             .findDisplayedById("ADDED_LIST_2")
             .end()
             
-            // ...and check that it is loading (this will be a result of the reload publication)...
-            .findByCssSelector("#ADDED_LIST_2 .info.data-loading")
-               .isDisplayed()
-               .then(function(displayed) {
-                  assert.isTrue(displayed, "The list should be attempting to load data");
-               });
+            // Switch back to the debug log...
+            .findById("TC1_TABCONTAINER_tablist_TC1_DEBUG_TAB")
+               .click()
+            .end()
+
+            // ...and check that it is loading request is published (this will be a result of the reload publication)...
+            .getLastPublish("LIST_2_SCOPE_ALF_DOCLIST_RELOAD_DATA", "Follow publication not made");
          },
 
          "Post Coverage Results": function() {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-766 to ensure that the selected tab in the tab container is always displayed.