### PR TITLE
AKU-827: Prevent double-encoding on DND item label

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -341,6 +341,27 @@
 // Previews
 @preview-background-color: #424242;
 
+// Drag and drop
+@dnd-border-width: 1px;
+@dnd-selected-border-width: 4px;
+@dnd-selected-border-colour: green;
+@dnd-selected-border-style: solid;
+@dnd-selected-border: @dnd-selected-border-width @dnd-selected-border-style @dnd-selected-border-colour;
+@dnd-focused-border-width: 4px;
+@dnd-focused-border-colour: orange;
+@dnd-focused-border-style: solid;
+@dnd-focused-border: @dnd-focused-border-width @dnd-focused-border-style @dnd-focused-border-colour;
+
+@dnd-item-width: 150px;
+@dnd-item-title-width: 90px;
+@dnd-item-margin: 5px;
+@dnd-item-padding: 5px;
+@dnd-item-hover-background: #eee;
+
+@dnd-palette-margin: 5px;
+@dnd-palette-padding: 5px;
+
+
 // Generic colours for displaying collections of items
 @collectionColour1: #f1e695;
 @collectionColour2: #f4af72;

--- a/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
+++ b/aikau/src/main/resources/alfresco/dnd/DragAndDropItems.js
@@ -346,7 +346,7 @@ define(["dojo/_base/declare",
          this.currentItem.title = "";
          if (clonedItem.label)
          {
-            this.currentItem.title = this.encodeHTML(this.message(clonedItem.label));
+            this.currentItem.title = this.message(clonedItem.label);
          }
          this.currentItem.iconClass = clonedItem.iconClass || "";
          var widgetModel = lang.clone(this.widgets);

--- a/aikau/src/main/resources/alfresco/dnd/css/DragAndDropItem.css
+++ b/aikau/src/main/resources/alfresco/dnd/css/DragAndDropItem.css
@@ -1,43 +1,47 @@
-.alfresco-dnd-DragAndDropItem.dragTemplate {
-   border: 1px solid #CCC;
-   margin: 5px;
-   padding: 5px;
-   width: 150px;
-   display: inline-block;
-   box-shadow: 0.33px 2px 8px rgba(0, 0, 0, 0.3);
-   background-color: #fff;
-   background-image: none;
-}
+.alfresco-dnd-DragAndDropItem {
 
-.alfresco-dnd-DragAndDropItem.dragTemplate:focus {
-   border: 4px solid orange;
-}
+   &.dragTemplate {
+      border: @standard-form-border;
+      margin: @dnd-item-margin;
+      padding: @dnd-item-padding;
+      width: @dnd-item-width;
+      display: inline-block;
+      box-shadow: @standard-box-shadow;
+      background-color: @primary-background-color;
+      background-image: none;
 
-.alfresco-dnd-DragAndDropItem.dragTemplate.selected {
-   border: 4px solid green;
-}
+      &:focus {
+         border: @dnd-focused-border;
+      }
 
-.alfresco-dnd-DragAndDropItem.dragTemplate.dojoDndItemAnchor {
-   background-color: #fff;
-   background-image: none;
-}
+      span {
+         vertical-align: middle;
+         display: inline-block;
+      }
 
-.alfresco-dnd-DragAndDropItem.dragTemplate.dojoDndItemOver {
-   background-color: #eee;
-   background-image: none;
-}
+      .icon {
+         background-repeat: no-repeat;
+         height: 20px;
+         width: 20px;
+      }
 
-.alfresco-dnd-DragAndDropItem.dragTemplate span {
-   vertical-align: middle;
-   display: inline-block;
-}
+      .title {
+         width: @dnd-item-title-width;
+         word-wrap: break-word;
+      }
 
-.alfresco-dnd-DragAndDropItem.dragTemplate .icon {
-   background-repeat: no-repeat;
-   height: 20px;
-   width: 20px;
-}
+      &.selected {
+         border: @dnd-selected-border;
+      }
 
-.alfresco-dnd-DragAndDropItem.dragTemplate .title {
-   width: 90px;
+      &.dojoDndItemAnchor {
+         background-color: @primary-background-color;
+         background-image: none;
+      }
+
+      &.dojoDndItemOver {
+         background-color: @dnd-item-hover-background;
+         background-image: none;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/dnd/css/DragAndDropItems.css
+++ b/aikau/src/main/resources/alfresco/dnd/css/DragAndDropItems.css
@@ -1,11 +1,13 @@
-.alfresco-dnd-DragAndDropItems .palette {
-   margin: 5px;
-   padding: 5px;
+.alfresco-dnd-DragAndDropItems {
+   .palette {
+      margin: @dnd-palette-margin;
+      padding: @dnd-palette-padding;
+   }
 }
 
 .alfresco-dnd-DragAndDropItems .dojoDndItem.dojoDndItemAnchor,
 .alfresco-dnd-DragAndDropItems .dojoDndItem.dojoDndItemOver {
-   background-color: #fff;
+   background-color: @primary-background-color;
    background-image: none;
-   border: none;
+   border-color: @primary-background-color;
 }

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -22,450 +22,465 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-var pause = 150;
+   var pause = 150;
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
+      return {
 
-      name: "Basic DND tests",
+         name: "Basic DND tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/basic-dnd", "Basic DND Testing")
-            .end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/basic-dnd", "Basic DND Testing")
+               .end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Test that labels are localized": function() {
-         return browser.findByCssSelector("#dojoUnique1 .title")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Value 1", "Item label was not localized");
-            });
-      },
-
-      "Test there are no dropped items on page load": function() {
-         return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > *")
-            .then(function(elements) {
-                  assert.lengthOf(elements, 0, "The dropped items widget should be empty");
-            });
-      },
-
-      "Test Drag From Palette To DropItems": function () {
-         return browser.findByCssSelector("#dojoUnique1 .title")
-            .moveMouseTo()
-            .click()
-            .pressMouseButton()
-            .moveMouseTo(1, 1)
-         .end()
-         .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
-            .then(function(element) {
-               return browser.moveMouseTo(element)
-                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-                  .releaseMouseButton();
-            })
-         .end()
-         .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-            .then(function(elements) {
-                  assert.lengthOf(elements, 1, "The dropped item was found");
-            });
-      },
-
-      "Test that dropped items labels are localized": function() {
-         return browser.findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper > .label")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Value 1", "Dropped item label was not localized");
-            });
-      },
-      
-      "Test Form Value Updated After Drop": function() {
-         return browser.findByCssSelector("#FORM1 .confirmationButton > span")
-            .click()
-         .end()
-         .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM1_POST","data","name","bob"))
-            .then(null, function() {
-               assert(false, "Form didn't contain the value from the dropped item");
-            });
-      },
-      
-      "Test Preset Form Control Populates Dropped Items": function() {
-         return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-            .then(function(elements) {
-                  assert.lengthOf(elements, 1, "The preset dropped item was found");
-            });
-      },
-      
-      "Test Preset Form Control Post Value": function() {
-         return browser.findByCssSelector("#FORM2 .confirmationButton > span")
-            .click()
-         .end()
-         .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM2_POST","data","preset","value1"))
-            .then(null, function() {
-               assert(false, "Preset form didn't contain the initialised value.");
-            });
-      },
-      
-      "Test deleting preset dropped item": function() {
-         return browser.findByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper .delete")
-            .click()
-         .end()
-         .findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > *")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "The dropped items widget should be empty after deleting preset dropped item");
-            });
-      },
-      
-      "Test deleted preset value form value": function() {
-         return browser.findAllByCssSelector(TestCommon.pubDataRowsCssSelector("FORM2_POST","data"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Preset dropped item was not deleted");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-   });
-
-registerSuite(function(){
-   var browser;
-
-   return {
-
-      name: "DND items provided by list",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/list-of-dnd-items", "DND items provided by list")
-            .end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Check items can be loaded from a list": function() {
-         return browser.findAllByCssSelector(".alfresco-dnd-DragAndDropItemsListView .alfresco-dnd-DragAndDropItem")
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "The DND items were not populated");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
-   });
-
-registerSuite(function(){
-   var browser;
-
-   return {
-
-      name: "Accessibility DND tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/basic-dnd", "Accessibility DND Testing")
-            .end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Select item using keyboard": function() {
-         return browser.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.ENTER)
-            .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "The wrong number of items were selected");
-               });
-      },
-
-      "Add item to target": function() {
-         // 3 more tabs should highlight the first drop target...
-         return browser.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-
-            // Hitting return should add the selected item...
-            .pressKeys(keys.ENTER)
-            .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-               .then(function(elements) {
-                     assert.lengthOf(elements, 1, "The item was not added");
-               });
-      },
-
-      "Submit the form to check the right item was added": function() {
-         // Six more tabs should highlight the confirmation button
-         return browser.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.ENTER)
-            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM1_POST","data","name","bob"))
-            .then(null, function() {
-               assert(false, "Form didn't contain the value added by keyboard");
-            });
-      },
-
-      "Select another item": function() {
-         // Shift tab 7 times should get back to the last item
-         return browser.pressKeys([keys.SHIFT])
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys([keys.SHIFT]) // Remember to release the shift key!
-            .pressKeys(keys.ENTER)
-            .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Only one item should be selected, the other should be deselected");
-               });
-
-      },
-
-      "Add the next item": function() {
-         // Just one more tab should get to the target again...
-         return browser.pressKeys(keys.TAB)
-            .sleep(pause)
-
-            // Hitting return should add the selected item...
-            .pressKeys(keys.ENTER)
-            .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-               .then(function(elements) {
-                     assert.lengthOf(elements, 2, "The second item was not added");
-               });
-      },
-
-      "Check the initial order": function() {
-         return browser.findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Value 1", "The items are not in the correct order");
-            });
-      },
-
-      "Move item down a place": function() {
-         // 3 tabs should get to the move down action...
-         return browser.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.ENTER)
-            .findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
+         "Test that labels are localized": function() {
+            return browser.findByCssSelector("#dojoUnique1 .title")
                .getVisibleText()
                .then(function(text) {
-                  assert.equal(text, "TextBox", "The item was not moved down a place");
+                  assert.equal(text, "Value 1", "Item label was not localized");
                });
-      },
+         },
 
