### PR TITLE
AKU-821: Zero percent tooltip always visible on panel

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -248,6 +248,18 @@ define(["alfresco/core/Core",
                left: (0 - Math.round(numberToUse / 2)) + units
             });
          }
+      },
+
+      /**
+       * Prevent the title property from being used to set the title
+       * attribute on the widget's root node.
+       *
+       * @instance
+       * @override
+       * @param {string} newTitle The new title
+       */
+      _setTitleAttr: function alfresco_layout_StickyPanel___setTitleAttr(newTitle) {
+         // NOOP
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
@@ -55,6 +55,14 @@ define(["intern!object",
                });
          },
 
+         "Panel has no title attribute": function() {
+            return browser.findByCssSelector(".alfresco-layout-StickyPanel")
+               .getAttribute("title")
+               .then(function(title) {
+                  assert.equal(title, null);
+               });
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }


### PR DESCRIPTION
This fixes [AKU-821](https://issues.alfresco.com/jira/browse/AKU-821) by overriding the Dojo function that was automatically putting the title attribute onto the root node.