### PR TITLE
Further update to PR 802 to fix scroll to behaviour

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/ListRenderer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/ListRenderer.js
@@ -264,9 +264,9 @@ define(["dojo/_base/declare",
       findScrollParent: function alfresco_lists_views_ListRenderer__findScrollParent(domNode) {
          var scrollParent = $(domNode).scrollParent();
          if (!scrollParent.is("html") &&
-             scrollParent.clientHeight === scrollParent.scrollHeight)
+             scrollParent[0].clientHeight === scrollParent[0].scrollHeight)
          {
-            scrollParent = this.findScrollParent(scrollParent);
+            scrollParent = this.findScrollParent(scrollParent[0]);
          }
          return scrollParent;
       }


### PR DESCRIPTION
This is an update to PR #802 that addressed correctly finding scroll parents. The previous change has introduced a failure in the FixedHeaderFooterTest due to incorrect recursion handling. This update resolves that problem.