-      "Move item back up a place": function() {
-         // We should still be focused on the same node, so a single shift-tab will get to the move up action...
-         return browser.pressKeys([keys.SHIFT])
-            .pressKeys(keys.TAB)
-            .pressKeys([keys.SHIFT]) // Release the SHIFT key!
-            .sleep(pause)
-            .pressKeys(keys.ENTER)
-            .findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Value 1", "The item was not moved back up");
-            });
-      },
+         "Test there are no dropped items on page load": function() {
+            return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > *")
+               .then(function(elements) {
+                     assert.lengthOf(elements, 0, "The dropped items widget should be empty");
+               });
+         },
 
-      // TODO: This test is passing on Chrome but failing on Firefox
-      // "Delete an item": function() {
-      //    // 2 tabs should get to the delete item action
-      //    return browser.pressKeys(keys.TAB)
-      //       .sleep(pause)
-      //       .pressKeys(keys.TAB)
-      //       .sleep(pause)
-      //       .pressKeys(keys.ENTER)
-            
-      //       .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-      //          .then(function(elements) {
-      //                assert.lengthOf(elements, 1, "The item was not deleted");
-      //          });
-      // },
+         "Test Drag From Palette To DropItems": function () {
+            return browser.findByCssSelector("#dojoUnique1 .title")
+               .moveMouseTo()
+               .click()
+               .pressMouseButton()
+               .moveMouseTo(1, 1)
+            .end()
+            .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
+               .then(function(element) {
+                  return browser.moveMouseTo(element)
+                     .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                     .releaseMouseButton();
+               })
+            .end()
+            .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+               .then(function(elements) {
+                     assert.lengthOf(elements, 1, "The dropped item was found");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Test that dropped items labels are localized": function() {
+            return browser.findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper > .label")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Value 1", "Dropped item label was not localized");
+               });
+         },
+         
+         "Test Form Value Updated After Drop": function() {
+            return browser.findByCssSelector("#FORM1 .confirmationButton > span")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM1_POST","data","name","bob"))
+               .then(null, function() {
+                  assert(false, "Form didn't contain the value from the dropped item");
+               });
+         },
+         
+         "Test Preset Form Control Populates Dropped Items": function() {
+            return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+               .then(function(elements) {
+                     assert.lengthOf(elements, 1, "The preset dropped item was found");
+               });
+         },
+         
+         "Test Preset Form Control Post Value": function() {
+            return browser.findByCssSelector("#FORM2 .confirmationButton > span")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM2_POST","data","preset","value1"))
+               .then(null, function() {
+                  assert(false, "Preset form didn't contain the initialised value.");
+               });
+         },
+         
+         "Test deleting preset dropped item": function() {
+            return browser.findByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper .delete")
+               .click()
+            .end()
+            .findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > *")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The dropped items widget should be empty after deleting preset dropped item");
+               });
+         },
+         
+         "Test deleted preset value form value": function() {
+            return browser.findAllByCssSelector(TestCommon.pubDataRowsCssSelector("FORM2_POST","data"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Preset dropped item was not deleted");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+      });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+
+         name: "DND items provided by list",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/list-of-dnd-items", "DND items provided by list")
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check items can be loaded from a list": function() {
+            return browser.findAllByCssSelector(".alfresco-dnd-DragAndDropItemsListView .alfresco-dnd-DragAndDropItem")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "The DND items were not populated");
+               });
+         },
+
+         "Labels should not be double encoded": function() {
+            return browser.findByCssSelector("#dojoUnique1 .title")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Workflows que j'ai initiés");
+               });
+         },
+
+         "Labels should be XSS safe": function() {
+            return browser.findByCssSelector("#dojoUnique2 .title")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "<img src=\"1\" onerror=\"window.hackedTextBoxValue=true\">");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
+      return {
 
-      name: "DND Nesting Tests",
+         name: "Accessibility DND tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/nested-dnd", "DND Nesting Tests")
-            .end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/basic-dnd", "Accessibility DND Testing")
+               .end();
+         },
 
