### PR TITLE
AKU-764: Base form test updates

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -401,7 +401,7 @@ define(["dojo/_base/declare",
                   widget.config.showValidationErrorsImmediately = this.showValidationErrorsImmediately;
                   if (widget.config.pubSubScope)
                   {
-                     this.alfLog("warn", "It is not recommended to set a pubSubScope attribute on a form control nested within a form - the pubSubScope should be inherited!", this, widget);
+                     this.alfLog("warn", "It is not recommended to set a pubSubScope attribute on a form control nested within a form, the value of the form control will not be included in the published form value", this, widget);
                   }
                }
             }, this);

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -399,6 +399,10 @@ define(["dojo/_base/declare",
                if (widget && widget.config)
                {
                   widget.config.showValidationErrorsImmediately = this.showValidationErrorsImmediately;
+                  if (widget.config.pubSubScope)
+                  {
+                     this.alfLog("warn", "It is not recommended to set a pubSubScope attribute on a form control nested within a form - the pubSubScope should be inherited!", this, widget);
+                  }
                }
             }, this);
 

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -29,186 +29,186 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, keys, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "Base Form Control Tests",
+      return {
+         name: "Base Form Control Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/BaseForm", "Base Form Control Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/BaseForm", "Base Form Control Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Checking the form field is initially empty": function() {
-         return browser.findByCssSelector("div#FORM_FIELD div.control input[name='control']")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "", "Form field not initially empty");
-            });
-      },
+         "Checking the form field is initially empty": function() {
+            return browser.findByCssSelector("div#FORM_FIELD div.control input[name='control']")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "", "Form field not initially empty");
+               });
+         },
 
-      "No payload does not update value": function() {
-         return browser.findById("SET_FORM_VALUE_1")
-            .click()
-            .end()
+         "No payload does not update value": function() {
+            return browser.findById("SET_FORM_VALUE_1")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "", "No payload published but field value updated");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "", "No payload published but field value updated");
+               });
+         },
 
-      "Invalid field name does not update value": function() {
-         return browser.findById("SET_FORM_VALUE_2")
-            .click()
-            .end()
+         "Invalid field name does not update value": function() {
+            return browser.findById("SET_FORM_VALUE_2")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "", "Invalid field name provided but value updated");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "", "Invalid field name provided but value updated");
+               });
+         },
 
-      "Setting string value updates field appropriately": function() {
-         return browser.findById("SET_FORM_VALUE_3")
-            .click()
-            .end()
+         "Setting string value updates field appropriately": function() {
+            return browser.findById("SET_FORM_VALUE_3")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "this is the new value", "Field value not updated to published string value");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "this is the new value", "Field value not updated to published string value");
+               });
+         },
 
-      "Setting number value updates field appropriately": function() {
-         return browser.findById("SET_FORM_VALUE_4")
-            .click()
-            .end()
+         "Setting number value updates field appropriately": function() {
+            return browser.findById("SET_FORM_VALUE_4")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "3.14159265", "Field value not updated to published numeric value");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "3.14159265", "Field value not updated to published numeric value");
+               });
+         },
 
-      "Setting boolean value updates field appropriately": function() {
-         return browser.findById("SET_FORM_VALUE_5")
-            .click()
-            .end()
+         "Setting boolean value updates field appropriately": function() {
+            return browser.findById("SET_FORM_VALUE_5")
+               .click()
+               .end()
 
-         .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
-            .getProperty("value")
-            .then(function(value) {
-               assert.equal(value, "true", "Field value not updated to published boolean value");
-            });
-      },
+            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value, "true", "Field value not updated to published boolean value");
+               });
+         },
 
-      "Autosave on a form removes OK/Cancel buttons": function() {
-         return browser.findAllByCssSelector("#BASIC_FORM .confirmationButton, #BASIC_FORM .cancelButton")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "OK/Cancel buttons not found on basic form");
-            })
-            .end()
+         "Autosave on a form removes OK/Cancel buttons": function() {
+            return browser.findAllByCssSelector("#BASIC_FORM .confirmationButton, #BASIC_FORM .cancelButton")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 2, "OK/Cancel buttons not found on basic form");
+               })
+               .end()
 
-         .findAllByCssSelector("#AUTOSAVE_FORM .confirmationButton, #AUTOSAVE_FORM .cancelButton")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "OK/Cancel buttons found on autosave form");
-            });
-      },
+            .findAllByCssSelector("#AUTOSAVE_FORM .confirmationButton, #AUTOSAVE_FORM .cancelButton")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "OK/Cancel buttons found on autosave form");
+               });
+         },
 
