### PR TITLE
AKU-787: Add "label" element to InlineEditProperty template

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
@@ -1,4 +1,5 @@
 <span class="alfresco-renderers-InlineEditProperty ${renderedValueClass}">
+   <span class="label">${label}</span>
    <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${!renderedValue}</span>
    <span data-dojo-attach-point="editNode" class="editor hidden" data-dojo-attach-event="onkeypress:onValueEntryKeyPress,onclick:suppressFocusRequest">
       <span data-dojo-attach-point="formWidgetNode"></span>

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -22,12 +22,10 @@
  * @author Martin Doyle
  */
 define(["intern!object",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"],
-   function(registerSuite, expect, assert, require, TestCommon, keys) {
+   function(registerSuite, assert, TestCommon, keys) {
 
 registerSuite(function(){
    var browser;
@@ -43,6 +41,10 @@ registerSuite(function(){
 
       beforeEach: function() {
          browser.end();
+      },
+
+      "Label is displayed": function() {
+         return browser.findDisplayedByCssSelector("#INLINE_EDIT_ITEM_0 .label");
       },
 
       "Property is rendered correctly": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
@@ -58,6 +58,7 @@ model.jsonModel = {
                                     id: "INLINE_EDIT",
                                     name: "alfresco/renderers/InlineEditProperty",
                                     config: {
+                                       label: "Label",
                                        propertyToRender: "name",
                                        permissionProperty: "node.permissions.user.Write",
                                        publishTopic: "ALF_CRUD_UPDATE",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-787 (#773) to add the missing label element back into the InlineEditProperty template.