### PR TITLE
AKU-788: Ensure menu arrow is visible on long labelled AlfMenuBarPopUp

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
@@ -140,8 +140,14 @@ define(["dojo/_base/declare",
             // Add in the "arrow" image to indicate a drop-down menu. We do this with DOM manipulation
             // rather than overriding the default template for such a minor change. This means that we
             // have some protection against changes to the template in future Dojo releases.
-            domConstruct.create("span", { className: "alf-menu-arrow",
-                                          innerHTML: "&#9662;"}, this.focusNode);
+            var arrowWrapperNode = domConstruct.create("span", {
+               className: "alfresco-menus-AlfMenuBarPopup__text-wrapper"
+            }, this.focusNode);
+            domConstruct.place(this.textDirNode, arrowWrapperNode);
+            domConstruct.create("span", { 
+               className: "alfresco-menus-AlfMenuBarPopup__arrow",
+               innerHTML: "&#9662;"
+            }, this.focusNode);
          }
          this.inherited(arguments);
          

--- a/aikau/src/main/resources/alfresco/menus/css/AlfMenuBarPopup.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfMenuBarPopup.css
@@ -1,10 +1,19 @@
-.@{alfresco} .alf-menu-arrow {
-   margin-left: 3px;
-   width: 20px;
-   height: 20px;
-   padding-bottom: 2px;
-}
+.@{alfresco} {
+   .alfresco-menus-AlfMenuBarPopup__text-wrapper {
+      display: inline-block;
+      max-width: 130px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+   }
 
+   .alfresco-menus-AlfMenuBarPopup__arrow {
+      margin-left: 3px;
+      width: 20px;
+      padding-bottom: 2px;
+      vertical-align: super;
+   }
+}
 
 /* This overrides the default Dojo box shadow for popups. Our box shadow is defined elsewhere */
 .@{alfresco} div.dijitPopup.Popup {

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentSelectorTest.js
@@ -95,7 +95,7 @@ define(["intern!object",
          },
 
          "Open the menu and select documents": function() {
-            return browser.findByCssSelector(".alf-menu-arrow")
+            return browser.findByCssSelector(".alfresco-menus-AlfMenuBarPopup__arrow")
                .click()
             .end()
 
@@ -116,7 +116,7 @@ define(["intern!object",
          },
 
          "Open the menu and select folders": function() {
-            return browser.findByCssSelector(".alf-menu-arrow")
+            return browser.findByCssSelector(".alfresco-menus-AlfMenuBarPopup__arrow")
                .click()
             .end()
 

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -41,6 +41,11 @@ define(["intern!object",
             browser.end();
          },
 
+         // See AKU-788...
+         "Down arrow is visible on long menu bar pop-up": function() {
+            return browser.findDisplayedByCssSelector("#HEADER_POPUP .alfresco-menus-AlfMenuBarPopup__arrow");
+         },
+
          "Test that header CSS is applied": function() {
             // Check that the header CSS is applied...         
             return browser.findByCssSelector(".alfresco-layout-LeftAndRight.alfresco-header-Header")
@@ -67,7 +72,7 @@ define(["intern!object",
          },
 
          "Test initial user status": function() {
-            return browser.findByCssSelector("#HEADER_POPUP_text")
+            return browser.findByCssSelector("#HEADER_POPUP .alfresco-menus-AlfMenuBarPopup__text-wrapper")
                .click()
                .end()
 
@@ -142,7 +147,7 @@ define(["intern!object",
          "Test setting status updates via PubSub (status)": function() {
             // Use the menus to simulate a status update...
             // (with the bonus of checking the header versions of the menu items work)...
-            return browser.findByCssSelector("#HEADER_POPUP_text")
+            return browser.findByCssSelector("#HEADER_POPUP .alfresco-menus-AlfMenuBarPopup__text-wrapper")
                .click()
                .end()
                .sleep(150)
@@ -156,7 +161,7 @@ define(["intern!object",
                .sleep(150)
 
             // Open the popup again...
-            .findByCssSelector("#HEADER_POPUP_text")
+            .findByCssSelector("#HEADER_POPUP .alfresco-menus-AlfMenuBarPopup__text-wrapper")
                .click()
                .end()
 

--- a/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
@@ -111,10 +111,7 @@ registerSuite(function(){
       },
 
       "Test non-legacy action version": function() {
-         return browser.findByCssSelector("#ACTIONS_ITEM_1_MENU_text")
-            .click()
-         .end()
-         .findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD_AS_ZIP")
+         return browser.findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD_AS_ZIP")
             .click()
          .end()
          .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/HeaderWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/HeaderWidgets.get.js
@@ -29,7 +29,7 @@ model.jsonModel = {
                                     id: "HEADER_POPUP",
                                     name: "alfresco/header/AlfMenuBarPopup",
                                     config: {
-                                       label: "Header Popup",
+                                       label: "Really, Really, Really Long Header Popup",
                                        widgets: [
                                           {
                                              id: "NO_STATUS",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-788 to ensure that the drop-down arrow added to the AlfMenuBarPopup is always visible even when the text is shortened to use an ellipsis. All unit tests have been run and some updated to make use of the new CSS classes to ensure tests work as expected.