### PR TITLE
AKU-786: Show preview on thumbnail click when MIME type present

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -948,9 +948,8 @@ define(["dojo/_base/declare",
          this.currentItem = nodeData;
 
          // Now check to see whether or not the preview can be shown...
-         var type = lang.getObject("node.type", false, this.currentItem),
-             mimetype = lang.getObject("node.mimetype", false, this.currentItem);
-         if (type === "cm:content")
+         var mimetype = lang.getObject("node.mimetype", false, this.currentItem);
+         if (mimetype)
          {
             this.onShowPreview(nodeRef, mimetype);
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-786 to change the behaviour of Thumbnail clicks so that the presence of a mimetype attribute in the node metadata is used to determine that a preview is possible (as opposed to a type of cm:content). This will allow types that extend cm:content to be previewed. The existing unit tests already cover that preview is shown and I've manually tested it still works.