### PR TITLE
AKU-807: Prevent sticky panel closing during upload

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1031,6 +1031,32 @@ define([],function() {
       STICKY_PANEL_CLOSED: "ALF_STICKY_PANEL_CLOSED",
 
       /**
+       * This topic can be published to request that the close button on a [StickyPanel]{@link module:alfresco/layout/StickyPanel}
+       * be disabled.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.54
+       *
+       * @event
+       */
+      STICKY_PANEL_DISABLE_CLOSE: "ALF_STICKY_PANEL_DISABLE_CLOSE",
+
+      /**
+       * This topic can be published to request that the close button on a [StickyPanel]{@link module:alfresco/layout/StickyPanel}
+       * be enabled.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.54
+       *
+       * @event
+       */
+      STICKY_PANEL_ENABLE_CLOSE: "ALF_STICKY_PANEL_ENABLE_CLOSE",
+
+      /**
        * This can be called to set the title of the StickyPanel.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -157,12 +157,37 @@ define(["alfresco/core/Core",
       },
 
       /**
-       * Handle clicks on the close button.
+       * Disables the close button.
+       * 
+       * @instance
+       * @param {object} payload Payload for the publication (expected to be empty)
+       * @since 1.0.54
+       */
+      disableCloseButton: function alfresco_layout_StickyPanel__disableCloseButton(/*jshint unused:false*/ payload) {
+         domClass.add(this.domNode, this.baseClass + "--close-disabled");
+      },
+
+      /**
+       * Enables the close button.
+       * 
+       * @instance
+       * @param {object} payload Payload for the publication (expected to be empty)
+       * @since 1.0.54
+       */
+      enableCloseButton: function alfresco_layout_StickyPanel__enableCloseButton(/*jshint unused:false*/ payload) {
+         domClass.remove(this.domNode, this.baseClass + "--close-disabled");
+      },
+
+      /**
+       * Handle clicks on the close button (unless it has been disabled).
        *
        * @instance
        */
       onClickClose: function alfresco_layout_StickyPanel__onClickClose() {
-         this.close();
+         if (!domClass.contains(this.domNode, this.baseClass + "--close-disabled"))
+         {
+            this.close();
+         }
       },
 
       /**
@@ -180,10 +205,14 @@ define(["alfresco/core/Core",
        * @instance
        * @listens module:alfresco/core/topics#STICKY_PANEL_CLOSE
        * @listens module:alfresco/core/topics#STICKY_PANEL_SET_TITLE
+       * @listens module:alfresco/core/topics#STICKY_PANEL_DISABLE_CLOSE
+       * @listens module:alfresco/core/topics#STICKY_PANEL_ENABLE_CLOSE
        */
       setupSubscriptions: function alfresco_layout_StickyPanel__setupSubscriptions() {
          this.alfSubscribe(topics.STICKY_PANEL_CLOSE, lang.hitch(this, this.close));
          this.alfSubscribe(topics.STICKY_PANEL_SET_TITLE, lang.hitch(this, this.setTitle));
+         this.alfSubscribe(topics.STICKY_PANEL_DISABLE_CLOSE, lang.hitch(this, this.disableCloseButton));
+         this.alfSubscribe(topics.STICKY_PANEL_ENABLE_CLOSE, lang.hitch(this, this.enableCloseButton));
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -67,4 +67,14 @@
          }
       }
    }
