### PR TITLE
AKU-833: Remove 100% upload on failure

### DIFF
--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -130,7 +130,7 @@ define(["alfresco/core/FileSizeMixin",
          // Add new row
          var itemRow = domConstruct.create("tr", {
                className: this.baseClass + "__item"
-            }, this.inProgressItemsNode, "first"),
+            }, this.inProgressItemsNode),
             itemName = domConstruct.create("td", {
                className: this.baseClass + "__item__name"
             }, itemRow),
@@ -292,6 +292,7 @@ define(["alfresco/core/FileSizeMixin",
          if (upload) {
             upload.completed = true;
             domConstruct.place(upload.nodes.row, this.unsuccessfulItemsNode, "first");
+            upload.nodes.progress.textContent = "";
             upload.nodes.error.textContent = (request && request.statusText) || this.message("upload.failure.unknown-reason");
             domClass.add(upload.nodes.row, this.baseClass + "__item--has-error");
          } else {


### PR DESCRIPTION
This fixes [AKU-833](https://issues.alfresco.com/jira/browse/AKU-833) by removing progress percentage when the upload fails. Also, it moves actively in-progress files to the top of the window, so that even with many uploads, one can still see the currently uploading files — this change has been discussed with Kev. No unit-test added, as simply minor visual changes that will not accidentally regress.