### PR TITLE
AKU-837: Provide test selectors JAR, update MultiSelectInput to use

### DIFF
--- a/aikau/package.json
+++ b/aikau/package.json
@@ -21,6 +21,7 @@
       "jshint-stylish": "2.1.0",
       "load-grunt-tasks": "3.4.0",
       "node-coverage": "1.0.7",
+      "properties-reader": "0.0.15",
       "tcp-port-used": "0.1.2",
       "time-grunt": "1.3.0"
    }

--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -213,13 +213,6 @@
                <exclude>testApp/WEB-INF/surf.xml</exclude>
             </excludes>
          </testResource>
-         <!-- <testResource>
-            <directory>src/test/resources/test-selectors</directory>
-            <filtering>false</filtering>
-            <includes>
-               <include>**/*.properties</include>
-            </includes>
-         </testResource> -->
       </testResources>
 
       <plugins>
@@ -282,16 +275,6 @@
                            <overWrite>true</overWrite>
                            <outputDirectory>${basedir}/target/classes/META-INF/js/lib</outputDirectory>
                         </artifactItem>
-                        <!-- <artifactItem>
-                           <groupId>org.alfresco</groupId>
-                           <artifactId>aikau-test-selectors</artifactId>
-                           <version>${project.version}</version>
-                           <type>jar</type>
-                           <overWrite>true</overWrite>
-                           <includes>**/*.properties</includes>
-                           <excludes>META-INF/**</excludes>
-                           <outputDirectory>${basedir}/src/test/resources/test-selectors</outputDirectory>
-                        </artifactItem> -->
                      </artifactItems>
                   </configuration>
                 </execution>

--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -213,6 +213,13 @@
                <exclude>testApp/WEB-INF/surf.xml</exclude>
             </excludes>
          </testResource>
+         <!-- <testResource>
+            <directory>src/test/resources/test-selectors</directory>
+            <filtering>false</filtering>
+            <includes>
+               <include>**/*.properties</include>
+            </includes>
+         </testResource> -->
       </testResources>
 
       <plugins>
@@ -275,9 +282,53 @@
                            <overWrite>true</overWrite>
                            <outputDirectory>${basedir}/target/classes/META-INF/js/lib</outputDirectory>
                         </artifactItem>
+                        <!-- <artifactItem>
+                           <groupId>org.alfresco</groupId>
+                           <artifactId>aikau-test-selectors</artifactId>
+                           <version>${project.version}</version>
+                           <type>jar</type>
+                           <overWrite>true</overWrite>
+                           <includes>**/*.properties</includes>
+                           <excludes>META-INF/**</excludes>
+                           <outputDirectory>${basedir}/src/test/resources/test-selectors</outputDirectory>
+                        </artifactItem> -->
                      </artifactItems>
                   </configuration>
                 </execution>
+            </executions>
+         </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+               <execution>
+                  <id>build-jar</id>
+                  <goals>
+                     <goal>jar</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+               <execution>
+                  <id>build-tests</id>
+                  <goals>
+                     <goal>test-jar</goal>
+                  </goals>
+                  <configuration>
+                     <testClassesDirectory>${project.build.testOutputDirectory}/test-selectors</testClassesDirectory>
+                     <includes>
+                        <include>**/*.properties</include>
+                     </includes>
+                  </configuration>
+               </execution>
             </executions>
          </plugin>
 