+   &--close-disabled {
+      .alfresco-layout-StickyPanel {
+         &__title-bar {
+            &__close {
+               cursor: default;
+               opacity: 0.3;
+            }
+         }
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -61,6 +61,21 @@ define(["alfresco/core/topics",
       }],
 
       /**
+       * Extends the [inherited function]{@link module:alfresco/services/_BaseUploadService#resetTotalUploads}
+       * to publish a topic to indicate that the [sticky panel]{@link module:alfresco/layout/StickyPanel} containing
+       * this upload monitor can re-enable its close button.
+       *
+       * @instance
+       * @param {object} payload A payload detailing the completed upload (not used)
+       * @since 1.0.54
+       * @fires module:alfresco/core/topics#STICKY_PANEL_DISABLE_CLOSE
+       */
+      resetTotalUploads: function alfresco_services_FileUploadService__resetTotalUploads() {
+         this.inherited(arguments);
+         this.alfPublish(topics.STICKY_PANEL_ENABLE_CLOSE);
+      },
+
+      /**
        * Register this service's subscriptions.
        * 
        * @instance
@@ -78,6 +93,7 @@ define(["alfresco/core/topics",
        * @instance
        * @override
        * @returns {object} A promise, that will resolve when the widget is ready to accept upload information.
+       * @fires module:alfresco/core/topics#STICKY_PANEL_DISABLE_CLOSE
        */
       showUploadsWidget: function alfresco_services_FileUploadService__showUploadsWidget() {
          var dfd = new Deferred();
@@ -90,6 +106,7 @@ define(["alfresco/core/topics",
                dfd.resolve();
             })
          });
+         this.alfPublish(topics.STICKY_PANEL_DISABLE_CLOSE);
          return dfd.promise;
       }
    });

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -25,220 +25,216 @@
  * @extends module:alfresco/services/_BaseUploadService
  * @author Dave Draper
  */
