### PR TITLE
AKU-834: File upload form component does not work when re-selecting same file for upload

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/FileSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FileSelect.js
@@ -47,6 +47,17 @@ define(["alfresco/forms/controls/BaseFormControl",
       createFormControl: function alfresco_forms_controls_FileSelect__createFormControl(config, /*jshint unused:false*/ domNode) {
          return new FileInput(config);
       },
+
+      recreateControl: function alfresco_forms_controls_FileSelect__recreateControl() {
+         var config = {
+            id: this.wrappedWidget.id,
+            name: this.name
+         };
+         this.wrappedWidget.destroy();
+         this.wrappedWidget = this.createFormControl(config);
+         this.wrappedWidget.placeAt(this._controlNode);
+         this.setupChangeEvents();
+      },
       
       /**
        * Overrides the default change events to use blur events on the text box. This is done so that we can validate
@@ -66,9 +77,10 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        * @param {object} evt The onchange event
        */
-      onFilesSelected: function alfresco_forms_controls_FileSelect__FileSelect(evt) {
+      onFilesSelected: function alfresco_forms_controls_FileSelect__onFilesSelected(evt) {
          this.alfLog("log", "Files selected", evt, this);
          this.onValueChangeEvent(this.name, this.lastValue, this.wrappedWidget.getValue());
+         this.recreateControl(); // This is needed to fix AKU-834
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/FileSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FileSelect.js
@@ -48,6 +48,12 @@ define(["alfresco/forms/controls/BaseFormControl",
          return new FileInput(config);
       },
 
+      /**
+       * Recreate the control (part of fix for AKU-834)
+       *
+       * @instance
+       * @since 1.0.57
+       */
       recreateControl: function alfresco_forms_controls_FileSelect__recreateControl() {
          var config = {
             id: this.wrappedWidget.id,

--- a/aikau/src/main/resources/alfresco/html/FileInput.js
+++ b/aikau/src/main/resources/alfresco/html/FileInput.js
@@ -72,13 +72,6 @@ define(["dojo/_base/declare",
       label: "",
 
       /**
-       * @instance
-       */
-      postMixinProperties: function alfresco_html_FileInput__postMixinProperties() {
-         // No action
-      },
-
-      /**
        * This returns the files attribute of the input element
        *
        * @instance

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>FileSelect Test</shortname>
+  <description>This WebScript exercises the alfresco/forms/controls/FileSelect widget</description>
+  <family>aikau-unit-tests</family>
+  <url>/FileSelect</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.js
@@ -1,0 +1,49 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "STANDARD_FORM",
+         name: "alfresco/forms/Form",
+         config: {
+            okButtonPublishTopic: "PUBLISH_FORM_DATA",
+            cancelButtonPublishTopic: "CANCEL_FORM_DATA",
+            widgets: [
+               {
+                  name: "alfresco/forms/ControlRow",
+                  config: {
+                     widgets: [
+                        {
+                           id: "FILE_SELECT",
+                           name: "alfresco/forms/controls/FileSelect",
+                           config: {
+                              label: "File(s) selector",
+                              name: "files_field",
+                              value: "",
+                              requirementConfig: {
+                                 initialValue: true
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses issue [AKU-834](https://issues.alfresco.com/jira/browse/AKU-834) by taking the cross-browser approach that the (hidden) `input[type=file]` should be replaced after every change event (i.e. when the wrapped widget has its value updated) so that every file selected is a change from the default, empty state. No unit-test added (but happy to add one on suggestion of an appropriate one), but has been tested in SFS and it fixes the problem. Additionally the existing upload regression tests pass successfully in all 5 BS environments.