### PR TITLE
AKU-776: Further improvement to no data message handling

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -981,7 +981,7 @@ define(["dojo/_base/declare",
        */
       showNoDataMessage: function alfresco_lists_AlfList__showNoDataMessage() {
          this.hideChildren(this.domNode);
-         if (this._readyToLoad)
+         if (!this.requestInProgress)
          {
             domClass.remove(this.noDataNode, "share-hidden");
          }

--- a/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SearchListTest.js
@@ -57,6 +57,14 @@ define(["intern!object",
                assert.lengthOf(payloads, 0, "Search request made unexpectedly");
             });
          },
+
+         "No data message is displayed": function() {
+            return browser.findByCssSelector(".alfresco-lists-AlfList .no-data")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "The no data message should not be hidden until a search request is made");
+               });
+         },
          
          "Test setting empty search term": function() {
             // Click the button to set a search term (but don't actually provide one)


### PR DESCRIPTION
This is a further enhancement to the fix for https://issues.alfresco.com/jira/browse/AKU-776 - after the previous commit was merged I noticed similar issues occurring in other test pages - this update further refines the previous fix.