### PR TITLE
AKU-744: SearchFilmStripView preview follow-up

### DIFF
--- a/aikau/src/main/resources/alfresco/search/SearchFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/search/SearchFilmStripView.js
@@ -80,7 +80,11 @@ define(["dojo/_base/declare",
             }
          },
          {
-            name: "alfresco/search/FilmStripViewSearchResult"
+            name: "alfresco/search/FilmStripViewSearchResult",
+            config: {
+               heightAdjustment: 0,
+               heightMode: "PARENT"
+            }
          }
       ],
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/SearchFilmStripView.get.js
@@ -1,7 +1,7 @@
 /* global page */
 /* jshint sub:true */
 
-var heightMode, heightAdjustment;
+var heightMode = "AUTO", heightAdjustment = 0;
 if (page.url.args["heightMode"])
 {
    heightMode = page.url.args["heightMode"];


### PR DESCRIPTION
This PR is a follow up to https://issues.alfresco.com/jira/browse/AKU-744. In the sprint review it was noticed that although the overall previewer had the height set correctly, the internal PDF.js rendering was too short so that the bottom of the scrollbar was not visible. This corrects that problem.