### PR TITLE
AKU-748: StripedContent CSS fix and minor tweaks to Sandpit app

### DIFF
--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/imports/sandpit.lib.js
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/imports/sandpit.lib.js
@@ -115,7 +115,8 @@ function buildPageModel(data) {
             },
             "alfresco/services/DialogService",
             "alfresco/services/PageService",
-            "alfresco/services/OptionsService"
+            "alfresco/services/OptionsService",
+            "alfresco/services/NavigationService"
          ].concat(data.services || []),
          widgets: [
             {
@@ -144,6 +145,22 @@ function buildPageModel(data) {
                                  config: {
                                     label: "Aikau Sandpit - " + data.title,
                                     setBrowserTitle: "Aikau Sandpit"
+                                 }
+                              },
+                              {
+                                 name: "alfresco/buttons/AlfButton",
+                                 align: "right",
+                                 config:
+                                 {
+                                    label: "Back to Examples List",
+                                    additionalCssClasses: "primary-call-to-action",
+                                    publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                                    publishPayload: {
+                                       url: "na/ws/home"
+                                    },
+                                    style: {
+                                       marginTop: "19px"
+                                    }
                                  }
                               }
                            ]

--- a/aikau/src/main/resources/alfresco/layout/css/StripedContent.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StripedContent.css
@@ -7,11 +7,14 @@
       &--header {
          background: @header-stripe-background-color;
          box-shadow: inset 0 0 2px 0 rgba(0,0,0,.75);
-         color: @header-stripe-font-color;
+         color: @header-stripe-font-color !important;
 
-         /* Special handling for title widgets in header, important is sadly required here! :( */
-         h1.alfresco-header-Title > .text {
-            color: @header-stripe-font-color !important;
+         h1.alfresco-header-Title {
+
+            .alfresco-header-Title__text {
+               /* Special handling for title widgets in header, important is sadly required here! :( */
+               color: @header-stripe-font-color !important;
+            }
          }
       }
       &--sub-header {


### PR DESCRIPTION
This PR provides some more minor updates to https://issues.alfresco.com/jira/browse/AKU-748. The StripedContent CSS selectors weren't quite correct for handling the title colour. I've also added a back button so that the user can easily return to the list of examples.