### PR TITLE
AKU-798: BrowserStack work

### DIFF
--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -36,6 +36,8 @@ define(["intern/dojo/node!fs",
         "intern/dojo/node!leadfoot/keys",
         "lodash"], 
         function(fs, http, os, lang, intern, Config, Promise, pollUntil, assert, keys, _) {
+
+   var unitTestAppBaseUrl;
    return {
 
       /**
@@ -45,15 +47,14 @@ define(["intern/dojo/node!fs",
        * @param {string} webScriptURL The WebScript URL
        * @param {string} webScriptPrefix Optional prefix to the test page.
        */
-      testWebScriptURL: function (webScriptURL, webScriptPrefix) {
-         if (!Config.urls.unitTestAppBaseUrl) {
-            var serverAddress = (intern.args.useLocalhost === "true") ? "localhost" : this._getLocalIP(),
-               testServer = "http://" + serverAddress + ":8089";
-            Config.urls.unitTestAppBaseUrl = testServer;
-            // console.log("Using test-server URL: " + testServer);
+      testWebScriptURL: function(webScriptURL, webScriptPrefix) {
+         var serverAddress,
+            prefix = webScriptPrefix || "/tp/ws";
+         if (!unitTestAppBaseUrl) {
+            serverAddress = (intern.args.useLocalhost === "true") ? "localhost" : this._getLocalIP();
+            unitTestAppBaseUrl = "http://" + serverAddress + ":8089";
          }
-         var prefix = webScriptPrefix || "/tp/ws";
-         return Config.urls.unitTestAppBaseUrl + "/aikau/page" + prefix + webScriptURL;
+         return unitTestAppBaseUrl + "/aikau/page" + prefix + webScriptURL;
       },
 
       /**


### PR DESCRIPTION
Remove legacy reference to virtual-box IP address. Tested with grunt test, test_local and test_bs and all work with this change. Previously all tests used the virtual-box IP address as setup when vagrant is used for testing.