-      beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Check that preset nested items are rendered": function() {
-         return browser.findAllByCssSelector("#FORM2 .alfresco-dnd-DroppedItem")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Could not find nested preset item");
-            });
-      },
+         "Select item using keyboard": function() {
+            return browser.pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.ENTER)
+               .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "The wrong number of items were selected");
+                  });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Add item to target": function() {
+            // 3 more tabs should highlight the first drop target...
+            return browser.pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+
+               // Hitting return should add the selected item...
+               .pressKeys(keys.ENTER)
+               .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+                  .then(function(elements) {
+                        assert.lengthOf(elements, 1, "The item was not added");
+                  });
+         },
+
+         "Submit the form to check the right item was added": function() {
+            // Six more tabs should highlight the confirmation button
+            return browser.pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.ENTER)
+               .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM1_POST","data","name","bob"))
+               .then(null, function() {
+                  assert(false, "Form didn't contain the value added by keyboard");
+               });
+         },
+
+         "Select another item": function() {
+            // Shift tab 7 times should get back to the last item
+            return browser.pressKeys([keys.SHIFT])
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys([keys.SHIFT]) // Remember to release the shift key!
+               .pressKeys(keys.ENTER)
+               .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Only one item should be selected, the other should be deselected");
+                  });
+
+         },
+
+         "Add the next item": function() {
+            // Just one more tab should get to the target again...
+            return browser.pressKeys(keys.TAB)
+               .sleep(pause)
+
+               // Hitting return should add the selected item...
+               .pressKeys(keys.ENTER)
+               .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+                  .then(function(elements) {
+                        assert.lengthOf(elements, 2, "The second item was not added");
+                  });
+         },
+
+         "Check the initial order": function() {
+            return browser.findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Value 1", "The items are not in the correct order");
+               });
+         },
+
+         "Move item down a place": function() {
+            // 3 tabs should get to the move down action...
+            return browser.pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.TAB)
+               .sleep(pause)
+               .pressKeys(keys.ENTER)
+               .findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
+                  .getVisibleText()
+                  .then(function(text) {
+                     assert.equal(text, "TextBox", "The item was not moved down a place");
+                  });
+         },
+
+         "Move item back up a place": function() {
+            // We should still be focused on the same node, so a single shift-tab will get to the move up action...
+            return browser.pressKeys([keys.SHIFT])
+               .pressKeys(keys.TAB)
+               .pressKeys([keys.SHIFT]) // Release the SHIFT key!
+               .sleep(pause)
+               .pressKeys(keys.ENTER)
+               .findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Value 1", "The item was not moved back up");
+               });
+         },
+
+         // TODO: This test is passing on Chrome but failing on Firefox
+         // "Delete an item": function() {
+         //    // 2 tabs should get to the delete item action
+         //    return browser.pressKeys(keys.TAB)
+         //       .sleep(pause)
+         //       .pressKeys(keys.TAB)
+         //       .sleep(pause)
+         //       .pressKeys(keys.ENTER)
+               
+         //       .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+         //          .then(function(elements) {
+         //                assert.lengthOf(elements, 1, "The item was not deleted");
+         //          });
+         // },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 
-registerSuite(function(){
-   var browser;
+   registerSuite(function(){
+      var browser;
 
-   return {
+      return {
 
-      name: "DND Modelling Tests",
+         name: "DND Nesting Tests",
 
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/modelled-dnd", "DND Modelling Tests")
-            .end();
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/nested-dnd", "DND Nesting Tests")
+               .end();
+         },
 
-       beforeEach: function() {
-         browser.end();
-      },
+         beforeEach: function() {
+            browser.end();
+         },
 
-      "Test Preset Form Control Populates Dropped Items": function() {
-         return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "The preset dropped item was found");
-            });
-      },
+         "Check that preset nested items are rendered": function() {
+            return browser.findAllByCssSelector("#FORM2 .alfresco-dnd-DroppedItem")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Could not find nested preset item");
+               });
+         },
 
