### PR TITLE
AKU-746: Create new UploadService

### DIFF
--- a/aikau/.jshintrc
+++ b/aikau/.jshintrc
@@ -30,6 +30,7 @@
       "module": false,
       "model": false,
       "appContext": false,
+      "JSON": false,
       "PDFJS": false
    },
 

--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -703,9 +703,10 @@ define(["dojo/_base/declare",
                      instantiatedWidget.startup();
                   }
                
+                  var assignToScope = widget.assignToScope || _this;
                   if (widget.assignTo)
                   {
-                     _this[widget.assignTo] = instantiatedWidget;
+                     assignToScope[widget.assignTo] = instantiatedWidget;
                   }
 
                   // Set any additional style attributes...

--- a/aikau/src/main/resources/alfresco/core/shims.js
+++ b/aikau/src/main/resources/alfresco/core/shims.js
@@ -43,9 +43,56 @@ define([], function() {
             return;
          }
          this._addObjectKeys();
+         this._addArrayReduce();
          this._addDateNow();
          this._addTextContent();
          _applied = true;
+      },
+
+      /**
+       * Add a reduce() function to the global Array object, because dojo/_base/array does not support it.
+       * From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#Polyfill
+       *
+       * @protected
+       * @instance
+       */
+      _addArrayReduce: function alfresco_core_shim___addArrayReduce() {
+         /*jshint bitwise:false,freeze:false,eqnull:true*/
+
+         // Production steps of ECMA-262, Edition 5, 15.4.4.21
+         // Reference: http://es5.github.io/#x15.4.4.21
+         if (!Array.prototype.reduce) {
+            Array.prototype.reduce = function(callback /*, initialValue*/ ) {
+               "use strict";
+               if (this == null) {
+                  throw new TypeError("Array.prototype.reduce called on null or undefined");
+               }
+               if (typeof callback !== "function") {
+                  throw new TypeError(callback + " is not a function");
+               }
+               var t = Object(this),
+                  len = t.length >>> 0,
+                  k = 0,
+                  value;
+               if (arguments.length === 2) {
+                  value = arguments[1];
+               } else {
+                  while (k < len && !(k in t)) {
+                     k++;
+                  }
+                  if (k >= len) {
+                     throw new TypeError("Reduce of empty array with no initial value");
+                  }
+                  value = t[k++];
+               }
+               for (; k < len; k++) {
+                  if (k in t) {
+                     value = callback(value, t[k], k, t);
+                  }
+               }
+               return value;
+            };
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/shims.js
+++ b/aikau/src/main/resources/alfresco/core/shims.js
@@ -55,6 +55,7 @@ define([], function() {
        *
        * @protected
        * @instance
+       * @since 1.0.52
        */
       _addArrayReduce: function alfresco_core_shim___addArrayReduce() {
          /*jshint bitwise:false,freeze:false,eqnull:true*/

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1030,6 +1030,22 @@ define([],function() {
       UPLOAD_CANCELLATION: "ALF_UPLOAD_DIALOG_CANCEL_CLICK",
 
       /**
+       * This topic is published to request an upload.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.51
+       *
+       * @event
+       * @property {object[]} files The files to upload
+       * @property {object} targetData An object describing where to upload the files to
+       * @property {string} [fileRefs] A dot-notation reference to the files in the context of
+       *                               [alfGetData]{@link module:alfresco/core/Core#alfGetData}
+       */
+      UPLOAD_REQUEST: "ALF_UPLOAD_REQUEST",
+
+      /**
        * This topic can be published to display a dialog that allows users to select one or more files
        * to upload and the location to upload them to. This is typically handled by the 
        * [ContentService]{@link module:alfresco/services/ContentService}.

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -307,6 +307,10 @@ define([],function() {
        * @property {string} [title=default.title] The title to display (uses i18n)
        * @property {number} [padding=10] The padding to be applied to the widgets area
        * @property {string|number} [width=50%] The width of the panel (CSS dimension or number of pixels)
+       * @property {boolean} [warnIfOpen=true] Whether to put a warning in the console if the panel is
+       *                                       already visible
+       * @property {function} [callback] The function to call after panel created (or if it already exists)
+       *                                 with the panel instance as the first and only argument
        */
       DISPLAY_STICKY_PANEL: "ALF_DISPLAY_STICKY_PANEL",
 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1039,7 +1039,7 @@ define([],function() {
        * @instance
        * @type {string}
        * @default
-       * @since 1.0.51
+       * @since 1.0.52
        *
        * @event
        * @property {object[]} files The files to upload

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1043,9 +1043,14 @@ define([],function() {
        *
        * @event
        * @property {object[]} files The files to upload
-       * @property {object} targetData An object describing where to upload the files to
        * @property {string} [fileRefs] A dot-notation reference to the files in the context of
        *                               [alfGetData]{@link module:alfresco/core/Core#alfGetData}
+       *                               which will override any included files
+       * @property {object} targetData An object describing where to upload the files to
+       * @property {string} alfResponseTopic The topic on which to respond after all files have
+       *                                     uploaded (successfully or unsuccessfully)
+       * @property {string} [responseScope] The scope of the response defined by the alfResponseTopic,
+       *                                    defaults to the scope of the publish caller
        */
       UPLOAD_REQUEST: "ALF_UPLOAD_REQUEST",
 

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -34,6 +34,7 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/core/PathUtils",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/mouse",
@@ -45,7 +46,7 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dojo/dom",
         "dojo/_base/window"], 
-        function(declare, AlfCore, _AlfDocumentListTopicMixin, PathUtils, lang, array, mouse, on, registry, domClass, 
+        function(declare, AlfCore, _AlfDocumentListTopicMixin, PathUtils, topics, lang, array, mouse, on, registry, domClass, 
                  domConstruct, domGeom, domStyle, dom, win) {
    
    return declare([AlfCore, _AlfDocumentListTopicMixin, PathUtils], {
@@ -575,6 +576,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} evt HTML5 drag and drop event
+       * @fires module:alfresco/core/topics#UPLOAD_REQUEST
        */
       onDndUploadDrop: function alfresco_documentlibrary__AlfDndDocumentUploadMixin__onDndUploadDrop(evt) {
          try
@@ -608,7 +610,7 @@ define(["dojo/_base/declare",
                   var responseTopic = this.generateUuid();
                   this._uploadSubHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onFileUploadComplete), true);
 
-                  this.alfPublish("ALF_UPLOAD_REQUEST", {
+                  this.alfPublish(topics.UPLOAD_REQUEST, {
                      alfResponseTopic: responseTopic,
                      files: evt.dataTransfer.files,
                      targetData: updatedConfig
@@ -667,7 +669,7 @@ define(["dojo/_base/declare",
             dialogTitle: "Update",
             dialogConfirmationButtonTitle: "Continue Update",
             dialogCancellationButtonTitle: "Cancel",
-            formSubmissionTopic: "ALF_UPLOAD_REQUEST",
+            formSubmissionTopic: topics.UPLOAD_REQUEST,
             formSubmissionPayloadMixin: {
                alfResponseTopic: responseTopic,
                filesRefs: filesRef,

--- a/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
@@ -119,9 +119,9 @@
          border-top-color: #ccc;
          cursor: pointer;
          &__highlighted-label {
+            color: @general-font-color;
             font-family: @bold-font;
             font-weight: 700;
-            color: @general-font-color;
             text-decoration: underline;
          }
          &:first-child {
@@ -168,11 +168,11 @@
    }
    &--has-error {
       border-color: #c00;
-      outline: 1px solid #faa;
+      box-shadow: 0 0 1px 1px #ffc4c4;
    }
    &--focused {
       border-color: #09c;
-      outline: 1px solid #0cf;
+      box-shadow: 0 0 1px 1px #80e5ff;
    }
    &--choices-nowrap {
       .alfresco-forms-controls-MultiSelect__choice__content {

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -1,6 +1,7 @@
 .alfresco-layout-StickyPanel {
    bottom: 0;
    left: 50%;
+   max-height: 90%;
    position: fixed;
    right: 0;
    &__panel {

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -254,7 +254,7 @@ define(["alfresco/core/ObjectTypeUtils",
             });
 
             // Re-apply the filters
-            this._applyFilters();
+            this._applyFilters(true);
          },
 
          /**
@@ -263,9 +263,10 @@ define(["alfresco/core/ObjectTypeUtils",
           * of the regular expression "checkbox".
           *
           * @instance
+          * @param {boolean} [force=false] Whether to force applying the current filters
           * @since 1.0.50
           */
-         _applyFilters: function alfresco_logging_DebugLog___applyFilters() {
+         _applyFilters: function alfresco_logging_DebugLog___applyFilters(force) {
             var filters = {
                   include: this.includeFilter.value,
                   exclude: this.excludeFilter.value,
@@ -277,9 +278,11 @@ define(["alfresco/core/ObjectTypeUtils",
                newInclude = prefix + filters.include + suffix,
                newExclude = prefix + filters.exclude + suffix,
                filtersChanged = newInclude !== this._lastIncludeFilter || newExclude !== this._lastExcludeFilter;
-            if (filtersChanged) {
-               this._lastIncludeFilter = newInclude;
-               this._lastExcludeFilter = newExclude;
+            if (filtersChanged || force) {
+               if (filtersChanged) {
+                  this._lastIncludeFilter = newInclude;
+                  this._lastExcludeFilter = newExclude;
+               }
                this._entries.forEach(lang.hitch(this, this._applyFilter, filters));
             }
          },

--- a/aikau/src/main/resources/alfresco/services/BaseService.js
+++ b/aikau/src/main/resources/alfresco/services/BaseService.js
@@ -70,6 +70,7 @@ define(["dojo/_base/declare",
        * class lifecycle.
        *
        * @instance
+       * @since 1.0.52
        */
       initService: function alfresco_services_BaseService__initService() {
          // No action required

--- a/aikau/src/main/resources/alfresco/services/BaseService.js
+++ b/aikau/src/main/resources/alfresco/services/BaseService.js
@@ -53,6 +53,7 @@ define(["dojo/_base/declare",
          declare.safeMixin(this, args);
          if (serviceRegistry.register(this.alfServiceName, this.pubSubScope))
          {
+            this.initService();
             this.registerSubscriptions();
          }
          else
@@ -61,6 +62,17 @@ define(["dojo/_base/declare",
             var message = lang.replace("A service with the Module ID: '{alfServiceName}' configured to use the pubSubScope '{pubSubScope}' has already been registered so this instance will NOT call 'registerSubscriptions'. This is typically nothing to be concerned about", this);
             this.alfLog("info", message);
          }
+      },
+
+      /**
+       * If a service needs to act upon its post-mixed-in state before registering subscriptions then
+       * this is where it should be done. It is comparable to postMixInProperties in a widget in the
+       * class lifecycle.
+       *
+       * @instance
+       */
+      initService: function alfresco_services_BaseService__initService() {
+         // No action required
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/services/ContentService.js
+++ b/aikau/src/main/resources/alfresco/services/ContentService.js
@@ -518,12 +518,13 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} payload The file upload data payload to pass on
+       * @fires module:alfresco/core/topics#UPLOAD_REQUEST
        */
       onFileUploadRequest: function alfresco_services_ContentService__onFileUploadRequest(payload) {
          var responseTopic = this.generateUuid();
          this._uploadSubHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onFileUploadComplete), true);
          payload.alfResponseTopic = responseTopic;
-         this.alfPublish("ALF_UPLOAD_REQUEST", payload);
+         this.alfPublish(topics.UPLOAD_REQUEST, payload);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -1,0 +1,709 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p><strong>BETA: Not yet suitable for production use</strong></p>
+ * 
+ * <p>This service can be used to control the uploading of content as well as
+ * the updating the content of existing nodes on an Alfresco Repository.</p>
+ * 
+ * @module alfresco/services/FileUploadService
+ * @extends module:alfresco/services/BaseService
+ * @mixes module:alfresco/core/CoreXhr
+ * @mixes module:alfresco/services/_UploadHistoryMixin
+ * @author Martin Doyle
+ */
+define(["alfresco/buttons/AlfButton", 
+        "alfresco/core/CoreXhr", 
+        "alfresco/core/ObjectTypeUtils", 
+        "alfresco/core/topics", 
+        "alfresco/dialogs/AlfDialog", 
+        "alfresco/services/_UploadHistoryMixin", 
+        "alfresco/services/BaseService", 
+        "dojo/_base/array", 
+        "dojo/_base/declare", 
+        "dojo/_base/lang", 
+        "dojo/Deferred", 
+        "dojo/on", 
+        "dojo/promise/all", 
+        "service/constants/Default"], 
+        function(AlfButton, CoreXhr, ObjectTypeUtils, topics, AlfDialog, _UploadHistoryMixin, BaseService, array, declare, lang, Deferred, on, all, AlfConstants) {
+
+   // Declare and return the class
+   return declare([BaseService, CoreXhr, _UploadHistoryMixin], {
+
+      /**
+       * The File object (referenced in other JSDoc comments)
+       *
+       * @instance
+       * @typedef {object} File
+       * @property {num} progress The current upload-progress as a percentage
+       * @property {string} fileName The name of the file
+       * @property {string} nodeRef The nodeRef that this file was uploaded to (if successful)
+       * @property {object} request The request object used to upload the file
+       * @property {num} state The state as per [FileUploadService.state]{@link module:alfresco/services/FileUploadService#state}
+       * @property {object} uploadData Information pertaining to the upload itself
+       *                               (see [constructUploadData]{@link module:alfresco/services/FileUploadService#constructUploadData})
+       * @property {object} _dfd An internal deferred object that is auto-generated and
+       *                         will resolve once the upload has finished (successfully
+       *                         or unsuccessfully)
+       */
+
+      /**
+       * An array of the i18n files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/FileUploadService.properties"}]
+       */
+      i18nRequirements: [{
+         i18nFile: "./i18n/FileUploadService.properties"
+      }],
+
+      /**
+       * Stores references and state for each file that is in the file list. The fileId
+       * parameter from the YAHOO.widget.Uploader is used as the key and the value is a
+       * [File object]{@link module:alfresco/FileUploadService#File}.
+       *
+       * @instance
+       * @type {object}
+       * @default
+       */
+      fileStore: null,
+
+      /**
+       * The maximum quantity of simultaneous uploads.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      maxSimultaneousUploads: 1,
+
+      /**
+       * A counter for the currently uploading files.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      numUploadsInProgress: 0,
+
+      /**
+       * Enum of upload states (BROWSING not used, but indexes not changed to avoid
+       * unexpected reliance errors).
+       *
+       * @instance
+       * @readOnly
+       * @type {Object}
+       * @property {num} ADDED File has been queued for upload
+       * @property {num} UPLOADING File being uploaded
+       * @property {num} FINISHED Uploading has finished
+       * @property {num} FAILURE Uploading failed
+       * @property {num} SUCCESS Uploading succeeded
+       */
+      state: {
+         ADDED: 2,
+         UPLOADING: 3,
+         FINISHED: 4,
+         FAILURE: 5,
+         SUCCESS: 6
+      },
+
+      /**
+       * This state-variable is used to track the current overall progress, and is equal to
+       * the number of queued uploads multiplied by 100. This is reset to zero every time
+       * all of the queued uploads complete.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      totalProgressPercent: 0,
+
+      /**
+       * The widget that displays the uploads' progress.
+       *
+       * @instance
+       * @type {object}
+       * @default
+       */
+      uploadDisplayWidget: null,
+
+      /**
+       * The widget that contains the uploads display widget.
+       *
+       * @instance
+       * @type {object}
+       * @default
+       */
+      uploadsContainer: null,
+
+      /**
+       * This is the default title for the uploads container.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      uploadsContainerTitle: "uploads-container.title",
+
+      /**
+       * This is the default title for the uploads container.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      uploadsContainerTitleComplete: "uploads-container-complete.title",
+
+      /**
+       * This is the topic on which to publish updates to the title container.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      uploadsContainerUpdateTopic: topics.STICKY_PANEL_SET_TITLE,
+
+      /**
+       * The topic that this service will listen to, to initiate a file upload.
+       * 
+       * @instance
+       * @type {string}
+       * @listens module:alfresco/core/topics#UPLOAD_REQUEST
+       * @default
+       */
+      uploadTopic: topics.UPLOAD_REQUEST,
+
+      /**
+       * The widget definition that displays the uploads' progress. This should
+       * be a single widget that implements the interface defined by
+       * [_UploadsDisplayMixin]{@link module:alfresco/services/_UploadsDisplayMixin}.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{name: "alfresco/upload/UploadMonitor"}]
+       */
+      widgetsForUploadDisplay: [{
+         name: "alfresco/upload/UploadMonitor"
+      }],
+
+      /**
+       * Check to see whether there are any waiting uploads that can be started (up to the
+       * [maxSimultaneousUploads]{@link module:alfresco/services/FileUploadService#maxSimultaneousUploads}).
+       *
+       * @instance
+       */
+      checkForWaitingUploads: function alfresco_services_FileUploadService__checkForWaitingUploads() {
+         array.forEach(Object.keys(this.fileStore), function(fileId) {
+            var fileInfo = this.fileStore[fileId];
+            if (fileInfo.state === this.state.ADDED) {
+               this.startFileUpload(fileInfo);
+            }
+         }, this);
+      },
+
+      /**
+       * Constructs the upload payload object to be added to the fileStore object for each file. 
+       * The object constructed is designed to work with the Alfresco REST service for uploading
+       * documents. This function can be overridden to support different APIs
+       *
+       * @instance
+       * @param {object} file The file being uploaded
+       * @param {object} fileName The name of the file being uploaded
+       * @param {object} targetData Information about where and how to upload the data
+       */
+      constructUploadData: function alfresco_services_FileUploadService__constructUploadData(file, fileName, targetData) {
+
+         // This is to work around the fact that pickers always return an array, even in
+         // single item mode - that needs to be better resolved at some point
+         var destination = targetData.destination;
+         if (destination.constructor === Array) {
+            destination = destination[0];
+         }
+         this.updateHistory(destination);
+
+         // Create object using information defined in payload
+         return {
+            filedata: file,
+            filename: fileName,
+            destination: destination,
+            siteId: targetData.siteId,
+            containerId: targetData.containerId,
+            uploaddirectory: targetData.uploadDirectory,
+            majorVersion: targetData.majorVersion ? targetData.majorVersion : "true",
+            updateNodeRef: targetData.updateNodeRef,
+            description: targetData.description,
+            overwrite: targetData.overwrite,
+            thumbnails: targetData.thumbnails,
+            username: targetData.username
+         };
+      },
+
+      /**
+       * Create the file-upload requests.
+       *
+       * @instance
+       * @param {object[]} filesToUpload The files to be uploaded
+       * @param {object} targetData The data that identifies where to upload the files to.
+       */
+      createFileUploadRequests: function alfresco_services_FileUploadService__createFileUploadRequests(filesToUpload, targetData) {
+
+         // Recursively add files to the queue
+         var nextFile;
+         while ((nextFile = filesToUpload.shift())) {
+
+            // Ensure a unique file ID
+            var fileId = "file" + Date.now();
+            while (this.fileStore.hasOwnProperty(fileId)) {
+               fileId = "file" + Date.now();
+            }
+
+            // Add the data to the upload property of XMLHttpRequest so that we can determine which file each
+            // progress update relates to (the event argument passed in the progress function does not contain
+            // file name details)
+            var request = new XMLHttpRequest();
+            request.upload._fileData = fileId;
+
+            // Add the event listener functions to the upload properties of the XMLHttpRequest object
+            on(request.upload, "progress", lang.hitch(this, this.onUploadProgress, fileId));
+            on(request.upload, "load", lang.hitch(this, this.onUploadRequestComplete, fileId));
+            on(request.upload, "error", lang.hitch(this, this.onUploadError, fileId));
+            on(request.upload, "abort", lang.hitch(this, this.onUploadCancelled, fileId));
+
+            // Construct an object containing the data required for file upload
+            // Note that we use .name and NOT .fileName which is non-standard and will break FireFox 7
+            var fileName = nextFile.name,
+               uploadData = this.constructUploadData(nextFile, fileName, targetData);
+
+            // Add the upload data to the file store
+            this.fileStore[fileId] = {
+               state: this.state.ADDED,
+               fileName: fileName,
+               uploadData: uploadData,
+               request: request,
+               progress: 0
+            };
+
+            // Update the display widget with the details of the file that will be uploaded
+            this.uploadDisplayWidget.addInProgressFile(fileId, nextFile);
+
+            // Update the total progress percentage
+            this.totalProgressPercent += 100;
+         }
+
+         // Start uploads
+         this.checkForWaitingUploads();
+      },
+
+      /**
+       * If a service needs to act upon its post-mixed-in state before registering subscriptions then
+       * this is where it should be done. It is comparable to postMixInProperties in a widget in the
+       * class lifecycle.
+       *
+       * @instance
+       * @override
+       */
+      initService: function alfresco_services_FileUploadService__initService() {
+         var widgets = this.widgetsForUploadDisplay;
+         if (widgets && widgets.constructor === Array && widgets.length === 1) {
+            lang.mixin(widgets[0], {
+               assignTo: "uploadDisplayWidget",
+               assignToScope: this
+            });
+         } else {
+            this.alfLog("error", "Must define a widget for displaying upload progress in property 'widgetsForUploadDisplay'");
+         }
+         this.reset();
+      },
+
+      /**
+       * Notifies the uploads-display widget that a file could not be uploaded.
+       *
+       * @instance
+       * @param {object} file The invalid file
+       */
+      notifyOfInvalidFile: function alfresco_services_FileUploadService__notifyOfInvalidFile(file, reason) {
+         this.uploadDisplayWidget.addFailedFile(file.name, {
+            reason: reason
+         });
+      },
+
+      /**
+       * Handle cancelled upload requests.
+       *
+       * @instance
+       * @param {string} fileId The unique id of the file being uploaded
+       * @param {object} evt The cancellation event
+       */
+      onUploadCancelled: function alfresco_services_FileUploadService__onUploadCancelled( /*jshint unused:false*/ fileId, /*jshint unused:false*/ evt) {
+         this.alfLog("warn", "Not yet implemented");
+         this.onUploadFinished();
+      },
+
+      /**
+       * Handle an error occurring during the upload.
+       *
+       * @instance
+       * @param {string} fileId The unique id of the file being uploaded
+       * @param {object} evt The failure event
+       */
+      onUploadError: function alfresco_services_FileUploadService__onUploadError(fileId, evt) {
+         var fileInfo = this.fileStore[fileId];
+         if (fileInfo) {
+            // Make sure we only update the UI once
+            if (fileInfo.state !== this.state.FAILURE) {
+               this.processUploadFailure(fileId, evt);
+            }
+         }
+      },
+
+      /**
+       * Handler that's called after an upload has finished (in any state)
+       *
+       * @instance
+       * @param {string} fileId The unique id of the file being uploaded
+       */
+      onUploadFinished: function alfresco_services_FileUploadService__onUploadFinished( /*jshint unused:false*/ fileId) {
+
+         // Resolve the deferred object on the file (used for firing requested topic when uploads complete)
+         var fileInfo = this.fileStore[fileId],
+            dfd = fileInfo && lang.getObject("fileObj._dfd", false, fileInfo);
+         dfd && dfd.resolve();
+
+         // Update the progress information in the UI
+         this.updateAggregateProgress();
+
+         // Decrement the in-progress counter and see if there are more to upload
+         this.numUploadsInProgress--;
+         this.checkForWaitingUploads();
+      },
+
+      /**
+       * Handler for the upload request completing.
+       * 
+       * @instance
+       * @param {string} fileId The unique id of the file being uploaded
+       * @param {object} evt The success event
+       */
+      onUploadRequestComplete: function alfresco_services_FileUploadService__onUploadRequestComplete(fileId, evt) {
+         var fileInfo = this.fileStore[fileId];
+         if (fileInfo) {
+            // NOTE: There is an occasional timing issue where the upload completion event fires before the
+            // readyState is correctly updated. This means that we can't check the upload actually completed
+            // successfully, if this occurs then we'll attach a function to the onreadystatechange extension
+            // point and things to catch up before we check everything was ok.
+            if (fileInfo.request.readyState !== 4) {
+               fileInfo.request.onreadystatechange = lang.hitch(this, function() {
+                  if (fileInfo.request.readyState === 4) {
+                     this.processUploadCompletion(fileId, evt);
+                  }
+               });
+            } else {
+               this.processUploadCompletion(fileId, evt);
+            }
+         }
+      },
+
+      /**
+       * This function listens for upload progress events retured from the XMLHttpRequest object and
+       * adjusts the display to give a visual indication of how the upload for the related file is
+       * progressing.
+       * 
+       * @instance
+       * @param {string} fileId The unique id of the file being uploaded
+       * @param {object} evt See [ProgressEvent on MDN]{@link https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent}
+       */
+      onUploadProgress: function alfresco_services_FileUploadService__onUploadProgress(fileId, evt) {
+         var fileInfo = this.fileStore[fileId];
+         if (fileInfo && evt.lengthComputable) {
+            var progress = Math.round(evt.loaded / evt.total * 100);
+            this.uploadDisplayWidget.updateUploadProgress(fileId, progress, evt);
+            fileInfo.progress = progress;
+            this.updateAggregateProgress();
+         } else {
+            this.alfLog("warn", "Unable to update upload progress for file (evt,file)", evt, fileInfo);
+         }
+      },
+
+      /**
+       * The main handler for an upload request.
+       * 
+       * @instance
+       * @param {object} payload The publication payload
+       */
+      onUploadRequest: function alfresco_services_UploadService(payload) {
+
+         // A files reference will take precedence over actual files in the payload
+         if (lang.exists("filesRefs", payload)) {
+            var files = this.alfGetData(payload.filesRefs);
+            if (files) {
+               payload.files = files;
+            }
+         }
+
+         // Make sure we have enough information to continue
+         if (payload.files && payload.targetData) {
+
+            // Make sure the upload display widget is present
+            this.showUploadsWidget().then(lang.hitch(this, function() {
+
+               // If a response is requested, set it up to fire after all uploads finish
+               if (payload.alfResponseTopic) {
+                  var filePromises = array.map(payload.files, function(file) {
+                     return (file._dfd = new Deferred()).promise;
+                  });
+                  all(filePromises).then(lang.hitch(this, function() {
+                     this.alfPublish(payload.alfResponseTopic, {}, false, false, payload.alfResponseScope);
+                  }));
+               }
+
+               // Validate the files
+               var filesToUpload = this.validateFiles(payload.files);
+
+               // Update the total progress
+               this.updateAggregateProgress();
+
+               // Start the uploads
+               this.createFileUploadRequests(filesToUpload, payload.targetData);
+            }));
+
+         } else {
+            this.alfLog("warn", "A request was received to upload files but either no 'files' attribute or no 'targetData' attribute was defined", payload, this);
+         }
+      },
+
+      /**
+       * Handles the closing of the uploads container.
+       *
+       * @instance
+       */
+      onUploadsContainerClosed: function alfresco_services_FileUploadService__onUploadsContainerClosed() {
+         this.reset();
+      },
+
+      /**
+       * Called when an upload "load" event fires. This merely means that the
+       * server has responded though, so it could still be an error.
+       *
+       * @instance
+       * @param {object} fileId The unique identifier of the file
+       * @param {object} evt The completion event
+       */
+      processUploadCompletion: function alfresco_services_FileUploadService__processUploadCompletion(fileId, evt) {
+
+         // Check the response code
+         var fileInfo = this.fileStore[fileId],
+            responseCode = fileInfo.request.status,
+            successful = responseCode >= 200 && responseCode < 300;
+
+         // Handle according to success
+         if (successful) {
+
+            // Get the response and update the file-info object
+            var response = JSON.parse(fileInfo.request.responseText);
+            fileInfo.nodeRef = response.nodeRef;
+            fileInfo.fileName = response.fileName;
+            fileInfo.state = this.state.SUCCESS;
+
+            // Notify uploads-display widget of completion
+            this.uploadDisplayWidget.handleCompletedUpload(fileId, evt, fileInfo.request);
+
+            // Execute post-upload actions
+            this.onUploadFinished();
+
+         } else {
+            this.processUploadFailure(fileId, evt);
+         }
+      },
+
+      /**
+       * Called if a request fails or completes with a non-success status code.
+       *
+       * @instance 
+       * @param {object} fileId The unique identifier of the file
+       * @param {object} evt The completion event
+       */
+      processUploadFailure: function alfresco_services_FileUploadService__processUploadFailure(fileId, evt) {
+         var fileInfo = this.fileStore[fileId];
+         if (fileInfo) {
+            fileInfo.state = this.state.FAILURE;
+            this.uploadDisplayWidget.handleFailedUpload(fileId, evt, fileInfo.request);
+            this.onUploadFinished();
+         }
+      },
+
+      /**
+       * Register this service's subscriptions.
+       * 
+       * @instance
+       * @override
+       * @listens module:alfresco/core/topics#UPLOAD_COMPLETION_ACKNOWLEDGEMENT
+       * @listens module:alfresco/core/topics#UPLOAD_CANCELLATION
+       */
+      registerSubscriptions: function alfresco_services_FileUploadService__registerSubscriptions() {
+         this.alfSubscribe(this.uploadTopic, lang.hitch(this, this.onUploadRequest));
+         this.alfSubscribe(topics.STICKY_PANEL_CLOSED, lang.hitch(this, this.onUploadsContainerClosed));
+      },
+
+      /**
+       * <p>Reset the state of the service.</p>
+       *
+       * <p><strong>NOTE:</strong> This does not cancel any in-progress uploads.</p>
+       *
+       * @instance
+       */
+      reset: function alfresco_services_FileUploadService__reset() {
+         this.fileStore = {};
+      },
+
+      /**
+       * Ensure the uploads display widget is available
+       *
+       * @instance
+       */
+      showUploadsWidget: function alfresco_services_FileUploadService__showUploadsWidget() {
+         var dfd = new Deferred();
+         this.alfServicePublish(topics.DISPLAY_STICKY_PANEL, {
+            title: this.message(this.uploadsContainerTitle, 0),
+            padding: 0,
+            widgets: this.widgetsForUploadDisplay,
+            callback: lang.hitch(this, function(panel) {
+               this.uploadsContainer = panel;
+               dfd.resolve();
+            })
+         });
+         return dfd.promise;
+      },
+
+      /**
+       * Starts the actual upload for a file
+       *
+       * @instance
+       * @param {object} Contains info about the file and its request.
+       */
+      startFileUpload: function alfresco_services_FileUploadService__startFileUpload(fileInfo) {
+
+         // Ensure we only upload the maximum allowed at a time
+         if (this.numUploadsInProgress === this.maxSimultaneousUploads) {
+            return;
+         }
+
+         // Increment uploads counter
+         this.numUploadsInProgress++;
+
+         // Mark file as being uploaded
+         fileInfo.state = this.state.UPLOADING;
+
+         var url = AlfConstants.PROXY_URI + (this.uploadURL || "api/upload");
+         if (this.isCsrfFilterEnabled()) {
+            url += "?" + this.getCsrfParameter() + "=" + encodeURIComponent(this.getCsrfToken());
+         }
+
+         // Setup the form data object
+         // NOTE: This is IE10+ but code is unchanged from existing UploadService, so maybe there's a hidden polyfill somewhere
+         var formData = new FormData();
+         formData.append("filedata", fileInfo.uploadData.filedata);
+         formData.append("filename", fileInfo.uploadData.filename);
+         formData.append("destination", fileInfo.uploadData.destination);
+         formData.append("siteId", fileInfo.uploadData.siteId);
+         formData.append("containerId", fileInfo.uploadData.containerId);
+         formData.append("uploaddirectory", fileInfo.uploadData.uploaddirectory);
+         formData.append("majorVersion", fileInfo.uploadData.majorVersion ? fileInfo.uploadData.majorVersion : "false");
+         formData.append("username", fileInfo.uploadData.username);
+         formData.append("overwrite", fileInfo.uploadData.overwrite);
+         formData.append("thumbnails", fileInfo.uploadData.thumbnails);
+         if (fileInfo.uploadData.updateNodeRef) {
+            formData.append("updateNodeRef", fileInfo.uploadData.updateNodeRef);
+         }
+         if (fileInfo.uploadData.description) {
+            formData.append("description", fileInfo.uploadData.description);
+         }
+
+         // Open and send the request
+         fileInfo.request.open("POST", url, true);
+         fileInfo.request.send(formData);
+      },
+
+      /**
+       * Calculates the overall progress of all the uploads and calls the display widget with the data.
+       *
+       * @instance
+       */
+      updateAggregateProgress: function alfresco_services_FileUploadService__updateAggregateProgress() {
+
+         // Setup variables
+         var fileIds = Object.keys(this.fileStore),
+            stillUploading = false,
+            cumulativeProgress = 0;
+
+         // Run through all uploads, calculating total and current progress
+         // NOTE: We don't include failed/completed uploads
+         array.forEach(fileIds, function(fileId) {
+            var fileInfo = this.fileStore[fileId];
+            switch (fileInfo.state) {
+               case this.state.ADDED:
+               case this.state.UPLOADING:
+                  cumulativeProgress += fileInfo.progress;
+                  stillUploading = true;
+                  break;
+               default:
+                  cumulativeProgress += 100;
+            }
+         }, this);
+
+         // Calculate total percentage and send to widget
+         var currentProgress = (cumulativeProgress / this.totalProgressPercent * 100) % 100, // Using modulus to cope with multiple batches
+            currentProgressPercent = stillUploading ? Math.round(currentProgress) : 100;
+         this.uploadDisplayWidget.updateAggregateProgress(currentProgressPercent);
+
+         // If no longer have uploads pending, reset the total progress counter
+         if (!stillUploading) {
+            this.totalProgressPercent = 0;
+         }
+
+         // Update the container title with the aggregate progress if possible
+         var title = this.message(this.uploadsContainerTitle, currentProgressPercent);
+         if (currentProgressPercent === 100) {
+            title = this.message(this.uploadsContainerTitleComplete);
+         }
+         this.uploadsContainerUpdateTopic && this.alfPublish(this.uploadsContainerUpdateTopic, {
+            title: title
+         });
+      },
+
+      /**
+       * Validate the supplied collection of files, sending a notification of any invalid ones, and returning the valid ones.
+       *
+       * @instance
+       * @param {object[]} files The files
+       * @returns {object[]} The valid files
+       */
+      validateFiles: function alfresco_services_FileUploadService__validateFiles(files) {
+         return array.filter(files, function(file) {
+            if (file.size > 0) {
+               return true;
+            } else {
+               this.notifyOfInvalidFile(file, "0kb files cannot be uploaded");
+            }
+         }, this);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -18,8 +18,6 @@
  */
 
 /**
- * <p><strong>BETA: Not yet suitable for production use</strong></p>
- * 
  * <p>This service can be used to control the uploading of content as well as
  * the updating the content of existing nodes on an Alfresco Repository.</p>
  * 
@@ -28,6 +26,7 @@
  * @mixes module:alfresco/core/CoreXhr
  * @mixes module:alfresco/services/_UploadHistoryMixin
  * @author Martin Doyle
+ * @since 1.0.52
  */
 define(["alfresco/buttons/AlfButton", 
         "alfresco/core/CoreXhr", 

--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -689,6 +689,18 @@ define(["alfresco/buttons/AlfButton",
       },
 
       /**
+       * Validate a single file, throwing an exception if it fails.
+       *
+       * @instance
+       * @param {object} file The file
+       */
+      validateFile: function alfresco_services_FileUploadService__validateFile(file) {
+         if (file.size === 0) {
+            throw new Error(this.message("upload.error.empty-file"));
+         }
+      },
+
+      /**
        * Validate the supplied collection of files, sending a notification of any invalid ones, and returning the valid ones.
        *
        * @instance
@@ -697,10 +709,11 @@ define(["alfresco/buttons/AlfButton",
        */
       validateFiles: function alfresco_services_FileUploadService__validateFiles(files) {
          return array.filter(files, function(file) {
-            if (file.size > 0) {
+            try {
+               this.validateFile(file);
                return true;
-            } else {
-               this.notifyOfInvalidFile(file, "0kb files cannot be uploaded");
+            } catch (e) {
+               this.notifyOfInvalidFile(file, e.message);
             }
          }, this);
       }

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -121,30 +121,49 @@ define(["dojo/_base/declare",
        * @since 1.0.48
        */
       onDisplayStickyPanel: function alfresco_services_NotificationService__onDisplayStickyPanel(payload) {
-         var panelOpts = {},
+
+         // Setup variables
+         var panelConfig = {},
             closeSubscription;
+
+         // Determine action
          if (theStickyPanel) {
-            this.alfLog("warn", "It was not possible to display a StickyPanel because one is already displayed", payload);
-            return;
-         }
-         if (payload.widgets) {
-            panelOpts.widgets = payload.widgets
-            if(payload.title) {
-               panelOpts.title = payload.title;
+
+            // Warn that panel aready exists if appropriate
+            payload.warnIfOpen && this.alfLog("warn", "It was not possible to display a StickyPanel because one is already displayed", payload);
+
+         } else if (payload.widgets) {
+
+            // Setup the panel-widget config
+            panelConfig.widgets = payload.widgets;
+            if (payload.title) {
+               panelConfig.title = payload.title;
             }
-            if(payload.width) {
-               panelOpts.panelWidth = payload.width;
+            if (payload.width) {
+               panelConfig.panelWidth = payload.width;
             }
-            if(payload.padding || payload.padding === 0) {
-               panelOpts.widgetsPadding = payload.padding;
+            if (payload.padding || payload.padding === 0) {
+               panelConfig.widgetsPadding = payload.padding;
             }
-            theStickyPanel = new StickyPanel(panelOpts);
+
+            // Create the panel
+            theStickyPanel = new StickyPanel(panelConfig);
+
+            // When the panel is closed, empty the static pointer to it
             closeSubscription = this.alfSubscribe(topics.STICKY_PANEL_CLOSED, lang.hitch(this, function() {
                theStickyPanel = null;
                this.alfUnsubscribe(closeSubscription);
             }));
+
          } else {
+
+            // Cannot create panel
             this.alfLog("warn", "It was not possible to display the StickyPanel because no suitable 'widgets' attribute was provided", payload);
+         }
+
+         // If we've got a panel and a callback, use it
+         if (theStickyPanel && payload.callback) {
+            payload.callback(theStickyPanel);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -219,39 +219,6 @@ define(["dojo/_base/declare",
       ],
 
       /**
-       * Ensure the uploads progress monitor is initialised.
-       *
-       * @instance
-       * @since 1.0.51
-       */
-      initProgressMonitor: function alfresco_services_UploadService__initProgressMonitor() {
-
-         // Set up template?
-         if (this.progressDialog === null || this.progressDialog === undefined)
-         {
-            // Create a new dialog... the content is variable, but the widgets are fixed...
-            this.progressDialog = new AlfDialog({
-               id: "ALF_UPLOAD_PROGRESS_DIALOG",
-               title: this.createProgressDialogTitle(),
-               widgetsContent: this.widgetsForProgressDialog,
-               widgetsButtons: [
-                  {
-                     id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
-                     name: "alfresco/buttons/AlfButton",
-                     assignTo: "_uploadDialogButton",
-                     config: {
-                        label: this.message("progress-dialog.cancel-button.label"),
-                        publishTopic: topics.UPLOAD_CANCELLATION,
-                        additionalCssClasses: "call-to-action"
-                     }
-                  }
-               ]
-            });
-            this.getUploadDisplayWidget();
-         }
-      },
-
-      /**
        * Resets the widget
        *
        * @instance
@@ -295,13 +262,33 @@ define(["dojo/_base/declare",
             callbackScope: this
          });
 
-         // Create topics to give to the dialog buttons, then subscribe to them to handle the
-         // events...
-         this.alfSubscribe(topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT, lang.hitch(this, this.onProgressDialogOkClick));
-         this.alfSubscribe(topics.UPLOAD_CANCELLATION, lang.hitch(this, this.onProgressDialogCancelClick));
+         // Set up template?
+         if (this.progressDialog === null || this.progressDialog === undefined) {
+            // Create topics to give to the dialog buttons, then subscribe to them to handle the
+            // events...
+            this.alfSubscribe(topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT, lang.hitch(this, this.onProgressDialogOkClick));
+            this.alfSubscribe(topics.UPLOAD_CANCELLATION, lang.hitch(this, this.onProgressDialogCancelClick));
 
-         // Ensure progress monitor setup
-         this.initProgressMonitor();
+            // Create a new dialog... the content is variable, but the widgets are fixed...
+            this.progressDialog = new AlfDialog({
+               id: "ALF_UPLOAD_PROGRESS_DIALOG",
+               title: this.createProgressDialogTitle(),
+               widgetsContent: this.widgetsForProgressDialog,
+               widgetsButtons: [
+                  {
+                     id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
+                     name: "alfresco/buttons/AlfButton",
+                     assignTo: "_uploadDialogButton",
+                     config: {
+                        label: this.message("progress-dialog.cancel-button.label"),
+                        publishTopic: topics.UPLOAD_CANCELLATION,
+                        additionalCssClasses: "call-to-action"
+                     }
+                  }
+               ]
+            });
+            this.getUploadDisplayWidget();
+         }
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -261,9 +261,10 @@ define(["dojo/_base/declare",
             callback: this.setUploadHistory,
             callbackScope: this
          });
-
+         
          // Set up template?
-         if (this.progressDialog === null || this.progressDialog === undefined) {
+         if (this.progressDialog === null || this.progressDialog === undefined)
+         {
             // Create topics to give to the dialog buttons, then subscribe to them to handle the
             // events...
             this.alfSubscribe(topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT, lang.hitch(this, this.onProgressDialogOkClick));

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -230,10 +230,9 @@ define(["dojo/_base/declare",
          if (this.progressDialog === null || this.progressDialog === undefined)
          {
             // Create a new dialog... the content is variable, but the widgets are fixed...
-            this.alfServicePublish(topics.CREATE_DIALOG, {})
             this.progressDialog = new AlfDialog({
-               dialogId: "ALF_UPLOAD_PROGRESS_DIALOG",
-               dialogTitle: this.createProgressDialogTitle(),
+               id: "ALF_UPLOAD_PROGRESS_DIALOG",
+               title: this.createProgressDialogTitle(),
                widgetsContent: this.widgetsForProgressDialog,
                widgetsButtons: [
                   {

--- a/aikau/src/main/resources/alfresco/services/_UploadHistoryMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_UploadHistoryMixin.js
@@ -18,11 +18,11 @@
  */
 
 /**
- * This mixin acts to group the upload-history handling of the [UploadService]{@link module:alfresco/services/UploadService}.
+ * This mixin acts to group the upload-history handling of the [FileUploadService]{@link module:alfresco/services/FileUploadService}.
  * 
  * @module alfresco/services/_UploadHistoryMixin
  * @author Martin Doyle
- * @since 1.0.51
+ * @since 1.0.52
  */
 define(["dojo/_base/declare", 
         "alfresco/core/topics", 
@@ -68,7 +68,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        */
-      constructor: function alfresco_services_FileUploadService__constructor() {
+      constructor: function alfresco_services__UploadHistoryMixin__constructor() {
          this.initHistory();
       },
 
@@ -78,7 +78,7 @@ define(["dojo/_base/declare",
        * @instance
        * @fires module:alfresco/core/topics#GET_PREFERENCE
        */
-      initHistory: function alfresco_services_FileUploadService__initHistory() {
+      initHistory: function alfresco_services__UploadHistoryMixin__initHistory() {
          this.history = [];
          this.alfPublish(topics.GET_PREFERENCE, {
             preference: this.historyPreferenceName,
@@ -93,7 +93,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {string} value The preference value containing the nodeRefs last uploaded to
        */
-      setHistory: function alfresco_services_FileUploadService__setHistory(value) {
+      setHistory: function alfresco_services__UploadHistoryMixin__setHistory(value) {
          this.history = value && value.split(",");
       },
 
@@ -108,7 +108,7 @@ define(["dojo/_base/declare",
        * @param {string} nodeRef The NodeRef to add to the upload history
        * @fires module:alfresco/core/topics#SET_PREFERENCE
        */
-      updateHistory: function alfresco_services_FileUploadService__updateHistory(nodeRef) {
+      updateHistory: function alfresco_services__UploadHistoryMixin__updateHistory(nodeRef) {
 
          // Iterate over the previous upload history and if the NodeRef being uploaded to already
          // exists in the history then move it to the first element.

--- a/aikau/src/main/resources/alfresco/services/_UploadHistoryMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_UploadHistoryMixin.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This mixin acts to group the upload-history handling of the [UploadService]{@link module:alfresco/services/UploadService}.
+ * 
+ * @module alfresco/services/_UploadHistoryMixin
+ * @author Martin Doyle
+ * @since 1.0.51
+ */
+define(["dojo/_base/declare", 
+        "alfresco/core/topics", 
+        "dojo/_base/array"], 
+        function(declare, topics, array) {
+
+   return declare(null, {
+
+      /**
+       * This will be populated with the NodeRefs of the last few locations that the user has previously
+       * uploaded to. The number of NodeRefs that are stored are determined by the 
+       * [historySize]{@link module:alfresco/services/_UploadHistoryMixin#historySize}.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       */
+      history: null,
+
+      /**
+       * The preference name to use for storing and retrieving upload location history.
+       * In order for this preference to be used it will also be necessary to ensure that the 
+       * [PreferenceService]{@link module:alfresco/services/PreferenceService} is included on the page.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      historyPreferenceName: "org.alfresco.share.upload.destination.history",
+
+      /**
+       * The number of nodes previously uploaded to that should be stored in the user preferences as their 
+       * upload history. This defaults to 3 but can be overridden through configuration if required.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      historySize: 3,
+
+      /**
+       * Constructor
+       *
+       * @instance
+       */
+      constructor: function alfresco_services_FileUploadService__constructor() {
+         this.initHistory();
+      },
+
+      /**
+       * Initialise the upload-history
+       * 
+       * @instance
+       * @fires module:alfresco/core/topics#GET_PREFERENCE
+       */
+      initHistory: function alfresco_services_FileUploadService__initHistory() {
+         this.history = [];
+         this.alfPublish(topics.GET_PREFERENCE, {
+            preference: this.historyPreferenceName,
+            callback: this.setHistory,
+            callbackScope: this
+         });
+      },
+
+      /**
+       * Set the current history.
+       * 
+       * @instance
+       * @param {string} value The preference value containing the nodeRefs last uploaded to
+       */
+      setHistory: function alfresco_services_FileUploadService__setHistory(value) {
+         this.history = value && value.split(",");
+      },
+
+      /**
+       * This updates the [upload history]{@link module:alfresco/services/FileUploadService#history}
+       * with the supplied NodeRef. If the NodeRef is already in the history then it will not be added
+       * again, but will be re-ordered to be at the beginning of the history. If the history already
+       * contains the [maximum number of entries]{@link module:alfresco/services/_UploadHistoryMixin#historySize}
+       * then the earliest used NodeRef in the history will be removed and the latest added.
+       *
+       * @instance
+       * @param {string} nodeRef The NodeRef to add to the upload history
+       * @fires module:alfresco/core/topics#SET_PREFERENCE
+       */
+      updateHistory: function alfresco_services_FileUploadService__updateHistory(nodeRef) {
+
+         // Iterate over the previous upload history and if the NodeRef being uploaded to already
+         // exists in the history then move it to the first element.
+         var alreadyInHistory = false,
+            processedHistory = [];
+         array.forEach(this.history, function(entry) {
+            if (entry === nodeRef) {
+               processedHistory.unshift(entry);
+               alreadyInHistory = true;
+            } else {
+               processedHistory.push(entry);
+            }
+         });
+         this.history = processedHistory;
+
+         // Add to the history (dropping one off the end if necessary)
+         if (!alreadyInHistory) {
+            if (this.history.length === this.historySize) {
+               this.history.pop();
+            }
+            this.history.unshift(nodeRef);
+         }
+
+         // Always update the latest history, even if no new NodeRef has
+         // been added as it may have been re-ordered
+         this.alfPublish(topics.SET_PREFERENCE, {
+            preference: this.historyPreferenceName,
+            value: this.history.join(",")
+         });
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/i18n/FileUploadService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/FileUploadService.properties
@@ -1,0 +1,4 @@
+uploads-container.title=Uploading... {0}%
+uploads-container-complete.title=Upload Complete
+uploads-container.ok-button.label=OK
+uploads-container.cancel-button.label=Cancel

--- a/aikau/src/main/resources/alfresco/services/i18n/FileUploadService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/FileUploadService.properties
@@ -2,3 +2,4 @@ uploads-container.title=Uploading... {0}%
 uploads-container-complete.title=Upload Complete
 uploads-container.ok-button.label=OK
 uploads-container.cancel-button.label=Cancel
+upload.error.empty-file=0kb files cannot be uploaded

--- a/aikau/src/main/resources/alfresco/upload/AlfFileDrop.js
+++ b/aikau/src/main/resources/alfresco/upload/AlfFileDrop.js
@@ -32,9 +32,10 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/AlfFileDrop.html",
         "alfresco/core/Core",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "dojo/on"], 
-        function(declare, _Widget, _Templated, template, Core, lang, on) {
+        function(declare, _Widget, _Templated, template, Core, topics, lang, on) {
    
    return declare([_Widget, _Templated, Core], {
       
@@ -94,11 +95,12 @@ define(["dojo/_base/declare",
 
       /**
        * @instance
+       * @fires module:alfresco/core/topics#UPLOAD_REQUEST
        */
       onDndDrop: function alfresco_upload_AlfFileDrop__onDndDrop(evt) {
         evt.stopPropagation();
         evt.preventDefault();
-        this.alfPublish("ALF_UPLOAD_REQUEST", {
+        this.alfPublish(topics.UPLOAD_REQUEST, {
            files: evt.dataTransfer.files,
            targetData: {
               destination: this.destinationNodeRef,

--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -47,6 +47,8 @@ define(["alfresco/core/FileSizeMixin",
        */
       i18nRequirements: [{
          i18nFile: "./i18n/UploadMonitor.properties"
+      }, {
+         i18nFile: "alfresco/renderers/i18n/Size.properties"
       }],
 
       /**

--- a/aikau/src/main/resources/alfresco/upload/UploadTarget.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadTarget.js
@@ -124,7 +124,7 @@ define(["dojo/_base/declare",
             dialogTitle: "upload.target.dialog.title",
             dialogConfirmationButtonTitle: "upload.target.dialog.confirmation",
             dialogCancellationButtonTitle: "upload.target.dialog.cancellation",
-            formSubmissionTopic: "ALF_UPLOAD_REQUEST",
+            formSubmissionTopic: topics.UPLOAD_REQUEST,
             formSubmissionPayloadMixin: {
                alfResponseTopic: responseTopic,
                filesRefs: filesRef,

--- a/aikau/src/main/resources/alfresco/upload/_UploadsDisplayMixin.js
+++ b/aikau/src/main/resources/alfresco/upload/_UploadsDisplayMixin.js
@@ -18,7 +18,8 @@
  */
 
 /**
- * This mixin acts as an interface for widgets displaying uploads' progress.
+ * This mixin acts as an interface for widgets displaying uploads' progress, and all widgets used for displaying
+ * uploads' progress through the [UploadService]{@link module:alfresco/services/UploadService} should extend it.
  *
  * @module alfresco/upload/_UploadsDisplayMixin
  * @extends external:dijit/_WidgetBase

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -1,5 +1,9 @@
 .alfresco-upload-UploadMonitor {
+   box-sizing: border-box;
    overflow: hidden;
+   * {
+      box-sizing: inherit;
+   }
    &__items {
       border-spacing: 0;
       position: relative;
@@ -14,10 +18,16 @@
       font-size: 0;
    }
    &__item {
-      line-height: 28px;
+      line-height: 32px;
       > * {
          border-top: 1px solid #ccc;
          vertical-align: top;
+         &:first-child {
+            padding-left: 10px;
+         }
+         &:last-child {
+            padding-right: 10px;
+         }
       }
       &__name__error {
          color: #c00;

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -46,7 +46,7 @@ define(["intern!object",
                .sleep(1000)
                .end()
 
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
+            .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
 
             .findByCssSelector(".alfresco-upload-UploadMonitor__item__name__error")
                .getVisibleText()
@@ -56,11 +56,8 @@ define(["intern!object",
                .end()
                .end() // Escape previous extra nesting
 
-            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
-               .click()
-               .end()
-
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click();
          },
 
          "Single file upload succeeds": function() {
@@ -69,14 +66,11 @@ define(["intern!object",
                .sleep(1000)
                .end()
 
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
+            .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
                .end()
 
-            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
-               .click()
-               .end()
-
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click();
          },
 
          "Multiple file upload succeeds with one failure": function() {
@@ -85,10 +79,10 @@ define(["intern!object",
                .sleep(1000)
                .end()
 
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
+            .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
                .end()
 
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed .alfresco-upload-UploadMonitor__successful-items")
+            .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items")
 
             .findByCssSelector(".alfresco-upload-UploadMonitor__item:nth-child(1)")
                .sleep(1000)
@@ -102,17 +96,14 @@ define(["intern!object",
                .end()
                .end()
 
-            .findAllByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogDisplayed .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
+            .findAllByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
                .then(function(elements) {
                   assert.lengthOf(elements, 3, "Should be three successful uploads");
                })
                .end()
 
-            .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
-               .click()
-               .end()
-
-            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG.dialogHidden");
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click();
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -106,6 +106,13 @@ define(["intern!object",
                .click();
          },
 
+         "Topic published after uploads finished": function() {
+            return browser.findByCssSelector("body")
+               .end()
+
+            .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED");
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -66,6 +66,8 @@ define(["intern!object",
                .sleep(1000)
                .end()
 
+            .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED", 5000)
+
             .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
                .end()
 
@@ -76,8 +78,9 @@ define(["intern!object",
          "Multiple file upload succeeds with one failure": function() {
             return browser.findById("MULTI_UPLOAD_label")
                .click()
-               .sleep(1000)
                .end()
+
+            .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED", 10000)
 
             .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
                .end()
@@ -85,11 +88,9 @@ define(["intern!object",
             .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items")
 
             .findByCssSelector(".alfresco-upload-UploadMonitor__item:nth-child(1)")
-               .sleep(1000)
                .end()
 
             .findByCssSelector(".alfresco-upload-UploadMonitor__item:nth-child(2)")
-               .sleep(1000)
                .end()
 
             .findByCssSelector(".alfresco-upload-UploadMonitor__item:nth-child(3)")

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -34,11 +34,11 @@ define({
    xbaseFunctionalSuites: [
       "src/test/resources/alfresco/upload/UploadMonitorTest"
 
-      // THESE SITES REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
-      // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",
+      // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/dnd/NestedConfigurationTest",
       // "src/test/resources/alfresco/layout/AlfTabContainerTest",
-      // "src/test/resources/alfresco/preview/PdfJsPreviewTest"
+      // "src/test/resources/alfresco/preview/PdfJsPreviewTest",
+      // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitor.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitor.get.js
@@ -44,6 +44,7 @@ model.jsonModel = {
             label: "Single File Upload",
             publishTopic: "ALF_UPLOAD_REQUEST",
             publishPayload: {
+               alfResponseTopic: "UPLOAD_COMPLETE_OR_CANCELLED",
                files: [
                   {
                      size: 100,

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitor.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitor.get.js
@@ -9,7 +9,13 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/PanelUploadService"
+      {
+         name: "alfresco/services/FileUploadService",
+         config: {
+            maxSimultaneousUploads: 3
+         }
+      },
+      "alfresco/services/NotificationService"
    ],
    widgets: [
       {
@@ -83,7 +89,10 @@ model.jsonModel = {
          }
       },
       {
-         name: "aikauTesting/mockservices/UploadMockXhr"
+         name: "aikauTesting/mockservices/UploadMockXhr",
+         config: {
+            averageUploadTimeSecs: 3
+         }
       },
       {
          name: "alfresco/logging/DebugLog"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitor.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitor.get.js
@@ -9,17 +9,7 @@ model.jsonModel = {
             }
          }
       },
-      {
-         name: "alfresco/services/UploadService",
-         config: {
-            widgetsForProgressDialog: [
-               {
-                  name: "alfresco/upload/UploadMonitor",
-                  assignTo: "uploadDisplayWidget"
-               }
-            ]
-         }
-      }
+      "alfresco/services/PanelUploadService"
    ],
    widgets: [
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
@@ -36,6 +36,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {number}
        * @default
+       * @since 1.0.52
        */
       averageUploadTimeSecs: 1,
 

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
@@ -31,6 +31,15 @@ define(["dojo/_base/declare",
    return declare([MockXhr], {
 
       /**
+       * How long the average upload takes to complete
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      averageUploadTimeSecs: 1,
+
+      /**
        * The response code to return. Default to 200 but can be overridden to test failures
        *
        * @instance
@@ -61,17 +70,17 @@ define(["dojo/_base/declare",
                }
 
                // Randomly increment the progress every few moments until it's at 100 percent
-               var i;
+               var delay = (this.averageUploadTimeSecs * 1000) / 100;
                request.readyState = 4; // Set the response to pretend to be completed, so Sinon doesn't send its own responses and close it before we finish
-               for (i = 1; i < 100; i += Math.round(Math.random() * 10)) {
-                  this.sendProgress(request, i, i * 20);
+               for (var i = 1; i < 100; i += Math.round(Math.random() * 10)) {
+                  this.sendProgress(request, i, i * delay);
                }
 
                // After progress has finished, send the final response
                setTimeout(function() {
                   request.readyState = 1; // Sinon won't send response unless it thinks the response is clean and only just opened
                   request.respond(this.responseCode, headers, body);
-               }, i * 20);
+               }, i * delay);
 
             }));
          } catch (e) {


### PR DESCRIPTION
This PR addresses primarily [AKU-746](https://issues.alfresco.com/jira/browse/AKU-746), and creates a new `FileUploadService` that works alongside the `StickyPanel` and the `UploadMonitor` to provide a new way of executing and tracking uploads. The existing regression tests have been run and pass, in addition to a full suite where any errors were corrected. This has not yet been tested in situ in Share.