### PR TITLE
Fix pagination scroll test

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/ListRenderer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/ListRenderer.js
@@ -230,7 +230,7 @@ define(["dojo/_base/declare",
          {
             // Find the scroll parent and check to see if it is the document, we need to special case scrolling within
             // the document as we need to animate the scrollTop of both the html and body elements.
-            var scrollParent = $(widget.domNode).scrollParent();
+            var scrollParent = this.findScrollParent(widget.domNode);
             if (scrollParent.is("html"))
             {
                var offset = $(widget.domNode).offset();
@@ -251,6 +251,24 @@ define(["dojo/_base/declare",
                });
             }
          }
+      },
+
+      /**
+       * This function recursively searches out through the DOM to find the first parent of the supplied element that
+       * is capable of scrolling vertically and has scrollbars displayed.
+       * 
+       * @instance
+       * @returns {element} The DOM element that is the scroll parent with scroll bars displayed
+       * @since 1.0.53
+       */
+      findScrollParent: function alfresco_lists_views_ListRenderer__findScrollParent(domNode) {
+         var scrollParent = $(domNode).scrollParent();
+         if (!scrollParent.is("html") &&
+             scrollParent.clientHeight === scrollParent.scrollHeight)
+         {
+            scrollParent = this.findScrollParent(scrollParent);
+         }
+         return scrollParent;
       }
    });
 });


### PR DESCRIPTION
This PR fixes a failing test with scrolling to items into view. The failure was introduced when we added support for scrolling in the ClassicWindow and as a result the scrollParent JQuery function was returning the scroll parent as an item capable of scrolling, although not necessarily one that has scroll bars displayed. This update improves the search for the scroll parent to ensure the first item that can actually be scrolled is returned.