-      "Test preset form control value renders the actual widget": function() {
-         return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-forms-controls-TextArea")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "The text area widget was not rendered");
-            });
-      },
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
 
-      "Check that custom wrapper CSS defined in the model is present": function() {
-         return browser.findAllByCssSelector(".custom-wrapper-class")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Could not find custom wrapper class");
-            });
-      },
+   registerSuite(function(){
+      var browser;
 
-      "Check that custom item CSS defined in the model is present": function() {
-         return browser.findAllByCssSelector(".custom-item-class")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Could not find custom item class");
-            });
-      },
+      return {
 
-      "Drag and drop and item": function () {
-         return browser.findByCssSelector("#dojoUnique1 .title")
-            .moveMouseTo()
-            .click()
-            .pressMouseButton()
-            .moveMouseTo(1, 1)
-         .end()
-         .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
-            .then(function(element) {
-               return browser.moveMouseTo(element)
-                  .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
-                  .releaseMouseButton();
-            })
-         .end()
-         .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-            .then(function(elements) {
-                  assert.lengthOf(elements, 1, "The dropped item was found");
-            });
-      },
+         name: "DND Modelling Tests",
 
-      "Check that the dropped item rendered the actual widget": function() {
-         return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-forms-controls-TextArea")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "The text area widget was not rendered");
-            });
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/modelled-dnd", "DND Modelling Tests")
+               .end();
+         },
 
