### PR TITLE
AKU-859: compactMode causes console error - Add condition

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -685,7 +685,9 @@ define(["dojo/_base/declare",
          domClass.add(this.pageBack.domNode, paginatorClass + "__page-back");
          domClass.add(this.pageForward.domNode, paginatorClass + "__page-forward");
          domClass.add(this.pageMarker.domNode, paginatorClass + "__page-marker");
-         domClass.add(this.resultsPerPageGroup.domNode, paginatorClass + "__results-per-page");
+         if (this.compactMode === false) {
+            domClass.add(this.resultsPerPageGroup.domNode, paginatorClass + "__results-per-page");
+         }
 
          // Check to see if any document data was provided before widget instantiation completed and
          // if so process it with the now available widgets...


### PR DESCRIPTION
This fixes [AKU-859](https://issues.alfresco.com/jira/browse/AKU-859) by adding a condition around the domNode that doesn't exist in compact mode. Full regression test run.