### PR TITLE
AKU-813: Correction to previous fix

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfHashMixin.js
@@ -106,7 +106,7 @@ define(["dojo/_base/declare",
        * anything to happen.
        */
       onHashChange: function alfresco_documentlibrary__AlfHashMixin__onHashChange(payload) {
-         var filterObj = this.processFilter(payload);
+         var filterObj = this.processHashFilter(payload);
          this.alfLog("log", "Publishing decoded filter", filterObj);
          this.alfPublish(this.hashChangeTopic, filterObj);
       },


### PR DESCRIPTION
This further addresses https://issues.alfresco.com/jira/browse/AKU-813 and updates #823 to update a call to processFilter that should have been changed to processHashFilter.