### PR TITLE
AKU-781: Added support for client-side property render filter evaluation

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -886,7 +886,21 @@ define(["dojo/_base/declare",
          {
             // Compare the property value against the applicable values...
             var renderFilterProperty = this.getRenderFilterPropertyValue(renderFilterConfig);
-            if (renderFilterConfig.values)
+            if (renderFilterConfig.value)
+            {
+               // See AKU-781 - We now allow client-side properties to be compared...
+               switch (renderFilterConfig.comparator) {
+                  case "lessThan":
+                     passesFilter = renderFilterProperty < renderFilterConfig.value;
+                     break;
+                  case "greaterThan":
+                     passesFilter = renderFilterProperty > renderFilterConfig.value;
+                     break;
+                  default:
+                     passesFilter = renderFilterProperty === renderFilterConfig.value;
+               }
+            }
+            else if (renderFilterConfig.values)
             {
                // Check that the target property matches one of the supplied values...
                var renderFilterValues = this.getRenderFilterValues(renderFilterConfig);
@@ -1048,7 +1062,11 @@ define(["dojo/_base/declare",
        */
       getRenderFilterPropertyValue: function alfresco_core_WidgetsProcessingFilterMixin__getRenderFilterPropertyValue(renderFilterConfig) {
          var targetObject = this.currentItem;
-         if (renderFilterConfig.target && this[renderFilterConfig.target])
+         if (renderFilterConfig.target && lang.exists(renderFilterConfig.target))
+         {
+            targetObject = lang.getObject(renderFilterConfig.target);
+         }
+         else if (renderFilterConfig.target && this[renderFilterConfig.target])
          {
             targetObject = this[renderFilterConfig.target];
          }

--- a/aikau/src/test/resources/alfresco/core/ClientPropRenderFilterTest.js
+++ b/aikau/src/test/resources/alfresco/core/ClientPropRenderFilterTest.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "RenderFilter Tests (Client Properties)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/ClientPropRenderFilter?property=outerHeight", "RenderFilter Tests (Client Properties)")
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "LessThan Comparator passes": function() {
+            return browser.setWindowSize(null, 900, 400).refresh()
+                  
+               .getLastPublish("ALF_WIDGETS_READY")
+
+               .findDisplayedById("BUTTON1");
+         },
+
+         "GreaterThan Comparator fails": function() {
+            return browser.findAllByCssSelector("#BUTTON2")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+         },
+
+         "EqualTo Comparator fails": function() {
+            return browser.findAllByCssSelector("#BUTTON3")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+         },
+
+         "Post Coverage Results (1)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         },
+
+         "LessThan Comparator fails (after resize 1)": function() {
+            return browser.setWindowSize(null, 900, 800).refresh()
+                  
+               .getLastPublish("ALF_WIDGETS_READY")
+
+               .findAllByCssSelector("#BUTTON1")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+            
+         },
+
+         "GreaterThan Comparator passes (after resize 1)": function() {
+            return browser.findDisplayedById("BUTTON2");
+         },
+
+         "EqualTo Comparator fails (after resize 1)": function() {
+            return browser.findAllByCssSelector("#BUTTON3")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+         },
+
+         "Post Coverage Results (2)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         },
+
+         "LessThan Comparator fails (after resize 2)": function() {
+            return browser.setWindowSize(null, 900, 500).refresh()
+                  
+               .getLastPublish("ALF_WIDGETS_READY")
+
+               .findAllByCssSelector("#BUTTON1")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+            
+         },
+
+         "GreaterThan Comparator passes (after resize 2)": function() {
+            return browser.findAllByCssSelector("#BUTTON2")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+         },
+
+         "EqualTo Comparator fails (after resize 2)": function() {
+            return browser.findDisplayedById("BUTTON3");
+         },
+
+         "Post Coverage Results (3)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -56,6 +56,7 @@ define({
       "src/test/resources/alfresco/charts/ccc/PieChartTest",
 
       "src/test/resources/alfresco/core/AdvancedVisibilityConfigTest",
+      "src/test/resources/alfresco/core/ClientPropRenderFilterTest",
       "src/test/resources/alfresco/core/CoreRwdTest",
       "src/test/resources/alfresco/core/CoreXhrTest",
       "src/test/resources/alfresco/core/NotificationUtilsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ClientPropRenderFilter.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ClientPropRenderFilter.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Render Filter (client properties)</shortname>
+  <description>This WebScript demonstrates how it is possible to control widget rendering based on client properties.</description>
+  <family>aikau-unit-tests</family>
+  <url>/ClientPropRenderFilter</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ClientPropRenderFilter.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ClientPropRenderFilter.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ClientPropRenderFilter.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/ClientPropRenderFilter.get.js
@@ -1,0 +1,150 @@
+/* global page */
+/* jshint sub:true */
+var iframed = false;
+if (page.url.args["iframed"])
+{
+   iframed = page.url.args["iframed"] === "true";
+}
+
+var iframeHeight = 200;
+if (page.url.args["iframeHeight"])
+{
+   iframeHeight = parseInt(page.url.args["iframeHeight"], 10);
+}
+
+// innerHeight is a better default for display purposes, but outerHeight is better for the actual
+// test - so this can be set through a parameter in the unit test...
+var property = "innerHeight";
+if (page.url.args["property"])
+{
+   property = page.url.args["property"];
+}
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/TitleDescriptionAndContent",
+                  config: {
+                     title: "Less Than",
+                     description: "A button will be displayed if the height of the window is LESS THAN 500px",
+                     widgets: [
+                        {
+                           id: "BUTTON1",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Button 1",
+                              additionalCssClasses: "call-to-action",
+                              renderFilter: [
+                                 {
+                                    target: "window",
+                                    property: property,
+                                    comparator: "lessThan",
+                                    value: 500
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/TitleDescriptionAndContent",
+                  config: {
+                     title: "Greater Than",
+                     description: "A button will be displayed if the height of the window is GREATER THAN 500px",
+                     widgets: [
+                        {
+                           id: "BUTTON2",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Button 2",
+                              additionalCssClasses: "call-to-action",
+                              renderFilter: [
+                                 {
+                                    target: "window",
+                                    property: property,
+                                    comparator: "greaterThan",
+                                    value: 500
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/layout/TitleDescriptionAndContent",
+                  config: {
+                     title: "Equal To",
+                     description: "A button will be displayed if the height of the window is EQUAL TO 500px",
+                     widgets: [
+                        {
+                           id: "BUTTON3",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              label: "Button 3",
+                              additionalCssClasses: "call-to-action",
+                              renderFilter: [
+                                 {
+                                    target: "window",
+                                    property: property,
+                                    value: 500
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};
+
+// Load the same page in an iframe, but use request parameters to prevent infinite recursion...
+if (!iframed)
+{
+   model.jsonModel.widgets.splice(0, 0, {
+      name: "alfresco/layout/TitleDescriptionAndContent",
+      config: {
+         title: "IFrame",
+         description: "This is the page displayed within an iframe (to test dimensions handled appropriately). The height of the iframe can be controlled with the 'iframeHeight' request parameter.",
+         widgets: [
+            {
+               name: "alfresco/integration/IFrame",
+               config: {
+                  src: "tp/ws/ClientPropRenderFilter?iframed=true",
+                  srcType: "PAGE_RELATIVE",
+                  height: iframeHeight
+               }
+            }
+         ]
+      }
+   });
+}
+else
+{
+   // Get rid of the DebugLog from the iframe...
+   model.jsonModel.widgets.pop();
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-781 to add support for client-side property render filter evaluation. Unit tests have been added to verify the behaviour. Rather than adding JSDoc into a mixin module I think I'm going to create a wiki page to document the various behaviour if the implementation passes review.