### PR TITLE
AKU-859: compactMode causes console error

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -685,7 +685,9 @@ define(["dojo/_base/declare",
          domClass.add(this.pageBack.domNode, paginatorClass + "__page-back");
          domClass.add(this.pageForward.domNode, paginatorClass + "__page-forward");
          domClass.add(this.pageMarker.domNode, paginatorClass + "__page-marker");
-         domClass.add(this.resultsPerPageGroup.domNode, paginatorClass + "__results-per-page");
+         if (this.compactMode === false) {
+            domClass.add(this.resultsPerPageGroup.domNode, paginatorClass + "__results-per-page");
+         }
 
          // Check to see if any document data was provided before widget instantiation completed and
          // if so process it with the now available widgets...

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -515,6 +515,86 @@ define(["intern!object",
       };
    });
 
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Pagination Tests (compact mode)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Paginator", "Pagination Tests (compact mode)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Correct items displayed": function() {
+            return browser.findAllByCssSelector("#COMPACT_MODE_LIST tr")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 25);
+               })
+            .end()
+
+            .findByCssSelector("#COMPACT_MODE_LIST tr:first-child")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "1");
+               })
+            .end()
+
+            .findByCssSelector("#COMPACT_MODE_LIST tr:last-child")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "25");
+               });
+         },
+
+         "Correct pagination controls displayed": function() {
+            return browser.findAllByCssSelector("#COMPACT_MODE_PAGE_SIZE_PAGINATOR .dijitMenuItem")
+               .then(function(elements){
+                  assert.lengthOf(elements, 3);
+               })
+            .end()
+
+            .findById("COMPACT_MODE_PAGE_SIZE_PAGINATOR_PAGE_BACK")
+            .end()
+
+            .findById("COMPACT_MODE_PAGE_SIZE_PAGINATOR_PAGE_MARKER")
+            .end()
+
+            .findById("COMPACT_MODE_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+         },
+
+         "Going to next page changes items": function() {
+            return browser.findById("COMPACT_MODE_PAGE_SIZE_PAGINATOR_PAGE_FORWARD")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("COMPACT_MODE_ALF_DOCLIST_REQUEST_FINISHED", true)
+
+            .findByCssSelector("#COMPACT_MODE_LIST tr:first-child")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "26");
+               })
+            .end()
+
+            .findByCssSelector("#COMPACT_MODE_LIST tr:last-child")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "50");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
    // See AKU-330...
    registerSuite(function(){
       var browser;

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/Paginator.get.js
@@ -353,6 +353,67 @@ model.jsonModel = {
                         }
                      ]
                   }
+               },
+               {
+                  id: "COMPACT_MODE_WINDOW",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Compact mode",
+                     pubSubScope: "COMPACT_MODE_",
+                     widgets: [
+                        {
+                           id: "COMPACT_MENU_BAR",
+                           name: "alfresco/menus/AlfMenuBar",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "COMPACT_MODE_PAGE_SIZE_PAGINATOR",
+                                    name: "alfresco/lists/Paginator",
+                                    config: {
+                                       compactMode: true
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "COMPACT_MODE_LIST",
+                           name: "alfresco/documentlibrary/AlfDocumentList",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/AlfListView",
+                                    config: {
+                                       itemKey: "index",
+                                       widgets: [
+                                          {
+                                             name: "alfresco/lists/views/layouts/Row",
+                                             config: {
+                                                widgets: [
+                                                   {
+                                                      name: "alfresco/lists/views/layouts/Cell",
+                                                      config: {
+                                                         widgets: [
+                                                            {
+                                                               name: "alfresco/renderers/Property",
+                                                               config: {
+                                                                  propertyToRender: "index"
+                                                               }
+                                                            }
+                                                         ]
+                                                      }
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
                }
             ]
          }


### PR DESCRIPTION
This fixes [AKU-859](https://issues.alfresco.com/jira/browse/AKU-859) by adding a condition around the domNode that doesn't exist in compact mode. New tests added (as per suggestion in #870) Full regression test run.