### PR TITLE
AKU-807: Updated unit test page for manual verification of locale specific issue

### DIFF
--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/NumberSpinner.get.js
@@ -10,7 +10,8 @@ model.jsonModel = {
                error: true
             }
          }
-      }
+      },
+      "alfresco/services/DialogService"
    ],
    widgets: [
       {
@@ -29,6 +30,45 @@ model.jsonModel = {
                six: 1001,
                seven: "",
                eight: 5.5
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "CREATE_NUMNER_SPINNER_DIALOG",
+         config: {
+            label: "Numner Spinner Dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishGlobal: true,
+            publishPayload: {
+               cancelPublishScope: "",
+               cancelPublishTopic: "DIALOG_CANCELLED",
+               dialogId: "TEST_DIALOG",
+               formSubmissionTopic: "NEVERMIND",
+               formValue: {
+                  filterValueMin: 1001,
+                  filterValueMax: 1001
+               },
+               widgets: [
+                  {
+                     name: "alfresco/forms/controls/NumberSpinner",
+                     config: {
+                        name: "filterValueMin",
+                        label: "min value",
+                        permitEmpty: true,
+                        permittedDecimalPlaces: 0
+                     }
+                  },
+                  {
+                     name: "alfresco/forms/controls/NumberSpinner",
+                     config: {
+                        name: "filterValueMax",
+                        label: "max value",
+                        permitEmpty: true,
+                        permittedDecimalPlaces: 0
+                     }
+                  }
+               ]
             }
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-807 to update the unit test page for NumberSpinner for the purposes of manually verifying the issue is fixed. There is no unit test for this update because at the moment we have no capability for locale specific testing so are reliant on manual testing. There is also no fix required because related issues committed in the current sprint have resolved the reported problem.