-      "Updating autosave value publishes form": function() {
-         return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD .dijitInputInner")
-            .clearValue()
-            .type("wibble")
-            .getLastPublish("AUTOSAVE_FORM_1")
-            .then(function(payload) {
-               assert.propertyVal(payload, "control", "wibble", "Did not autosave updated value");
-               assert.propertyVal(payload, "alfValidForm", true, "Did not autosave validity property");
-            });
-      },
+         "Updating autosave value publishes form": function() {
+            return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD .dijitInputInner")
+               .clearValue()
+               .type("wibble")
+               .getLastPublish("AUTOSAVE_FORM_1")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "control", "wibble", "Did not autosave updated value");
+                  assert.propertyVal(payload, "alfValidForm", true, "Did not autosave validity property");
+               });
+         },
 
-      "Updating to invalid value does not autosave form": function() {
-         return browser.findById("CLEAR_AUTOSAVE_1")
-            .click()
-            .clearLog()
-            .getAllPublishes("AUTOSAVE_FORM_1")
-            .then(function(payloads) {
-               assert.lengthOf(payloads, 0, "Published form when invalid");
-            });
-      },
+         "Updating to invalid value does not autosave form": function() {
+            return browser.findById("CLEAR_AUTOSAVE_1")
+               .click()
+               .clearLog()
+               .getAllPublishes("AUTOSAVE_FORM_1")
+               .then(function(payloads) {
+                  assert.lengthOf(payloads, 0, "Published form when invalid");
+               });
+         },
 
-      "Autosave on invalid flag publishes invalid form": function() {
-         return browser.findByCssSelector("#AUTOSAVE_INVALID_FORM_FIELD .dijitInputInner")
-            .clearLog()
-            .clearValue()
-            .pressKeys(keys.BACKSPACE) // Need to trigger an update!
-            .getLastPublish("AUTOSAVE_FORM_2")
-            .then(function(payload) {
-               assert.propertyVal(payload, "control", "", "Did not autosave updated, invalid value");
-               assert.propertyVal(payload, "alfValidForm", false, "Did not autosave validity property");
-            });
-      },
+         "Autosave on invalid flag publishes invalid form": function() {
+            return browser.findByCssSelector("#AUTOSAVE_INVALID_FORM_FIELD .dijitInputInner")
+               .clearLog()
+               .clearValue()
+               .pressKeys(keys.BACKSPACE) // Need to trigger an update!
+               .getLastPublish("AUTOSAVE_FORM_2")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "control", "", "Did not autosave updated, invalid value");
+                  assert.propertyVal(payload, "alfValidForm", false, "Did not autosave validity property");
+               });
+         },
 
-      "Autosaving with defined payload mixes payload into form values": function(){
-         return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD") // Need to get session to check for publish
-            .getLastPublish("AUTOSAVE_FORM_2")
-            .then(function(payload) {
-               assert.propertyVal(payload, "customProperty", "awooga", "Did not mix custom payload into form values");
-            });
-      },
+         "Autosaving with defined payload mixes payload into form values": function(){
+            return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD") // Need to get session to check for publish
+               .getLastPublish("AUTOSAVE_FORM_2")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "customProperty", "awooga", "Did not mix custom payload into form values");
+               });
+         },
 
-      "Ensure hidden button inputs have value": function() {
-         return browser.findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(1) input[type=\"button\"]")
-            .getAttribute("value")
-            .then(function(value) {
-               assert.equal(value, "OK");
-            })
-            .end()
+         "Ensure hidden button inputs have value": function() {
+            return browser.findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(1) input[type=\"button\"]")
+               .getAttribute("value")
+               .then(function(value) {
+                  assert.equal(value, "OK");
+               })
+               .end()
 
-         .findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(2) input[type=\"button\"]")
-            .getAttribute("value")
-            .then(function(value) {
-               assert.equal(value, "CANCEL");
-            });
-      },
+            .findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(2) input[type=\"button\"]")
+               .getAttribute("value")
+               .then(function(value) {
+                  assert.equal(value, "CANCEL");
+               });
+         },
 
