### PR TITLE
AKU-779: Film strip view video previews

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -655,6 +655,22 @@ define([],function() {
       POST_TO_PAGE: "ALF_POST_TO_PAGE",
 
       /**
+       * This topic should be published when indicating what [previewers]{@link module:alfresco/preview/AlfDocumentPreview}
+       * are currently displayed. This has been added to support the 
+       * [DocumentCarousel]{@link module:alfresco/documentlibrary/views/layouts/DocumentCarousel} so that audio and video
+       * previewers can automatically be stopped and started as they leave are hidden and displayed.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.51
+       *
+       * @event module:alfresco/core/topics~PREVIEWS_SHOWN
+       * @property {object[]} items An array of the items that have been displayed.
+       */
+      PREVIEWS_SHOWN: "ALF_PREVIEWS_SHOWN",
+
+      /**
        * This topic is published to indicate that data needs to be uploaded. This is typically list based data but can
        * be used by other widgets.
        *

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -665,7 +665,7 @@ define([],function() {
        * @default
        * @since 1.0.51
        *
-       * @event module:alfresco/core/topics~PREVIEWS_SHOWN
+       * @event
        * @property {object[]} items An array of the items that have been displayed.
        */
       PREVIEWS_SHOWN: "ALF_PREVIEWS_SHOWN",

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -302,6 +302,9 @@
 // Filters
 @filter-hover-color: @list-hover-color;
 
+// Previews
+@preview-background-color: #424242;
+
 // Generic colours for displaying collections of items
 @collectionColour1: #f1e695;
 @collectionColour2: #f4af72;

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfFilmStripView.js
@@ -27,6 +27,7 @@
  */
 define(["dojo/_base/declare",
         "alfresco/lists/views/AlfListView",
+        "alfresco/core/ObjectProcessingMixin",
         "dojo/text!./templates/AlfFilmStripView.html",
         "alfresco/documentlibrary/AlfDocument",
         "alfresco/preview/AlfDocumentPreview",
@@ -34,10 +35,10 @@ define(["dojo/_base/declare",
         "alfresco/lists/views/layouts/Carousel",
         "dojo/_base/lang",
         "dojo/dom-construct"], 
-        function(declare, AlfDocumentListView, template, AlfDocument, AlfDocumentPreview, DocumentCarousel, Carousel, 
-                 lang, domConstruct) {
+        function(declare, AlfListView, ObjectProcessingMixin, template, AlfDocument, AlfDocumentPreview, 
+                 DocumentCarousel, Carousel, lang, domConstruct) {
    
-   return declare([AlfDocumentListView], {
+   return declare([AlfListView, ObjectProcessingMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -127,6 +128,23 @@ define(["dojo/_base/declare",
        * @since 1.0.51
        */
       itemCarouselHeight: 112,
+
+      /**
+       * The value configured is passed to the 
+       * [previewerPluginOverrides]{@link module:alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument#previewerPluginOverrides}
+       * which is then passed to the 
+       * [widgetsForPluginsOverrides]{@link module:alfresco/preview/AlfDocumentPreview#widgetsForPluginsOverrides}
+       * of the [widgetsForPluginsOverrides]{@link module:alfresco/preview/AlfDocumentPreview} that is rendered
+       * by default. Configuring or overriding 
+       * [widgetsForContent]{@link module:alfresco/documentlibrary/views/AlfFilmStripView#widgetsForContent}
+       * can potentially change this depending upon the change made.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.51
+       */
+      previewerPluginOverrides: null,
 
       /**
        * The configuration for selecting the view (configured the menu item)
@@ -224,6 +242,7 @@ define(["dojo/_base/declare",
          }
 
          var clonedWidgetsForContent = lang.clone(this.widgetsForContent);
+         this.processObject(["processInstanceTokens"], clonedWidgetsForContent);
          this.contentCarousel = this.createWidget({
             id: (this._alfPreferredWidgetId || this.id) + "_PREVIEWS",
             name: "alfresco/documentlibrary/views/layouts/DocumentCarousel",
@@ -311,7 +330,8 @@ define(["dojo/_base/declare",
             name: "alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument",
             config: {
                heightAdjustment: 0,
-               heightMode: "PARENT"
+               heightMode: "PARENT",
+               previewerPluginOverrides: "{previewerPluginOverrides}"
             }
          }
       ],

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/css/AlfFilmStripView.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/css/AlfFilmStripView.css
@@ -13,7 +13,9 @@
                padding: 10px 0;
                text-shadow: 1px 1px #333;
                .alfresco-renderers-Property {
-                  color: #fff;
+                  span {
+                     color: #fff;
+                  }
                }
             }
          }

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/AlfFilmStripViewDocument.js
@@ -65,6 +65,19 @@ define(["dojo/_base/declare",
       heightMode: "AUTO",
 
       /**
+       * The value configured is passed to the
+       * [widgetsForPluginsOverrides]{@link module:alfresco/preview/AlfDocumentPreview#widgetsForPluginsOverrides}
+       * of the [widgetsForPluginsOverrides]{@link module:alfresco/preview/AlfDocumentPreview} that is rendered
+       * by default.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.51
+       */
+      previewerPluginOverrides: null,
+
+      /**
        * Overrides the [inherited function]{@link module:alfresco/documentlibrary/AlfDocument#postMixInProperties}
        * to prevent the subscription to the standard document request from being created.
        * 
@@ -102,7 +115,8 @@ define(["dojo/_base/declare",
                name: "alfresco/preview/AlfDocumentPreview",
                config: {
                   heightMode: this.heightMode,
-                  heightAdjustment: this.heightAdjustment
+                  heightAdjustment: this.heightAdjustment,
+                  widgetsForPluginsOverrides: this.previewerPluginOverrides
                }
             }];
             this.alfSubscribe("ALF_FILMSTRIP_DOCUMENT_REQUEST__" + this.nodeRef, lang.hitch(this, this.requestDocument, this.nodeRef));

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/DocumentCarousel.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/DocumentCarousel.js
@@ -147,6 +147,20 @@ define(["dojo/_base/declare",
          this.alfPublish("ALF_FILMSTRIP_ITEM_CHANGED", {
             index: this.firstDisplayedIndex
          });
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/lists/views/layouts/Carousel#renderDisplayedItems}
+       * to publish a topic indicating that the items being played should be stopped.
+       * 
+       * @instance
+       * @since 1.0.51
+       */
+      renderDisplayedItems: function alfresco_documentlibrary_views_layouts_DocumentCarousel__renderDisplayedItems() {
+         this.inherited(arguments);
+         this.alfPublish("DISPLAYED_CAROUSEL_ITEMS", {
+            items: this.currentData.items.slice(this.firstDisplayedIndex, this.lastDisplayedIndex + 1)
+         });
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/DocumentCarousel.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/layouts/DocumentCarousel.js
@@ -29,6 +29,7 @@
  */
 define(["dojo/_base/declare",
         "alfresco/lists/views/layouts/Carousel",
+        "alfresco/core/topics",
         "alfresco/enums/urlTypes",
         "dojo/_base/lang",
         "dojo/dom-class",
@@ -37,7 +38,7 @@ define(["dojo/_base/declare",
         "dojo/dom-geometry",
         "dojo/query", 
         "dojo/NodeList-dom"], 
-        function(declare, Carousel, urlTypes, lang, domClass, domConstruct, domStyle, domGeom, query, nodeListDom) {
+        function(declare, Carousel, topics, urlTypes, lang, domClass, domConstruct, domStyle, domGeom, query, /*jshint unused:false*/ nodeListDom) {
 
    return declare([Carousel], {
       
@@ -155,10 +156,11 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @since 1.0.51
+       * @fires module:alfresco/core/topics#PREVIEWS_SHOWN
        */
       renderDisplayedItems: function alfresco_documentlibrary_views_layouts_DocumentCarousel__renderDisplayedItems() {
          this.inherited(arguments);
-         this.alfPublish("DISPLAYED_CAROUSEL_ITEMS", {
+         this.alfPublish(topics.PREVIEWS_SHOWN, {
             items: this.currentData.items.slice(this.firstDisplayedIndex, this.lastDisplayedIndex + 1)
          });
       }

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
@@ -397,6 +397,10 @@ define(["dojo/_base/declare",
             }
          }
 
+         this.alfPublish("DISPLAYED_CAROUSEL_ITEMS", {
+            items: this.currentData.items.slice(this.firstDisplayedIndex, this.lastDisplayedIndex + 1)
+         });
+
          // Make sure the frame is aligned correctly...
          this.currentLeftPosition = (this.firstDisplayedIndex / this.numberOfItemsShown) * this.itemsNodeWidth;
          var left = "-" + this.currentLeftPosition + "px";

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Carousel.js
@@ -397,10 +397,6 @@ define(["dojo/_base/declare",
             }
          }
 
-         this.alfPublish("DISPLAYED_CAROUSEL_ITEMS", {
-            items: this.currentData.items.slice(this.firstDisplayedIndex, this.lastDisplayedIndex + 1)
-         });
-
          // Make sure the frame is aligned correctly...
          this.currentLeftPosition = (this.firstDisplayedIndex / this.numberOfItemsShown) * this.itemsNodeWidth;
          var left = "-" + this.currentLeftPosition + "px";

--- a/aikau/src/main/resources/alfresco/preview/AVPlugin.js
+++ b/aikau/src/main/resources/alfresco/preview/AVPlugin.js
@@ -61,7 +61,6 @@ define(["dojo/_base/declare",
        * to start playing the preview if [autoPlay]{@link module:alfresco/preview/AVPlugin#autoPlay} is true.
        * 
        * @instance
-       * @since 1.0.51
        */
       onMarkupAdded: function alfresco_preview_AlfDocumentPreviewPlugin__onMarkupAdded() {
          this.inherited(arguments);
@@ -78,7 +77,6 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param  {object} payload The list of items that are currently displayed.
-       * @since 1.0.51
        */
       onPreviewDisplayChange: function alfresco_preview_AVPlugin__onPreviewDisplayChange(payload) {
          var displayed = array.some(payload.items, function(item) {

--- a/aikau/src/main/resources/alfresco/preview/AVPlugin.js
+++ b/aikau/src/main/resources/alfresco/preview/AVPlugin.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An abstract module for [preview plugins]{@link module:alfresco/preview/AlfDocumentPreviewPlugin} to extend
+ * that handles auto-play and auto-pause capabilities.
+ *
+ * @module alfresco/preview/AVPlugin
+ * @extends module:alfresco/preview/AlfDocumentPreviewPlugin
+ * @author Dave Draper
+ * @since 1.0.51
+ */
+define(["dojo/_base/declare",
+        "alfresco/preview/AlfDocumentPreviewPlugin", 
+        "alfresco/core/topics",
+        "dojo/_base/lang",
+        "dojo/_base/array"], 
+        function(declare, AlfDocumentPreviewPlugin, topics, lang, array) {
+   
+   return declare([AlfDocumentPreviewPlugin], {
+
+      /**
+       * Indicates whether or not the the AV previewer should automatically play when it is displayed.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      autoPlay: false,
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/preview/AlfDocumentPreviewPlugin#display}
+       * to set up a subscription to handle when the plugin is hiden or displayed. 
+       *
+       * @instance
+       * @listens module:alfresco/core/topics#PREVIEWS_SHOWN
+       */
+      display: function alfresco_preview_AVPlugin__display() {
+         this.alfSubscribe(topics.PREVIEWS_SHOWN, lang.hitch(this, this.onPreviewDisplayChange));
+         this.inherited(arguments);
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/preview/AlfDocumentPreviewPlugin#onMarkupAdded}
+       * to start playing the preview if [autoPlay]{@link module:alfresco/preview/AVPlugin#autoPlay} is true.
+       * 
+       * @instance
+       * @since 1.0.51
+       */
+      onMarkupAdded: function alfresco_preview_AlfDocumentPreviewPlugin__onMarkupAdded() {
+         this.inherited(arguments);
+         if (this.autoPlay)
+         {
+            this.previewManager.getPreviewerElement().firstChild.play();
+         }
+      },
+
+      /**
+       * Inspects the payload to see if the item represented by this plugin instance is being displayed.
+       * If [autoPlay]{@link module:alfresco/preview/AVPlugin#autoPlay} is true then the preview will begin
+       * playing when displayed, but it will always stop playing when hidden.
+       * 
+       * @instance
+       * @param  {object} payload The list of items that are currently displayed.
+       * @since 1.0.51
+       */
+      onPreviewDisplayChange: function alfresco_preview_AVPlugin__onPreviewDisplayChange(payload) {
+         var displayed = array.some(payload.items, function(item) {
+            return item.nodeRef === this.previewManager.nodeRef;
+         }, this);
+
+         if (!displayed)
+         {
+            this.previewManager.getPreviewerElement().firstChild.pause();
+         }
+         else if (this.autoPlay)
+         {
+            this.previewManager.getPreviewerElement().firstChild.play();
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
@@ -483,6 +483,8 @@ define(["dojo/_base/declare",
                            {
                               // Insert markup if plugin provided it
                               this.previewerNode.innerHTML = markup;
+
+                              plugin._setPreviewerElementHeight();
                            }
 
                            // Finally! We found a plugin that works and didn't crash

--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
@@ -240,10 +240,6 @@ define(["dojo/_base/declare",
             name: "alfresco/preview/PdfJs/PdfJs"
          },
          {
-            id: "WebPreviewer",
-            name: "alfresco/preview/WebPreviewer"
-         },
-         {
             id: "Image",
             name: "alfresco/preview/Image"
          },
@@ -464,13 +460,6 @@ define(["dojo/_base/declare",
                      // Get plugin
                      plugin = this.plugins[pluginDescriptor.name];
                      plugin.setAttributes(pluginDescriptor.attributes);
-
-                     // Special case to ignore the WebPreviewer plugin on iOS - we don't want to report output either
-                     // as the output is simply an HTML message unhelpfully informing the user to install Adobe Flash
-                     if (sniff("ios") && pluginDescriptor.name === "WebPreviewer")
-                     {
-                        continue;
-                     }
 
                      // Make sure it may run in this browser...
                      var report = plugin.report();
@@ -819,22 +808,6 @@ define(["dojo/_base/declare",
                {
                   name: "Audio",
                   attributes: {}
-               }
-            ]
-         },
-         {
-            attributes:
-            {
-               thumbnail: "webpreview"
-            },
-            plugins: [
-               {
-                  name: "WebPreviewer",
-                  attributes:
-                  {
-                     paging: "true",
-                     src: "webpreview"
-                  }
                }
             ]
          },

--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
@@ -228,8 +228,9 @@ define(["dojo/_base/declare",
 
       /**
        * This is the default set of plugins for the previewer. These can be overridden in their entirety
-       * or changes to a subset can be made through configuration of the [widgetsForPluginsOverrides]
-       * {@link module:alfresco/preview/AlfDocumentPreview#widgetsForPluginsOverrides} attribute.
+       * or changes to a subset can be made through configuration of the 
+       * [widgetsForPluginsOverrides]{@link module:alfresco/preview/AlfDocumentPreview#widgetsForPluginsOverrides} 
+       * attribute.
        * 
        * @instance
        * @type {object[]}
@@ -483,8 +484,8 @@ define(["dojo/_base/declare",
                            {
                               // Insert markup if plugin provided it
                               this.previewerNode.innerHTML = markup;
-
                               plugin._setPreviewerElementHeight();
+                              plugin.onMarkupAdded();
                            }
 
                            // Finally! We found a plugin that works and didn't crash

--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreviewPlugin.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreviewPlugin.js
@@ -71,6 +71,18 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * If [display]{@link module:alfresco/preview/AlfDocumentPreview#display} returns HTML to be
+       * added as the preview then this function will be called after it has been added to the document.
+       * This provides an opportunity for the plugin to perform any additional initialisation.
+       * 
+       * @instance
+       * @since 1.0.51
+       */
+      onMarkupAdded: function alfresco_preview_AlfDocumentPreviewPlugin__onMarkupAdded() {
+         // By default don't report anything.
+      },
+
+      /**
        * Tests if the plugin can be used in the users browser.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/preview/Audio.js
+++ b/aikau/src/main/resources/alfresco/preview/Audio.js
@@ -92,10 +92,10 @@ define(["dojo/_base/declare",
       display: function alfresco_preview_Audio__display() {
          var src = this.attributes.src ? this.previewManager.getThumbnailUrl(this.attributes.src) : this.previewManager.getContentUrl(),
          mimeType = this.attributes.srcMimeType ? this.attributes.srcMimeType : this.previewManager.mimeType;
-         var str = '';
-         str += '<audio width="100%" height="100%" controls alt="' + this.previewManager.name  + '" title="' + this.previewManager.name  + '">';
-         str += '   <source src="' + src + '"  type=\'' + mimeType + '\'>';
-         str += '</audio>';
+         var str = "";
+         str += "<audio width=\"100%\" height=\"100%\" controls alt=\"" + this.previewManager.name  + "\" title=\"" + this.previewManager.name  + "\">";
+         str += "   <source src=\"" + src + "\"  type=\"" + mimeType + "\">";
+         str += "</audio>";
          return str;
       }
    });

--- a/aikau/src/main/resources/alfresco/preview/Audio.js
+++ b/aikau/src/main/resources/alfresco/preview/Audio.js
@@ -21,16 +21,16 @@
  * This plugin will render the HTML5 audio element to preview the content of an audio node.
  *
  * @module alfresco/preview/Audio
- * @extends module:alfresco/preview/AlfDocumentPreviewPlugin
+ * @extends module:alfresco/preview/AVPlugin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/preview/AlfDocumentPreviewPlugin", 
+        "alfresco/preview/AVPlugin", 
         "dojo/_base/lang",
         "dojo/has"], 
-        function(declare, AlfDocumentPreviewPlugin, lang, has) {
+        function(declare, AVPlugin, lang, has) {
    
-   return declare([AlfDocumentPreviewPlugin], {
+   return declare([AVPlugin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -72,8 +72,7 @@ define(["dojo/_base/declare",
        * @return {String} Returns nothing if the plugin may be used, otherwise returns a message containing the reason
        *         it cant be used as a string.
        */
-      report: function alfresco_preview_Audio__report()
-      {
+      report: function alfresco_preview_Audio__report() {
          // Should ideally use a future proof algorithm for testing if the browsers video element can display video of the current mimetype
          if ((has("ie") > 0 && has("ie") < 9) || // IE 9
              (has("ff") > 0 && has("ff") < 1.91) || // FireFox 3.5
@@ -90,6 +89,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       display: function alfresco_preview_Audio__display() {
+         this.inherited(arguments);
          var src = this.attributes.src ? this.previewManager.getThumbnailUrl(this.attributes.src) : this.previewManager.getContentUrl(),
          mimeType = this.attributes.srcMimeType ? this.attributes.srcMimeType : this.previewManager.mimeType;
          var str = "";

--- a/aikau/src/main/resources/alfresco/preview/Image.js
+++ b/aikau/src/main/resources/alfresco/preview/Image.js
@@ -103,6 +103,7 @@ define(["dojo/_base/declare",
                // At this point, there's no error.
                this.previewManager.previewerNode.innerHTML = "";
                this.previewManager.previewerNode.appendChild(image);
+               this.previewManager.plugin._setPreviewerElementHeight();
             };
             image.onerror = function()
             {

--- a/aikau/src/main/resources/alfresco/preview/Video.js
+++ b/aikau/src/main/resources/alfresco/preview/Video.js
@@ -97,6 +97,8 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          this._setPreviewerElementHeight();
 
+         this.alfSubscribe("DISPLAYED_CAROUSEL_ITEMS", lang.hitch(this, this.onCarouselDisplayChange));
+
          var src = this.attributes.src ? this.previewManager.getThumbnailUrl(this.attributes.src) : this.previewManager.getContentUrl(),
              mimeType = this.attributes.srcMimeType ? this.attributes.srcMimeType : this.previewManager.mimeType;
          var str = "";
@@ -104,6 +106,10 @@ define(["dojo/_base/declare",
          str += "   <source src=\"" + src + "\"  type=\"" + mimeType + "\">";
          str += "</video>";
          return str;
+      },
+
+      onCarouselDisplayChange: function alfresco_preview_Video__onCarouselDisplayChange(payload) {
+         this.alfLog("info", "Moomin", payload);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/preview/Video.js
+++ b/aikau/src/main/resources/alfresco/preview/Video.js
@@ -27,8 +27,9 @@
 define(["dojo/_base/declare",
         "alfresco/preview/AlfDocumentPreviewPlugin", 
         "dojo/_base/lang",
+        "dojo/_base/array",
         "dojo/has"], 
-        function(declare, AlfDocumentPreviewPlugin, lang, has) {
+        function(declare, AlfDocumentPreviewPlugin, lang, array, has) {
    
    return declare([AlfDocumentPreviewPlugin], {
 
@@ -109,7 +110,11 @@ define(["dojo/_base/declare",
       },
 
       onCarouselDisplayChange: function alfresco_preview_Video__onCarouselDisplayChange(payload) {
-         this.alfLog("info", "Moomin", payload);
+         var displayed = array.some(payload.items, function(item) {
+            return item.nodeRef === this.previewManager.nodeRef;
+         }, this);
+
+         this.alfLog("info", "I am displayed", displayed);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/preview/Video.js
+++ b/aikau/src/main/resources/alfresco/preview/Video.js
@@ -21,17 +21,17 @@
  * This plugin will render the HTML5 video element to preview the content of a video node.
  *
  * @module alfresco/preview/Video
- * @extends module:alfresco/preview/AlfDocumentPreviewPlugin
+ * @extends module:alfresco/preview/AVPlugin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/preview/AlfDocumentPreviewPlugin", 
+        "alfresco/preview/AVPlugin", 
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/has"], 
-        function(declare, AlfDocumentPreviewPlugin, lang, array, has) {
+        function(declare, AVPlugin, lang, array, has) {
    
-   return declare([AlfDocumentPreviewPlugin], {
+   return declare([AVPlugin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -98,8 +98,6 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          this._setPreviewerElementHeight();
 
-         this.alfSubscribe("DISPLAYED_CAROUSEL_ITEMS", lang.hitch(this, this.onCarouselDisplayChange));
-
          var src = this.attributes.src ? this.previewManager.getThumbnailUrl(this.attributes.src) : this.previewManager.getContentUrl(),
              mimeType = this.attributes.srcMimeType ? this.attributes.srcMimeType : this.previewManager.mimeType;
          var str = "";
@@ -107,23 +105,6 @@ define(["dojo/_base/declare",
          str += "   <source src=\"" + src + "\"  type=\"" + mimeType + "\">";
          str += "</video>";
          return str;
-      },
-
-      /**
-       * 
-       * @instance
-       * @param  {object} payload The list of items that are currently displayed.
-       * @since 1.0.51
-       */
-      onCarouselDisplayChange: function alfresco_preview_Video__onCarouselDisplayChange(payload) {
-         var displayed = array.some(payload.items, function(item) {
-            return item.nodeRef === this.previewManager.nodeRef;
-         }, this);
-
-         if (!displayed)
-         {
-            this.previewManager.getPreviewerElement().firstChild.pause();
-         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/preview/Video.js
+++ b/aikau/src/main/resources/alfresco/preview/Video.js
@@ -109,12 +109,21 @@ define(["dojo/_base/declare",
          return str;
       },
 
+      /**
+       * 
+       * @instance
+       * @param  {object} payload The list of items that are currently displayed.
+       * @since 1.0.51
+       */
       onCarouselDisplayChange: function alfresco_preview_Video__onCarouselDisplayChange(payload) {
          var displayed = array.some(payload.items, function(item) {
             return item.nodeRef === this.previewManager.nodeRef;
          }, this);
 
-         this.alfLog("info", "I am displayed", displayed);
+         if (!displayed)
+         {
+            this.previewManager.getPreviewerElement().firstChild.pause();
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/preview/css/AlfDocumentPreview.css
+++ b/aikau/src/main/resources/alfresco/preview/css/AlfDocumentPreview.css
@@ -1,29 +1,16 @@
-.alfresco-preview-AlfDocumentPreview .previewer.Image > img {
-   max-height: 100%;
-   max-width: 100%;
-   overflow: auto;
-}
+.alfresco-preview-AlfDocumentPreview {
 
-.alfresco-preview-AlfDocumentPreview .previewer.WebPreviewer {
-   min-height: 400px;
-}
+   .previewer {
+      background-color: @preview-background-color;
 
-.alfresco-preview-AlfDocumentPreview .previewer.StrobeMediaPlayback {
-   height: 480px;
-}
+      .message {
+         text-align: center;
+         margin: 100px 0;
+      }
+   }
 
-.alfresco-preview-AlfDocumentPreview .previewer .message {
-   text-align: center;
-   margin: 100px 0;
-}
-
-/* This should potentially be in a CSS file directly associated with the Image plugin */
-.alfresco-preview-AlfDocumentPreview .previewer.Image {
-   text-align: center;
-   background-color: transparent;
-}
-
-.alfresco-preview-AlfDocumentPreview .notification {
-   margin: 100px 0;
-   text-align: center;
+   .notification {
+      margin: 100px 0;
+      text-align: center;
+   }
 }

--- a/aikau/src/main/resources/alfresco/preview/css/Audio.css
+++ b/aikau/src/main/resources/alfresco/preview/css/Audio.css
@@ -2,9 +2,10 @@
    line-height: 325px;
 }
 
-.alfresco-preview-AlfDocumentPreview .previewer .Audio audio
-{
+.alfresco-preview-AlfDocumentPreview .previewer.Audio audio {
    max-height: 100%;
    max-width: 100%;
    overflow: auto;
+   display: block;
+   margin: 0 auto;
 }

--- a/aikau/src/main/resources/alfresco/preview/css/Image.css
+++ b/aikau/src/main/resources/alfresco/preview/css/Image.css
@@ -1,8 +1,18 @@
-.alfresco-preview-AlfDocumentPreview .previewer .Image img
-{
-   max-height: 100%;
-   max-width: 100%;
-   overflow: auto;
-   width: auto;
-   height: auto;
+.alfresco-preview-AlfDocumentPreview {
+   
+   .previewer {
+      
+      &.Image {
+         text-align: center;
+         
+         img {
+            max-height: 100%;
+            max-width: 100%;
+            overflow: auto;
+            width: auto;
+            height: auto;
+         }
+      }
+   }
+   
 }

--- a/aikau/src/main/resources/alfresco/preview/css/Video.css
+++ b/aikau/src/main/resources/alfresco/preview/css/Video.css
@@ -1,4 +1,7 @@
 .alfresco-preview-AlfDocumentPreview .previewer.Video video {
    max-width: 100%;
    max-height: 100%;
+   overflow: auto;
+   display: block;
+   margin: 0 auto;
 }

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The purpose of this test is to ensure that keyboard accessibility is possible between the header and the 
+ * main table. It should be possible to use the tab/shift-tab keys to navigate along the headers (and the enter/space key
+ * to make requests for sorting) and then the cursor keys to navigate around the table itself.
+ * 
+ * @author Dave Draper
+ * @author Martin Doyle
+ */
+define(["alfresco/TestCommon",
+        "intern!object",
+        "intern/chai!assert"],
+       function(TestCommon, registerSuite, assert) {
+
+   registerSuite(function() {
+      var browser;
+
+      return {
+         name: "Film Strip View Tests (Media Playing)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/MediaFilmStripView?autoPlay=true", "Film Strip View Tests (Media Playing)").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+
+         // By default autoPlay is disabled, but the test page overrides the plugin configuration...
+         "Check that video is playing": function() {
+            return browser.findDisplayedByCssSelector("video")
+               .execute("return document.querySelector('video').paused")
+               .then(function(paused) {
+                  assert.isFalse(paused, "The video is not playing");
+               });
+         },
+
+         "Check that audio preview has not been created": function() {
+            return browser.findAllByCssSelector("audio")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Audio previews shouldn't exist yet");
+               });
+         },
+
+         "Show the audio preview, check video is paused": function() {
+            return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .next img")
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector("video")
+               .execute("return document.querySelector('video').paused")
+               .then(function(paused) {
+                  assert.isTrue(paused, "The video is not paused");
+               });
+         },
+
+         "Audio should be playing": function() {
+            return browser.findDisplayedByCssSelector("audio")
+               .execute("return document.querySelector('audio').paused")
+               .then(function(paused) {
+                  assert.isFalse(paused, "The audio is not playing");
+               });
+         },
+
+         "Go back to the video preview, check the audio stops": function() {
+            return browser.findByCssSelector("#FILMSTRIP_VIEW_PREVIEWS .prev img")
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector("audio")
+               .execute("return document.querySelector('audio').paused")
+               .then(function(paused) {
+                  assert.isTrue(paused, "The audio is not paused");
+               });
+         },
+
+         "Video should be playing": function() {
+            return browser.findDisplayedByCssSelector("video")
+               .execute("return document.querySelector('video').paused")
+               .then(function(paused) {
+                  assert.isFalse(paused, "The video is not playing");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function() {
+      var browser;
+
+      return {
+         name: "Film Strip View Tests (Media Playing - no auto play)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/MediaFilmStripView?autoPlay=false", "Film Strip View Tests (Media Playing)").end();
+         },
+         
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check that video is playing": function() {
+            return browser.findDisplayedByCssSelector("video")
+               .execute("return document.querySelector('video').paused")
+               .then(function(paused) {
+                  assert.isTrue(paused, "The video should not be playing");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest.js
@@ -50,14 +50,14 @@ define(["alfresco/TestCommon",
             return browser.findDisplayedByCssSelector("video")
                .execute("return document.querySelector('video').paused")
                .then(function(paused) {
-                  assert.isFalse(paused, "The video is not playing");
+                  assert.isFalse(paused);
                });
          },
 
          "Check that audio preview has not been created": function() {
             return browser.findAllByCssSelector("audio")
                .then(function(elements) {
-                  assert.lengthOf(elements, 0, "Audio previews shouldn't exist yet");
+                  assert.lengthOf(elements, 0);
                });
          },
 
@@ -69,7 +69,7 @@ define(["alfresco/TestCommon",
             .findDisplayedByCssSelector("video")
                .execute("return document.querySelector('video').paused")
                .then(function(paused) {
-                  assert.isTrue(paused, "The video is not paused");
+                  assert.isTrue(paused);
                });
          },
 
@@ -77,7 +77,7 @@ define(["alfresco/TestCommon",
             return browser.findDisplayedByCssSelector("audio")
                .execute("return document.querySelector('audio').paused")
                .then(function(paused) {
-                  assert.isFalse(paused, "The audio is not playing");
+                  assert.isFalse(paused);
                });
          },
 
@@ -89,7 +89,7 @@ define(["alfresco/TestCommon",
             .findDisplayedByCssSelector("audio")
                .execute("return document.querySelector('audio').paused")
                .then(function(paused) {
-                  assert.isTrue(paused, "The audio is not paused");
+                  assert.isTrue(paused);
                });
          },
 
@@ -97,7 +97,7 @@ define(["alfresco/TestCommon",
             return browser.findDisplayedByCssSelector("video")
                .execute("return document.querySelector('video').paused")
                .then(function(paused) {
-                  assert.isFalse(paused, "The video is not playing");
+                  assert.isFalse(paused);
                });
          },
 
@@ -122,11 +122,11 @@ define(["alfresco/TestCommon",
             browser.end();
          },
 
-         "Check that video is playing": function() {
+         "Check that video is NOT playing": function() {
             return browser.findDisplayedByCssSelector("video")
                .execute("return document.querySelector('video').paused")
                .then(function(paused) {
-                  assert.isTrue(paused, "The video should not be playing");
+                  assert.isTrue(paused);
                });
          },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -101,6 +101,7 @@ define({
       "src/test/resources/alfresco/documentlibrary/views/AlfDetailedViewTest",
       "src/test/resources/alfresco/documentlibrary/views/AlfDocumentListWithHeaderTest",
       "src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest",
+      "src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest",
       "src/test/resources/alfresco/documentlibrary/views/GalleryViewTest",
       "src/test/resources/alfresco/documentlibrary/views/GalleryViewThumbnailSizingTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfFilmStripView (Media Previews)</shortname>
+  <description>This shows an AlfFilmStripView configured with mocked media documents for previewing.</description>
+  <family>aikau-unit-tests</family>
+  <url>/MediaFilmStripView</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
@@ -52,6 +52,21 @@ model.jsonModel = {
                         isContainer: false,
                         contentURL: "/slingshot/node/content/workspace/SpacesStore/50e8fa78-86ee-4209-9de0-b5c996b7ee52/content/Demo%203.mp3"
                      }
+                  },
+                  {
+                     nodeRef: "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4",
+                     fileName: "2013-12-29 09.58.43.jpg",
+                     displayName: "2013-12-29 09.58.43.jpg",
+                     node: {
+                        properties: {
+                           "cm:name": "2013-12-29 09.58.43.jpg"
+                        },
+                        mimetypeDisplayName: "JPEG Image",
+                        mimetype: "image/jpeg",
+                        nodeRef: "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4",
+                        isContainer: false,
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/content/2013-12-29 09.58.43.jpg"
+                     }
                   }
                ]
             },
@@ -60,7 +75,7 @@ model.jsonModel = {
                   id: "FILMSTRIP_VIEW",
                   name: "alfresco/documentlibrary/views/AlfFilmStripView",
                   config: {
-                     heightMode: 400
+                     heightMode: 600
                   }
                }
             ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
@@ -1,0 +1,76 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService",
+      "alfresco/services/DocumentService",
+      "alfresco/services/ErrorReporter"
+   ],
+   widgets: [
+      {
+         id: "DOCLIST",
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            waitForPageWidgets: false,
+            currentData: {
+               items: [
+                  {
+                     nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+                     fileName: "Video Test Binary.mp4",
+                     displayName: "Video Test Binary.mp4",
+                     node: {
+                        properties: {
+                           "cm:name": "Video Test Binary.mp4"
+                        },
+                        mimetypeDisplayName: "MPEG4 Video",
+                        mimetype: "video/mp4",
+                        nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+                        isContainer: false,
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5/Video%20Test%20Binary.mp4"
+                     }
+                  },
+                  {
+                     nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+                     fileName: "Video Test Binary.mp4",
+                     displayName: "Video Test Binary.mp4",
+                     node: {
+                        properties: {
+                           "cm:name": "Video Test Binary.mp4"
+                        },
+                        mimetypeDisplayName: "MPEG4 Video",
+                        mimetype: "video/mp4",
+                        nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+                        isContainer: false,
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5/Video%20Test%20Binary.mp4"
+                     }
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  id: "FILMSTRIP_VIEW",
+                  name: "alfresco/documentlibrary/views/AlfFilmStripView",
+                  config: {
+                     heightMode: 400
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PreviewMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
@@ -39,18 +39,18 @@ model.jsonModel = {
                      }
                   },
                   {
-                     nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
-                     fileName: "Video Test Binary.mp4",
-                     displayName: "Video Test Binary.mp4",
+                     nodeRef: "workspace://SpacesStore/3db19b32-6d92-45ef-b5b1-5bda34dd5728",
+                     fileName: "Demo 3.mp3",
+                     displayName: "Demo 3.mp3",
                      node: {
                         properties: {
-                           "cm:name": "Video Test Binary.mp4"
+                           "cm:name": "Demo 3.mp3"
                         },
-                        mimetypeDisplayName: "MPEG4 Video",
-                        mimetype: "video/mp4",
-                        nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+                        mimetypeDisplayName: "MPEG Audio",
+                        mimetype: "audio/mpeg",
+                        nodeRef: "workspace://SpacesStore/3db19b32-6d92-45ef-b5b1-5bda34dd5728",
                         isContainer: false,
-                        contentURL: "/slingshot/node/content/workspace/SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5/Video%20Test%20Binary.mp4"
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/50e8fa78-86ee-4209-9de0-b5c996b7ee52/Demo%203.mp3"
                      }
                   }
                ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
@@ -39,7 +39,7 @@ model.jsonModel = {
                      }
                   },
                   {
-                     nodeRef: "workspace://SpacesStore/3db19b32-6d92-45ef-b5b1-5bda34dd5728",
+                     nodeRef: "workspace://SpacesStore/50e8fa78-86ee-4209-9de0-b5c996b7ee52",
                      fileName: "Demo 3.mp3",
                      displayName: "Demo 3.mp3",
                      node: {
@@ -48,9 +48,9 @@ model.jsonModel = {
                         },
                         mimetypeDisplayName: "MPEG Audio",
                         mimetype: "audio/mpeg",
-                        nodeRef: "workspace://SpacesStore/3db19b32-6d92-45ef-b5b1-5bda34dd5728",
+                        nodeRef: "workspace://SpacesStore/50e8fa78-86ee-4209-9de0-b5c996b7ee52",
                         isContainer: false,
-                        contentURL: "/slingshot/node/content/workspace/SpacesStore/50e8fa78-86ee-4209-9de0-b5c996b7ee52/Demo%203.mp3"
+                        contentURL: "/slingshot/node/content/workspace/SpacesStore/50e8fa78-86ee-4209-9de0-b5c996b7ee52/content/Demo%203.mp3"
                      }
                   }
                ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/views/MediaFilmStripView.get.js
@@ -1,3 +1,12 @@
+/* global page */
+/* jshint sub:true */
+
+var autoPlay = true;
+if (page.url.args["autoPlay"])
+{
+   autoPlay = page.url.args["autoPlay"] === "true";
+}
+
 model.jsonModel = {
    services: [
       {
@@ -75,7 +84,23 @@ model.jsonModel = {
                   id: "FILMSTRIP_VIEW",
                   name: "alfresco/documentlibrary/views/AlfFilmStripView",
                   config: {
-                     heightMode: 600
+                     heightMode: 600,
+                     previewerPluginOverrides: [
+                        {
+                           id: "Video",
+                           name: "alfresco/preview/Video",
+                           config: {
+                              autoPlay: autoPlay
+                           }
+                        },
+                        {
+                           id: "Audio",
+                           name: "alfresco/preview/Audio",
+                           config: {
+                              autoPlay: autoPlay
+                           }
+                        }
+                     ]
                   }
                }
             ]

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/previews/Video.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/previews/Video.json
@@ -1,1 +1,290 @@
-{"metadata": {"repositoryId": "18024d45-cea1-4dde-a4f4-24160ee7d1c5", "custom": {"vtiServer": null, "aos": {"baseUrl": "http:\/\/dave-Latitude-E6530:8080\/alfresco\/aos"}}, "onlineEditing": false, "workingCopyLabel": " (Working Copy)", "shareURL": "http:\/\/localhost:8081\/share", "serverURL": "http:\/\/localhost:8080", "parent": {"permissions": {"user": {}, "roles": []}}}, "item": {"thumbnailDefinitions": [], "node": {"isLink": false, "aspects": ["cm:auditable", "sys:referenceable", "cm:titled", "cm:author", "sys:localized", "audio:audio", "cm:versionable"], "properties": {"cm:modified": {"value": "Fri Jan 16 14:30:06 GMT 2015", "iso8601": "2015-01-16T14:30:06.080Z"}, "cm:content": null, "sys:node-uuid": null, "cm:name": "Video Test Binary.mp4", "sys:store-protocol": null, "sys:locale": null, "audio:sampleRate": "1000", "cm:autoVersion": "true", "sys:node-dbid": null, "cm:initialVersion": "true", "cm:creator": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "cm:created": {"value": "Fri Jan 16 14:30:06 GMT 2015", "iso8601": "2015-01-16T14:30:06.080Z"}, "cm:versionLabel": "1.0", "cm:autoVersionOnUpdateProps": "false", "cm:modifier": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:store-identifier": null}, "type": "cm:content", "isLocked": false, "size": 5520127, "mimetypeDisplayName": "MPEG4 Video", "mimetype": "video\/mp4", "encoding": "UTF-8", "permissions": {"roles": ["ALLOWED;GROUP_site_site-1_SiteCollaborator;SiteCollaborator;INHERITED", "ALLOWED;GROUP_site_site-1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED"], "inherited": true, "user": {"ChangePermissions": true, "CancelCheckOut": false, "CreateChildren": true, "Write": true, "Delete": true, "Unlock": false}}, "nodeRef": "workspace:\/\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5", "isContainer": false, "contentURL": "\/slingshot\/node\/content\/workspace\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5\/Video%20Test%20Binary.mp4"}, "parent": {"isLink": false, "aspects": ["cm:auditable", "st:siteContainer", "cm:ownable", "cm:tagscope", "sys:referenceable", "cm:titled", "sys:localized"], "permissions": {"roles": ["ALLOWED;GROUP_site_site-1_SiteCollaborator;SiteCollaborator;INHERITED", "ALLOWED;GROUP_site_site-1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED"], "inherited": true, "user": {"ChangePermissions": true, "CancelCheckOut": false, "CreateChildren": true, "Write": true, "Delete": true, "Unlock": false}}, "nodeRef": "workspace:\/\/SpacesStore\/3db19b32-6d92-45ef-b5b1-5bda34dd5728", "properties": {"cm:modified": {"value": "Fri Jan 16 14:30:06 GMT 2015", "iso8601": "2015-01-16T14:30:06.212Z"}, "sys:node-dbid": null, "cm:description": "Document Library", "cm:creator": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:node-uuid": null, "cm:created": {"value": "Wed Jan 14 10:51:04 GMT 2015", "iso8601": "2015-01-14T10:51:04.569Z"}, "st:componentId": "documentLibrary", "cm:name": "documentLibrary", "sys:store-protocol": null, "cm:owner": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:locale": null, "cm:modifier": {"lastName": "", "userName": "admin", "displayName": "Administrator", "firstName": "Administrator"}, "sys:store-identifier": null}, "type": "cm:folder", "isContainer": true, "isLocked": false}, "version": "1.0", "webdavUrl": "\/webdav\/Sites\/site-1\/documentLibrary\/Video%20Test%20Binary.mp4", "isFavourite": false, "likes": {"isLiked": false, "totalLikes": 0}, "location": {"repositoryId": "18024d45-cea1-4dde-a4f4-24160ee7d1c5", "site": {"name": "site-1", "title": "Site 1", "preset": "site-dashboard"}, "container": {"name": "documentLibrary", "type": "cm:folder", "nodeRef": ""}, "path": "\/", "repoPath": "\/Sites\/site-1\/documentLibrary", "file": "Video Test Binary.mp4", "parent": {}}, "nodeRef": "workspace:\/\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5", "fileName": "Video Test Binary.mp4", "displayName": "Video Test Binary.mp4", "actionGroupId": "document-browse", "actions": [{"id": "document-download", "icon": "document-download", "type": "link", "label": "actions.document.download", "params": {"href": "{downloadUrl}"}, "index": "100"}, {"id": "document-view-content", "icon": "document-view-content", "type": "link", "label": "actions.document.view", "params": {"href": "{viewUrl}"}, "index": "110"}, {"id": "document-edit-properties", "icon": "document-edit-properties", "type": "javascript", "label": "actions.document.edit-metadata", "params": {"function": "onActionDetails"}, "index": "130"}, {"id": "document-upload-new-version", "icon": "document-upload-new-version", "type": "javascript", "label": "actions.document.upload-new-version", "params": {"function": "onActionUploadNewVersion"}, "index": "140"}, {"id": "document-edit-offline", "icon": "document-edit-offline", "type": "javascript", "label": "actions.document.edit-offline", "params": {"function": "onActionEditOffline"}, "index": "210"}, {"id": "document-copy-to", "icon": "document-copy-to", "type": "javascript", "label": "actions.document.copy-to", "params": {"function": "onActionCopyTo"}, "index": "250"}, {"id": "document-move-to", "icon": "document-move-to", "type": "javascript", "label": "actions.document.move-to", "params": {"function": "onActionMoveTo"}, "index": "260"}, {"id": "document-delete", "icon": "document-delete", "type": "javascript", "label": "actions.document.delete", "params": {"function": "onActionDelete"}, "index": "270"}, {"id": "document-assign-workflow", "icon": "document-assign-workflow", "type": "javascript", "label": "actions.document.assign-workflow", "params": {"function": "onActionAssignWorkflow"}, "index": "280"}, {"id": "document-manage-granular-permissions", "icon": "document-manage-permissions", "type": "link", "label": "actions.document.manage-permissions", "params": {"href": "{managePermissionsUrl}"}, "index": "297"}, {"id": "document-cloud-sync", "icon": "document-cloud-sync", "type": "javascript", "label": "actions.document.cloud-sync", "params": {"function": "onActionCloudSync"}, "index": "330"}], "indicators": [], "metadataTemplate": {"id": "default", "title": null, "banners": [], "lines": [{"index": "10", "template": "{date}{size}", "view": ""}, {"index": "20", "template": "{description}", "view": "detailed"}, {"index": "30", "template": "{tags}", "view": "detailed"}, {"index": "50", "template": "{social}", "view": "detailed"}]}}}
+{
+   "metadata": {
+      "repositoryId": "18024d45-cea1-4dde-a4f4-24160ee7d1c5",
+      "custom": {
+         "vtiServer": null,
+         "aos": {
+            "baseUrl": "http:\/\/dave-Latitude-E6530:8080\/alfresco\/aos"
+         }
+      },
+      "onlineEditing": false,
+      "workingCopyLabel": " (Working Copy)",
+      "shareURL": "http:\/\/localhost:8081\/share",
+      "serverURL": "http:\/\/localhost:8080",
+      "parent": {
+         "permissions": {
+            "user": {},
+            "roles": []
+         }
+      }
+   },
+   "item": {
+      "thumbnailDefinitions": [],
+      "node": {
+         "isLink": false,
+         "aspects": ["cm:auditable", "sys:referenceable", "cm:titled", "cm:author", "sys:localized", "audio:audio", "cm:versionable"],
+         "properties": {
+            "cm:modified": {
+               "value": "Fri Jan 16 14:30:06 GMT 2015",
+               "iso8601": "2015-01-16T14:30:06.080Z"
+            },
+            "cm:content": null,
+            "sys:node-uuid": null,
+            "cm:name": "Video Test Binary.mp4",
+            "sys:store-protocol": null,
+            "sys:locale": null,
+            "audio:sampleRate": "1000",
+            "cm:autoVersion": "true",
+            "sys:node-dbid": null,
+            "cm:initialVersion": "true",
+            "cm:creator": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "cm:created": {
+               "value": "Fri Jan 16 14:30:06 GMT 2015",
+               "iso8601": "2015-01-16T14:30:06.080Z"
+            },
+            "cm:versionLabel": "1.0",
+            "cm:autoVersionOnUpdateProps": "false",
+            "cm:modifier": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:store-identifier": null
+         },
+         "type": "cm:content",
+         "isLocked": false,
+         "size": 5520127,
+         "mimetypeDisplayName": "MPEG4 Video",
+         "mimetype": "video\/mp4",
+         "encoding": "UTF-8",
+         "permissions": {
+            "roles": ["ALLOWED;GROUP_site_site-1_SiteCollaborator;SiteCollaborator;INHERITED", "ALLOWED;GROUP_site_site-1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED"],
+            "inherited": true,
+            "user": {
+               "ChangePermissions": true,
+               "CancelCheckOut": false,
+               "CreateChildren": true,
+               "Write": true,
+               "Delete": true,
+               "Unlock": false
+            }
+         },
+         "nodeRef": "workspace:\/\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+         "isContainer": false,
+         "contentURL": "\/slingshot\/node\/content\/workspace\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5\/Video%20Test%20Binary.mp4"
+      },
+      "parent": {
+         "isLink": false,
+         "aspects": ["cm:auditable", "st:siteContainer", "cm:ownable", "cm:tagscope", "sys:referenceable", "cm:titled", "sys:localized"],
+         "permissions": {
+            "roles": ["ALLOWED;GROUP_site_site-1_SiteCollaborator;SiteCollaborator;INHERITED", "ALLOWED;GROUP_site_site-1_SiteConsumer;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteContributor;SiteContributor;INHERITED", "ALLOWED;GROUP_EVERYONE;SiteConsumer;INHERITED", "ALLOWED;GROUP_site_site-1_SiteManager;SiteManager;INHERITED", "ALLOWED;GROUP_EVERYONE;ReadPermissions;INHERITED"],
+            "inherited": true,
+            "user": {
+               "ChangePermissions": true,
+               "CancelCheckOut": false,
+               "CreateChildren": true,
+               "Write": true,
+               "Delete": true,
+               "Unlock": false
+            }
+         },
+         "nodeRef": "workspace:\/\/SpacesStore\/3db19b32-6d92-45ef-b5b1-5bda34dd5728",
+         "properties": {
+            "cm:modified": {
+               "value": "Fri Jan 16 14:30:06 GMT 2015",
+               "iso8601": "2015-01-16T14:30:06.212Z"
+            },
+            "sys:node-dbid": null,
+            "cm:description": "Document Library",
+            "cm:creator": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:node-uuid": null,
+            "cm:created": {
+               "value": "Wed Jan 14 10:51:04 GMT 2015",
+               "iso8601": "2015-01-14T10:51:04.569Z"
+            },
+            "st:componentId": "documentLibrary",
+            "cm:name": "documentLibrary",
+            "sys:store-protocol": null,
+            "cm:owner": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:locale": null,
+            "cm:modifier": {
+               "lastName": "",
+               "userName": "admin",
+               "displayName": "Administrator",
+               "firstName": "Administrator"
+            },
+            "sys:store-identifier": null
+         },
+         "type": "cm:folder",
+         "isContainer": true,
+         "isLocked": false
+      },
+      "version": "1.0",
+      "webdavUrl": "\/webdav\/Sites\/site-1\/documentLibrary\/Video%20Test%20Binary.mp4",
+      "isFavourite": false,
+      "likes": {
+         "isLiked": false,
+         "totalLikes": 0
+      },
+      "location": {
+         "repositoryId": "18024d45-cea1-4dde-a4f4-24160ee7d1c5",
+         "site": {
+            "name": "site-1",
+            "title": "Site 1",
+            "preset": "site-dashboard"
+         },
+         "container": {
+            "name": "documentLibrary",
+            "type": "cm:folder",
+            "nodeRef": ""
+         },
+         "path": "\/",
+         "repoPath": "\/Sites\/site-1\/documentLibrary",
+         "file": "Video Test Binary.mp4",
+         "parent": {}
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+      "fileName": "Video Test Binary.mp4",
+      "displayName": "Video Test Binary.mp4",
+      "actionGroupId": "document-browse",
+      "actions": [{
+         "id": "document-download",
+         "icon": "document-download",
+         "type": "link",
+         "label": "actions.document.download",
+         "params": {
+            "href": "{downloadUrl}"
+         },
+         "index": "100"
+      }, {
+         "id": "document-view-content",
+         "icon": "document-view-content",
+         "type": "link",
+         "label": "actions.document.view",
+         "params": {
+            "href": "{viewUrl}"
+         },
+         "index": "110"
+      }, {
+         "id": "document-edit-properties",
+         "icon": "document-edit-properties",
+         "type": "javascript",
+         "label": "actions.document.edit-metadata",
+         "params": {
+            "function": "onActionDetails"
+         },
+         "index": "130"
+      }, {
+         "id": "document-upload-new-version",
+         "icon": "document-upload-new-version",
+         "type": "javascript",
+         "label": "actions.document.upload-new-version",
+         "params": {
+            "function": "onActionUploadNewVersion"
+         },
+         "index": "140"
+      }, {
+         "id": "document-edit-offline",
+         "icon": "document-edit-offline",
+         "type": "javascript",
+         "label": "actions.document.edit-offline",
+         "params": {
+            "function": "onActionEditOffline"
+         },
+         "index": "210"
+      }, {
+         "id": "document-copy-to",
+         "icon": "document-copy-to",
+         "type": "javascript",
+         "label": "actions.document.copy-to",
+         "params": {
+            "function": "onActionCopyTo"
+         },
+         "index": "250"
+      }, {
+         "id": "document-move-to",
+         "icon": "document-move-to",
+         "type": "javascript",
+         "label": "actions.document.move-to",
+         "params": {
+            "function": "onActionMoveTo"
+         },
+         "index": "260"
+      }, {
+         "id": "document-delete",
+         "icon": "document-delete",
+         "type": "javascript",
+         "label": "actions.document.delete",
+         "params": {
+            "function": "onActionDelete"
+         },
+         "index": "270"
+      }, {
+         "id": "document-assign-workflow",
+         "icon": "document-assign-workflow",
+         "type": "javascript",
+         "label": "actions.document.assign-workflow",
+         "params": {
+            "function": "onActionAssignWorkflow"
+         },
+         "index": "280"
+      }, {
+         "id": "document-manage-granular-permissions",
+         "icon": "document-manage-permissions",
+         "type": "link",
+         "label": "actions.document.manage-permissions",
+         "params": {
+            "href": "{managePermissionsUrl}"
+         },
+         "index": "297"
+      }, {
+         "id": "document-cloud-sync",
+         "icon": "document-cloud-sync",
+         "type": "javascript",
+         "label": "actions.document.cloud-sync",
+         "params": {
+            "function": "onActionCloudSync"
+         },
+         "index": "330"
+      }],
+      "indicators": [],
+      "metadataTemplate": {
+         "id": "default",
+         "title": null,
+         "banners": [],
+         "lines": [{
+            "index": "10",
+            "template": "{date}{size}",
+            "view": ""
+         }, {
+            "index": "20",
+            "template": "{description}",
+            "view": "detailed"
+         }, {
+            "index": "30",
+            "template": "{tags}",
+            "view": "detailed"
+         }, {
+            "index": "50",
+            "template": "{social}",
+            "view": "detailed"
+         }]
+      }
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-779 to primarily ensure that video previews do not continue to play when they are no longer displayed in the AlfFilmStripView. However, I've taken this further to do some general tidying up of the AlfFilmStripView as well as providing an auto-play feature for the previewer so that it can be configured to automatically play audio/video previews if required.