### PR TITLE
AKU-775: Ensure TinyMCE resize works effectively

### DIFF
--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -391,7 +391,8 @@ define(["dojo/_base/declare",
          if (this._resizeWhenInitialized)
          {
             // See AKU-775 - adding a short timeout here allows everything to complete initialization before resizing
-            setTimeout(lang.hitch(this, this.onResize), 100);
+            //               by using timeout without a time we can delay until all synchronous processes have completed.
+            setTimeout(lang.hitch(this, this.onResize));
          }
          this.setDisabled(this.initiallyDisabled);
 

--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -390,7 +390,8 @@ define(["dojo/_base/declare",
          }
          if (this._resizeWhenInitialized)
          {
-            this.onResize();
+            // See AKU-775 - adding a short timeout here allows everything to complete initialization before resizing
+            setTimeout(lang.hitch(this, this.onResize), 100);
          }
          this.setDisabled(this.initiallyDisabled);
 

--- a/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
@@ -160,10 +160,15 @@ define(["intern!object",
             return browser.findByCssSelector(".dijitMenuBar .dijitMenuItem:nth-child(6) span")
                .click()
             .end()
+
+            .clearLog()
+
             .findByCssSelector(".dijitPopup tr:nth-child(2) .dijitMenuItemLabel")
                .click()
             .end()
-            .sleep(500)
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+
             .findAllByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row")
                .then(function(elements) {
                   assert.lengthOf(elements, 7, "Page size change didn't work");
@@ -171,27 +176,53 @@ define(["intern!object",
          },
 
          "Delete all the comments": function() {
-            return browser.findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+            return browser.findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+               .clearLog()
                .click()
             .end()
-            .findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
                .click()
             .end()
-            .findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
                .click()
             .end()
-            .findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
                .click()
             .end()
-            .findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
                .click()
             .end()
-            .findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+
+            .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
                .click()
             .end()
-            .findByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
                .click()
             .end()
+
+            .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
             .findByCssSelector("#COMMENT_LIST .alfresco-lists-AlfList")
                .getVisibleText()
                .then(function(text) {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-775. Because of the lack of proper AMD support for TinyMCE we're forced to load the resources on demand. This means that the first time we create a TinyMCE editor we go through a slightly different code path and for some reason the timing of this results in a dimension calculation error. The simplest resolution to this problem is to add a short timeout on this initial code path that results in the TinyMCE editor being resized correctly. 

This PR also updates the related CommentsList test to make it more reliable on Chrome.