### PR TITLE
AKU-769: Update LinkClickMixin to handle Mac cmd key

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
@@ -29,8 +29,9 @@
  * @since 1.0.50
  */
 define(["dojo/_base/declare",
-        "alfresco/services/_NavigationServiceTopicMixin"], 
-        function(declare, _NavigationServiceTopicMixin) {
+        "alfresco/services/_NavigationServiceTopicMixin",
+        "dojo/has"], 
+        function(declare, _NavigationServiceTopicMixin, has) {
    
    return declare([_NavigationServiceTopicMixin], {
 
@@ -71,7 +72,9 @@ define(["dojo/_base/declare",
       processMiddleOrCtrlClick: function alfresco_navigation_LinkClickMixin__processMiddleOrCtrlClick(evt, publishTopic, publishPayload) {
          if (this.newTabOnMiddleOrCtrlClick && publishTopic === this.navigateToPageTopic) 
          {
-            if ((evt.which === 2 || (evt.which === 1 && evt.ctrlKey)) && publishPayload.target !== this.newTarget)
+            if ((evt.which === 2 || 
+                (evt.which === 1 && evt.ctrlKey) ||
+                (evt.which === 1 && has("mac") && evt.metaKey)) && publishPayload.target !== this.newTarget)
             {
                publishPayload.target = this.newTarget;
             }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-769 to make a further update to the LinkClickMixin to handle the cmd key on OSX. Unit tests not updated as not possible to test in our current testing environment. A manual test would be useful by someone with a Mac at some point (hint hint).