### PR TITLE
AKU-823: Minimised panel not restored on new uploads

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1057,6 +1057,30 @@ define([],function() {
       STICKY_PANEL_ENABLE_CLOSE: "ALF_STICKY_PANEL_ENABLE_CLOSE",
 
       /**
+       * This can be called to minimise the StickyPanel.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.55
+       *
+       * @event
+       */
+      STICKY_PANEL_MINIMISE: "ALF_STICKY_PANEL_MINIMISE",
+
+      /**
+       * This can be called to restore the StickyPanel from a minimised state.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.55
+       *
+       * @event
+       */
+      STICKY_PANEL_RESTORE: "ALF_STICKY_PANEL_RESTORE",
+
+      /**
        * This can be called to set the title of the StickyPanel.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -139,7 +139,7 @@ define(["alfresco/core/Core",
          document.body.appendChild(this.domNode);
          this.setTitle();
          this.widgets && this.processWidgets(this.widgets, this.widgetsNode);
-         if(this.widgetsPadding || this.widgetsPadding === 0) {
+         if (this.widgetsPadding || this.widgetsPadding === 0) {
             domStyle.set(this.widgetsNode, "padding", this.widgetsPadding + "px");
          }
          this.sizePanel();
@@ -163,7 +163,7 @@ define(["alfresco/core/Core",
        * @param {object} payload Payload for the publication (expected to be empty)
        * @since 1.0.54
        */
-      disableCloseButton: function alfresco_layout_StickyPanel__disableCloseButton(/*jshint unused:false*/ payload) {
+      disableCloseButton: function alfresco_layout_StickyPanel__disableCloseButton( /*jshint unused:false*/ payload) {
          domClass.add(this.domNode, this.baseClass + "--close-disabled");
       },
 
@@ -174,7 +174,7 @@ define(["alfresco/core/Core",
        * @param {object} payload Payload for the publication (expected to be empty)
        * @since 1.0.54
        */
-      enableCloseButton: function alfresco_layout_StickyPanel__enableCloseButton(/*jshint unused:false*/ payload) {
+      enableCloseButton: function alfresco_layout_StickyPanel__enableCloseButton( /*jshint unused:false*/ payload) {
          domClass.remove(this.domNode, this.baseClass + "--close-disabled");
       },
 
@@ -196,7 +196,7 @@ define(["alfresco/core/Core",
        * @instance
        */
       onClickMinimiseRestore: function alfresco_layout_StickyPanel__onClickMinimiseRestore() {
-         domClass.toggle(this.domNode, this.baseClass + "--minimised");
+         this.toggleMinimised();
       },
 
       /**
@@ -207,12 +207,16 @@ define(["alfresco/core/Core",
        * @listens module:alfresco/core/topics#STICKY_PANEL_SET_TITLE
        * @listens module:alfresco/core/topics#STICKY_PANEL_DISABLE_CLOSE
        * @listens module:alfresco/core/topics#STICKY_PANEL_ENABLE_CLOSE
+       * @listens module:alfresco/core/topics#STICKY_PANEL_RESTORE
+       * @listens module:alfresco/core/topics#STICKY_PANEL_MINIMISE
        */
       setupSubscriptions: function alfresco_layout_StickyPanel__setupSubscriptions() {
          this.alfSubscribe(topics.STICKY_PANEL_CLOSE, lang.hitch(this, this.close));
          this.alfSubscribe(topics.STICKY_PANEL_SET_TITLE, lang.hitch(this, this.setTitle));
          this.alfSubscribe(topics.STICKY_PANEL_DISABLE_CLOSE, lang.hitch(this, this.disableCloseButton));
          this.alfSubscribe(topics.STICKY_PANEL_ENABLE_CLOSE, lang.hitch(this, this.enableCloseButton));
+         this.alfSubscribe(topics.STICKY_PANEL_RESTORE, lang.hitch(this, this.toggleMinimised, "restore"));
+         this.alfSubscribe(topics.STICKY_PANEL_MINIMISE, lang.hitch(this, this.toggleMinimised, "minimise"));
       },
 
       /**
@@ -245,14 +249,29 @@ define(["alfresco/core/Core",
       },
 
       /**
+       * Toggle between minimised/restored states.
+       *
+       * @instance
+       * @param {string} [forceTo] This can be used to force the panel to either "minimise" or "restore".
+       * @since 1.0.55
+       */
+      toggleMinimised: function alfresco_layout_StickyPanel__toggleMinimised(forceTo) {
+         var doOpen = (forceTo === "restore"),
+            doMinimise = (forceTo === "minimise"),
+            funcName = doOpen ? "remove" : doMinimise ? "add" : "toggle";
+         domClass[funcName](this.domNode, this.baseClass + "--minimised");
+      },
+
+      /**
        * Prevent the title property from being used to set the title
        * attribute on the widget's root node.
        *
        * @instance
        * @override
        * @param {string} newTitle The new title
+       * @since 1.0.55
        */
-      _setTitleAttr: function alfresco_layout_StickyPanel___setTitleAttr(newTitle) {
+      _setTitleAttr: function alfresco_layout_StickyPanel___setTitleAttr(/*jshint unused:false*/ newTitle) {
          // NOOP
       }
    });

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -132,6 +132,9 @@ define(["dojo/_base/declare",
             // Warn that panel aready exists if appropriate
             payload.warnIfOpen && this.alfLog("warn", "It was not possible to display a StickyPanel because one is already displayed", payload);
 
+            // Make sure panel isn't minimised
+            this.alfPublish(topics.STICKY_PANEL_RESTORE);
+
          } else if (payload.widgets) {
 
             // Setup the panel-widget config

--- a/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
@@ -42,6 +42,16 @@ define(["intern!object",
             browser.end();
          },
 
+         "Panel opens when requested": function() {
+            return browser.findByCssSelector("[widgetid=\"OPEN_STICKY_PANEL\"] .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLastPublish("ALF_DISPLAY_STICKY_PANEL")
+
+            .findDisplayedByCssSelector(".alfresco-layout-StickyPanel__panel");
+         },
+
          "Panel scrolls when content too great for window size": function() {
             return browser.setWindowSize(null, 1024, 300)
                .hasScrollbars(".alfresco-layout-StickyPanel__widgets")
@@ -60,6 +70,37 @@ define(["intern!object",
                .getAttribute("title")
                .then(function(title) {
                   assert.equal(title, null);
+               });
+         },
+
+         "Panel can be minimised": function() {
+            return browser.findByCssSelector(".alfresco-layout-StickyPanel__title-bar__minimise")
+               .click()
+               .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel--minimised")
+               .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__widgets")
+               .isDisplayed()
+               .then(function(isDisplayed){
+                  assert.isFalse(isDisplayed);
+               });
+         },
+
+         "If StickyPanel requested when minimised, it will restore automatically": function(){
+            return browser.findByCssSelector("[widgetid=\"OPEN_STICKY_PANEL\"] .dijitButtonNode")
+               .click()
+               .end()
+
+            .getLastPublish("ALF_DISPLAY_STICKY_PANEL")
+
+            .waitForDeletedByCssSelector(".alfresco-layout-StickyPanel--minimised")
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__widgets")
+               .isDisplayed()
+               .then(function(isDisplayed){
+                  assert.isTrue(isDisplayed);
                });
          },
 

--- a/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
@@ -53,11 +53,18 @@ define(["intern!object",
          },
 
          "Panel scrolls when content too great for window size": function() {
-            return browser.setWindowSize(null, 1024, 300)
+            return browser.findByCssSelector("body")
+               .hasScrollbars(".alfresco-layout-StickyPanel__widgets")
+               .then(function(hasScrollbars) {
+                  assert.isFalse(hasScrollbars.vertical, "Scrollbar should not initially be present");
+               })
+
+               .setWindowSize(null, 1024, 300)
                .hasScrollbars(".alfresco-layout-StickyPanel__widgets")
                .then(function(hasScrollbars) {
                   assert.isTrue(hasScrollbars.vertical, "Should have scrollbar after resize");
                })
+
                .setWindowSize(null, 1024, 768)
                .hasScrollbars(".alfresco-layout-StickyPanel__widgets")
                .then(function(hasScrollbars) {
@@ -88,8 +95,30 @@ define(["intern!object",
                });
          },
 
+         "Panel can be restored": function() {
+            return browser.findByCssSelector(".alfresco-layout-StickyPanel__title-bar__restore")
+               .click()
+               .end()
+
+            .waitForDeletedByCssSelector(".alfresco-layout-StickyPanel--minimised")
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__widgets")
+               .isDisplayed()
+               .then(function(isDisplayed){
+                  assert.isTrue(isDisplayed);
+               });
+         },
+
          "If StickyPanel requested when minimised, it will restore automatically": function(){
-            return browser.findByCssSelector("[widgetid=\"OPEN_STICKY_PANEL\"] .dijitButtonNode")
+            return browser.findByCssSelector(".alfresco-layout-StickyPanel__title-bar__minimise")
+               .click()
+               .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel--minimised")
+               .end()
+
+            .findByCssSelector("[widgetid=\"OPEN_STICKY_PANEL\"] .dijitButtonNode")
+               .clearLog()
                .click()
                .end()
 

--- a/aikau/src/test/resources/intern_bamboo.js
+++ b/aikau/src/test/resources/intern_bamboo.js
@@ -27,7 +27,7 @@ define(["./config/Suites"],
          settings = {
             project: "Aikau",
             name: "[AKU] BrowserStack Tests @ " + isoTimestamp,
-            "browserstack.debug": false
+            "browserstack.debug": true
          },
          envData = [{
             browserName: "chrome",

--- a/aikau/src/test/resources/intern_bs.js
+++ b/aikau/src/test/resources/intern_bs.js
@@ -26,7 +26,7 @@ define(["./config/Suites"],
       var settings = {
             project: "Aikau",
             name: "[AKU] BrowserStack Tests @ " + (new Date()).toISOString(),
-            "browserstack.debug": false
+            "browserstack.debug": true
          },
          envData = [{
             browserName: "chrome",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -7,7 +7,7 @@ var multipleWidgets = [],
          label: "This is a heading"
       }
    },
-   numWidgets = 10;
+   numWidgets = 8;
 for(var i = 0; i < numWidgets; i++) {
    multipleWidgets.push(singleWidget);
 }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -22,23 +22,22 @@ model.jsonModel = {
                all: true
             }
          }
-      }
+      },
+      "alfresco/services/NotificationService"
    ],
    widgets:[
       {
-         name: "alfresco/html/Heading",
-         id: "PAGE_HEADING",
+         name: "alfresco/buttons/AlfButton",
+         id: "OPEN_STICKY_PANEL",
          config: {
-            level: 3,
-            label: "Page used for development only. This widget should be instantiated through the NotificationService."
-         }
-      },
-      {
-         name: "alfresco/layout/StickyPanel",
-         id: "STICKY_PANEL",
-         config: {
-            panelWidth: 400,
-            widgets: multipleWidgets
+            label: "Open StickyPanel",
+            publishTopic: "ALF_DISPLAY_STICKY_PANEL",
+            publishPayload: {
+               title: "This is a sticky panel",
+               widgets: multipleWidgets,
+               width: 500,
+               warnIfOpen: false
+            }
          }
       },
       {


### PR DESCRIPTION
This PR fixes [AKU-823](https://issues.alfresco.com/jira/browse/AKU-823) by always attempting to restore a minimised StickyPanel when a request is made for one. Tests have been added (including previously missing ones) and run successfully in Vagrant and BrowserStack (FF/Chrome/IE11).