### PR TITLE
AKU-842: Ensure data cleared on infinite scrolling DocumentList sort request

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
@@ -38,7 +38,7 @@ define(["dojo/_base/declare",
       getViewName: function alfresco_documentlibrary_views_AlfTableView__getViewName() {
          return "table";
       },
-      
+
       /**
        * The configuration for selecting the view (configured the menu item)
        * @instance
@@ -51,8 +51,15 @@ define(["dojo/_base/declare",
          iconClass: "alf-tableview-icon"
       },
       
+      /**
+       * The view model.
+       * 
+       * @instance
+       * @type {opject}
+       */
       widgetsForHeader: [
          {
+            id: "TABLE_VIEW_SELECTOR_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "",
@@ -60,6 +67,7 @@ define(["dojo/_base/declare",
             }
          },
          {
+            id: "TABLE_VIEW_INDICATORS_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "",
@@ -67,62 +75,77 @@ define(["dojo/_base/declare",
             }
          },
          {
+            id: "TABLE_VIEW_NAME_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.name",
                sortable: true,
-               sortValue: "cm:name"
+               sortValue: "cm:name",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_TITLE_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.title",
                sortable: true,
-               sortValue: "cm:title"
+               sortValue: "cm:title",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_DESCRIPTION_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.description",
                sortable: true,
-               sortValue: "cm:description"
+               sortValue: "cm:description",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_CREATOR_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.creator",
                sortable: true,
-               sortValue: "cm:creator"
+               sortValue: "cm:creator",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_CREATED_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.created",
                sortable: true,
-               sortValue: "cm:created"
+               sortValue: "cm:created",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_MODIFIER_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.modifier",
                sortable: true,
-               sortValue: "cm:modifier"
+               sortValue: "cm:modifier",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_MODIFIED_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "label.modified",
                sortable: true,
-               sortValue: "cm:modified"
+               sortValue: "cm:modified",
+               useHash: "{useHash}"
             }
          },
          {
+            id: "TABLE_VIEW_ACTIONS_HEADING",
             name: "alfresco/lists/views/layouts/HeaderCell",
             config: {
                label: "",

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -114,6 +114,36 @@ define(["dojo/_base/declare",
       ___filtersRemoved: 0,
 
       /**
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#postCreate} to ensure that all views
+       * have access to the [useHash]{@link module:alfresco/lists/AlfHashList#useHash} configuration. This is important 
+       * because it may be necessary for them to update child widgets to reflect hash data in some way (this has been 
+       * specifically added to address the issue of sort indication rendered by 
+       * [HeaderCells]{@link module:alfresco/lists/views/layouts/HeaderCell}).
+       * 
+       * @instance
+       * @since 1.0.56
+       */
+      postCreate: function alfresco_lists_AlfList__postCreate() {
+         if (this.useHash)
+         {
+            if (this.widgets) {
+               array.forEach(this.widgets, function(view) {
+                  if (view)
+                  {
+                     if (!view.config)
+                     {
+                        view.config = {};
+                     }
+                     view.config.useHash = true;
+                  }
+               });
+            }
+         }
+         this.inherited(arguments);
+      },
+
+
+      /**
        * The AlfHashList is intended to work co-operatively with other widgets on a page to assist with
        * setting the data that should be retrieved. As related widgets are created and publish their initial
        * state they may trigger requests to load data. As such, data loading should not be started until

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -220,6 +220,10 @@ define(["dojo/_base/declare",
             }
             if (this._readyToLoad === true)
             {
+               if (this.useInfiniteScroll)
+               {
+                  this.clearViews();
+               }
                if (this.useHash === true)
                {
                   var currHash = hashUtils.getHash();

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -153,7 +153,19 @@ define(["dojo/_base/declare",
        * @since 1.0.39
        */
       suppressDndUploading: true,
-    
+      
+      /**
+       * This will be automatically set when the view is used in an [AlfHashList]{@link module:alfresco/lists/AlfHashList}.
+       * It indicates whether or not the list is being driven by data set on the browser URL hash and it can be useful
+       * for views to have access to this information.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.56
+       */
+      useHash: null,
+
       /**
        * Whether the list that's creating this view has infinite scroll turned on
        *
@@ -587,7 +599,9 @@ define(["dojo/_base/declare",
          if (this.widgetsForHeader)
          {
             var thead = domConstruct.create("thead", null, this.tableNode, "first");
-            this.processWidgets(this.widgetsForHeader, thead);
+            var clonedWidgets = lang.clone(this.widgetsForHeader);
+            this.processObject(["processInstanceTokens"], clonedWidgets);
+            this.processWidgets(clonedWidgets, thead);
          }
          this.currentItem = null;
       },

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
@@ -30,11 +30,12 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/HeaderCell.html",
         "alfresco/core/Core",
+        "alfresco/util/hashUtils",
         "dojo/_base/lang",
         "dojo/dom-class",
         "dojo/query",
         "dojo/dom-attr"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, lang, domClass, query, domAttr) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, hashUtils, lang, domClass, query, domAttr) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
 
@@ -56,6 +57,15 @@ define(["dojo/_base/declare",
       templateString: template,
 
       /**
+       * Optional accessibility scope.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      a11yScope: null,
+
+      /**
        * Indicates whether or not this header can actually be used to trigger sort requests.
        * 
        * @instance
@@ -65,13 +75,22 @@ define(["dojo/_base/declare",
       sortable: false,
 
       /**
-       * Indicate whether or not this cell is currently being used as the sort field.
+       * Optional alt text for the sort ascending icon
        *
        * @instance
-       * @type boolean
+       * @type {string}
        * @default
        */
-      usedForSort: false,
+      sortAscAlt: null,
+
+      /**
+       * Optional alt text for the sort descending icon
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      sortDescAlt: null,
 
       /**
        * Indicates whether or not the column headed by this cell is sorted in ascending order or not.
@@ -103,31 +122,24 @@ define(["dojo/_base/declare",
       toolTipMsg: null,
 
       /**
-       * Optional accessibility scope.
+       * Indicate whether or not this cell is currently being used as the sort field.
        *
        * @instance
-       * @type {string}
+       * @type boolean
        * @default
        */
-      a11yScope: null,
+      usedForSort: false,
 
       /**
-       * Optional alt text for the sort ascending icon
-       *
+       * Indicates whether or not the current browser URL hash should be used to determine whether or not
+       * the header is currently marked as being sorted.
+       * 
        * @instance
-       * @type {string}
+       * @type {boolean}
        * @default
+       * @since 1.0.56
        */
-      sortAscAlt: null,
-
-      /**
-       * Optional alt text for the sort descending icon
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      sortDescAlt: null,
+      useHash: false,
 
       /**
        * @instance
@@ -146,6 +158,15 @@ define(["dojo/_base/declare",
        * @instance postCreate
        */
       postCreate: function alfresco_lists_views_layouts_HeaderCell__postCreate() {
+         if (this.useHash && this.sortable)
+         {
+            var currHash = hashUtils.getHash();
+            if (currHash.sortField === this.sortValue)
+            {
+               this.usedForSort = true;
+               this.sortedAscending = currHash.sortAscending === "true";
+            }
+         }
 
          this.alfSubscribe("ALF_DOCLIST_SORT", lang.hitch(this, this.onExternalSortRequest));
          this.alfSubscribe("ALF_DOCLIST_SORT_FIELD_SELECTION", lang.hitch(this, this.onExternalSortRequest));

--- a/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function (registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfDocumentList Tests (infinite scrolling)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollDocumentList", "AlfDocumentList Tests (infinite scrolling)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "No initial sorting indicated": function() {
+            return browser.findDisplayedByCssSelector(".alfresco-lists-views-layouts-HeaderCell img")
+               .then(function() {
+                  assert(false, "Should not have found any displayed sort indicators");
+               },
+               function() {
+                  assert(true);
+               });
+         },
+
+         "Four results shown initially": function() {
+            return browser.findByCssSelector("body").end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findAllByCssSelector(".alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4);
+               });
+         },
+
+         "Sort on name, check four results are still shown": function() {
+            return browser.findByCssSelector("#TABLE_VIEW_NAME_HEADING .label")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findAllByCssSelector(".alfresco-lists-views-layouts-Row")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4);
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         },
+
+         "Reload the page and check initial sorting displayed": function() {
+            return browser.refresh().findByCssSelector("body").end()
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findDisplayedByCssSelector("#TABLE_VIEW_NAME_HEADING img");
+         },
+
+         "Post Coverage Results (1)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -93,6 +93,7 @@ define({
       "src/test/resources/alfresco/documentlibrary/DocumentListTest",
       "src/test/resources/alfresco/documentlibrary/DocumentSelectorTest",
       "src/test/resources/alfresco/documentlibrary/FilteredDocumentListTest",
+      "src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest",
       "src/test/resources/alfresco/documentlibrary/PaginationTest",
       "src/test/resources/alfresco/documentlibrary/SearchListScrollTest",
       "src/test/resources/alfresco/documentlibrary/SearchListTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Infinite Scrolling Document List</shortname>
+  <description>This page demonstrates the alfresco/documentlibrary/AlfDocumentList configured with infinite scrolling. It was added to test sorting and pagination of data with infinite scrolling.</description>
+  <family>aikau-unit-tests</family>
+  <url>/InfiniteScrollDocumentList</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
@@ -1,0 +1,42 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/NavigationService",
+      "alfresco/services/DocumentService",
+      "alfresco/services/InfiniteScrollService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/documentlibrary/AlfDocumentList",
+         config: {
+            useHash: true,
+            useInfiniteScroll: true,
+             widgets: [
+               {
+                  name: "alfresco/documentlibrary/views/AlfTableView"
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/testing/NodesMockXhr",
+         config: {
+            totalItems: 4,
+            folderRatio: [100]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-842 to ensure that when lists (in this case the AlfDocumentList) is used with useInfiniteScroll configured to be true, that sorting data clears the current results. This PR also includes improvements to the HeaderCell widget to enable it to correctly reflect the initial sort state based on the current browser URL hash (when useHash is enabled). Unit tests have been added to verify the fix.