-define([
-      "dojo/_base/declare",
-      "alfresco/services/_BaseUploadService",
-      "alfresco/core/topics",
-      "dojo/_base/lang",
-      "dojo/_base/array",
-      "dojo/on",
-      "dojo/Deferred",
-      "alfresco/dialogs/AlfDialog",
-      "alfresco/buttons/AlfButton" // Not explicitly used
-   ],
-   function(declare, _BaseUploadService, topics, lang, array, on, Deferred, AlfDialog) {
+define(["dojo/_base/declare",
+        "alfresco/services/_BaseUploadService",
+        "alfresco/core/topics",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "dojo/on",
+        "dojo/Deferred"],
+        function(declare, _BaseUploadService, topics, lang, array, on, Deferred) {
 
-      return declare([_BaseUploadService], {
+   return declare([_BaseUploadService], {
 
-         /**
-          * An array of the i18n files to use with this widget.
-          * 
-          * @instance
-          * @type {object[]}
-          * @default [{i18nFile: "./i18n/UploadService.properties"}]
-          */
-         i18nRequirements: [{
-            i18nFile: "./i18n/UploadService.properties"
-         }],
+      /**
+       * An array of the i18n files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/UploadService.properties"}]
+       */
+      i18nRequirements: [{
+         i18nFile: "./i18n/UploadService.properties"
+      }],
 
-         /**
-          * An internal reference to the progress dialog button
-          *
-          * @instance
-          * @type {object}
-          * @default
-          * @since 1.0.52
-          */
-         dialogButton: null,
+      /**
+       * An internal reference to the progress dialog button
+       *
+       * @instance
+       * @type {object}
+       * @default
+       * @since 1.0.52
+       */
+      dialogButton: null,
 
-         /**
-          * This is the default title key for the progress dialog.
-          * 
-          * @instance
-          * @type {string}
-          * @default
-          * @deprecated since 1.0.52 - Use [uploadsContainerTitle]{@link module:alfresco/services/_BaseUploadService#uploadsContainerTitle} instead
-          */
-         progressDialogTitleKey: null,
+      /**
+       * This is the default title key for the progress dialog.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @deprecated since 1.0.52 - Use [uploadsContainerTitle]{@link module:alfresco/services/_BaseUploadService#uploadsContainerTitle} instead
+       */
+      progressDialogTitleKey: null,
 
-         /**
-          * This is the default title for the uploads container.
-          *
-          * @instance
-          * @override
-          * @type {string}
-          * @default
-          */
-         uploadsContainerTitle: "progress-dialog.title",
+      /**
+       * This is the default title for the uploads container.
+       *
+       * @instance
+       * @override
+       * @type {string}
+       * @default
+       */
+      uploadsContainerTitle: "progress-dialog.title",
 
-         /**
-          * This is the topic on which to publish updates to the title container.
-          *
-          * @instance
-          * @override
-          * @type {string}
-          * @default
-          */
-         uploadsContainerTitleUpdateTopic: topics.DIALOG_CHANGE_TITLE,
+      /**
+       * This is the topic on which to publish updates to the title container.
+       *
+       * @instance
+       * @override
+       * @type {string}
+       * @default
+       */
+      uploadsContainerTitleUpdateTopic: topics.DIALOG_CHANGE_TITLE,
 
-         /**
-          * This defines the JSON structure for the widgets to be displayed in the progress dialog. This
-          * can be overridden by extending widgets to render a different display in the dialog
-          *
-          * @instance
-          * @type {object}
-          * @default
-          * @deprecated since 1.0.52 - Use [widgetsForUploadDisplay]{@link module:alfresco/services/UploadService#widgetsForUploadDisplay} instead
-          */
-         widgetsForProgressDialog: null,
+      /**
+       * This defines the JSON structure for the widgets to be displayed in the progress dialog. This
+       * can be overridden by extending widgets to render a different display in the dialog
+       *
+       * @instance
+       * @type {object}
+       * @default
+       * @deprecated since 1.0.52 - Use [widgetsForUploadDisplay]{@link module:alfresco/services/UploadService#widgetsForUploadDisplay} instead
+       */
+      widgetsForProgressDialog: null,
 
-         /**
-          * The widget definition that displays the uploads' progress. This should
-          * be a single widget that implements the interface defined by
-          * [_UploadsDisplayMixin]{@link module:alfresco/services/_UploadsDisplayMixin}.
-          *
-          * @instance
-          * @override
-          * @type {object[]}
-          * @default [{name: "alfresco/upload/AlfUploadDisplay"}]
-          * @since 1.0.52
-          */
-         widgetsForUploadDisplay: [{
-            name: "alfresco/upload/AlfUploadDisplay"
-         }],
+      /**
+       * The widget definition that displays the uploads' progress. This should
+       * be a single widget that implements the interface defined by
+       * [_UploadsDisplayMixin]{@link module:alfresco/services/_UploadsDisplayMixin}.
+       *
+       * @instance
+       * @override
+       * @type {object[]}
+       * @default [{name: "alfresco/upload/AlfUploadDisplay"}]
+       * @since 1.0.52
+       */
+      widgetsForUploadDisplay: [{
+         name: "alfresco/upload/AlfUploadDisplay"
+      }],
 
-         /**
-          * If a service needs to act upon its post-mixed-in state before registering subscriptions then
-          * this is where it should be done. It is comparable to postMixInProperties in a widget in the
-          * class lifecycle.
-          *
-          * @instance
-          * @override
-          * @since 1.0.52
-          */
-         initService: function alfresco_services_UploadService__initService() {
-            if (!this.widgetsForUploadDisplay && this.widgetsForProgressDialog) {
-               this.alfLog("warn", "'widgetsForProgressDialog' in UploadService has been deprecated - use 'widgetsForUploadDisplay' instead");
-               this.widgetsForUploadDisplay = this.widgetsForProgressDialog;
-            }
-            if (this.progressDialogTitleKey) {
-               this.alfLog("warn", "'progressDialogTitleKey' in UploadService has been deprecated - use 'uploadsContainerTitle' instead");
-               this.uploadsContainerTitle = this.progressDialogTitleKey;
-            }
-            this.inherited(arguments);
-         },
-
-         /**
-          * This function generates the title for the progress dialog. By default it simply displays the
-          * localized value of the [uploadsContainerTitle]{@link module:alfresco/upload/AlfUpload#uploadsContainerTitle}
-          *
-          * @instance
-          * @return {string} The localized title for the progress dialog
-          */
-         createProgressDialogTitle: function alfresco_services_UploadService__createProgressDialogTitle() {
-            return this.message(this.uploadsContainerTitle);
-         },
-
-         /**
-          * Handles the user clicking on the "OK" button in the dialog.
-          *
-          * @instance
-          * @param {object} payload The details of the button click.
-          */
-         onProgressDialogOkClick: function alfresco_services_UploadService__onProgressDialogOkClick( /*jshint unused:false*/ payload) {
-            this.onUploadsContainerClosed();
-         },
-
-         /**
-          * Handles the user clicking on the "Cancel" button in the dialog.
-          *
-          * @instance
-          * @param {object} payload The details of the button click.
-          */
-         onProgressDialogCancelClick: function alfresco_services_UploadService__onProgressDialogCancelClick( /*jshint unused:false*/ payload) {
-            var fileIds = Object.keys(this.fileStore);
-            array.forEach(fileIds, function(fileId) {
-               var fileInfo = this.fileStore[fileId];
-               if (fileInfo && fileInfo.state === this.STATE_UPLOADING) {
-                  fileInfo.request.abort();
-               }
-            }, this);
-            this.onUploadsContainerClosed();
-         },
-
-         /**
-          * This listener will be called each time a batch of uploads (grouped by upload request) completes.
-          *
-          * @instance
-          * @override
-          * @param {object} payload The payload containing the original upload request
-          * @since 1.0.52
-          */
-         onUploadsBatchComplete: function alfresco_services__BaseUploadService__onUploadsBatchComplete(payload) {
-            this.inherited(arguments);
-            this.dialogButton.setLabel(this.message("progress-dialog.ok-button.label"));
-            this.dialogButton.publishTopic = topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT;
-         },
-
-         /**
-          * Register this service's subscriptions.
-          * 
-          * @instance
-          * @override
-          * @listens module:alfresco/core/topics#UPLOAD_COMPLETION_ACKNOWLEDGEMENT
-          * @listens module:alfresco/core/topics#UPLOAD_CANCELLATION
-          */
-         registerSubscriptions: function alfresco_services_FileUploadService__registerSubscriptions() {
-            this.inherited(arguments);
-            this.alfSubscribe(topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT, lang.hitch(this, this.onProgressDialogOkClick));
-            this.alfSubscribe(topics.UPLOAD_CANCELLATION, lang.hitch(this, this.onProgressDialogCancelClick));
-         },
-
-         /**
-          * Ensure the uploads display widget is available
-          *
-          * @instance
-          * @returns {object} A promise, that will resolve when the widget is ready to accept upload information.
-          * @listens module:alfresco/core/topics#UPLOAD_COMPLETION_ACKNOWLEDGEMENT
-          * @listens module:alfresco/core/topics#UPLOAD_CANCELLATION
-          */
-         showUploadsWidget: function alfresco_services_UploadService__showUploadsWidget() {
-            var dfd = new Deferred(),
-               dialogDisplayedTopic = "PROGRESS_DIALOG_DISPLAYED",
-               displayedSubHandle = this.alfSubscribe(dialogDisplayedTopic, lang.hitch(this, function() {
-                  this.alfUnsubscribe(displayedSubHandle);
-                  dfd.resolve();
-               }));
-            this.alfServicePublish(topics.CREATE_DIALOG, {
-               dialogId: "ALF_UPLOAD_PROGRESS_DIALOG",
-               dialogTitle: this.createProgressDialogTitle(),
-               publishOnShow: [{
-                  publishTopic: dialogDisplayedTopic
-               }],
-               widgetsContent: this.widgetsForUploadDisplay,
-               widgetsButtons: [{
-                  id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
-                  name: "alfresco/buttons/AlfButton",
-                  assignTo: "dialogButton",
-                  assignToScope: this,
-                  config: {
-                     label: this.message("progress-dialog.cancel-button.label"),
-                     publishTopic: topics.UPLOAD_CANCELLATION,
-                     additionalCssClasses: "call-to-action"
-                  }
-               }]
-            });
-            return dfd.promise;
+      /**
+       * If a service needs to act upon its post-mixed-in state before registering subscriptions then
+       * this is where it should be done. It is comparable to postMixInProperties in a widget in the
+       * class lifecycle.
+       *
+       * @instance
+       * @override
+       * @since 1.0.52
+       */
+      initService: function alfresco_services_UploadService__initService() {
+         if (!this.widgetsForUploadDisplay && this.widgetsForProgressDialog) {
+            this.alfLog("warn", "'widgetsForProgressDialog' in UploadService has been deprecated - use 'widgetsForUploadDisplay' instead");
+            this.widgetsForUploadDisplay = this.widgetsForProgressDialog;
          }
-      });
+         if (this.progressDialogTitleKey) {
+            this.alfLog("warn", "'progressDialogTitleKey' in UploadService has been deprecated - use 'uploadsContainerTitle' instead");
+            this.uploadsContainerTitle = this.progressDialogTitleKey;
+         }
+         this.inherited(arguments);
+      },
+
+      /**
+       * This function generates the title for the progress dialog. By default it simply displays the
+       * localized value of the [uploadsContainerTitle]{@link module:alfresco/upload/AlfUpload#uploadsContainerTitle}
+       *
+       * @instance
+       * @return {string} The localized title for the progress dialog
+       */
+      createProgressDialogTitle: function alfresco_services_UploadService__createProgressDialogTitle() {
+         return this.message(this.uploadsContainerTitle);
+      },
+
+      /**
+       * Handles the user clicking on the "OK" button in the dialog.
+       *
+       * @instance
+       * @param {object} payload The details of the button click.
+       */
+      onProgressDialogOkClick: function alfresco_services_UploadService__onProgressDialogOkClick( /*jshint unused:false*/ payload) {
+         this.onUploadsContainerClosed();
+      },
+
+      /**
+       * Handles the user clicking on the "Cancel" button in the dialog.
+       *
+       * @instance
+       * @param {object} payload The details of the button click.
+       */
+      onProgressDialogCancelClick: function alfresco_services_UploadService__onProgressDialogCancelClick( /*jshint unused:false*/ payload) {
+         var fileIds = Object.keys(this.fileStore);
+         array.forEach(fileIds, function(fileId) {
+            var fileInfo = this.fileStore[fileId];
+            if (fileInfo && fileInfo.state === this.STATE_UPLOADING) {
+               fileInfo.request.abort();
+            }
+         }, this);
+         this.onUploadsContainerClosed();
+      },
+
+      /**
+       * This listener will be called each time a batch of uploads (grouped by upload request) completes.
+       *
+       * @instance
+       * @override
+       * @param {object} payload The payload containing the original upload request
+       * @since 1.0.52
+       */
+      onUploadsBatchComplete: function alfresco_services__BaseUploadService__onUploadsBatchComplete(/*jshint unused:false*/ payload) {
+         this.inherited(arguments);
+         this.dialogButton.setLabel(this.message("progress-dialog.ok-button.label"));
+         this.dialogButton.publishTopic = topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT;
+      },
+
+      /**
+       * Register this service's subscriptions.
+       * 
+       * @instance
+       * @override
+       * @listens module:alfresco/core/topics#UPLOAD_COMPLETION_ACKNOWLEDGEMENT
+       * @listens module:alfresco/core/topics#UPLOAD_CANCELLATION
+       */
+      registerSubscriptions: function alfresco_services_FileUploadService__registerSubscriptions() {
+         this.inherited(arguments);
+         this.alfSubscribe(topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT, lang.hitch(this, this.onProgressDialogOkClick));
+         this.alfSubscribe(topics.UPLOAD_CANCELLATION, lang.hitch(this, this.onProgressDialogCancelClick));
+      },
+
+      /**
+       * Ensure the uploads display widget is available
+       *
+       * @instance
+       * @returns {object} A promise, that will resolve when the widget is ready to accept upload information.
+       * @listens module:alfresco/core/topics#UPLOAD_COMPLETION_ACKNOWLEDGEMENT
+       * @listens module:alfresco/core/topics#UPLOAD_CANCELLATION
+       */
+      showUploadsWidget: function alfresco_services_UploadService__showUploadsWidget() {
+         var dfd = new Deferred(),
+            dialogDisplayedTopic = "PROGRESS_DIALOG_DISPLAYED",
+            displayedSubHandle = this.alfSubscribe(dialogDisplayedTopic, lang.hitch(this, function() {
+               this.alfUnsubscribe(displayedSubHandle);
+               dfd.resolve();
+            }));
+         this.alfServicePublish(topics.CREATE_DIALOG, {
+            dialogId: "ALF_UPLOAD_PROGRESS_DIALOG",
+            dialogTitle: this.createProgressDialogTitle(),
+            publishOnShow: [{
+               publishTopic: dialogDisplayedTopic
+            }],
+            widgetsContent: this.widgetsForUploadDisplay,
+            widgetsButtons: [{
+               id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
+               name: "alfresco/buttons/AlfButton",
+               assignTo: "dialogButton",
+               assignToScope: this,
+               config: {
+                  label: this.message("progress-dialog.cancel-button.label"),
+                  publishTopic: topics.UPLOAD_CANCELLATION,
+                  additionalCssClasses: "call-to-action"
+               }
+            }]
+         });
+         return dfd.promise;
+      }
    });
+});

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -492,9 +492,13 @@ define(["alfresco/core/CoreXhr",
       },
 
       /**
+       * This function is called when all uploads have completed and resets the
+       * [totalNewUploads counter]{@link module:alfresco/services/_BaseUploadService#totalNewUploads}
+       * to zero.
        * 
        * @instance
        * @since 1.0.54
+       * @extendable
        */
       resetTotalUploads: function alfresco_services__BaseUploadService__resetTotalUploads() {
          this.totalNewUploads = 0;

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -492,6 +492,15 @@ define(["alfresco/core/CoreXhr",
       },
 
       /**
+       * 
+       * @instance
+       * @since 1.0.54
+       */
+      resetTotalUploads: function alfresco_services__BaseUploadService__resetTotalUploads() {
+         this.totalNewUploads = 0;
+      },
+
+      /**
        * Ensure the uploads display widget is available
        *
        * @instance
@@ -675,7 +684,7 @@ define(["alfresco/core/CoreXhr",
 
          // If no longer have uploads pending, update the total-completed variable
          if (currentProgressPercent === 100) {
-            this.totalNewUploads = 0;
+            this.resetTotalUploads();
          }
 
          // Update the container title with the aggregate progress if required

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -63,7 +63,7 @@ define(["intern!object",
          "Single file upload succeeds": function() {
             return browser.findById("SINGLE_UPLOAD_label")
                .click()
-               .end()
+            .end()
 
             .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED", 5000)
 
@@ -74,25 +74,43 @@ define(["intern!object",
                .click();
          },
 
-         "Multiple file upload succeeds with one failure": function() {
+         "Close button disabled on upload start": function() {
             return browser.findById("MULTI_UPLOAD_label")
                .clearLog()
                .click()
-               .end()
+            .end()
+
+            .getLastPublish("ALF_STICKY_PANEL_DISABLE_CLOSE")
+
+            .findByCssSelector(".alfresco-layout-StickyPanel--close-disabled");
+         },
+
+         "Multiple file upload succeeds with one failure": function() {
+            return browser.findByCssSelector("body").end()
 
             .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED", 10000)
 
             .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
-               .end()
+            .end()
 
             .findAllByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
                .then(function(elements) {
                   assert.lengthOf(elements, 3, "Should be three successful uploads");
                })
-               .end()
+            .end()
 
             .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
                .click();
+         },
+
+         "Close button enabled on upload complete": function() {
+            return browser.findAllByCssSelector(".alfresco-layout-StickyPanel--close-disabled")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Found disablement class");
+               })
+            .end()
+
+            .getLastPublish("ALF_STICKY_PANEL_ENABLE_CLOSE");
          },
 
          "Post Coverage Results": function() {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-794 to ensure that the StickyPanel close button is disabled whilst uploads are in-progress.