### PR TITLE
AKU-798: BrowserStack improvements

### DIFF
--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -36,6 +36,8 @@ define(["intern/dojo/node!fs",
         "intern/dojo/node!leadfoot/keys",
         "lodash"], 
         function(fs, http, os, lang, intern, Config, Promise, pollUntil, assert, keys, _) {
+
+   var unitTestAppBaseUrl;
    return {
 
       /**
@@ -45,15 +47,14 @@ define(["intern/dojo/node!fs",
        * @param {string} webScriptURL The WebScript URL
        * @param {string} webScriptPrefix Optional prefix to the test page.
        */
-      testWebScriptURL: function (webScriptURL, webScriptPrefix) {
-         if (!Config.urls.unitTestAppBaseUrl) {
-            var serverAddress = (intern.args.useLocalhost === "true") ? "localhost" : this._getLocalIP(),
-               testServer = "http://" + serverAddress + ":8089";
-            Config.urls.unitTestAppBaseUrl = testServer;
-            // console.log("Using test-server URL: " + testServer);
+      testWebScriptURL: function(webScriptURL, webScriptPrefix) {
+         var serverAddress,
+            prefix = webScriptPrefix || "/tp/ws";
+         if (!unitTestAppBaseUrl) {
+            serverAddress = (intern.args.useLocalhost === "true") ? "localhost" : this._getLocalIP();
+            unitTestAppBaseUrl = "http://" + serverAddress + ":8089";
          }
-         var prefix = webScriptPrefix || "/tp/ws";
-         return Config.urls.unitTestAppBaseUrl + "/aikau/page" + prefix + webScriptURL;
+         return unitTestAppBaseUrl + "/aikau/page" + prefix + webScriptURL;
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
+++ b/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
@@ -143,7 +143,7 @@ define(["intern!object",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload) {
-                  assert.propertyVal(payload, "url", Config.urls.unitTestAppBaseUrl + "/aikau/page/site/swsdp/documentlibrary", "Wrong URL");
+                  assert.include(payload.url, "/aikau/page/site/swsdp/documentlibrary", "Wrong URL");
                });
          },
 
@@ -153,7 +153,7 @@ define(["intern!object",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload) {
-                  assert.propertyVal(payload, "url", Config.urls.unitTestAppBaseUrl + "/aikau/page/user/admin/profile", "Wrong URL");
+                  assert.include(payload.url, "/aikau/page/user/admin/profile", "Wrong URL");
                });
          },
 

--- a/aikau/src/test/resources/config/grid/Config.js
+++ b/aikau/src/test/resources/config/grid/Config.js
@@ -25,17 +25,6 @@
 define({
 
    /**
-    * This is a selection of urls for test purposes. They should ONLY be defined here so that
-    * pervasive changes can be made in this one file.
-    *
-    * @instance
-    * @type {object}
-    */
-   urls: {
-      unitTestAppBaseUrl: null
-   },
-
-   /**
     * A selection of timeouts
     *
     * @instance

--- a/aikau/src/test/resources/config/loc/Config.js
+++ b/aikau/src/test/resources/config/loc/Config.js
@@ -25,17 +25,6 @@
 define({
 
    /**
-    * This is a selection of urls for test purposes. They should ONLY be defined here so that
-    * pervasive changes can be made in this one file.
-    *
-    * @instance
-    * @type {object}
-    */
-   urls: {
-      unitTestAppBaseUrl: "http://localhost:8089"
-   },
-
-   /**
     * A selection of timeouts
     *
     * @instance

--- a/aikau/src/test/resources/config/sl/Config.js
+++ b/aikau/src/test/resources/config/sl/Config.js
@@ -25,17 +25,6 @@
 define({
 
    /**
-    * This is a selection of urls for test purposes. They should ONLY be defined here so that
-    * pervasive changes can be made in this one file.
-    *
-    * @instance
-    * @type {object}
-    */
-   urls: {
-      unitTestAppBaseUrl: "http://localhost:8089"
-   },
-
-   /**
     * A selection of timeouts
     *
     * @instance

--- a/aikau/src/test/resources/config/vm/Config.js
+++ b/aikau/src/test/resources/config/vm/Config.js
@@ -25,17 +25,6 @@
 define({
 
    /**
-    * This is a selection of urls for test purposes. They should ONLY be defined here so that
-    * pervasive changes can be made in this one file.
-    *
-    * @instance
-    * @type {object}
-    */
-   urls: {
-      unitTestAppBaseUrl: "http://192.168.56.1:8089"
-   },
-
-   /**
     * A selection of timeouts
     *
     * @instance


### PR DESCRIPTION
Remove legacy reference to virtual-box IP address. Picked up a few problems that were missed in previous PR. Again, tested with `grunt test`, `grunt test_local` and `grunt test_bs`.