### PR TITLE
AKU-809: Ensure that overflowing lists can be scrolled

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/css/AlfList.css
+++ b/aikau/src/main/resources/alfresco/lists/css/AlfList.css
@@ -1,6 +1,7 @@
 .alfresco-lists-AlfList {
+   overflow: auto;
+
    > .rendered-view {
-      overflow: hidden;
       position: relative;
       &::before, &::after {
          box-sizing: border-box;

--- a/aikau/src/test/resources/alfresco/lists/AlfHashListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/AlfHashListTest.js
@@ -153,6 +153,10 @@ define(["alfresco/TestCommon",
             .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST");
          },
 
+         "Post Coverage Results (prior to reload)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         },
+
          "Navigating to another page and then back will re-apply hash": function() {
             var anotherPageUrl = TestCommon.testWebScriptURL("/Index"),
                returnUrl = TestCommon.testWebScriptURL("/AlfHashList#var1=test1&var2=test2&var3=test3");
@@ -173,6 +177,19 @@ define(["alfresco/TestCommon",
                   assert.propertyVal(payload, "var1", "test1", "Hash not read and used correctly");
                   assert.propertyVal(payload, "var2", "test2", "Hash not read and used correctly");
                   assert.notProperty(payload, "var3", "Hash not read and used correctly");
+               });
+         },
+
+         "Check overflow on list": function() {
+            function nodeOverflows(selector) {
+               var node = document.querySelector(selector);
+               return node.scrollWidth > node.clientWidth;
+            }
+
+            return browser.setWindowSize(null, 400, 768)
+               .execute(nodeOverflows, ["#HASHLIST1"])
+               .then(function(overflows) {
+                  assert.isTrue(overflows, "Scroll bar is not displayed");
                });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/AlfHashList.get.js
@@ -100,6 +100,41 @@ model.jsonModel = {
                               id: "COLUMN1_HEADER",
                               label: "Header"
                            }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              id: "COLUMN1_HEADER",
+                              label: "Header"
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              id: "COLUMN1_HEADER",
+                              label: "Header"
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              id: "COLUMN1_HEADER",
+                              label: "Header"
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              id: "COLUMN1_HEADER",
+                              label: "Header"
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/HeaderCell",
+                           config: {
+                              id: "COLUMN1_HEADER",
+                              label: "Header"
+                           }
                         }
                      ],
                      widgets: [
@@ -107,6 +142,76 @@ model.jsonModel = {
                            name: "alfresco/lists/views/layouts/Row",
                            config: {
                               widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       additionalCssClasses: "mediumpad",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       additionalCssClasses: "mediumpad",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       additionalCssClasses: "mediumpad",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       additionalCssClasses: "mediumpad",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       additionalCssClasses: "mediumpad",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
                                  {
                                     name: "alfresco/lists/views/layouts/Cell",
                                     config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-809 to ensure that overflowing lists can be scrolled. When reviewing it's worth noting the changes made to the CSS to resolve this - it was not clear why overflow hidden was applied to list views in the first place.