### PR TITLE
AKU-782: Block facet filtering when search is in progress

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -484,6 +484,18 @@ define([],function() {
       GET_DOCUMENT_LIST: "ALF_RETRIEVE_DOCUMENTS_REQUEST",
 
       /**
+       * This topic is typically published as a result of request to load documents by publishing
+       * [GET_DOCUMENT_LIST]{@link module:alfresco/core/topics#GET_DOCUMENT_LIST}. It will contain
+       * the results of the request and can have a varying payload depending upon the API being used.
+       *
+       * @instance
+       * @type {string}
+       * @default 
+       * @since 1.0.51
+       */
+      GET_DOCUMENT_LIST_SUCCESS: "ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS",
+
+      /**
        * Get the node ref for the current node's parent.
        *
        * @instance
@@ -754,6 +766,30 @@ define([],function() {
        * @since 1.0.32
        */
       SCROLL_NEAR_BOTTOM: "ALF_SCROLL_NEAR_BOTTOM",
+
+      /**
+       * This topic can be used to publish a request to perform a search.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.51
+       *
+       * @event module:alfresco/core/topics~SEARCH_REQUEST
+       * @property {string} term The term to search for
+       * @property {number} [startIndex] The index in the search results to start the page of data from
+       * @property {number} [pageSize] The number of results to include in the page of data
+       * @property {string} [site] The shortName of a site to search within
+       * @property {string} rootNode The nodeRef of the node to search within
+       * @property {boolean} [repo] Indicates whether or not so search within the entire Alfresco Repository or just sites
+       * @property {string} [facetFields] Comma delimited fields to facet on in the search
+       * @property {string} [filters] Comma delimited facet filters to apply to the search
+       * @property {boolean} [spellcheck] Indicates whether or not to perform alternative searches based on better spelling
+       * @property {object} [query] Additinal query parameters to apply to the search
+       * @property {string} [sortField] The field to sort the search results on
+       * @property {boolean} [sortAscending] Indicates whether or not to sort the search results in ascending order
+       */
+      SEARCH_REQUEST: "ALF_SEARCH_REQUEST",
 
       /**
        * This topic should be published by [menu items]{@link module:alfresco/menus/AlfMenuItem} contained within

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -27,6 +27,7 @@
  */
 define(["dojo/_base/declare",
         "alfresco/lists/AlfSortablePaginatedList",
+        "alfresco/core/topics",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-class",
@@ -35,7 +36,7 @@ define(["dojo/_base/declare",
         "alfresco/core/ArrayUtils",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/search/AlfSearchListView"],
-        function(declare, AlfSortablePaginatedList, array, lang, domClass, hashUtils, ioQuery, arrayUtils, ObjectTypeUtils) {
+        function(declare, AlfSortablePaginatedList, topics, array, lang, domClass, hashUtils, ioQuery, arrayUtils, ObjectTypeUtils) {
 
    return declare([AlfSortablePaginatedList], {
 
@@ -660,7 +661,7 @@ define(["dojo/_base/declare",
 
                // Set a response topic that is scoped to this widget...
                searchPayload.alfResponseTopic = this.pubSubScope + "ALF_RETRIEVE_DOCUMENTS_REQUEST";
-               this.alfPublish("ALF_SEARCH_REQUEST", searchPayload, true);
+               this.alfPublish(topics.SEARCH_REQUEST, searchPayload, true);
             }
             else
             {

--- a/aikau/src/main/resources/alfresco/search/FacetFilter.js
+++ b/aikau/src/main/resources/alfresco/search/FacetFilter.js
@@ -32,6 +32,7 @@ define(["dojo/_base/declare",
         "dijit/_OnDijitClickMixin",
         "dojo/text!./templates/FacetFilter.html",
         "alfresco/core/Core",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
@@ -40,7 +41,8 @@ define(["dojo/_base/declare",
         "alfresco/util/hashUtils",
         "dojo/io-query",
         "alfresco/core/ArrayUtils"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, template,  AlfCore, lang, array, domConstruct, domClass, on, hashUtils, ioQuery, arrayUtils) {
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, template,  AlfCore, topics, 
+                 lang, array, domConstruct, domClass, on, hashUtils, ioQuery, arrayUtils) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
       
@@ -210,8 +212,8 @@ define(["dojo/_base/declare",
          }
 
          // See AKU-782 - Ensure that filters cannot be applied when search requests are in progress...
-         this.alfSubscribe("ALF_SEARCH_REQUEST", lang.hitch(this, this.onSearchRequestStart));
-         this.alfSubscribe("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS", lang.hitch(this, this.onSearchRequestEnd));
+         this.alfSubscribe(topics.SEARCH_REQUEST, lang.hitch(this, this.onSearchRequestStart));
+         this.alfSubscribe(topics.GET_DOCUMENT_LIST_SUCCESS, lang.hitch(this, this.onSearchRequestEnd));
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/search/css/FacetFilter.css
+++ b/aikau/src/main/resources/alfresco/search/css/FacetFilter.css
@@ -1,4 +1,5 @@
 .alfresco-search-FacetFilter {
+
    overflow: hidden;
    line-height: ceil(@small-font-size/@standard-line-height) * @standard-line-height;
    font-size: @small-font-size;
@@ -49,6 +50,41 @@
 
          &:hover {
             background-color: @filter-hover-color;
+         }
+      }
+   }
+
+   &--full-width-click {
+      .details {
+         cursor: pointer;
+
+         &:hover {
+            background-color: @filter-hover-color;
+         }
+      }
+   }
+
+   /* See AKU-782 - If a search request is in-flight we want to prevent further facet filtering
+                    the JS in the widget prevents additional requests from being made but these
+                    selectors ensure it doesn't appear to the user as though they can further filter */
+   &--block-requests {
+      cursor: default;
+
+      .status {
+         .remove {
+            cursor: default;
+         }
+      }
+
+      .details {
+         cursor: default;
+
+         &:hover {
+            background-color: inherit;
+         }
+
+         .filterLabel {
+            cursor: default;
          }
       }
    }

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -46,7 +46,7 @@ define(["dojo/_base/declare",
        * @since 1.0.32
        */
       registerSubscriptions: function alfresco_services_SearchService__registerSubscriptions() {
-         this.alfSubscribe("ALF_SEARCH_REQUEST", lang.hitch(this, this.onSearchRequest));
+         this.alfSubscribe(topics.SEARCH_REQUEST, lang.hitch(this, this.onSearchRequest));
          this.alfSubscribe("ALF_STOP_SEARCH_REQUEST", lang.hitch(this, this.onStopRequest));
          this.alfSubscribe("ALF_AUTO_SUGGEST_SEARCH", lang.hitch(this, this.onAutoSuggest));
       },
@@ -173,7 +173,7 @@ define(["dojo/_base/declare",
          else
          {
             // Check to see whether or not a success topic has been provided...
-            var alfTopic = (payload.alfResponseTopic) ? payload.alfResponseTopic : "ALF_SEARCH_REQUEST";
+            var alfTopic = (payload.alfResponseTopic) ? payload.alfResponseTopic : topics.SEARCH_REQUEST;
             var url = this.searchAPI;
 
             // Use any unexpected attributes as a query attribute...

--- a/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
+++ b/aikau/src/test/resources/alfresco/search/FacetFiltersTest.js
@@ -34,6 +34,60 @@ define(["intern!object",
       var browser;
 
       return {
+         name: "FacetFilters Tests (Filter blocking)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/FacetFilters", "FacetFilters Tests (Filter blocking)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Simulate search request": function() {
+            return browser.findById("DO_FACET_BUTTON_1_label")
+               .click()
+            .end()
+
+            .findById("SIM_SEARCH_REQUEST_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .findByCssSelector("#FACET1 .alfresco-search-FacetFilter:first-child .details .filterLabel")
+               .click()
+            .end()
+
+            .getAllPublishes("ALF_APPLY_FACET_FILTER")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0, "Filter click should not be applied");
+            });
+         },
+
+         "Simulate search results": function() {
+            return browser.findById("SIM_SEARCH_RESULTS_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .findByCssSelector("#FACET1 .alfresco-search-FacetFilter:first-child .details .filterLabel")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_APPLY_FACET_FILTER", "Filter click not applied");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
          name: "FacetFilters Tests (Mouse)",
 
          setup: function() {
@@ -228,7 +282,7 @@ define(["intern!object",
 
             .getLastPublish("ALF_REMOVE_FACET_FILTER");
          },
-
+        
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/FacetFilters.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/search/FacetFilters.get.js
@@ -14,11 +14,7 @@ model.jsonModel = {
       },
       {
          name: "alfresco/services/NavigationService"
-      },
-      {
-         name: "alfresco/services/SearchService"
-      },
-      "alfresco/services/ErrorReporter"
+      }
    ],
    widgets: [
       {
@@ -210,6 +206,22 @@ model.jsonModel = {
                   }
                }
             ]
+         }
+      },
+      {
+         id: "SIM_SEARCH_REQUEST",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Simulate Search Request",
+            publishTopic: "ALF_SEARCH_REQUEST"
+         }
+      },
+      {
+         id: "SIM_SEARCH_RESULTS",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Simulate Search Results",
+            publishTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS"
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-782 to ensure that it is not possible to apply facet filters whilst a search request is in progress.