### PR TITLE
AKU-776: Ensure that no data message is not displayed during initial list load

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -981,7 +981,10 @@ define(["dojo/_base/declare",
        */
       showNoDataMessage: function alfresco_lists_AlfList__showNoDataMessage() {
          this.hideChildren(this.domNode);
-         domClass.remove(this.noDataNode, "share-hidden");
+         if (this._readyToLoad)
+         {
+            domClass.remove(this.noDataNode, "share-hidden");
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1096,6 +1096,8 @@ define(["dojo/_base/declare",
       loadData: function alfresco_lists_AlfList__loadData() {
          if (!this.requestInProgress)
          {
+            // Ensure any no data node is hidden...
+            domClass.add(this.noDataNode, "share-hidden");
             this.showLoadingMessage();
 
             var payload;

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -29,12 +29,13 @@ define(["dojo/_base/declare",
         "alfresco/lists/AlfSortablePaginatedList",
         "dojo/_base/array",
         "dojo/_base/lang",
+        "dojo/dom-class",
         "alfresco/util/hashUtils",
         "dojo/io-query",
         "alfresco/core/ArrayUtils",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/search/AlfSearchListView"],
-        function(declare, AlfSortablePaginatedList, array, lang, hashUtils, ioQuery, arrayUtils, ObjectTypeUtils) {
+        function(declare, AlfSortablePaginatedList, array, lang, domClass, hashUtils, ioQuery, arrayUtils, ObjectTypeUtils) {
 
    return declare([AlfSortablePaginatedList], {
 
@@ -553,6 +554,10 @@ define(["dojo/_base/declare",
        */
       loadData: function alfresco_search_AlfSearchList__loadData() {
          // jshint maxcomplexity:false,maxstatements:false
+         
+         // Ensure any no data node is hidden...
+         domClass.add(this.noDataNode, "share-hidden");
+
          var key;
          if (this.requestInProgress)
          {

--- a/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
@@ -82,6 +82,14 @@ define(["intern!object",
             });
          },
 
+         "No data message is hidden": function() {
+            return browser.findByCssSelector(".alfresco-lists-AlfList .no-data")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The no data message should have been hidden when loading data");
+               });
+         },
+
          "Test that setting different search term does not issues new search request when current request is ongoing": function() {
             // Click the button to set a DIFFERENT search term (a new request SHOULD NOT be issued because a request is in progress)...
             return browser.findByCssSelector("#SET_SEARCH_TERM_3")


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-776 to ensure that the "no data" message is not displayed between initial list creation and first loading of data. The search list unit test has been updated to verify and prevent future regressions.