--- a/aikau/src/test/resources/alfresco/TestCommon.js
+++ b/aikau/src/test/resources/alfresco/TestCommon.js
@@ -27,6 +27,7 @@
 define(["intern/dojo/node!fs",
         "intern/dojo/node!http",
         "intern/dojo/node!os",
+        "intern/dojo/node!properties-reader",
         "intern/dojo/lang",
         "intern",
         "config/Config",
@@ -35,7 +36,7 @@ define(["intern/dojo/node!fs",
         "intern/chai!assert",
         "intern/dojo/node!leadfoot/keys",
         "lodash"], 
-        function(fs, http, os, lang, intern, Config, Promise, pollUntil, assert, keys, _) {
+        function(fs, http, os, propertiesReader, lang, intern, Config, Promise, pollUntil, assert, keys, _) {
 
    return {
 
@@ -125,6 +126,43 @@ define(["intern/dojo/node!fs",
                   dfd.reject(e);
                });
          }
+      },
+
+      /**
+       * This function returns the test selectors for a given widget. The wiget should be the passed
+       * as the full AMD module name, e.g. "alfresco/forms/controls/MultiInputSelect". The value
+       * returned can then be passed to the getTestSelector function to retrieve individual selectors
+       * for that widget.
+       * 
+       * @param  {string} widget The AMD module name for the widget to return selectors for.
+       * @return {object} The selectors object.
+       */
+      getTestSelectors: function(widget) {
+         var properties = propertiesReader("./src/test/resources/test-selectors/" + widget + ".properties");
+         return properties;
+      },
+
+      /**
+       * This function can be used to retrieve an individual test selector for a given key. It is possible to
+       * provide tokens to substitute into the selector as an array. Each entry in the token substitution array
+       * will try to be replaced against a substitution point in the selector matching the index, for example 
+       * in the selector "#{0} span:nth-child({1})" it would be expected to pass in an array of ["WIDGET_ID", "1"]
+       * in order to get the 1st span element in a widget with the id "WIDGET_ID".
+       * 
+       * @param  {object} selectors   The selectors object returned by calling getTestSelectors for a particular widget
+       * @param  {string} selectorKey The key that identifiers the particular selector to load
+       * @param  {string[]} tokens    An array of substitution tokens to apply to any selector string.
+       * @return {string}             The selector that can be used in a test.
+       */
+      getTestSelector: function(selectors, selectorKey, tokens) {
+         var selector = selectors.get(selectorKey);
+         if (tokens)
+         {
+            tokens.forEach(function(token, index) {
+               selector = selector.replace("{" + index + "}", token);
+            });
+         }
+         return selector;
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -20,13 +20,101 @@
 /**
  * @author Martin Doyle
  */
-define([
-      "intern!object",
-      "intern/chai!assert",
-      "alfresco/TestCommon",
-      "intern/dojo/node!leadfoot/keys"
-   ],
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"],
    function(registerSuite, assert, TestCommon, keys) {
+
+      // Get the selectors for the MultiInputSelect widget...
+      var MultiSelectInputSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/MultiInputSelect");
+      var FormSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+      var DialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+
+      // Build a map of the selectors to use...
+      var selectors = {
+         control1: {
+            loaded: TestCommon.getTestSelector(MultiSelectInputSelectors, "options.loaded.state", ["MULTISELECT_1"]),
+            choice: TestCommon.getTestSelector(MultiSelectInputSelectors, "choice", ["MULTISELECT_1"]),
+            firstChoice: {
+               element: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice", ["MULTISELECT_1", "1"]),
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.content", ["MULTISELECT_1", "1"]),
+               delete: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.delete", ["MULTISELECT_1", "1"])
+            },
+            secondChoice: {
+               element: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice", ["MULTISELECT_1", "2"]),
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.content", ["MULTISELECT_1", "2"]),
+               delete: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.delete", ["MULTISELECT_1", "2"])
+            },
+            thirdChoice: {
+               element: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice", ["MULTISELECT_1", "3"]),
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.content", ["MULTISELECT_1", "3"]),
+               delete: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.delete", ["MULTISELECT_1", "3"])
+            },
+            result: TestCommon.getTestSelector(MultiSelectInputSelectors, "result", ["MULTISELECT_1"]),
+            secondResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_1", "2"]),
+            fourthResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_1", "4"]),
+            fifthResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_1", "5"]),
+            seventhResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_1", "7"]),
+            searchbox: TestCommon.getTestSelector(MultiSelectInputSelectors, "searchbox", ["MULTISELECT_1"]),
+         },
+         control2: {
+            loaded: TestCommon.getTestSelector(MultiSelectInputSelectors, "options.loaded.state", ["MULTISELECT_2"]),
+            searchbox: TestCommon.getTestSelector(MultiSelectInputSelectors, "searchbox", ["MULTISELECT_2"]),
+            result: TestCommon.getTestSelector(MultiSelectInputSelectors, "result", ["MULTISELECT_2"]),
+            choice: {
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "choice.content", ["MULTISELECT_2"]),
+            },
+            selectedChoice: {
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "selected.choice.content", ["MULTISELECT_2"])
+            },
+            firstChoice: {
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.content", ["MULTISELECT_2", "1"])
+            },
+            secondChoice: {
+               element: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice", ["MULTISELECT_2", "2"]),
+            },
+            fourthResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_2", "4"]),
+            seventhResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_2", "7"])
+         },
+         control3: {
+            disabled: TestCommon.getTestSelector(MultiSelectInputSelectors, "disabled", ["MULTISELECT_3"])
+         },
+         control4: {
+            control: TestCommon.getTestSelector(MultiSelectInputSelectors, "control", ["MULTISELECT_4"]),
+            choice: {
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "choice.content", ["MULTISELECT_4"]),
+               element: TestCommon.getTestSelector(MultiSelectInputSelectors, "choice", ["MULTISELECT_4"]),
+               delete: TestCommon.getTestSelector(MultiSelectInputSelectors, "choice.delete", ["MULTISELECT_4"])
+            },
+            secondChoice: {
+               content: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.choice.content", ["MULTISELECT_4", "2"])
+            },
+            result: TestCommon.getTestSelector(MultiSelectInputSelectors, "result", ["MULTISELECT_4"]),
+            results: TestCommon.getTestSelector(MultiSelectInputSelectors, "results", ["MULTISELECT_4"])
+         },
+         controlInDialog: {
+            result: TestCommon.getTestSelector(MultiSelectInputSelectors, "result", ["MULTISELECT_IN_DIALOG_CONTROL_RESULTS"]),
+            fifthResult: TestCommon.getTestSelector(MultiSelectInputSelectors, "nth.result", ["MULTISELECT_IN_DIALOG", "5"]),
+         }
+      };
+
+      var formSelectors = {
+         form1: {
+            confirmationButton: TestCommon.getTestSelector(FormSelectors, "confirmation.button", ["FORM1"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(FormSelectors, "confirmation.button.disabled", ["FORM1"])
+         },
+         form3: {
+            confirmationButton: TestCommon.getTestSelector(FormSelectors, "confirmation.button", ["FORM3"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(FormSelectors, "confirmation.button.disabled", ["FORM3"])
+         }
+      };
+
+      var dialogSelectors = {
+         dialog1: {
+            confirmationButton: TestCommon.getTestSelector(DialogSelectors, "form.dialog.confirmation.button", ["DIALOG_WITH_MULTISELECT"])
+         }
+      };
 
       registerSuite(function() {
          var browser;
@@ -74,13 +162,14 @@ define([
             //    focused element: none
             //    
             "Controls are fully loaded": function() {
-               return browser.findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect--loaded")
+
+               return browser.findAllByCssSelector(selectors.control1.loaded)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1, "First MultiSelect control not fully loaded");
                   })
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect--loaded")
+               .findAllByCssSelector(selectors.control2.loaded)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1, "Second MultiSelect control not fully loaded");
                   });
@@ -102,20 +191,20 @@ define([
             //    focused element: none
             //    
             "Preset values are rendered by control": function() {
-               return browser.findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               return browser.findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 2, "Did not render two preset values for control");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.firstChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag1", "Did not display first tag label correctly");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.secondChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag11", "Did not display second tag label correctly");
@@ -138,11 +227,11 @@ define([
             //    *focused element: Control 2
             //    
             "Clicking on control no longer loses responses to a second query": function() {
-               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control2.searchbox)
                   .click()
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findAllByCssSelector(selectors.control2.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 14, "Did not bring up results");
                   });
@@ -167,9 +256,9 @@ define([
                return browser.findById("FOCUS_HELPER_BUTTON")
                   .click()
                   .pressKeys(keys.TAB)
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findAllByCssSelector(selectors.control1.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 7, "Did not bring up initial results");
                   });
@@ -191,12 +280,12 @@ define([
             //    focused element: Control 1
             //    
             "Selecting already-chosen item in dropdown does not choose item again": function() {
-               return browser.findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
+               return browser.findByCssSelector(selectors.control1.fourthResult)
                   .click()
                   .pressKeys(keys.ESCAPE)
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 2, "Added already-selected choice to control");
                   });
@@ -221,19 +310,19 @@ define([
                return browser.findById("FOCUS_HELPER_BUTTON")
                   .click()
                   .pressKeys(keys.TAB)
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+               .findByCssSelector(selectors.control1.fifthResult)
                   .click()
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 3, "Did not add new choice to control");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(3) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.thirdChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag2", "Did not add selected tag at end of choices");
@@ -256,12 +345,12 @@ define([
             //    focused element: Control 1
             //    
             "Typing into search box filters results": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control1.searchbox)
                   .type("tag2")
-                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-                  .end()
+                  .waitForDeletedByCssSelector(selectors.control1.fifthResult)
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findAllByCssSelector(selectors.control1.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1, "Did not filter results");
                   });
@@ -283,13 +372,13 @@ define([
             //    focused element: Control 1
             //    
             "Typing into search box filters results for strings in middle of name": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control1.searchbox)
                   .clearValue()
                   .type("12")
-                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(2)")
-                  .end()
+                  .waitForDeletedByCssSelector(selectors.control1.secondResult)
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findAllByCssSelector(selectors.control1.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1, "Did not filter results for string in middle of name" + elements);
                   });
@@ -311,19 +400,19 @@ define([
             //    focused element: Control 1
             //    
             "Search box correctly filters on special reg exp chars": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control1.searchbox)
                   .clearValue()
                   .type("(a")
-                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
-                  .end()
+                  .waitForDeletedByCssSelector(selectors.control1.fifthResult)
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findAllByCssSelector(selectors.control1.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1, "Did not filter results using special reg exp character");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+               .findByCssSelector(selectors.control1.searchbox)
                   .clearValue();
             },
 
@@ -343,12 +432,12 @@ define([
             //    focused element: Control 1
             //    
             "Clicking cross on a chosen item removes it": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2) .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button")
+               return browser.findByCssSelector(selectors.control1.secondChoice.delete)
                   .click()
-                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(3)")
-                  .end()
+                  .waitForDeletedByCssSelector(selectors.control1.thirdChoice.element)
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 2, "Did not remove choice");
                   });
@@ -370,7 +459,7 @@ define([
             //    *focused element: Form 1 submit
             //    
             "Submitting form submits correct values from control": function() {
-               return browser.findByCssSelector("#FORM1 .confirmationButton .dijitButtonNode")
+               return browser.findByCssSelector(formSelectors.form1.confirmationButton)
                   .click()
                   .end()
 
@@ -399,19 +488,19 @@ define([
             //    *focused element: Control 1
             //    
             "Keyboard can navigate and select items in dropdown": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control1.searchbox)
                   .type("new")
-                  .waitForDeletedByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+                  .waitForDeletedByCssSelector(selectors.control1.seventhResult)
                   .pressKeys([keys.ARROW_DOWN, keys.ARROW_DOWN, keys.ARROW_UP, keys.ENTER])
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 3, "Did not add new choice to control");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(3) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.thirdChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "newtag13(a)", "Did not add selected tag at end of choices");
@@ -434,16 +523,18 @@ define([
             //    *focused element: Focus helper
             //    
             "Selecting item with keyboard does not persist previous search": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control1.searchbox)
                   .pressKeys(keys.ARROW_DOWN)
-                  .end()
-                  .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
-                  .end()
-                  .findAllByCssSelector("#MULTISELECT_1_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .end()
+               
+               .findAllByCssSelector(selectors.control1.seventhResult)
+               .end()
+               
+               .findAllByCssSelector(selectors.control1.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 7, "Did not return full list of results after keyboard choice selection");
                   })
-                  .end()
+               .end()
 
                .findById("FOCUS_HELPER_BUTTON")
                   .click();
@@ -465,22 +556,22 @@ define([
             //    *focused element: Control 1
             //    
             "Deleting all items disables confirmation button": function() {
-               return browser.findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button")
+               return browser.findByCssSelector(selectors.control1.firstChoice.delete)
                   .click()
-                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(3)")
+                  .waitForDeletedByCssSelector(selectors.control1.thirdChoice.element)
                   .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button")
+               .findByCssSelector(selectors.control1.secondChoice.delete)
                   .click()
-                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2)")
+                  .waitForDeletedByCssSelector(selectors.control1.secondChoice.element)
                   .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button")
+               .findByCssSelector(selectors.control1.firstChoice.delete)
                   .click()
-                  .waitForDeletedByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1)")
+                  .waitForDeletedByCssSelector(selectors.control1.firstChoice.element)
                   .end()
 
-               .findAllByCssSelector("#FORM1 .confirmationButton.dijitDisabled")
+               .findAllByCssSelector(formSelectors.form1.disabledConfirmationButton)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1, "The confirmation button was not disabled when all the items were removed");
                   });
@@ -502,7 +593,7 @@ define([
             //    focused element: Control 1
             //    
             "Custom label format is used for choices": function() {
-               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               return browser.findByCssSelector(selectors.control2.firstChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "Those that belong to the emperor", "Did not display custom label format (type=choice) for choice");
@@ -529,12 +620,12 @@ define([
             //    *focused element: Control 2
             //    
             "Custom label format is used for results": function() {
-               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control2.searchbox)
                   .type("the")
-                  .waitForDeletedByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(7)")
+                  .waitForDeletedByCssSelector(selectors.control2.seventhResult)
                   .end()
 
-               .findByCssSelector("#MULTISELECT_2_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(4)")
+               .findByCssSelector(selectors.control2.fourthResult)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "CAT_01: Those that belong to the emperor", "Did not display custom label format (type=result) for result");
@@ -561,7 +652,7 @@ define([
             //    focused element: Control 2
             //    
             "Choices do not exceed max width": function() {
-               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               return browser.findByCssSelector(selectors.control2.firstChoice.content)
                   .getSize()
                   .then(function(size) {
                      assert(size.width < 151, "Choice was not restricted to under 150px as requested");
@@ -584,25 +675,25 @@ define([
             //    focused element: Control 2
             //    
             "Arrow key selects choice and backspace key deletes selected choice only": function() {
-               return browser.findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+               return browser.findByCssSelector(selectors.control2.searchbox)
                   .pressKeys(keys.ESCAPE)
                   .sleep(100)
                   .pressKeys(keys.ARROW_LEFT)
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-utilities-ChoiceMixin__choice--selected .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control2.selectedChoice.content)
                   .getVisibleText()
                   .then(function(visibleText) {
                      assert.equal(visibleText, "Innumerable ones", "Did not select correct choice");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-MultiSelect__search-box")
+               .findByCssSelector(selectors.control2.searchbox)
                   .pressKeys(keys.BACKSPACE)
-                  .waitForDeletedByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2)")
-                  .end()
+                  .waitForDeletedByCssSelector(selectors.control2.secondChoice.element)
+               .end()
 
-               .findByCssSelector("#MULTISELECT_2 .alfresco-forms-controls-utilities-ChoiceMixin__choice .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control2.choice.content)
                   .getVisibleText()
                   .then(function(visibleText) {
                      assert.equal(visibleText, "Those that belong to the emperor", "Did not delete correct choice");
@@ -628,9 +719,9 @@ define([
             "Opening MultiSelect in dialog still displays dropdown properly": function() {
                return browser.findByCssSelector("[widgetid=\"CREATE_FORM_DIALOG\"] .dijitButtonNode")
                   .click()
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+               .findByCssSelector(selectors.controlInDialog.fifthResult)
                   .isDisplayed()
                   .then(function(isDisplayed) {
                      assert.isTrue(isDisplayed, "Unable to see result in dropdown");
@@ -654,13 +745,13 @@ define([
             //    *
             //    
             "Dialog MultiSelect submits correct data": function() {
-               return browser.findByCssSelector("#MULTISELECT_IN_DIALOG_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child(5)")
+               return browser.findByCssSelector(selectors.controlInDialog.fifthResult)
                   .click()
-                  .end()
+               .end()
 
-               .findByCssSelector("#DIALOG_WITH_MULTISELECT .footer .confirmationButton .dijitButtonNode")
+               .findByCssSelector(dialogSelectors.dialog1.confirmationButton)
                   .click()
-                  .end()
+               .end()
 
                .getLastPublish("DIALOG_POST", "Could not find dialog submission")
                   .then(function(payload) {
@@ -685,7 +776,7 @@ define([
             //    focused element: Create dialog button
             //    
             "Third control is disabled": function() {
-               return browser.findByCssSelector("#FORM3 .alfresco-forms-controls-MultiSelect--disabled");
+               return browser.findByCssSelector(selectors.control3.disabled);
             },
 
             // STATE AFTER THIS TEST
@@ -706,22 +797,22 @@ define([
             "Setting a value replaces not appends": function() {
                return browser.findById("SET_TAGS_VALUE_BUTTON")
                   .click()
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 2, "Did not render two values for control");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.firstChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag1", "Did not display first tag label correctly");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.secondChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag11", "Did not display second tag label correctly");
@@ -730,22 +821,22 @@ define([
 
                .findById("SET_TAGS_VALUE_BUTTON")
                   .click()
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .findAllByCssSelector(selectors.control1.choice)
                   .then(function(elements) {
                      assert.lengthOf(elements, 2, "Does not still render two values for control");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(1) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.firstChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag1", "Did not display first tag label correctly");
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_1 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control1.secondChoice.content)
                   .getVisibleText()
                   .then(function(text) {
                      assert.equal(text, "tag11", "Did not display second tag label correctly");
@@ -774,13 +865,13 @@ define([
             },
 
             "Removing option from unfocused control does not induce dropdown": function() {
-               return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button")
+               return browser.findByCssSelector(selectors.control4.choice.delete)
                   .click()
-                  .end()
+               .end()
 
-               .waitForDeletedByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-utilities-ChoiceMixin__choice")
+               .waitForDeletedByCssSelector(selectors.control4.choice.content)
 
-               .findById("MULTISELECT_4_CONTROL_RESULTS")
+               .findByCssSelector(selectors.control4.results)
                   .isDisplayed()
                   .then(function(isDisplayed) {
                      assert.isFalse(isDisplayed);
@@ -788,15 +879,15 @@ define([
             },
 
             "Can click on control and choose an option": function() {
-               return browser.findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-MultiSelect")
+               return browser.findByCssSelector(selectors.control4.control)
                   .click()
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_4_CONTROL_RESULTS [title=\"Foam Strawberries\"]")
+               .findByCssSelector(selectors.control4.results + " [title=\"Foam Strawberries\"]")
                   .click()
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control4.choice.content)
                   .getVisibleText()
                   .then(function(visibleText) {
                      assert.equal(visibleText, "Foam Strawberries");
@@ -804,22 +895,22 @@ define([
             },
 
             "Can filter options and select second option": function() {
-               return browser.findById("MULTISELECT_4_CONTROL")
+               return browser.findByCssSelector(selectors.control4.control)
                   .click()
                   .pressKeys("mi")
-                  .end()
+               .end()
 
-               .findAllByCssSelector("#MULTISELECT_4_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findAllByCssSelector(selectors.control4.result)
                   .then(function(elements) {
                      assert.lengthOf(elements, 1);
                   })
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_4_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result")
+               .findByCssSelector(selectors.control4.result)
                   .click()
-                  .end()
+               .end()
 
-               .findByCssSelector("#MULTISELECT_4 .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child(2) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
+               .findByCssSelector(selectors.control4.secondChoice.content)
                   .getVisibleText()
                   .then(function(visibleText) {
                      assert.equal(visibleText, "White Chocolate Mice");

--- a/aikau/src/test/resources/intern.js
+++ b/aikau/src/test/resources/intern.js
@@ -93,6 +93,9 @@ define(["./config/Suites"],
                name: "lodash",
                location: "./src/test/resources/lib/lodash",
                main: "lodash.compat"
+            }, {
+               name: "properties",
+               location: "./node_modules/properties/lib"
             }]
          },
 

--- a/aikau/src/test/resources/intern_bamboo.js
+++ b/aikau/src/test/resources/intern_bamboo.js
@@ -88,6 +88,9 @@ define(["./config/Suites"],
                name: "lodash",
                location: "./src/test/resources/lib/lodash",
                main: "lodash.compat"
+            }, {
+               name: "properties",
+               location: "./node_modules/properties/lib"
             }]
          },
 

--- a/aikau/src/test/resources/intern_bs.js
+++ b/aikau/src/test/resources/intern_bs.js
@@ -98,6 +98,9 @@ define(["./config/Suites"],
                name: "lodash",
                location: "./src/test/resources/lib/lodash",
                main: "lodash.compat"
+            }, {
+               name: "properties",
+               location: "./node_modules/properties/lib"
             }]
          },
 

--- a/aikau/src/test/resources/intern_grid.js
+++ b/aikau/src/test/resources/intern_grid.js
@@ -67,6 +67,9 @@ define(["./config/Suites"],
                name: "lodash",
                location: "./src/test/resources/lib/lodash",
                main: "lodash.compat"
+            }, {
+               name: "properties",
+               location: "./node_modules/properties/lib"
             }]
          },
 

--- a/aikau/src/test/resources/intern_local.js
+++ b/aikau/src/test/resources/intern_local.js
@@ -92,6 +92,9 @@ define(["./config/Suites"],
                name: "lodash",
                location: "./src/test/resources/lib/lodash",
                main: "lodash.compat"
+            }, {
+               name: "properties",
+               location: "./node_modules/properties/lib"
             }]
          },
 

--- a/aikau/src/test/resources/intern_sl.js
+++ b/aikau/src/test/resources/intern_sl.js
@@ -9,7 +9,7 @@ define(["./config/Suites"],
       proxyPort: 9000,
 
       // A fully qualified URL to the Intern proxy
-      proxyUrl: 'http://localhost:9000/',
+      proxyUrl: "http://localhost:9000/",
 
       // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
       // specified browser environments in the `environments` array below as well. See
@@ -18,43 +18,43 @@ define(["./config/Suites"],
       // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
       // automatically
       capabilities: {
-         'selenium-version': '2.43.0'
+         "selenium-version": "2.43.0"
       },
 
       // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
       // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
       // capabilities options specified for an environment will be copied as-is
       environments: [
-         //{ browserName: 'internet explorer', version: '11', platform: 'Windows 8.1' },
-         //{ browserName: 'internet explorer', version: '10', platform: 'Windows 8' },
-         //{ browserName: 'internet explorer', version: '9', platform: 'Windows 7', 'Windows XP' },
-         //{ browserName: 'internet explorer', version: '8', platform: 'Windows 7', 'Windows XP' },
-         //{ browserName: 'firefox', version: '28', platform: [ 'OS X 10.9', 'Windows 7', 'Linux' ] },
-         { browserName: 'chrome', version: '34', platform: [/* 'OS X 10.9', */'Windows 7'/*, 'Linux'*/ ] }
-         //{ browserName: 'safari', version: '6', platform: 'OS X 10.8' },
-         //{ browserName: 'safari', version: '7', platform: 'OS X 10.9' }
+         //{ browserName: "internet explorer", version: "11", platform: "Windows 8.1" },
+         //{ browserName: "internet explorer", version: "10", platform: "Windows 8" },
+         //{ browserName: "internet explorer", version: "9", platform: "Windows 7", "Windows XP" },
+         //{ browserName: "internet explorer", version: "8", platform: "Windows 7", "Windows XP" },
+         //{ browserName: "firefox", version: "28", platform: [ "OS X 10.9", "Windows 7", "Linux" ] },
+         { browserName: "chrome", version: "34", platform: [/* "OS X 10.9", */"Windows 7"/*, "Linux"*/ ] }
+         //{ browserName: "safari", version: "6", platform: "OS X 10.8" },
+         //{ browserName: "safari", version: "7", platform: "OS X 10.9" }
       ],
 
       // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
       maxConcurrency: 1,
 
       // Name of the tunnel class to use for WebDriver tests
-      tunnel: 'SauceLabsTunnel',
+      tunnel: "SauceLabsTunnel",
 
       // Connection information for the remote WebDriver service.
       tunnelOptions: {
-         hostname: 'localhost',
+         hostname: "localhost",
          port: 4444,
          directDomains: [
-            'www.alfresco.com'
+            "www.alfresco.com"
          ]
       },
 
       // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
       // loader
       useLoader: {
-         'host-node': 'dojo/dojo',
-         'host-browser': 'node_modules/dojo/dojo.js'
+         "host-node": "dojo/dojo",
+         "host-browser": "node_modules/dojo/dojo.js"
       },
 
       // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
@@ -62,11 +62,26 @@ define(["./config/Suites"],
       loaderOptions: {
          // Packages that should be registered with the loader in each testing environment
 	      // Note: the config package is specifically for sauce labs (sl)
-	      packages: [
-            { name: 'alfresco', location: './src/test/resources/alfresco' },
-            { name: 'config', location: './src/test/resources/config/sl' },
-            { name: "lodash", location: "./src/test/resources/lib/lodash", main: "lodash.compat" }
-         ]
+	      packages: [{
+            name: "alfresco",
+            location: "./src/test/resources/alfresco"
+         }, {
+            name: "config",
+            location: "./src/test/resources/config/loc"
+         }, {
+            name: "reporters",
+            location: "./src/test/resources/reporters"
+         }, {
+            name: "dojo",
+            location: "./node_modules/intern/node_modules/dojo"
+         }, {
+            name: "lodash",
+            location: "./src/test/resources/lib/lodash",
+            main: "lodash.compat"
+         }, {
+            name: "properties",
+            location: "./node_modules/properties/lib"
+         }]
       },
 
       // Non-functional test suite(s) to run in each browser
@@ -80,8 +95,8 @@ define(["./config/Suites"],
    
       // An array of code coverage reporters to invoke
       reporters: [
-         'Console',
-         'Runner'
+         "Console",
+         "Runner"
       ]
 
    };

--- a/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
@@ -1,0 +1,2 @@
+# Use to find the confirmation button on a form dialog
+form.dialog.confirmation.button=#{0} .footer .confirmationButton .dijitButtonNode

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/Form.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/Form.properties
@@ -1,0 +1,5 @@
+# Use to find the confirmation button of the form
+confirmation.button=#{0} .confirmationButton .dijitButtonNode
+
+# Use to find the disabled confirmation button in the form
+confirmation.button.disabled=#{0} .confirmationButton.dijitDisabled

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/MultiInputSelect.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/MultiInputSelect.properties
@@ -1,0 +1,41 @@
+# All rendered choices
+choice=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice
+
+# All choice content elements
+choice.content=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice .alfresco-forms-controls-utilities-ChoiceMixin__choice__content
+
+# A non-specific delete button on a choice
+choice.delete=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button
+
+# The wrapped control within the widget
+control=#{0}_CONTROL
+
+# A disabled control
+disabled=#{0} .alfresco-forms-controls-MultiSelect--disabled
+
+# Will exist when choices have been loaded
+options.loaded.state=#{0} .alfresco-forms-controls-MultiSelect--loaded
+
+# A specific choice
+nth.choice=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child({1})
+
+# The content of a specific choice 
+nth.choice.content=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child({1}) .alfresco-forms-controls-utilities-ChoiceMixin__choice__content
+
+# The delete button on a specific choice
+nth.choice.delete=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child({1}) .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button
+
+# A specific choice in the drop-down
+nth.result=#{0}_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child({1})
+
+# All results rendered in the drop-down
+result=#{0}_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result
+
+# The results-dropdown
+results=#{0}_CONTROL_RESULTS
+
+# The search box (for entering text)
+searchbox=#{0} .alfresco-forms-controls-MultiSelect__search-box
+
+# The content of the selected choice
+selected.choice.content=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice--selected .alfresco-forms-controls-utilities-ChoiceMixin__choice__content

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
       <module>aikau-archetype</module>
       <module>aikau-additional-languages</module>
       <module>aikau-sandpit-application</module>
+      <module>aikau-test-selectors</module>
    </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,6 @@
       <module>aikau-archetype</module>
       <module>aikau-additional-languages</module>
       <module>aikau-sandpit-application</module>
-      <module>aikau-test-selectors</module>
    </modules>
 
 </project>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-837 (and is a follow-up to #866) to provide a way in which the CSS selectors used for unit testing can be externalised (they will now be built and provided as a separate test JAR). The MultiSelectInput widget tests have been used to test this as a proof-of-concept.