-      "Enter key can submit form": function() {
-         var firstPublish;
+         "Enter key can submit form": function() {
+            var firstPublish;
 
-         return browser.findByCssSelector("#ENTER_TEXT_FIELD .dijitInputInner")
-            .clearLog()
-            .type("wibble")
-            .pressKeys(keys.ENTER)
-            .end()
+            return browser.findByCssSelector("#ENTER_TEXT_FIELD .dijitInputInner")
+               .clearLog()
+               .type("wibble")
+               .pressKeys(keys.ENTER)
+               .end()
 
-         .getLastPublish("FORM_PUBLISH")
-            .then(function(payload) {
-               firstPublish = payload;
-            })
+            .getLastPublish("FORM_PUBLISH")
+               .then(function(payload) {
+                  firstPublish = payload;
+               })
 
-         .findByCssSelector("#ENTER_FORM .confirmationButton .dijitButtonNode")
-            .clearLog()
-            .click()
-            .end()
+            .findByCssSelector("#ENTER_FORM .confirmationButton .dijitButtonNode")
+               .clearLog()
+               .click()
+               .end()
 
-         .getLastPublish("FORM_PUBLISH")
-            .then(function(payload) {
-               assert.deepEqual(payload, firstPublish, "ENTER publish did not match button-click publish");
-            });
-      },
+            .getLastPublish("FORM_PUBLISH")
+               .then(function(payload) {
+                  assert.deepEqual(payload, firstPublish, "ENTER publish did not match button-click publish");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>BasicForm Test</shortname>
-  <description>This WebScript defines the BasicForm page test</description>
+  <shortname>Basic Forms Test</shortname>
+  <description>Demonstrates the basic capabilities of the alfresco/forms/Form widget</description>
   <family>aikau-unit-tests</family>
   <url>/BaseForm</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -75,13 +75,14 @@ model.jsonModel = {
          name: "alfresco/html/HR"
       },
       {
-         "name": "alfresco/layout/HorizontalWidgets",
-         "config": {
-            "widgets": [
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
                {
-                  name: "alfresco/forms/Form",
                   id: "BASIC_FORM",
+                  name: "alfresco/forms/Form",
                   config: {
+                     pubSubScope: "TEST_SCOPE_",
                      okButtonPublishTopic: "OK",
                      cancelButtonPublishTopic: "CANCEL",
                      widgets: [
@@ -89,7 +90,6 @@ model.jsonModel = {
                            id: "FORM_FIELD",
                            name: "alfresco/forms/controls/TextBox",
                            config: {
-                              pubSubScope: "TEST_SCOPE_",
                               valueSubscriptionTopic: "SET_FORM_CONTROL_VALUE",
                               name: "control",
                               label: "Basic form control"
@@ -99,12 +99,12 @@ model.jsonModel = {
                   }
                },
                {
-                  "name": "alfresco/layout/VerticalWidgets",
-                  "config": {
-                     "widgets": [
+                  name: "alfresco/layout/VerticalWidgets",
+                  config: {
+                     widgets: [
                         {
-                           name: "alfresco/forms/Form",
                            id: "AUTOSAVE_FORM",
+                           name: "alfresco/forms/Form",
                            config: {
                               autoSavePublishTopic: "AUTOSAVE_FORM_1",
                               autoSavePublishGlobal: true,
@@ -133,8 +133,8 @@ model.jsonModel = {
                            }
                         },
                         {
-                           name: "alfresco/buttons/AlfButton",
                            id: "CLEAR_AUTOSAVE_1",
+                           name: "alfresco/buttons/AlfButton",
                            config: {
                               label: "Clear autosave text box",
                               publishTopic: "SET_FORM_CONTROL_VALUE",
@@ -148,8 +148,8 @@ model.jsonModel = {
                   }
                },
                {
-                  name: "alfresco/forms/Form",
                   id: "AUTOSAVE_FORM_INVALID",
+                  name: "alfresco/forms/Form",
                   config: {
                      autoSavePublishTopic: "AUTOSAVE_FORM_2",
                      autoSavePublishGlobal: true,
@@ -179,12 +179,12 @@ model.jsonModel = {
          }
       },
       {
-         "name": "alfresco/layout/HorizontalWidgets",
-         "config": {
-            "widgets": [
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
                {
-                  name: "alfresco/forms/Form",
                   id: "ENTER_FORM",
+                  name: "alfresco/forms/Form",
                   config: {
                      okButtonPublishTopic: "FORM_PUBLISH",
                      cancelButtonPublishTopic: "FORM_CANCEL",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-764 to tidy up the base form control test and ensure that pubSubScopes are set correctly. I've added a warning if a control within a form is given an explicit pubSubScope - I've resisted the urge to remove it completely.