### PR TITLE
Remove duplicate subscription from AlfSearchList

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -203,7 +203,6 @@ define(["dojo/_base/declare",
          this.alfSubscribe("ALF_REMOVE_FACET_FILTER", lang.hitch(this, this.onRemoveFacetFilter));
          this.alfSubscribe("ALF_SEARCHLIST_SCOPE_SELECTION", lang.hitch(this, this.onScopeSelection));
          this.alfSubscribe("ALF_ADVANCED_SEARCH", lang.hitch(this, this.onAdvancedSearch));
-         this.alfSubscribe(this.reloadDataTopic, lang.hitch(this, this.onReloadData));
       },
 
       /**


### PR DESCRIPTION
A customer reported that they had noticed a duplicate subscription in AlfSearchList. It is subscribing to the "reloadDataTopic" topic - but the inherited function from AlfList was already creating this subcription. I've removed it and run the unit tests to verify that this does not cause any issues.