### PR TITLE
AKU-822: Upload panel grows without scrolling

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -229,24 +229,18 @@ define(["alfresco/core/Core",
       },
 
       /**
-       * Size the panel, based on the panelWidth property.
+       * Size the panel, based on the panelWidth property. If we receive a number without
+       * units (apart from 0), we should assume it's pixels.
        *
        * @instance
        */
       sizePanel: function alfresco_layout_StickyPanel__sizePanel() {
-         var widthRegex = /([0-9.]+)(.*)/,
-            widthString = (typeof this.panelWidth !== "string") ? this.panelWidth : "" + this.panelWidth,
-            matchResult = widthRegex.exec(widthString),
-            number = parseInt(matchResult[1], 10),
-            units = matchResult[2] || "px",
-            numberToUse = units === "%" ? number * 2 : number;
-         if (isNaN(number)) {
-            this.alfLog("error", "Invalid panel width supplied for StickyPanel (" + this.panelWidth + ")");
-         } else {
-            domStyle.set(this.panelNode, {
-               width: numberToUse + units,
-               left: (0 - Math.round(numberToUse / 2)) + units
-            });
+         var newWidth = this.panelWidth;
+         if (newWidth) {
+            if (!isNaN(newWidth)) {
+               newWidth += "px";
+            }
+            domStyle.set(this.panelNode, "width", newWidth);
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -1,6 +1,6 @@
 .alfresco-layout-StickyPanel {
    bottom: 0;
-   left: 50%;
+   left: 0;
    position: fixed;
    right: 0;
    &__panel {
@@ -10,7 +10,7 @@
       border-radius: @sticky-panel-border-radius;
       box-shadow: @sticky-panel-box-shadow;
       box-sizing: border-box;
-      left: -50%;
+      margin: 0 auto;
       position: relative;
    }
    &__title-bar {
@@ -44,9 +44,9 @@
       }
    }
    &__widgets {
+      max-height: @sticky-panel-max-height;
       overflow-x: hidden;
       overflow-y: auto;
-      max-height: @sticky-panel-max-height;
    }
    &--minimised {
       .alfresco-layout-StickyPanel {
@@ -71,7 +71,7 @@
          &__title-bar {
             &__close {
                cursor: default;
-               opacity: 0.3;
+               opacity: .3;
             }
          }
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -37,6 +37,7 @@ model.jsonModel = {
          name: "alfresco/layout/StickyPanel",
          id: "STICKY_PANEL",
          config: {
+            panelWidth: 400,
             widgets: multipleWidgets
          }
       },


### PR DESCRIPTION
Further update to [AKU-822](https://issues.alfresco.com/jira/browse/AKU-822) to fix Chrome+OSX scrollbar rendering bug.