### PR TITLE
AKU-808: Ensure min/max validation allows empty values with permitEmpty configured

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/FormControlValidationMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FormControlValidationMixin.js
@@ -371,23 +371,32 @@ define(["dojo/_base/declare",
          var isValid = true;
          var value = parseFloat(this.getValue());
          var minValue = lang.getObject("min", false, validationConfig);
-         if (minValue !== null && !isNaN(minValue))
+         var permitEmpty = lang.getObject("permitEmpty", false, validationConfig);
+         if (permitEmpty && this.getValue() === null)
          {
-            isValid = (!isNaN(value) && value >= minValue);
+            // If permitEmpty is true, and there is no value then there is no need to check min/max
          }
          else
          {
-            this.alfLog("warn", "A numericalRange validation was configured with an invalid 'min' attribute", validationConfig, this);
+            if (minValue !== null && !isNaN(minValue))
+            {
+               isValid = (!isNaN(value) && value >= minValue);
+            }
+            else
+            {
+               this.alfLog("warn", "A numericalRange validation was configured with an invalid 'min' attribute", validationConfig, this);
+            }
+            var maxValue = lang.getObject("max", false, validationConfig);
+            if (maxValue !== null && !isNaN(maxValue))
+            {
+               isValid = isValid && (!isNaN(value) && value <= maxValue);
+            }
+            else
+            {
+               this.alfLog("warn", "A numericalRange validation was configured with an invalid 'max' attribute", validationConfig, this);
+            }
          }
-         var maxValue = lang.getObject("max", false, validationConfig);
-         if (maxValue !== null && !isNaN(maxValue))
-         {
-            isValid = isValid && (!isNaN(value) && value <= maxValue);
-         }
-         else
-         {
-            this.alfLog("warn", "A numericalRange validation was configured with an invalid 'max' attribute", validationConfig, this);
-         }
+         
          this.reportValidationResult(validationConfig, isValid);
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/NumberSpinner.js
@@ -93,8 +93,8 @@ define(["alfresco/forms/controls/BaseFormControl",
        */
       _getValueAttr: function alfresco_forms_controls_NumberSpinner__DijitNumberSpinner___getValueAttr() {
          var rawValue = this.textbox.value,
-            numberValue = number.parse(rawValue),
-            value = null;
+             numberValue = number.parse(rawValue),
+             value = null;
          if (!isNaN(numberValue)) {
             value = numberValue;
             if (value === Math.round(value)) {
@@ -112,8 +112,10 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {number} newValue The new value to set
        */
       _setValueAttr: function alfresco_forms_controls_NumberSpinner__DijitNumberSpinner___setValueAttr(newValue) {
-         if (!isNaN(newValue)) {
-            if (typeof newValue === "string") {
+         if (newValue !== null && !isNaN(newValue)) 
+         {
+            if (typeof newValue === "string") 
+            {
                newValue = parseFloat(newValue);
             }
             this.textbox.value = number.format(newValue);
@@ -338,6 +340,7 @@ define(["alfresco/forms/controls/BaseFormControl",
                validation: "numericalRange",
                min: this.min,
                max: this.max,
+               permitEmpty: this.permitEmpty,
                errorMessage: errorMessage
             });
          }

--- a/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/NumberSpinnerTest.js
@@ -23,8 +23,9 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "alfresco/TestCommon"],
-        function(registerSuite, assert, TestCommon) {
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"],
+        function(registerSuite, assert, TestCommon, keys) {
 
    registerSuite(function(){
       var browser;
@@ -275,6 +276,36 @@ define(["intern!object",
                });
          },
 
+         "Min validation with permitEmpty can be empty": function() {
+            return browser.findByCssSelector("#NS9 input.dijitInputInner")
+               .clearValue()
+               .click()
+            .end()
+
+            .pressKeys(keys.TAB)
+
+            .findByCssSelector("#NS9 span.validation-message")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed);
+               });
+         },
+
+         "Max validation with permitEmpty can be empty": function() {
+            return browser.findByCssSelector("#NS10 input.dijitInputInner")
+               .clearValue()
+               .click()
+            .end()
+
+            .pressKeys(keys.TAB)
+
+            .findByCssSelector("#NS10 span.validation-message")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed);
+               });
+         },
+
          // Make sure this is always the final test, and update accordingly
          "All values publish correctly": function() {
             return browser.findByCssSelector(".alfresco-buttons-AlfButton[widgetid=\"RESET_VALUES\"] .dijitButtonNode")
@@ -299,6 +330,8 @@ define(["intern!object",
                   assert.propertyVal(payload, "six", 1001, "Invalid published value for control with ID \"NS6\"");
                   assert.propertyVal(payload, "seven", null, "Invalid published value for control with ID \"NS7\"");
                   assert.propertyVal(payload, "eight", 5.5, "Invalid published value for control with ID \"NS8\"");
+                  assert.propertyVal(payload, "nine", null, "Invalid published value for control with ID \"NS9\"");
+                  assert.propertyVal(payload, "ten", null, "Invalid published value for control with ID \"NS10\"");
                });
          },
          // Make sure this is always the final test, and update accordingly

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
@@ -152,6 +152,39 @@ model.jsonModel = {
                         }
                      ]
                   }
+               },
+               {
+                  name: "alfresco/forms/ControlRow",
+                  config: {
+                     widgets: [
+                        {
+                           id: "NS9",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS9",
+                              name: "nine",
+                              label: "Min and permit empty",
+                              description: "This number spinner is used to confirm that min validation does not apply when permitEmpty is true",
+                              value: 4,
+                              min: 3,
+                              permitEmpty: true
+                           }
+                        },
+                        {
+                           id: "NS10",
+                           name: "alfresco/forms/controls/NumberSpinner", 
+                           config: {
+                              fieldId: "NS10",
+                              name: "ten",
+                              label: "Max and permit empty",
+                              description: "This number spinner is used to confirm that max validation does not apply when permitEmpty is true",
+                              value: 4,
+                              max: 5,
+                              permitEmpty: true
+                           }
+                        }
+                     ]
+                  }
                }
             ]
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-808 to ensure that min/max validation does not apply to empty NumberSpinner fields when permitEmpty is configured to be true.