-      "Edit the widget to check that the dialog is displayed": function() {
-         return browser.findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper .action.edit")
-            .click()
-         .end()
-         .findAllByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "The edit dialog was not displayed");
-            });
-      },
+          beforeEach: function() {
+            browser.end();
+         },
 
-      "Check that the form is initialised correctly": function() {
-         return browser.findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG #ALF_EDIT_FORM_CONTROL_LABEL .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(resultText) {
-               assert.equal(resultText, "No Label", "The edit dialog was not initialised correctly");
-            });
-      },
+         "Test Preset Form Control Populates Dropped Items": function() {
+            return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "The preset dropped item was found");
+               });
+         },
 
-      "Update the label and check that the widget renders again": function() {
-         return browser.findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG #ALF_EDIT_FORM_CONTROL_LABEL .dijitInputContainer input")
-            .clearValue()
-            .type("Updated Label")
-         .end()
-         .findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG .confirmationButton > span")
-            .click()
-         .end()
-         .findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-forms-controls-TextArea label")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert.equal(resultText, "Updated Label", "The widget was not re-rendered");
-            });
-      },
+         "Test preset form control value renders the actual widget": function() {
+            return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS2 .alfresco-forms-controls-TextArea")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "The text area widget was not rendered");
+               });
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Check that custom wrapper CSS defined in the model is present": function() {
+            return browser.findAllByCssSelector(".custom-wrapper-class")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Could not find custom wrapper class");
+               });
+         },
+
+         "Check that custom item CSS defined in the model is present": function() {
+            return browser.findAllByCssSelector(".custom-item-class")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Could not find custom item class");
+               });
+         },
+
+         "Drag and drop and item": function () {
+            return browser.findByCssSelector("#dojoUnique1 .title")
+               .moveMouseTo()
+               .click()
+               .pressMouseButton()
+               .moveMouseTo(1, 1)
+            .end()
+            .findByCssSelector(".alfresco-dnd-DragAndDropTarget > div")
+               .then(function(element) {
+                  return browser.moveMouseTo(element)
+                     .sleep(500) // The drag is 'elastic' and this sleep allows the item to catch up with the mouse movement
+                     .releaseMouseButton();
+               })
+            .end()
+            .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+               .then(function(elements) {
+                     assert.lengthOf(elements, 1, "The dropped item was found");
+               });
+         },
+
+         "Check that the dropped item rendered the actual widget": function() {
+            return browser.findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-forms-controls-TextArea")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "The text area widget was not rendered");
+               });
+         },
+
+         "Edit the widget to check that the dialog is displayed": function() {
+            return browser.findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper .action.edit")
+               .click()
+            .end()
+            .findAllByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "The edit dialog was not displayed");
+               });
+         },
+
+         "Check that the form is initialised correctly": function() {
+            return browser.findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG #ALF_EDIT_FORM_CONTROL_LABEL .dijitInputContainer input")
+               .getProperty("value")
+               .then(function(resultText) {
+                  assert.equal(resultText, "No Label", "The edit dialog was not initialised correctly");
+               });
+         },
+
+         "Update the label and check that the widget renders again": function() {
+            return browser.findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG #ALF_EDIT_FORM_CONTROL_LABEL .dijitInputContainer input")
+               .clearValue()
+               .type("Updated Label")
+            .end()
+            .findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG .confirmationButton > span")
+               .click()
+            .end()
+            .findByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-forms-controls-TextArea label")
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Updated Label", "The widget was not re-rendered");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/list-of-items.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/list-of-items.get.js
@@ -38,7 +38,7 @@ model.jsonModel = {
                            },
                            {
                               type: [ "widget" ],
-                              label: "Value 2",
+                              label: "dnd.item.xss",
                               value: {
                                  name: "1",
                                  b: "2"
@@ -86,7 +86,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/list-of-items.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/list-of-items.get.properties
@@ -1,0 +1,2 @@
+dnd.item.label=Workflows que j'ai initi\u00e9s
+dnd.item.xss=<img src="1" onerror="window.hackedTextBoxValue=true">


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-827 to ensure that DND item labels are not double-encoded. The unit test has been updated to verify this and to ensure that XSS-style attacks are not possible. The CSS has also been tidied up and LESS variables added.