### PR TITLE
AKU-784: Ensure new view instance has correct data

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -115,6 +115,31 @@ define(["dojo/_base/declare",
       updateInstanceValues: true,
 
       /**
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#copyViewData} to set the
+       * drag-and-drop upload capabilities based on the 
+       * [currentFilter]{@link module:alfresco/documentlibrary/AlfDocumentList#currentFilter} value.
+       * If the filter has a path value then
+       * [addUploadDragAndDrop]{@link module:alfresco/documentlibrary/_AlfDndDocumentUploadMixin#addUploadDragAndDrop}
+       * is called, otherwise 
+       * [removeUploadDragAndDrop]{@link module:alfresco/documentlibrary/_AlfDndDocumentUploadMixin#removeUploadDragAndDrop}
+       * is called.
+       * 
+       * @instance
+       * @since 1.0.50.1
+       */
+      copyViewData: function alfresco_lists_AlfList__copyViewData(/*jshint unused:false*/oldView, newView) {
+         this.inherited(arguments);
+         if (this.currentFilter && this.currentFilter.path)
+         {
+            newView.addUploadDragAndDrop(newView.dragAndDropNode);
+         }
+         else
+         {
+            newView.removeUploadDragAndDrop(newView.dragAndDropNode);
+         }
+      },
+
+      /**
        * Extends the [inherited function]{@link module:alfresco/lists/AlfSortablePaginatedListt#postMixInProperties}
        * to set a default filter to be a root path.
        *

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -414,6 +414,7 @@ define(["dojo/_base/declare",
        * @since 1.0.41
        */
       removeDndUploadHandlers: function alfresco_documentlibrary__AlfDndDocumentUploadMixin__removeDndUploadHandlers() {
+         this.dndUploadEnabled = false;
          if (this.dndUploadEventHandlers)
          {
             array.forEach(this.dndUploadEventHandlers, function(handle){ handle.remove(); });

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -633,8 +633,7 @@ define(["dojo/_base/declare",
                var newAspect = aspect.after(newView, "renderView", lang.hitch(this, this.publishSelectedItems));
                this.viewAspectHandles[this._currentlySelectedView] = newAspect;
 
-               // Set the current data...
-               newView.setData(this.currentData);
+               this.copyViewData(oldView, newView);
                newView.renderView(this.useInfiniteScroll);
 
                // Clear up the old view...
@@ -646,7 +645,22 @@ define(["dojo/_base/declare",
                this.showView(newView);
             }
         }
-     },
+      },
+
+      /**
+       * This is called from [handleNewViewInstances]{@link module:alfresco/lists/AlfList#handleNewViewInstances}
+       * when a new view is created to replace the existing view. It allows all relevant data to be copied from
+       * the old view to the new view.
+       * 
+       * @instance
+       * @extendable
+       * @since 1.0.50.1
+       */
+      copyViewData: function alfresco_lists_AlfList__copyViewData(oldView, newView) {
+         // Set the current data...
+         newView.setData(this.currentData);
+         newView._currentNode = oldView._currentNode;
+      },
 
       /**
        * Create the subscriptions for the [filteringTopics]{@link module:alfresco/lists/AlfList#filteringTopics}. This is

--- a/aikau/src/main/resources/alfresco/testing/NodesMockXhr.js
+++ b/aikau/src/main/resources/alfresco/testing/NodesMockXhr.js
@@ -179,7 +179,16 @@ define(["alfresco/testing/MockXhr",
          var response = {
             totalRecords: filteredItems.length,
             startIndex: startIndex,
-            items: responseData
+            items: responseData,
+            // TODO: Add metadata from seed data, this is sufficient for current testing requirements 
+            metadata: {
+               parent: {
+                  nodeRef: "parent://node/ref",
+                  node: {
+                     nodeRef: "parent://node/ref"
+                  }
+               }
+            }
          };
 
          // Send the response

--- a/aikau/src/test/resources/alfresco/upload/DndUploadTest.js
+++ b/aikau/src/test/resources/alfresco/upload/DndUploadTest.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Drag-and-drop file upload tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/dnd-upload", "Drag-and-drop file upload tests").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+         
+         "Simulate file drop": function() {
+            return browser.findByCssSelector("body")
+
+            // Wait for the document library to finish loading...
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            // Simulate dropping a node...
+            .findById("SIM_DROP_label")
+               .click()
+            .end()
+
+            // Check that an upload request is published and includes the metadata...
+            .getLastPublish("ALF_UPLOAD_REQUEST")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "targetData.destination", "parent://node/ref", "Target data not included in upload request");
+               });
+         },
+
+         // See AKU-784 - We need to ensure that when new list data is loaded (such that a new view instance is created
+         // to replace the current view instance) that target metadata is retained...
+         "Update view and drop": function() {
+            return browser.findByCssSelector("#SIMPLE_VIEW_NAME_ITEM_0 .alfresco-renderers-Property")
+               .click()
+            .end()
+
+            // Wait for the document library to finish loading...
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+            .clearLog()
+
+            // Simulate dropping a node...
+            .findById("SIM_DROP_label")
+               .click()
+            .end()
+
+            // Check that an upload request is published and includes the metadata...
+            .getLastPublish("ALF_UPLOAD_REQUEST")
+               .then(function(payload) {
+                  assert.deepPropertyVal(payload, "targetData.destination", "parent://node/ref", "Target data not included in upload request");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -284,6 +284,7 @@ define({
       "src/test/resources/alfresco/services/actions/NodeLocationTest",
       "src/test/resources/alfresco/services/actions/WorkflowTest",
 
+      "src/test/resources/alfresco/upload/DndUploadTest",
       "src/test/resources/alfresco/upload/UploadMonitorTest",
       "src/test/resources/alfresco/upload/UploadTest",
       "src/test/resources/alfresco/upload/UploadTargetTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/DndUpload.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/DndUpload.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Drag-and-drop File Upload Test</shortname>
+  <description>This test page is used to simulate drag-and-drop file upload to verify that target node data is included in upload requsts</description>
+  <family>aikau-unit-tests</family>
+  <url>/dnd-upload</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/DndUpload.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/DndUpload.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/DndUpload.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/DndUpload.get.js
@@ -1,0 +1,42 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "SIM_DROP",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Simulate file drop",
+            publishTopic: "SIM_FILE_DROP",
+            publishPayload: {
+               files: []
+            }
+         }
+      },
+      {
+         name: "aikauTesting/widgets/DragAndDropUploadTester",
+         config: {
+            
+         }
+      },
+      {
+         name: "alfresco/testing/NodesMockXhr",
+         config: {
+            totalItems: 11
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/DragAndDropUploadTester.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/DragAndDropUploadTester.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @module aikauTesting/widgets/DragAndDropUploadTester
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/layout/HeightMixin
+ * @mixes module:alfresco/core/Core
+ * @author Dave Draper
+ * @since 1.0.50.1
+ */
+define(["dojo/_base/declare",
+        "dijit/_WidgetBase", 
+        "dijit/_TemplatedMixin",
+        "alfresco/core/Core",
+        "alfresco/documentlibrary/AlfDocumentList",
+        "dojo/text!./templates/DragAndDropUploadTester.html",
+        "dojo/_base/lang"], 
+        function(declare, _WidgetBase, _TemplatedMixin, AlfCore, AlfDocumentList, template, lang) {
+   
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
+
+      /**
+       * The HTML template to use for the widget.
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
+
+      /**
+       * Call setHeight to set the height
+       * @instance
+       */
+      postCreate: function aikauTesting_widgets_DragAndDropUploadTester__postCreate() {
+         
+         var doclist = new AlfDocumentList({
+            widgets: [
+               {
+                  assignTo: "view",
+                  name: "alfresco/documentlibrary/views/AlfSimpleView"
+               }
+            ]
+         });
+         doclist.placeAt(this.domNode);
+
+         this.alfSubscribe("SIM_FILE_DROP", lang.hitch(this, function() {
+            doclist.view.onDndUploadDrop({ 
+               dataTransfer: {
+                  files: ["test"]
+               }
+            });
+         }));
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/templates/DragAndDropUploadTester.html
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/templates/DragAndDropUploadTester.html
@@ -1,0 +1,1 @@
+<div class="aikauTesting-layout-DragAndDropUploadTester"></div>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-784 to ensure that new view instances have all the appropriate metadata to allow drag-and-drop file upload to progress. This resolves an issue introduced by the re-implementation of list rendering. The unit tests have been updated to simulate drag-and-drop file events as it is not possible to do a real drag-and-drop from OS desktop to browser in the selenium tests