### PR TITLE
DocLib mock xhr correction

### DIFF
--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FullDocLibMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FullDocLibMockXhr.js
@@ -67,7 +67,8 @@ define(["dojo/_base/declare",
             this.server.respondWith("POST",
                                     "/aikau/proxy/alfresco/slingshot/doclib/action/files?alf_method=delete",
                                     [200,
-                                     {"Content-Type":"application/json;charset=UTF-8"}]);
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     ""]);
 
             this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
          }


### PR DESCRIPTION
This PR addresses an issue that has been introduced with the mocking of data for the Document Library test since the update to Sinon 1.17.2... it seems we need to include some kind of response to void a 404.