### PR TITLE
AKU-796: Delete uploaded files individually

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -102,6 +102,19 @@ define([],function() {
       CANCEL_EDIT: "ALF_DOC_CANCEL_EDITING",
 
       /**
+       * Cancel an in-progress upload.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.56
+       *
+       * @event
+       * @property {string} fileId The ID of the file to cancel
+       */
+      CANCEL_INPROGRESS_UPLOAD: "CANCEL_INPROGRESS_UPLOAD",
+
+      /**
        * This can be published to clear any selected items that are logged by widgets
        * such as the [AlfSelectedItemsMenuBarPopup]{@link module:alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup}.
        *

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -331,7 +331,7 @@
 @upload-monitor-error-message-top: -7px;
 @upload-monitor-progress-column-width: 50px;
 @upload-monitor-status-column-width: 150px;
-@upload-monitor-status-color-in-progress: #ccc;
+@upload-monitor-status-color-inprogress: #ccc;
 @upload-monitor-status-color-successful: #090;
 @upload-monitor-status-color-unsuccessful: #c00;
 

--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -114,10 +114,6 @@ define(["dojo/_base/declare",
          this.altText = this.message(this.altText, {
             0: altTextId
          });
-
-         this.publishPayload = this.getGeneratedPayload();
-         this.publishGlobal = this.publishGlobal || false;
-         this.publishToParent = this.publishToParent || false;
       },
 
       /**
@@ -128,7 +124,8 @@ define(["dojo/_base/declare",
        * @param {object} evt The click event object
        */
       onClick: function alfresco_renderers_PublishAction__onClick(/*jshint unused:false*/ evt) {
-         this.alfPublish(this.publishTopic, this.publishPayload, this.publishGlobal, this.publishToParent);
+         this.publishPayload = this.getGeneratedPayload();
+         this.alfPublish(this.publishTopic, this.publishPayload, !!this.publishGlobal, !!this.publishToParent);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -291,9 +291,14 @@ define(["alfresco/core/CoreXhr",
        * @param {string} fileId The unique id of the file being uploaded
        * @param {object} evt The cancellation event
        */
-      cancelListener: function alfresco_services__BaseUploadService__cancelListener( /*jshint unused:false*/ fileId, /*jshint unused:false*/ evt) {
-         this.alfLog("debug", "Cancelled uploads not yet handled");
-         this.onUploadFinished(fileId);
+      cancelListener: function alfresco_services__BaseUploadService__cancelListener(fileId, evt) {
+         var fileInfo = this.fileStore[fileId];
+         if (fileInfo) {
+            fileInfo.request = lang.mixin(fileInfo.request || {}, {
+               statusText: this.message("upload.cancelled")
+            });
+            this.processUploadFailure(fileId, evt);
+         }
       },
 
       /**
@@ -347,6 +352,23 @@ define(["alfresco/core/CoreXhr",
             if (fileInfo.state !== this.STATE_FAILURE) {
                this.processUploadFailure(fileId, evt);
             }
+         }
+      },
+
+      /**
+       * Cancel the specified upload.
+       *
+       * @instance
+       * @param {object} payload The publication payload
+       * @since 1.0.56
+       */
+      onUploadCancelRequest: function alfresco_services__BaseUploadService__onUploadCancelRequest(payload) {
+         var fileId = payload && payload.fileId,
+            fileInfo = this.fileStore[fileId];
+         try {
+            fileInfo.request.abort();
+         } catch (e) {
+            this.alfLog("info", "Unable to cancel upload: ", fileInfo, e);
          }
       },
 
@@ -518,6 +540,7 @@ define(["alfresco/core/CoreXhr",
        */
       registerSubscriptions: function alfresco_services_FileUploadService__registerSubscriptions() {
          this.alfSubscribe(topics.UPLOAD_REQUEST, lang.hitch(this, this.onUploadRequest));
+         this.alfSubscribe(topics.CANCEL_INPROGRESS_UPLOAD, lang.hitch(this, this.onUploadCancelRequest));
       },
 
       /**
@@ -577,6 +600,7 @@ define(["alfresco/core/CoreXhr",
        * @param {object} Contains info about the file and its request.
        */
       startFileUpload: function alfresco_services__BaseUploadService__startFileUpload(fileInfo) {
+         /*jshint maxstatements:false*/
 
          // Ensure we only upload the maximum allowed at a time
          if (this._numUploadsInProgress === this.maxSimultaneousUploads) {

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -291,14 +291,8 @@ define(["alfresco/core/CoreXhr",
        * @param {string} fileId The unique id of the file being uploaded
        * @param {object} evt The cancellation event
        */
-      cancelListener: function alfresco_services__BaseUploadService__cancelListener(fileId, evt) {
-         var fileInfo = this.fileStore[fileId];
-         if (fileInfo) {
-            fileInfo.request = lang.mixin(fileInfo.request || {}, {
-               statusText: this.message("upload.cancelled")
-            });
-            this.processUploadFailure(fileId, evt);
-         }
+      cancelListener: function alfresco_services__BaseUploadService__cancelListener(/*jshint unused:false*/ fileId, /*jshint unused:false*/ evt) {
+         this.failureListener.apply(this, arguments); // Defer directly to the failure listener
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/i18n/_BaseUploadService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/_BaseUploadService.properties
@@ -2,3 +2,4 @@ uploads-container.title=Uploading... {0}%
 uploads-container.title-complete=Upload Complete
 upload.error.empty-file=0kb files cannot be uploaded
 upload.error.reason-unknown=Failed
+upload.cancelled=Upload cancelled

--- a/aikau/src/main/resources/alfresco/services/i18n/_BaseUploadService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/_BaseUploadService.properties
@@ -2,4 +2,3 @@ uploads-container.title=Uploading... {0}%
 uploads-container.title-complete=Upload Complete
 upload.error.empty-file=0kb files cannot be uploaded
 upload.error.reason-unknown=Failed
-upload.cancelled=Upload cancelled

--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -399,13 +399,29 @@ define(["alfresco/core/FileSizeMixin",
        * @param {object} request The request object used to attempt to upload the file
        */
       handleFailedUpload: function alfesco_upload_UploadMonitor__handleFailedUpload(fileId, /*jshint unused:false*/ failureEvt, request) {
+
+         // Get the upload
          var upload = this._uploads[fileId];
          if (upload) {
+
+            // Get the error message
+            var errorMessage = "upload.failure.unknown-reason";
+            if (request) {
+               if (request.status === 0) {
+                  errorMessage = "upload.cancelled";
+               } else if (request.statusText) {
+                  errorMessage = request.statusText;
+               }
+            }
+            errorMessage = this.message(errorMessage);
+
+            // Move the item to the unsuccessful items section and update the properties accordingly
             upload.completed = true;
             domConstruct.place(upload.nodes.row, this.unsuccessfulItemsNode, "first");
             upload.nodes.progress.textContent = "";
-            upload.nodes.error.textContent = (request && request.statusText) || this.message("upload.failure.unknown-reason");
+            upload.nodes.error.textContent = errorMessage;
             domClass.add(upload.nodes.row, this.baseClass + "__item--has-error");
+
          } else {
             this.alfLog("warn", "Attempt to mark as failed an upload that is not being tracked (id=" + fileId + ")");
          }

--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -154,8 +154,8 @@ define(["alfresco/core/FileSizeMixin",
 
          // Add localised status messages
          domConstruct.create("span", {
-            className: this.baseClass + "__item__status__in-progress",
-            textContent: this.message("upload.status.in-progress")
+            className: this.baseClass + "__item__status__inprogress",
+            textContent: this.message("upload.status.inprogress")
          }, itemStatus);
          domConstruct.create("span", {
             className: this.baseClass + "__item__status__successful",

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -54,6 +54,15 @@
             color: @upload-monitor-status-color-unsuccessful;
          }
       }
+      &__actions {
+         width: 30px;
+         .alfresco-renderers-PublishAction .image {
+            vertical-align: text-bottom;
+         }
+      }
+      &__action {
+         display: none;
+      }
       &--has-error {
          .alfresco-upload-UploadMonitor {
             &__item__name__error {
@@ -67,6 +76,9 @@
          &__item {
             &__status__inprogress {
                display: inline;
+            }
+            &__action__inprogress {
+               display: inline-block;
             }
          }
       }
@@ -82,6 +94,9 @@
             &__status__successful {
                display: inline;
             }
+            &__action__successful {
+               display: inline-block;
+            }
          }
       }
    }
@@ -90,6 +105,9 @@
          &__item {
             &__status__unsuccessful {
                display: inline;
+            }
+            &__action__unsuccessful {
+               display: inline-block;
             }
          }
       }

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -41,11 +41,11 @@
       }
       &__status {
          width: @upload-monitor-status-column-width;
-         &__in-progress, &__successful, &__unsuccessful {
+         &__inprogress, &__successful, &__unsuccessful {
             display: none;
          }
-         &__in-progress {
-            color: @upload-monitor-status-color-in-progress;
+         &__inprogress {
+            color: @upload-monitor-status-color-inprogress;
          }
          &__successful {
             color: @upload-monitor-status-color-successful;
@@ -62,10 +62,10 @@
          }
       }
    }
-   &__in-progress-items {
+   &__inprogress-items {
       .alfresco-upload-UploadMonitor {
          &__item {
-            &__status__in-progress {
+            &__status__inprogress {
                display: inline;
             }
          }

--- a/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
+++ b/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
@@ -1,4 +1,4 @@
-upload.status.in-progress=In progress
+upload.status.inprogress=In progress
 upload.status.successful=Successful
 upload.status.unsuccessful=Unsuccessful
 upload.failure.unknown-reason=Failed for unknown reason

--- a/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
+++ b/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
@@ -2,3 +2,4 @@ upload.status.inprogress=In progress
 upload.status.successful=Successful
 upload.status.unsuccessful=Unsuccessful
 upload.failure.unknown-reason=Failed for unknown reason
+upload.cancelled=Upload cancelled

--- a/aikau/src/main/resources/alfresco/upload/templates/UploadMonitor.html
+++ b/aikau/src/main/resources/alfresco/upload/templates/UploadMonitor.html
@@ -8,7 +8,7 @@
             <!-- <td class="${baseClass}__item__close-button">&nbsp;</td> -->
          </tr>
       </thead>
-      <tbody data-dojo-attach-point="inProgressItemsNode" class="${baseClass}__in-progress-items"></tbody>
+      <tbody data-dojo-attach-point="inProgressItemsNode" class="${baseClass}__inprogress-items"></tbody>
       <tbody data-dojo-attach-point="unsuccessfulItemsNode" class="${baseClass}__unsuccessful-items"></tbody>
       <tbody data-dojo-attach-point="successfulItemsNode" class="${baseClass}__successful-items"></tbody>
    </table>

--- a/aikau/src/main/resources/alfresco/upload/templates/UploadMonitor.html
+++ b/aikau/src/main/resources/alfresco/upload/templates/UploadMonitor.html
@@ -5,7 +5,7 @@
             <td class="${baseClass}__item__name">&nbsp;</td>
             <td class="${baseClass}__item__progress">&nbsp;</td>
             <td class="${baseClass}__item__status">&nbsp;</td>
-            <!-- <td class="${baseClass}__item__close-button">&nbsp;</td> -->
+            <td class="${baseClass}__item__actions">&nbsp;</td>
          </tr>
       </thead>
       <tbody data-dojo-attach-point="inProgressItemsNode" class="${baseClass}__inprogress-items"></tbody>

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -101,11 +101,7 @@ define(["intern!object",
             .findAllByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__successful-items .alfresco-upload-UploadMonitor__item")
                .then(function(elements) {
                   assert.lengthOf(elements, 3, "Should be three successful uploads");
-               })
-            .end()
-
-            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
-               .click();
+               });
          },
 
          "Close button enabled on upload complete": function() {
@@ -115,7 +111,30 @@ define(["intern!object",
                })
             .end()
 
-            .getLastPublish("ALF_STICKY_PANEL_ENABLE_CLOSE");
+            .getLastPublish("ALF_STICKY_PANEL_ENABLE_CLOSE")
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_STICKY_PANEL_CLOSED");
+         },
+
+         "Can cancel in-progress upload": function() {
+            return browser.findById("SINGLE_UPLOAD_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(".alfresco-upload-UploadMonitor__item__action__inprogress")
+               .click()
+            .end()
+
+            .findByCssSelector(".alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item__name__error")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "Upload cancelled");
+               });
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
@@ -79,11 +79,8 @@ define(["dojo/_base/declare",
 
                // After progress has finished, send the final response
                setTimeout(function() {
-                  if (request.aborted) {
-                     return;
-                  }
                   request.readyState = 1; // Sinon won't send response unless it thinks the response is clean and only just opened
-                  request.respond(this.responseCode, headers, body);
+                  request.respond(request.aborted ? 0 : this.responseCode, headers, body);
                }, i * delay);
 
             }));

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UploadMockXhr.js
@@ -79,6 +79,9 @@ define(["dojo/_base/declare",
 
                // After progress has finished, send the final response
                setTimeout(function() {
+                  if (request.aborted) {
+                     return;
+                  }
                   request.readyState = 1; // Sinon won't send response unless it thinks the response is clean and only just opened
                   request.respond(this.responseCode, headers, body);
                }, i * delay);
@@ -97,8 +100,11 @@ define(["dojo/_base/declare",
        * @param {number} percent The percentage progress to send
        * @param {number} delay The delay, in milliseconds, until the progress is sent
        */
-      sendProgress: function(request, percent, delay) {
+      sendProgress: function alfresco_testing_MockXhr__sendProgress(request, percent, delay) {
          setTimeout(function() {
+            if (request.aborted) {
+               return;
+            }
             request.uploadProgress({
                total: 100,
                loaded: percent


### PR DESCRIPTION
This addresses [AKU-796](https://issues.alfresco.com/jira/browse/AKU-796) which is about permitting contextual actions for uploads, based on their current upload-state. There is a default "cancel" action, which was used to ensure that process works, but also serves as a useful example implementation and a good feature to have. A unit test has been added for the cancellation and works on BrowserStack.