### PR TITLE
AKU-817: Remove double encoding from menu items

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
@@ -107,7 +107,7 @@ define(["dojo/_base/declare",
          }
          if (this.title)
          {
-            this.title = this.encodeHTML(this.message(this.title));
+            this.title = this.message(this.title);
          }
          this.inherited(arguments);
       },

--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -152,7 +152,7 @@ define(["dojo/_base/declare",
          }
          if (this.title)
          {
-            this.title = this.encodeHTML(this.message(this.title));
+            this.title = this.message(this.title);
          }
 
          this.inherited(arguments);

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuItemTest.js
@@ -22,41 +22,59 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
-      name: "AlfMenuItem Tests",
+      return {
+         name: "AlfMenuItem Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfMenuItem", "AlfMenuItem Tests").end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfMenuItem", "AlfMenuItem Tests").end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check processed payload": function() {
-         return browser.findByCssSelector("#MENU_BAR_POPUP_text")
-            .click()
-         .end()
-         .findByCssSelector("#PROCESS_PAYLOAD_MENU_ITEM_text")
-            .click()
-         .end()
-         .getLastPublish("PROCESSED_PAYLOAD")
-         .then(function(payload) {
-            assert.propertyVal(payload, "value", "test", "Processed payload not generated correctly");
-         });
-      },
+         "Check title encoding (popup)": function() {
+            return browser.findById("MENU_BAR_POPUP")
+               .getAttribute("title")
+               .then(function(title) {
+                  assert.equal(title, "Workflows que j'ai initiés");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Check title (menu item)": function() {
+            return browser.findByCssSelector("#MENU_BAR_POPUP_text")
+               .click()
+            .end()
+
+            .findByCssSelector(".alfresco-menus-_AlfMenuItemMixin")
+               .getAttribute("title")
+               .then(function(title) {
+                  assert.equal(title, "Workflows que j'ai initiés");
+               });
+         },
+
+         "Check processed payload": function() {
+            return browser.findByCssSelector("#PROCESS_PAYLOAD_MENU_ITEM_text")
+               .click()
+            .end()
+
+            .getLastPublish("PROCESSED_PAYLOAD")
+
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "test", "Processed payload not generated correctly");
+            });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.js
@@ -21,6 +21,7 @@ model.jsonModel = {
                   name: "alfresco/menus/AlfMenuBarPopup",
                   config: {
                      label: "Drop down menu",
+                     title: "menu.item.label",
                      widgets: [
                         {
                            id: "PROCESS_PAYLOAD_MENU_ITEM",
@@ -32,6 +33,7 @@ model.jsonModel = {
                                  }
                               },
                               label: "Processed Payload",
+                              title: "menu.item.label",
                               publishTopic: "PROCESSED_PAYLOAD",
                               publishPayloadType: "PROCESS",
                               publishPayloadModifiers: ["processCurrentItemTokens"],

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuItem.get.properties
@@ -1,0 +1,1 @@
+menu.item.label=Workflows que j'ai initi\u00e9s


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-817 to ensure that titles in menu items are not double-encoded. A unit test has been added to verify this.