### PR TITLE
AKU-791: AlfDialog - Scrolling when dialog is open shows that part of the page is hidden

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -116,12 +116,7 @@
       text-align: center;
    }
    &--dialogs-visible {
-      &, body, .alfresco-core-Page {
-         height: 100%;
-      }
-      body, .alfresco-core-Page {
-         overflow: hidden;
-      }
+      overflow: hidden;
    }
 }
 

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -297,6 +297,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {number}
        * @default
+       * @since 1.0.53
        */
       _scrollbarWidth: null,
 
@@ -881,6 +882,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @returns {number} The scrollbar width
+       * @since 1.0.53
        */
       _getScrollbarWidth: function alfresco_services_DialogService___getScrollbarWidth() {
          if (!this._scrollbarWidth) {

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -180,11 +180,12 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/aspect",
         "dojo/dom-class",
+        "dojo/dom-style",
         "dojo/on",
         "dojo/keys",
         "dojo/when",
         "jquery"],
-        function(declare, BaseService, topics, AlfDialog, AlfForm, lang, array, aspect, domClass, on, keys, when, $) {
+        function(declare, BaseService, topics, AlfDialog, AlfForm, lang, array, aspect, domClass, domStyle, on, keys, when, $) {
 
    return declare([BaseService], {
 
@@ -289,6 +290,15 @@ define(["dojo/_base/declare",
        * @type {Object[]}
        */
       _activeDialogs: [],
+
+      /**
+       * The scrollbar width for this browser-environment
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      _scrollbarWidth: null,
 
       /**
        * @instance
@@ -837,6 +847,7 @@ define(["dojo/_base/declare",
 
          // Ensure the dialogs-showing CSS state is "true"
          // NOTE: This selector is used in AlfDialog.css as this service has no CSS file itself
+         domStyle.set(document.body, "margin-right", this._getScrollbarWidth() + "px");
          domClass.add(document.documentElement, "alfresco-dialog-AlfDialog--dialogs-visible");
 
          // Handle cancelling
@@ -859,8 +870,23 @@ define(["dojo/_base/declare",
             // If there are no dialogs "left" then set the dialogs-showing CSS state to "false"
             if(this._activeDialogs.length === 0) {
                domClass.remove(document.documentElement, "alfresco-dialog-AlfDialog--dialogs-visible");
+               domStyle.set(document.body, "margin-right", "0");
             }
          }));
+      },
+
+      /**
+       * Get the scrollbar width for the current browser environment. This is cached
+       * after first retrieval for faster access.
+       *
+       * @instance
+       * @returns {number} The scrollbar width
+       */
+      _getScrollbarWidth: function alfresco_services_DialogService___getScrollbarWidth() {
+         if (!this._scrollbarWidth) {
+            this._scrollbarWidth = window.innerWidth - document.documentElement.offsetWidth;
+         }
+         return this._scrollbarWidth;
       },
 
        /**

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -404,30 +404,18 @@ define(["intern!object",
          },
 
          "Page does not scroll when dialogs present": function() {
-            var inital_y,
-               getScrollTop = function() {
-                  return window.scrollY || window.pageYOffset || document.documentElement.scrollTop || 0;
-               };
+            var documentHasScrollbar = function() {
+               return document.documentElement.scrollWidth !== window.innerWidth;
+            };
 
             return browser.findById("FULL_SCREEN_DIALOG_label")
                .click()
             .end()
 
             .findByCssSelector("#FSD1.dialogDisplayed")
-               .execute(getScrollTop)
-               .then(function(scrollTop) {
-                  initial_y = scrollTop;
-               })
-            .end()
-
-            // Scroll to the bottom of the page...
-            .execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
-            .end()
-
-            .findById("FSD1")
-               .execute(getScrollTop)
-               .then(function(scrollTop) {
-                  assert.equal(scrollTop, initial_y, "The page scrolled with a dialog present");
+               .execute(documentHasScrollbar)
+               .then(function(hasScrollbar) {
+                  assert.isFalse(hasScrollbar);
                })
             .end()
 

--- a/aikau/src/test/resources/alfresco/services/FullScreenDialogTest.js
+++ b/aikau/src/test/resources/alfresco/services/FullScreenDialogTest.js
@@ -28,6 +28,13 @@ define(["intern!object",
 registerSuite(function(){
    var browser;
 
+   function getWindowSize() {
+      return {
+         width: window.innerWidth,
+         height: window.innerHeight
+      }
+   };
+
    return {
 
       name: "Full Screen Dialog Tests",
@@ -43,16 +50,15 @@ registerSuite(function(){
 
       "Create full screen dialog": function() {
          var windowSize;
-         return browser.setWindowSize(null, 1024, 400).findByCssSelector("body")
-            .getSize()
-            .then(function(size) {
-               windowSize = size;
-            })
-         .end()
+         return browser.setWindowSize(null, 1024, 400)
          .findById("FULL_SCREEN_DIALOG_label")
             .click()
          .end()
          .findByCssSelector("#FSD1.dialogDisplayed")
+            .execute(getWindowSize)
+            .then(function(size) {
+               windowSize = size;
+            })
             .getSize()
             .then(function(size) {
                assert.equal(windowSize.height - 40, size.height, "Height wrong");
@@ -62,14 +68,12 @@ registerSuite(function(){
 
       "Resize window (1)": function() {
          var windowSize;
-         return browser.setWindowSize(null, 1024, 600).end()
-            .findByCssSelector("body")
-            .getSize()
+         return browser.setWindowSize(null, 1024, 600)
+         .findByCssSelector("#FSD1.dialogDisplayed")
+            .execute(getWindowSize)
             .then(function(size) {
                windowSize = size;
             })
-         .end()
-         .findByCssSelector("#FSD1.dialogDisplayed")
             .getSize()
             .then(function(size) {
                assert.equal(windowSize.height - 40, size.height, "Height wrong");
@@ -84,16 +88,14 @@ registerSuite(function(){
 
       "Create full screen form dialog": function() {
          var windowSize;
-         return browser.findByCssSelector("body")
-            .getSize()
-            .then(function(size) {
-               windowSize = size;
-            })
-         .end()
-         .findById("FULL_SCREEN_FORM_DIALOG_label")
+         return browser.findById("FULL_SCREEN_FORM_DIALOG_label")
             .click()
          .end()
          .findByCssSelector("#FSD2.dialogDisplayed")
+            .execute(getWindowSize)
+            .then(function(size) {
+               windowSize = size;
+            })
             .getSize()
             .then(function(size) {
                assert.equal(windowSize.height - 80, size.height, "Height wrong");
@@ -104,13 +106,11 @@ registerSuite(function(){
       "Resize window (2)": function() {
          var windowSize;
          return browser.setWindowSize(null, 1024, 700)
-            .findByCssSelector("body")
-            .getSize()
+         .findByCssSelector("#FSD2.dialogDisplayed")
+            .execute(getWindowSize)
             .then(function(size) {
                windowSize = size;
             })
-         .end()
-         .findByCssSelector("#FSD2.dialogDisplayed")
             .getSize()
             .then(function(size) {
                assert.equal(windowSize.height - 80, size.height, "Height wrong");


### PR DESCRIPTION
This PR addresses the page still scrolling in https://issues.alfresco.com/jira/browse/AKU-791. The only way to truly fix this is to remove the scrollbar completely when the dialog is visible, however to avoid the display "jumping" it's also necessary to temporarily add a right-hand margin to the body to compensate for the loss of the scrollbar. This has been tested in a local RM instance and on the Aikau test pages, and a full Aikau test suite has been run successfully.