### PR TITLE
AKU-792: List loading and rendering message

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/css/AlfList.css
+++ b/aikau/src/main/resources/alfresco/lists/css/AlfList.css
@@ -1,7 +1,5 @@
 .alfresco-lists-AlfList {
    > .rendered-view {
-
-      
       overflow: hidden;
       position: relative;
       &::before, &::after {

--- a/aikau/src/main/resources/alfresco/lists/css/AlfList.css
+++ b/aikau/src/main/resources/alfresco/lists/css/AlfList.css
@@ -1,5 +1,7 @@
 .alfresco-lists-AlfList {
    > .rendered-view {
+
+      
       overflow: hidden;
       position: relative;
       &::before, &::after {
@@ -39,6 +41,10 @@
    }
    &--loading, &--rendering {
       > .rendered-view {
+
+         min-height: 200px;
+         display: block;
+
          &::before, &::after {
             opacity: 1;
          }

--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -325,10 +325,7 @@ define(["dojo/_base/declare",
             this.publishPayload.value = this.value;
             this.publishPayload.label = this.label;
 
-            // Using setTimeout here to give popup menus a chance to close before the publish action begins..
-            setTimeout(lang.hitch(this, function(){
-               this.alfPublish(this.publishTopic, this.publishPayload);
-            }));
+            this.alfPublish(this.publishTopic, this.publishPayload);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -324,7 +324,11 @@ define(["dojo/_base/declare",
             this.publishPayload.selected = this.checked;
             this.publishPayload.value = this.value;
             this.publishPayload.label = this.label;
-            this.alfPublish(this.publishTopic, this.publishPayload);
+
+            // Using setTimeout here to give popup menus a chance to close before the publish action begins..
+            setTimeout(lang.hitch(this, function(){
+               this.alfPublish(this.publishTopic, this.publishPayload);
+            }));
          }
       },
 

--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -293,11 +293,7 @@ define(["dojo/_base/declare",
             // TODO: DD: Not keen on the fact that somehow this "document" specific stuff has crept in here...
             //           Ideally it shouldn't be there...
             var payload = this.generatePayload((this.publishPayload) ? this.publishPayload : {document: this.currentItem}, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
-            
-            // Using setTimeout here to give popup menus a chance to close before the publish action begins..
-            setTimeout(lang.hitch(this, function(){
-               this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
-            }));
+            this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -293,7 +293,11 @@ define(["dojo/_base/declare",
             // TODO: DD: Not keen on the fact that somehow this "document" specific stuff has crept in here...
             //           Ideally it shouldn't be there...
             var payload = this.generatePayload((this.publishPayload) ? this.publishPayload : {document: this.currentItem}, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
-            this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
+            
+            // Using setTimeout here to give popup menus a chance to close before the publish action begins..
+            setTimeout(lang.hitch(this, function(){
+               this.alfPublish(this.publishTopic, payload, publishGlobal, publishToParent);
+            }));
          }
          else
          {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-792 to improve the way that lists handle loading and rendering messages. In particularly this focuses on making sure that messages do not remain on the screen, and that rendering messages are correctly displayed when switching views (e.g. in the Document Library). I've not added any unit tests for this because the reported problem was incredibly tricky to reproduce, and the existing unit tests should cover the current behaviour.