### PR TITLE
Fix TaggingMockXhr issue following upgrade to Sinon 1.17.2

### DIFF
--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/TaggingMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/TaggingMockXhr.js
@@ -51,7 +51,7 @@ define(["dojo/_base/declare",
                                     lang.hitch(this, this.getTags));
             this.server.respondWith("POST",
                                     /.*\/aikau\/proxy\/alfresco\/api\/node\/.*\/formprocessor/,
-                                    "OK");
+                                    "{}");
          }
          catch(e)
          {


### PR DESCRIPTION
This PR fixes another issue with mock data introduced following the update to Sinon 1.17.2. The response needs to be valid JSON.