### PR TITLE
AKU-799: Form dialog layout fix

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -10,7 +10,7 @@
       box-shadow: 0 3px 8px rgba(0,0,0,.1);
       font-family: @standard-font;
       font-size: @normal-font-size;
-      min-width: 560px;
+      min-width: 580px;
       &.tinymce-dialog {
          min-width: 540px;
          .control {
@@ -70,7 +70,7 @@
    }
    .dialog-body {
       margin-bottom: 40px; // NOTE: If this is changed, the associated margin adjustment in the JS needs updating
-      min-width: 560px;
+      min-width: 580px;
       overflow: auto;
       padding: 12px; // NOTE: If this is changed, the associated paddingAdjustment in the JS needs updating
       &.no-buttons {

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -248,6 +248,32 @@ define(["intern!object",
                });
          },
 
+         "Long form dialog controls are fully displayed": function() {
+            var getDimensions = function() {
+               var dialogPanel = document.querySelector("#LFD .alfresco-layout-SimplePanel");
+               return {
+                  scrollWidth: dialogPanel.scrollWidth,
+                  offsetWidth: dialogPanel.offsetWidth
+               };
+            };
+
+            return closeAllDialogs(browser)
+               .then(function() {
+
+                  return browser.findById("CREATE_LONG_FORM_DIALOG")
+                     .click()
+                  .end()
+
+                  .findByCssSelector("#LFD.dialogDisplayed")
+                  .end()
+
+                  .execute(getDimensions)
+                     .then(function(dimensions){
+                        assert.equal(dimensions.scrollWidth, dimensions.offsetWidth);
+                  });
+               });
+         },
+
          "Count golden path repeating dialog buttons": function() {
             return closeAllDialogs(browser)
                .then(function() {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-799. Although there are other layout issues with the form dialog (see comments in the JIRA ticket) this PR focuses on the primary reported issue and in particular adding a test to prevent future regressions.