### PR TITLE
AKU-770: Ensure PathTree content creation reloads work for root nodes

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -125,6 +125,17 @@ define(["dojo/_base/declare",
                parentTreeNode = parentTreeNode[0];
                this.refreshTreeNode(parentTreeNode);
             }
+            else
+            {
+               // For the root node, the supplied parentNoderef will be undefined - therefore
+               // we need to use the ROOT id (which is known)...
+               parentTreeNode = this.tree._itemNodesMap[this.id + "_ROOT"];
+               if (parentTreeNode && parentTreeNode.length)
+               {
+                  parentTreeNode = parentTreeNode[0];
+                  this.refreshTreeNode(parentTreeNode);
+               }
+            }
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -170,7 +170,7 @@ define(["intern!object",
                .getLastXhr()
                   .then(function(xhr) {
                      /* jshint maxlen:500*/
-                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319");
                   });
          },
 
@@ -183,7 +183,7 @@ define(["intern!object",
                .getLastXhr()
                   .then(function(xhr) {
                      /* jshint maxlen:500*/
-                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/Budget Files/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319");
                   });
          },
 
@@ -197,7 +197,7 @@ define(["intern!object",
                .getLastXhr()
                   .then(function(xhr) {
                      /* jshint maxlen:500*/
-                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319");
                   });
          },
 
@@ -210,7 +210,7 @@ define(["intern!object",
                .getLastXhr()
                   .then(function(xhr) {
                      /* jshint maxlen:500*/
-                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319");
                   });
          },
 

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -187,6 +187,33 @@ define(["intern!object",
                   });
          },
 
+         // See AKU-770 - As with previous two tests, but in this case checking at the root node which wasn't previously working
+         "Check root node refresh on folder add": function() {
+            return browser.findById("ADD_FOLDER_AT_ROOT_label")
+                  .clearXhrLog()
+                  .click()
+               .end()
+
+               .getLastXhr()
+                  .then(function(xhr) {
+                     /* jshint maxlen:500*/
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/documentLibrary/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                  });
+         },
+
+         "Check root node refresh on folder delete": function() {
+            return browser.findById("DELETE_FOLDER_AT_ROOT_label")
+                  .clearXhrLog()
+                  .click()
+               .end()
+
+               .getLastXhr()
+                  .then(function(xhr) {
+                     /* jshint maxlen:500*/
+                     assert.include(xhr.request.url, "/slingshot/doclib/treenode/node/alfresco/company/home/?perms=false&children=false&max=500&libraryRoot=workspace%3A%2F%2FSpacesStore%2Fb4cff62a-664d-4d45-9302-98723eac1319", "Node refresh not requested");
+                  });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
@@ -26,7 +26,7 @@ model.jsonModel = {
                      widgets: [
                         {
                            name: "alfresco/layout/VerticalWidgets",
-                           widthPx: "100",
+                           widthPx: "150",
                            config: {
                               widgetMarginBottom: 10,
                               widgets: [
@@ -73,7 +73,30 @@ model.jsonModel = {
                                           nodeRefs: ["workspace://SpacesStore/d56afdc3-0174-4f8c-bce8-977cafd712ab"] 
                                        }
                                     }
+                                 },
+                                 {
+                                    id: "ADD_FOLDER_AT_ROOT",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Add Folder (at root)",
+                                       publishTopic: "ALF_CONTENT_CREATED",
+                                       publishPayload: {
+                                          parentNodeRef: "workspace://SpacesStore/8f2105b4-daaf-4874-9e8a-2152569d109b"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "DELETE_FOLDER_AT_ROOT",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Delete Folder (at root)",
+                                       publishTopic: "ALF_CONTENT_DELETED",
+                                       publishPayload: {
+                                          nodeRefs: ["workspace://SpacesStore/8f2105b4-daaf-4874-9e8a-2152569d109b"] 
+                                       }
+                                    }
                                  }
+
                               ]
                            }
                         },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-770 to ensure that root tree nodes in the PathTree can be refreshed on content creation topic publications. The unit tests have been updated to verify this works - delete was already working but a test has been added to be sure and prevent regressions.