### PR TITLE
AKU-793: Fix vagrant testing issues

### DIFF
--- a/aikau/resources/vagrant/setup.sh
+++ b/aikau/resources/vagrant/setup.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
 
 # Version numbers (change these)
-CHROMEDRIVER_VERSION="2.15"
-FIREFOX_VERSION="38.0"
-PHANTOMJS_VERSION="1.9.8"
-SELENIUM_VERSION="2.48"
+CHROMEDRIVER_VERSION="2.20"
+SELENIUM_VERSION="2.49"
+SELENIUM_REVISION="2.49.1"
 
 # Filenames (normally don't change these)
 CHROMEDRIVER_FILENAME="chromedriver_linux64.zip"
-PHANTOMJS_FILENAME="phantomjs-$PHANTOMJS_VERSION-linux-x86_64" # NOTE: Don't include .tar.bz2 extension here
-SELENIUM_FILENAME="selenium-server-standalone-$SELENIUM_VERSION.0.jar"
+SELENIUM_FILENAME="selenium-server-standalone-$SELENIUM_REVISION.jar"
 
 # Avoid re-downloading if already installed
 set -e
@@ -40,11 +38,6 @@ else
    unzip $CHROMEDRIVER_FILENAME
    mv chromedriver /usr/local/bin
 
-   # Download and copy Phantomjs to /usr/local/bin
-   wget "https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOMJS_FILENAME.tar.bz2"
-   tar -xjvf $PHANTOMJS_FILENAME.tar.bz2
-   mv $PHANTOMJS_FILENAME/bin/phantomjs /usr/local/bin
-
    # Download and copy Selenium to /usr/local/bin
    wget "http://selenium-release.storage.googleapis.com/$SELENIUM_VERSION/$SELENIUM_FILENAME"
    mv $SELENIUM_FILENAME /usr/local/bin
@@ -63,11 +56,8 @@ Xvfb :10 -screen 0 1366x768x24 -ac -extension RANDR &
 echo "Starting Google Chrome (v`dpkg -s google-chrome-stable| grep Version|cut -d: -f2` w/ Chrome Driver v$CHROMEDRIVER_VERSION)..."
 google-chrome --remote-debugging-port=9222 &
 
-echo "Starting Firefox (v$FIREFOX_VERSION)..."
+echo "Starting Firefox..."
 firefox &
-
-echo "Starting Phantomjs ($PHANTOMJS_VERSION)..."
-phantomjs --ignore-ssl-errors=true --web-security=false --webdriver=192.168.56.4:4444 &
 
 echo "Starting Selenium (v$SELENIUM_VERSION)..."
 nohup java -jar /usr/local/bin/$SELENIUM_FILENAME &

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -31,7 +31,7 @@ define(["./config/Suites"],
          // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
          // automatically
          capabilities: {
-            "selenium-version": "2.48.0"
+            "selenium-version": "2.49.1"
          },
 
          // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce


### PR DESCRIPTION
This PR makes further updates against [AKU-793](https://issues.alfresco.com/jira/browse/AKU-793) after errors were noticed when running tests against Chrome more than once. It updates the Chromedriver and Selenium versions (2.20 and 2.49.1 respectively).