### PR TITLE
AKU-777: MultiSelect options expanding when choice removed

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -622,7 +622,7 @@ define([
             // Setup the listeners
             var choiceObject = {},
                selectListener = on(choiceNode, "click", lang.hitch(this, this._onChoiceClick, choiceObject)),
-               closeListener = on(closeButton, "click", lang.hitch(this, this._onChoiceCloseClick, choiceObject));
+               closeListener = on(closeButton, "mousedown", lang.hitch(this, this._onChoiceCloseMouseDown, choiceObject));
             this.own(selectListener, closeListener);
             lang.mixin(choiceObject, {
                domNode: choiceNode,
@@ -760,7 +760,7 @@ define([
           * @instance
           */
          _deleteSelectedChoice: function alfresco_forms_controls_MultiSelect___deleteSelectedChoice() {
-            on.emit(this._selectedChoice.closeButton, "click", {
+            on.emit(this._selectedChoice.closeButton, "mousedown", {
                bubbles: true,
                cancelable: true
             });
@@ -997,7 +997,7 @@ define([
           * @param    {object} choiceToRemove The choice object to remove
           * @param    {object} evt Dojo-normalised event object
           */
-         _onChoiceCloseClick: function alfresco_forms_controls_MultiSelect___onChoiceCloseClick(choiceToRemove, evt) {
+         _onChoiceCloseMouseDown: function alfresco_forms_controls_MultiSelect___onChoiceCloseMouseDown(choiceToRemove, evt) {
             this._removeChoice(choiceToRemove);
             evt.preventDefault();
             evt.stopPropagation();
@@ -1331,7 +1331,7 @@ define([
          _setupDisabling: function alfresco_forms_controls_MultiSelect___setupDisabling() {
             var methodsToDisable = [
                "_onChoiceClick",
-               "_onChoiceCloseClick",
+               "_onChoiceCloseMouseDown",
                "_onControlClick",
                "_onFocus",
                "_onResultMousedown",

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -774,6 +774,20 @@ define([
                browser.end();
             },
 
+            "Removing option from unfocused control does not induce dropdown": function() {
+               return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice__close-button")
+                  .click()
+                  .end()
+
+               .waitForDeletedByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice")
+
+               .findById("MULTISELECT_4_CONTROL_RESULTS")
+                  .isDisplayed()
+                  .then(function(isDisplayed) {
+                     assert.isFalse(isDisplayed);
+                  });
+            },
+
             "Can click on control and choose an option": function() {
                return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect")
                   .click()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -206,6 +206,7 @@ model.jsonModel = {
                               label: "Sweets (fixed options)",
                               name: "sweets",
                               width: "300px",
+                              value: "foam_strawberries",
                               optionsConfig: {
                                  fixed: [
                                     {


### PR DESCRIPTION
This addresses [AKU-777](https://issues.alfresco.com/jira/browse/AKU-777) by changing the event-handler from click to mousedown on the item's "delete" button, to correct event-firing order and prevent the focus event firing in this context. Test added and MultiSelect tests all now passing. Full suite not run because of nature of change.