### PR TITLE
AKU-830: Add Alfresco v1 API support to upload services

### DIFF
--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -72,7 +72,7 @@ define(["alfresco/core/topics",
        */
       resetTotalUploads: function alfresco_services_FileUploadService__resetTotalUploads() {
          this.inherited(arguments);
-         this.alfPublish(topics.STICKY_PANEL_ENABLE_CLOSE);
+         this.alfServicePublish(topics.STICKY_PANEL_ENABLE_CLOSE);
       },
 
       /**
@@ -84,7 +84,7 @@ define(["alfresco/core/topics",
        */
       registerSubscriptions: function alfresco_services_FileUploadService__registerSubscriptions() {
          this.inherited(arguments);
-         this.alfSubscribe(topics.STICKY_PANEL_CLOSED, lang.hitch(this, this.onUploadsContainerClosed));
+         this.alfSubscribe(topics.STICKY_PANEL_CLOSED, lang.hitch(this, this.onUploadsContainerClosed), true);
       },
 
       /**
@@ -106,7 +106,7 @@ define(["alfresco/core/topics",
                dfd.resolve();
             })
          });
-         this.alfPublish(topics.STICKY_PANEL_DISABLE_CLOSE);
+         this.alfServicePublish(topics.STICKY_PANEL_DISABLE_CLOSE);
          return dfd.promise;
       }
    });

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -463,6 +463,7 @@ define(["alfresco/core/CoreXhr",
                   fileInfo.nodeRef = "workspace://SpacesStore/" + response.id;
                   fileInfo.fileName = response.name;
                   fileInfo.state = this.STATE_SUCCESS;
+                  break;
                }
                default:
                   this.alfLog("error", "Unknown Upload API version specified: " + this.apiVersion);

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -73,6 +73,19 @@ define(["alfresco/core/CoreXhr",
       }],
 
       /**
+       * The Alfresco repository features multiple upload REST APIs. Up to and including version 5.1 of Alfresco
+       * supports the "version zero" REST API (also known as Share Services API) for Upload. In addition post 5.1
+       * there is a "version one" Public Upload API also. Set this value to 1 to use the new version one API, else
+       * the classic v0 API will be used and Share Services AMP must be applied to the repository.
+       *
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.55
+       */
+      apiVersion: 0,
+
+      /**
        * Stores references and state for each file that is in the file list. The fileId is used as
        * the key and the value is a [File object]{@link module:alfresco/services/_BaseUploadService#File}.
        *
@@ -205,6 +218,17 @@ define(["alfresco/core/CoreXhr",
       uploadTopic: topics.UPLOAD_REQUEST,
 
       /**
+       * The location of the upload endpoint, used when using an
+       * [apiVersion]{@link module:alfresco/services/_BaseUploadService#apiVersion} of 0.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.55
+       */
+      uploadURL: "api/upload",
+
+      /**
        * The widget definition that displays the uploads' progress. This should
        * be a single widget that implements the interface defined by
        * [_UploadsDisplayMixin]{@link module:alfresco/services/_UploadsDisplayMixin}.
@@ -214,18 +238,6 @@ define(["alfresco/core/CoreXhr",
        * @default
        */
       widgetsForUploadDisplay: null,
-
-      /**
-       * The Alfresco repository features multiple upload REST APIs. Up to and including version 5.1 of Alfresco
-       * supports the "version zero" REST API (also known as Share Services API) for Upload. In addition post 5.1
-       * there is a "version one" Public Upload API also. Set this value to 1 to use the new version one API, else
-       * the classic v0 API will be used and Share Services AMP must be applied to the repository.
-       *
-       * @instance
-       * @type {number}
-       * @default
-       */
-      apiVersion: 0,
 
       /**
        * An internal counter for the currently uploading files.
@@ -246,6 +258,7 @@ define(["alfresco/core/CoreXhr",
        */
       initService: function alfresco_services__BaseUploadService__initService() {
          this.inherited(arguments);
+         this.widgetsForUploadDisplay = lang.clone(this.widgetsForUploadDisplay);
          var widgets = this.widgetsForUploadDisplay;
          if (widgets && widgets.constructor === Array && widgets.length === 1) {
             lang.mixin(widgets[0], {
@@ -576,8 +589,10 @@ define(["alfresco/core/CoreXhr",
          // Mark file as being uploaded
          fileInfo.state = this.STATE_UPLOADING;
 
-         var url;
-         var formData = new FormData();
+         // Setup variables
+         var formData = new FormData(),
+            uploadData = fileInfo.uploadData,
+            url;
 
          // resolve final API URL and Form structure based on configuration and apiVersion setting
          switch (this.apiVersion)
@@ -585,27 +600,27 @@ define(["alfresco/core/CoreXhr",
             case 0:
             {
                // Set-up the API URL
-               url = AlfConstants.PROXY_URI + (this.uploadURL || "api/upload");
+               url = AlfConstants.PROXY_URI + this.uploadURL;
                if (this.isCsrfFilterEnabled()) {
                   url += "?" + this.getCsrfParameter() + "=" + encodeURIComponent(this.getCsrfToken());
                }
                
                // Set-up the form data object
-               formData.append("filedata", fileInfo.uploadData.filedata);
-               formData.append("filename", fileInfo.uploadData.filename);
-               formData.append("destination", fileInfo.uploadData.destination);
-               formData.append("siteId", fileInfo.uploadData.siteId);
-               formData.append("containerId", fileInfo.uploadData.containerId);
-               formData.append("uploaddirectory", fileInfo.uploadData.uploaddirectory);
-               formData.append("majorVersion", fileInfo.uploadData.majorVersion ? fileInfo.uploadData.majorVersion : "false");
-               formData.append("username", fileInfo.uploadData.username);
-               formData.append("overwrite", fileInfo.uploadData.overwrite);
-               formData.append("thumbnails", fileInfo.uploadData.thumbnails);
-               if (fileInfo.uploadData.updateNodeRef) {
-                  formData.append("updateNodeRef", fileInfo.uploadData.updateNodeRef);
+               formData.append("filedata", uploadData.filedata);
+               formData.append("filename", uploadData.filename);
+               formData.append("destination", uploadData.destination);
+               formData.append("siteId", uploadData.siteId);
+               formData.append("containerId", uploadData.containerId);
+               formData.append("uploaddirectory", uploadData.uploaddirectory);
+               formData.append("majorVersion", uploadData.majorVersion ? uploadData.majorVersion : "false");
+               formData.append("username", uploadData.username);
+               formData.append("overwrite", uploadData.overwrite);
+               formData.append("thumbnails", uploadData.thumbnails);
+               if (uploadData.updateNodeRef) {
+                  formData.append("updateNodeRef", uploadData.updateNodeRef);
                }
-               if (fileInfo.uploadData.description) {
-                  formData.append("description", fileInfo.uploadData.description);
+               if (uploadData.description) {
+                  formData.append("description", uploadData.description);
                }
                
                break;
@@ -617,16 +632,16 @@ define(["alfresco/core/CoreXhr",
                url = AlfConstants.PROXY_URI + "public/alfresco/versions/1/nodes/{nodeId}/children";
                // extract node id only from expected NodeRef
                url = lang.replace(url, {
-                  nodeId: fileInfo.uploadData.destination.split("/")[3]
+                  nodeId: uploadData.destination.split("/")[3]
                });
                if (this.isCsrfFilterEnabled()) {
                   url += "?" + this.getCsrfParameter() + "=" + encodeURIComponent(this.getCsrfToken());
                }
                
                // Set-up the form data object
-               formData.append("fileData", fileInfo.uploadData.filedata);
-               formData.append("fileName", fileInfo.uploadData.filename);
-               formData.append("autoRename", !fileInfo.uploadData.overwrite);
+               formData.append("fileData", uploadData.filedata);
+               formData.append("fileName", uploadData.filename);
+               formData.append("autoRename", !uploadData.overwrite);
                
                break;
             }
@@ -764,7 +779,7 @@ define(["alfresco/core/CoreXhr",
             if (currentProgressPercent === 100) {
                title = this.message(this.uploadsContainerTitleComplete);
             }
-            this.alfPublish(this.uploadsContainerTitleUpdateTopic, {
+            this.alfServicePublish(this.uploadsContainerTitleUpdateTopic, {
                title: title
             });
          }

--- a/aikau/src/main/resources/alfresco/services/_UploadHistoryServiceMixin.js
+++ b/aikau/src/main/resources/alfresco/services/_UploadHistoryServiceMixin.js
@@ -84,7 +84,7 @@ define(["dojo/_base/declare",
        */
       initUploadHistory: function alfresco_services__UploadHistoryServiceMixin__initUploadHistory() {
          this.uploadHistory = [];
-         this.alfPublish(topics.GET_PREFERENCE, {
+         this.alfServicePublish(topics.GET_PREFERENCE, {
             preference: this.uploadHistoryPreferenceName,
             callback: this.setUploadHistory,
             callbackScope: this
@@ -138,7 +138,7 @@ define(["dojo/_base/declare",
 
          // Always update the latest history, even if no new NodeRef has
          // been added as it may have been re-ordered
-         this.alfPublish(topics.SET_PREFERENCE, {
+         this.alfServicePublish(topics.SET_PREFERENCE, {
             preference: this.uploadHistoryPreferenceName,
             value: this.uploadHistory.join(",")
          });

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -74,6 +74,11 @@ define(["intern!object",
                .click();
          },
 
+         "Upload service uses v0 API by default": function() {
+            return browser.findByCssSelector("body")
+               .getLastXhr("api/upload");
+         },
+
          "Close button disabled on upload start": function() {
             return browser.findById("MULTI_UPLOAD_label")
                .clearLog()
@@ -111,6 +116,46 @@ define(["intern!object",
             .end()
 
             .getLastPublish("ALF_STICKY_PANEL_ENABLE_CLOSE");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function() {
+      var browser;
+
+      return {
+         name: "UploadMonitor V1 API Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/UploadMonitorV1", "UploadMonitor V1 API Tests");
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Single file upload succeeds": function() {
+            return browser.findById("V1_API_UPLOAD_label")
+               .click()
+            .end()
+
+            .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED", 5000)
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
+               .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click();
+         },
+
+         "Upload service uses v0 API by default": function() {
+            return browser.findByCssSelector("body")
+               .getLastXhr("public/alfresco/versions/1/nodes/node/children");
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitorV1.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitorV1.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>UploadMonitor V1 API Test</shortname>
+  <description>This test page exercises the UploadMonitor control with the V1 API</description>
+  <family>aikau-unit-tests</family>
+  <url>/UploadMonitorV1</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitorV1.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitorV1.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitorV1.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/UploadMonitorV1.get.js
@@ -1,0 +1,51 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      {
+         name: "alfresco/services/FileUploadService",
+         config: {
+            apiVersion: 1
+         }
+      },
+      "alfresco/services/NotificationService"
+   ],
+   widgets: [
+      {
+         id: "V1_API_UPLOAD",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "V1 API Upload",
+            publishTopic: "ALF_UPLOAD_REQUEST",
+            publishPayload: {
+               alfResponseTopic: "UPLOAD_COMPLETE_OR_CANCELLED",
+               files: [
+                  {
+                     size: 1337,
+                     name: "File for v1 API.docx"
+                  }
+               ],
+               targetData: {
+                  destination: "some://fake/node"
+               }
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/UploadMockXhr",
+         config: {
+            averageUploadTimeSecs: 3
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This pull request supersedes #831 as a fix for [AKU-830](https://issues.alfresco.com/jira/browse/AKU-830), and adds v1 API support to the upload service, including appropriate tests.