### PR TITLE
AKU-843: Cannot click to sides of upload panel

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -18,9 +18,12 @@
  */
 
 /**
- * This widget is used by the [NotificationService]{@link module:alfresco/services/NotificationService}
+ * <p>This widget is used by the [NotificationService]{@link module:alfresco/services/NotificationService}
  * to display a sticky panel attached to the bottom of the screen. It should not be instantiated
- * directly.
+ * directly.</p>
+ *
+ * <p><strong>NOTE:</strong> There is a bug with older browsers (IE8/IE9/IE10 only) that means that it is
+ * not possible to click on elements to the left or right of the sticky panel.</p>
  * 
  * @module alfresco/layout/StickyPanel
  * @extends external:dijit/_WidgetBase

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -1,6 +1,8 @@
 .alfresco-layout-StickyPanel {
    bottom: 0;
+   display: block;
    left: 0;
+   pointer-event: none;
    position: fixed;
    right: 0;
    &__panel {
@@ -11,6 +13,7 @@
       box-shadow: @sticky-panel-box-shadow;
       box-sizing: border-box;
       margin: 0 auto;
+      pointer-events: all;
       position: relative;
    }
    &__title-bar {

--- a/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
+++ b/aikau/src/main/resources/alfresco/layout/css/StickyPanel.css
@@ -2,7 +2,7 @@
    bottom: 0;
    display: block;
    left: 0;
-   pointer-event: none;
+   pointer-events: none;
    position: fixed;
    right: 0;
    &__panel {

--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -21,6 +21,10 @@
  * <p>This service can be used to control the uploading of content as well as
  * the updating the content of existing nodes on an Alfresco Repository.</p>
  * 
+ * <p><strong>NOTE:</strong> There is a bug with older browsers (IE8/IE9/IE10 only)
+ * that means that it is not possible to click on elements to the left or right of
+ * the upload panel.</p>
+ * 
  * @module alfresco/services/FileUploadService
  * @extends module:alfresco/services/_BaseUploadService
  * @author Martin Doyle

--- a/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
+++ b/aikau/src/test/resources/alfresco/layout/StickyPanelTest.js
@@ -133,6 +133,17 @@ define(["intern!object",
                });
          },
 
+         "Panel allows clicks either side of it": function(){
+            return browser.findByCssSelector("[widgetid=\"LEFT_BUTTON\"] .dijitButtonNode")
+               .click()
+               .getLastPublish("LEFT_BUTTON_PUSHED")
+            .end()  
+
+            .findByCssSelector("[widgetid=\"RIGHT_BUTTON\"] .dijitButtonNode")
+               .click()
+               .getLastPublish("RIGHT_BUTTON_PUSHED");
+         },
+
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/StickyPanel.get.js
@@ -8,7 +8,7 @@ var multipleWidgets = [],
       }
    },
    numWidgets = 8;
-for(var i = 0; i < numWidgets; i++) {
+for (var i = 0; i < numWidgets; i++) {
    multipleWidgets.push(singleWidget);
 }
 
@@ -25,23 +25,60 @@ model.jsonModel = {
       },
       "alfresco/services/NotificationService"
    ],
-   widgets:[
+   widgets: [
       {
-         name: "alfresco/buttons/AlfButton",
-         id: "OPEN_STICKY_PANEL",
+         name: "alfresco/layout/FixedHeaderFooter",
          config: {
-            label: "Open StickyPanel",
-            publishTopic: "ALF_DISPLAY_STICKY_PANEL",
-            publishPayload: {
-               title: "This is a sticky panel",
-               widgets: multipleWidgets,
-               width: 500,
-               warnIfOpen: false
-            }
+            height: "auto",
+            widgetsForHeader: [
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  id: "OPEN_STICKY_PANEL",
+                  config: {
+                     label: "Open StickyPanel",
+                     publishTopic: "ALF_DISPLAY_STICKY_PANEL",
+                     publishPayload: {
+                        title: "This is a sticky panel",
+                        widgets: multipleWidgets,
+                        width: 500,
+                        warnIfOpen: false
+                     }
+                  }
+               }
+            ],
+            widgets: [
+               {
+                  name: "alfresco/logging/DebugLog"
+               }
+            ],
+            widgetsForFooter: [
+               {
+                  name: "alfresco/layout/LeftAndRight",
+                  config: {
+                     widgetsLeft: [
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           id: "LEFT_BUTTON",
+                           config: {
+                              label: "Left button",
+                              publishTopic: "LEFT_BUTTON_PUSHED"
+                           }
+                        }
+                     ],
+                     widgetsRight: [
+                        {
+                           name: "alfresco/buttons/AlfButton",
+                           id: "RIGHT_BUTTON",
+                           config: {
+                              label: "Right button",
+                              publishTopic: "RIGHT_BUTTON_PUSHED"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
          }
-      },
-      {
-         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This addresses issue [AKU-843](https://issues.alfresco.com/jira/browse/AKU-843) and uses CSS to allow clicks to pass through the panel-container element on IE11+, Chrome and Firefox. JSDoc has been added to explain that it will not work in older browsers. Automated test created and passing. Full regression suite not run, only tested StickyPanelTest and UploadMonitorTest on BrowserStack (because the CSS change can't affect anything else).