### PR TITLE
AKU-778: MultiSelect fixed options not filtering

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelect.js
@@ -483,6 +483,13 @@ define([
                item[this.store.queryAttribute] = itemName;
                item[this.store.labelAttribute] = itemLabel;
                item[this.store.valueAttribute] = itemValue;
+            } else if (!this.inferMissingProperties) {
+               array.forEach(["query", "label", "value"], function(attrType) {
+                  var attrName = this.store[attrType + "Attribute"];
+                  if (!item[attrName]) {
+                     this.alfLog("warn", "Missing \"" + attrName + "\" property on retrieved item: ", item);
+                  }
+               }, this);
             }
 
             // Items MUST have values for the widget to work

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -804,25 +804,26 @@ define([
                   });
             },
 
-            "Can click on control again and choose a second option": function() {
-               return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect")
+            "Can filter options and select second option": function() {
+               return browser.findById("MULTISELECT_4_CONTROL")
                   .click()
+                  .pressKeys("mi")
                   .end()
 
-               .findByCssSelector("#MULTISELECT_4_CONTROL_RESULTS [title=\"Refreshers\"]")
-                  .click()
-                  .end()
-
-               .findAllByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice")
+               .findAllByCssSelector("#MULTISELECT_4_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
                   .then(function(elements) {
-                     assert.lengthOf(elements, 2);
+                     assert.lengthOf(elements, 1);
                   })
+                  .end()
+
+               .findByCssSelector("#MULTISELECT_4_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+                  .click()
                   .end()
 
                .findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect__choice:nth-child(2) .alfresco-forms-controls-MultiSelect__choice__content")
                   .getVisibleText()
                   .then(function(visibleText) {
-                     assert.equal(visibleText, "Refreshers");
+                     assert.equal(visibleText, "White Chocolate Mice");
                   });
             },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MultiSelectInput.get.js
@@ -210,22 +210,27 @@ model.jsonModel = {
                               optionsConfig: {
                                  fixed: [
                                     {
+                                       name: "Foam Strawberries",
                                        label: "Foam Strawberries",
                                        value: "foam_strawberries"
                                     },
                                     {
+                                       name: "Sherbert Lemons",
                                        label: "Sherbert Lemons",
                                        value: "sherbert_lemons"
                                     },
                                     {
+                                       name: "White Chocolate Mice",
                                        label: "White Chocolate Mice",
                                        value: "white_chocolate_mice"
                                     },
                                     {
+                                       name: "Refreshers",
                                        label: "Refreshers",
                                        value: "refreshers"
                                     },
                                     {
+                                       name: "Flying Saucers",
                                        label: "Flying Saucers",
                                        value: "flying_saucers"
                                     }


### PR DESCRIPTION
This addresses [AKU-778](https://issues.alfresco.com/jira/browse/AKU-778) which is about MultiSelect options not filtering correctly. The fix is to put the missing properties into the fixed options on the test page, however a regression test has been added, and warnings will now be logged if properties are missing on retrieved items.