### PR TITLE
AKU-789: Support page reload option when becoming site manager

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -78,6 +78,20 @@ define([],function() {
       ASSIGN_WORKFLOW: "ALF_ASSIGN_WORKFLOW",
 
       /**
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.52
+       *
+       * @event
+       * @property {string} site The site shortname to change the user role in
+       * @property {string} [role=SiteManager] The role for the user to become
+       * @property {string} [user] The userid to change the role for
+       */
+      BECOME_SITE_MANAGER: "ALF_BECOME_SITE_MANAGER",
+
+      /**
        * Event topic to trigger the cancel the editing of a checkout document
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/renderers/Selector.js
+++ b/aikau/src/main/resources/alfresco/renderers/Selector.js
@@ -60,7 +60,7 @@ define(["dojo/_base/declare",
        * Set up the attributes to be used when rendering the template.
        * 
        * @instance
-       * @listens module:alfresco/core/topics~event:DOCUMENT_SELECTION_UPDATE
+       * @listens module:alfresco/core/topics~event#DOCUMENT_SELECTION_UPDATE
        */
       postMixInProperties: function alfresco_renderers_Selector__postMixInProperties() {
          // Set up a subscription to handle file selection events, these will be along the lines of

--- a/aikau/src/main/resources/alfresco/renderers/Selector.js
+++ b/aikau/src/main/resources/alfresco/renderers/Selector.js
@@ -60,7 +60,7 @@ define(["dojo/_base/declare",
        * Set up the attributes to be used when rendering the template.
        * 
        * @instance
-       * @listens module:alfresco/core/topics~event#DOCUMENT_SELECTION_UPDATE
+       * @listens module:alfresco/core/topics#DOCUMENT_SELECTION_UPDATE
        */
       postMixInProperties: function alfresco_renderers_Selector__postMixInProperties() {
          // Set up a subscription to handle file selection events, these will be along the lines of

--- a/aikau/src/main/resources/alfresco/services/LoggingService.js
+++ b/aikau/src/main/resources/alfresco/services/LoggingService.js
@@ -83,7 +83,7 @@ define(["dojo/_base/declare",
        * @listens ALF_SHOW_DATA_MODEL
        * @listens ALF_TOGGLE_DEVELOPER_MODE
        *
-       * @fires module:alfresco/core/topics~event#GET_PREFERENCE
+       * @fires module:alfresco/core/topics#GET_PREFERENCE
        * @since 1.0.32
        */
       registerSubscriptions: function alfresco_services_LoggingService__registerSubscriptions() {

--- a/aikau/src/main/resources/alfresco/services/LoggingService.js
+++ b/aikau/src/main/resources/alfresco/services/LoggingService.js
@@ -83,7 +83,7 @@ define(["dojo/_base/declare",
        * @listens ALF_SHOW_DATA_MODEL
        * @listens ALF_TOGGLE_DEVELOPER_MODE
        *
-       * @fires module:alfresco/core/topics~event:GET_PREFERENCE
+       * @fires module:alfresco/core/topics~event#GET_PREFERENCE
        * @since 1.0.32
        */
       registerSubscriptions: function alfresco_services_LoggingService__registerSubscriptions() {

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -62,9 +62,9 @@ define(["dojo/_base/declare",
        * @listens reloadPageTopic
        * @listens postToPageTopic
        * @since 1.0.32
-       * @listens module:alfresco/core/topics~event:NAVIGATE_TO_PAGE
-       * @listens module:alfresco/core/topics~event:RELOAD_PAGE
-       * @listens module:alfresco/core/topics~event:POST_TO_PAGE
+       * @listens module:alfresco/core/topics~event#NAVIGATE_TO_PAGE
+       * @listens module:alfresco/core/topics~event#RELOAD_PAGE
+       * @listens module:alfresco/core/topics~event#POST_TO_PAGE
        */
       registerSubscriptions: function alfresco_services_NavigationService__registerSubscriptions() {
          this.alfSubscribe(this.navigateToPageTopic, lang.hitch(this, this.navigateToPage));

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -62,9 +62,9 @@ define(["dojo/_base/declare",
        * @listens reloadPageTopic
        * @listens postToPageTopic
        * @since 1.0.32
-       * @listens module:alfresco/core/topics~event#NAVIGATE_TO_PAGE
-       * @listens module:alfresco/core/topics~event#RELOAD_PAGE
-       * @listens module:alfresco/core/topics~event#POST_TO_PAGE
+       * @listens module:alfresco/core/topics#NAVIGATE_TO_PAGE
+       * @listens module:alfresco/core/topics#RELOAD_PAGE
+       * @listens module:alfresco/core/topics#POST_TO_PAGE
        */
       registerSubscriptions: function alfresco_services_NavigationService__registerSubscriptions() {
          this.alfSubscribe(this.navigateToPageTopic, lang.hitch(this, this.navigateToPage));

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -60,8 +60,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @since 1.0.32
-       * @listens module:alfresco/core/topics~event#DELETE_SITE
-       * @listens module:alfresco/core/topics~event#BECOME_SITE_MANAGER
+       * @listens module:alfresco/core/topics#DELETE_SITE
+       * @listens module:alfresco/core/topics#BECOME_SITE_MANAGER
        */
       registerSubscriptions: function alfresco_services_SiteService__registerSubscriptions() {
          this.alfSubscribe("ALF_GET_SITES", lang.hitch(this, this.getSites));
@@ -288,8 +288,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload
-       * @fires module:alfresco/core/topics~event#NAVIGATE_TO_PAGE
-       * @fires module:alfresco/core/topics~event#RELOAD_DATA_TOPIC
+       * @fires module:alfresco/core/topics#NAVIGATE_TO_PAGE
+       * @fires module:alfresco/core/topics#RELOAD_DATA_TOPIC
        */
       onActionDeleteSiteSuccess: function alfresco_services_SiteService__onActionDeleteSiteSuccess(payload) {
          var subscriptionHandle = lang.getObject("requestConfig.subscriptionHandle", false, payload);
@@ -738,7 +738,7 @@ define(["dojo/_base/declare",
        * referenced in the request. This method needs to be updated accordingly.
        *
        * @instance
-       * @fires module:alfresco/core/topics~event#RELOAD_PAGE
+       * @fires module:alfresco/core/topics#RELOAD_PAGE
        */
       reloadPage: function alfresco_services_SiteService__reloadPage(response, requestConfig) {
          /*jshint unused:false*/
@@ -750,7 +750,7 @@ define(["dojo/_base/declare",
        * This is a method that reloads DocList data
        *
        * @instance
-       * @fires module:alfresco/core/topics~event#RELOAD_DATA_TOPIC
+       * @fires module:alfresco/core/topics#RELOAD_DATA_TOPIC
        */
       reloadData: function alfresco_services_SiteService__reloadData(response, requestConfig) {
          /*jshint unused:false*/

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -61,6 +61,7 @@ define(["dojo/_base/declare",
        * @instance
        * @since 1.0.32
        * @listens module:alfresco/core/topics~event:DELETE_SITE
+       * @listens module:alfresco/core/topics~event:BECOME_SITE_MANAGER
        */
       registerSubscriptions: function alfresco_services_SiteService__registerSubscriptions() {
          this.alfSubscribe("ALF_GET_SITES", lang.hitch(this, this.getSites));
@@ -68,7 +69,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe("ALF_GET_SITE_MEMBERSHIPS", lang.hitch(this, this.getSiteMemberships));
          this.alfSubscribe("ALF_GET_SITE_DETAILS", lang.hitch(this, this.getSiteDetails));
          this.alfSubscribe("ALF_UPDATE_SITE_DETAILS", lang.hitch(this, this.updateSite));
-         this.alfSubscribe("ALF_BECOME_SITE_MANAGER", lang.hitch(this, this.becomeSiteManager));
+         this.alfSubscribe(topics.BECOME_SITE_MANAGER, lang.hitch(this, this.becomeSiteManager));
          this.alfSubscribe("ALF_JOIN_SITE", lang.hitch(this, this.joinSite));
          this.alfSubscribe("ALF_REQUEST_SITE_MEMBERSHIP", lang.hitch(this, this.requestSiteMembership));
          this.alfSubscribe("ALF_LEAVE_SITE", lang.hitch(this, this.leaveSiteRequest));
@@ -444,7 +445,7 @@ define(["dojo/_base/declare",
             this.serviceXhr({url : url,
                              data: data,
                              method: "POST",
-                             successCallback: this.reloadData,
+                             successCallback: config.reloadPage ? this.reloadPage : this.reloadData,
                              callbackScope: this});
          }
          else
@@ -735,19 +736,25 @@ define(["dojo/_base/declare",
        * This is a catch all success handler for both the join site and become site manager. It simply reloads
        * the current page. It is ** INCORRECTLY ** assumed that the current user will always be on the site
        * referenced in the request. This method needs to be updated accordingly.
+       *
+       * @instance
+       * @fires module:alfresco/core/topics~event:RELOAD_PAGE
        */
       reloadPage: function alfresco_services_SiteService__reloadPage(response, requestConfig) {
          /*jshint unused:false*/
          // TODO: Check user in request is current user and that site in request is current site
-         this.alfPublish("ALF_RELOAD_PAGE", {});
+         this.alfPublish(topics.RELOAD_PAGE);
       },
 
       /**
        * This is a method that reloads DocList data
+       *
+       * @instance
+       * @fires module:alfresco/core/topics~event:RELOAD_DATA_TOPIC
        */
       reloadData: function alfresco_services_SiteService__reloadData(response, requestConfig) {
          /*jshint unused:false*/
-         this.alfPublish("ALF_DOCLIST_RELOAD_DATA", {});
+         this.alfPublish(topics.RELOAD_DATA_TOPIC);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -60,8 +60,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @since 1.0.32
-       * @listens module:alfresco/core/topics~event:DELETE_SITE
-       * @listens module:alfresco/core/topics~event:BECOME_SITE_MANAGER
+       * @listens module:alfresco/core/topics~event#DELETE_SITE
+       * @listens module:alfresco/core/topics~event#BECOME_SITE_MANAGER
        */
       registerSubscriptions: function alfresco_services_SiteService__registerSubscriptions() {
          this.alfSubscribe("ALF_GET_SITES", lang.hitch(this, this.getSites));
@@ -288,8 +288,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload
-       * @fires module:alfresco/core/topics~event:NAVIGATE_TO_PAGE
-       * @fires module:alfresco/core/topics~event:RELOAD_DATA_TOPIC
+       * @fires module:alfresco/core/topics~event#NAVIGATE_TO_PAGE
+       * @fires module:alfresco/core/topics~event#RELOAD_DATA_TOPIC
        */
       onActionDeleteSiteSuccess: function alfresco_services_SiteService__onActionDeleteSiteSuccess(payload) {
          var subscriptionHandle = lang.getObject("requestConfig.subscriptionHandle", false, payload);
@@ -738,7 +738,7 @@ define(["dojo/_base/declare",
        * referenced in the request. This method needs to be updated accordingly.
        *
        * @instance
-       * @fires module:alfresco/core/topics~event:RELOAD_PAGE
+       * @fires module:alfresco/core/topics~event#RELOAD_PAGE
        */
       reloadPage: function alfresco_services_SiteService__reloadPage(response, requestConfig) {
          /*jshint unused:false*/
@@ -750,7 +750,7 @@ define(["dojo/_base/declare",
        * This is a method that reloads DocList data
        *
        * @instance
-       * @fires module:alfresco/core/topics~event:RELOAD_DATA_TOPIC
+       * @fires module:alfresco/core/topics~event#RELOAD_DATA_TOPIC
        */
       reloadData: function alfresco_services_SiteService__reloadData(response, requestConfig) {
          /*jshint unused:false*/

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -78,6 +78,24 @@ define(["alfresco/TestCommon",
                });
          },
 
+         "Become site manager (and reload data)": function() {
+            return browser.findById("BECOME_SITE_MANAGER_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_DOCLIST_RELOAD_DATA");
+         },
+
+         "Become site manager (and reload page)": function() {
+            return browser.findById("BECOME_SITE_MANAGER_PAGE_RELOAD_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RELOAD_PAGE");
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -238,7 +238,6 @@ model.jsonModel = {
             }
          }
       },
-
       {
          name: "alfresco/buttons/AlfButton",
          config: {
@@ -288,7 +287,19 @@ model.jsonModel = {
             }
          }
       },
-
+      {
+         id: "BECOME_SITE_MANAGER_PAGE_RELOAD",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Become Site Manager (reload page)",
+            publishTopic: "ALF_BECOME_SITE_MANAGER",
+            publishPayload: {
+               site: "swsdp",
+               role: "SiteCollaborator",
+               reloadPage: true
+            }
+         }
+      },
       {
          name: "alfresco/buttons/AlfButton",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-789 to ensure that page refresh occurs when leaving a site via the header menu in Share. An additional change will need to be made to the Share code-base publishPayload when resolving https://issues.alfresco.com/jira/browse/MNT-14600 (a change set has been created pending release of 1.0.52).