### PR TITLE
AKU-822: Upload panel grows without scrolling

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -302,7 +302,7 @@
 @breadcrumb-hover-color: #eee;
 
 // Sticky panel
-@sticky-panel-max-height: 90%;
+@sticky-panel-max-height: 85vh;
 @sticky-panel-background: #fff;
 @sticky-panel-border: 1px solid #07c;
 @sticky-panel-border-radius: 3px 3px 0 0;

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -1,7 +1,6 @@
 .alfresco-layout-StickyPanel {
    bottom: 0;
    left: 50%;
-   max-height: @sticky-panel-max-height;
    position: fixed;
    right: 0;
    &__panel {
@@ -47,7 +46,7 @@
    &__widgets {
       overflow-x: hidden;
       overflow-y: auto;
-      padding: 0;
+      max-height: @sticky-panel-max-height;
    }
    &--minimised {
       .alfresco-layout-StickyPanel {

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -585,6 +585,27 @@ define(["intern/dojo/node!fs",
             // Pass back the base promise
             return dfd.promise;
          };
+         command.session.hasScrollbars = function(selector) {
+            return browser.execute(function(cssSelector) {
+               var elem = document.querySelectorAll(cssSelector)[0],
+                  contentIsTaller = false,
+                  contentIsWider = false,
+                  canScrollVertically = false,
+                  canScrollHorizontally = false,
+                  computedStyle = elem && getComputedStyle(elem),
+                  validOverflows = ["auto", "scroll"];
+               if (computedStyle) {
+                  contentIsTaller = elem.scrollHeight > elem.clientHeight;
+                  contentIsWider = elem.scrollWidth > elem.clientWidth;
+                  canScrollVertically = validOverflows.indexOf(computedStyle.overflowY) !== -1;
+                  canScrollHorizontally = validOverflows.indexOf(computedStyle.overflowX) !== -1;
+               }
+               return {
+                  vertical: contentIsTaller && canScrollVertically,
+                  horizontal: contentIsWider && canScrollHorizontally
+               };
+            }, [selector]);
+         };
 
          return command;
       },

--- a/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
@@ -1,0 +1,63 @@
+
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "require",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, require, TestCommon) {
+
+   registerSuite(function() {
+      var browser;
+
+      return {
+         name: "StickyPanel Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/StickyPanel", "StickyPanel Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Panel scrolls when content too great for window size": function() {
+            return browser.setWindowSize(null, 1024, 300)
+               .hasScrollbars(".alfresco-layout-StickyPanel__widgets")
+               .then(function(hasScrollbars) {
+                  assert.isTrue(hasScrollbars.vertical, "Should have scrollbar after resize");
+               })
+               .setWindowSize(null, 1024, 768)
+               .hasScrollbars(".alfresco-layout-StickyPanel__widgets")
+               .then(function(hasScrollbars) {
+                  assert.isFalse(hasScrollbars.vertical, "Scrollbar should disappear after resize to original size");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -170,6 +170,7 @@ define({
       "src/test/resources/alfresco/layout/FullScreenWidgetsTest",
       "src/test/resources/alfresco/layout/HeightMixinTest",
       "src/test/resources/alfresco/layout/IFramedTabContainerTest",
+      "src/test/resources/alfresco/layout/StickyPanelTest",
       "src/test/resources/alfresco/layout/StripedContentTest",
       "src/test/resources/alfresco/layout/TwisterTest",
       "src/test/resources/alfresco/layout/VerticalRevealTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -1,3 +1,17 @@
+// Easily change number of widgets in panel (just used to vertically fill it)
+var multipleWidgets = [],
+   singleWidget = {
+      name: "alfresco/html/Heading",
+      config: {
+         level: 3,
+         label: "This is a heading"
+      }
+   },
+   numWidgets = 10;
+for(var i = 0; i < numWidgets; i++) {
+   multipleWidgets.push(singleWidget);
+}
+
 model.jsonModel = {
    services: [
       {
@@ -23,16 +37,7 @@ model.jsonModel = {
          name: "alfresco/layout/StickyPanel",
          id: "STICKY_PANEL",
          config: {
-            widgets: [
-               {
-                  name: "alfresco/html/Heading",
-                  id: "TEST_HEADING",
-                  config: {
-                     level: 3,
-                     label: "This is a heading"
-                  }
-               }
-            ]
+            widgets: multipleWidgets
          }
       },
       {

--- a/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf-config/themes/aikauTestTheme.xml
@@ -23,6 +23,8 @@
 
          @sidebar-container-sidebar-background-color: #eee;
          @sidebar-container-main-background-color: #f8f8f8;
+
+         @sticky-panel-max-height: 50vh;
       </less-variables>
    </css-tokens>
 </theme>


### PR DESCRIPTION
This fixes [AKU-822](https://issues.alfresco.com/jira/browse/AKU-822), which is about the uploads panel not scrolling when too many items are present. A test has also been included. No regression suite has been run, as not deemed to be necessary?