### PR TITLE
Fix legibility problems with MultiSelect caused by CSS issues

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MultiSelect.css
@@ -84,6 +84,9 @@
          &--focused {
             background: #06a;
             color: @highlighted-font-color;
+            * {
+               color: @highlighted-font-color;
+            }
          }
          &--already-chosen {
             background: @list-background-color;

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/css/ChoiceMixin.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/css/ChoiceMixin.css
@@ -46,7 +46,7 @@
       &--selected {
          background: #06a linear-gradient(to bottom, #08c, #06a);
          border-color: #039;
-         .alfresco-forms-controls-MultiSelect__choice {
+         .alfresco-forms-controls-utilities-ChoiceMixin__choice {
             &__content {
                color: @highlighted-font-color;
             }
@@ -60,7 +60,7 @@
       }
    }
    &--choices-nowrap {
-      .alfresco-forms-controls-MultiSelect__choice__content {
+      .alfresco-forms-controls-utilities-ChoiceMixin__choice__content {
          white-space: nowrap;
       }
    }


### PR DESCRIPTION
Couple of minor tweaks to restore two instances of white-text-on-blue-background (had regressed to black text at some point).