### PR TITLE
AKU-853: Upload Dialog Enhancements

### DIFF
--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -101,7 +101,6 @@ define(["dojo/_base/declare",
             id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
             name: "alfresco/buttons/AlfButton",
             assignTo: "dialogButton",
-            assignToScope: this,
             config: {
                label: "progress-dialog.cancel-button.label",
                publishTopic: topics.UPLOAD_CANCELLATION,
@@ -153,6 +152,13 @@ define(["dojo/_base/declare",
          if (this.progressDialogTitleKey) {
             this.alfLog("warn", "'progressDialogTitleKey' in UploadService has been deprecated - use 'uploadsContainerTitle' instead");
             this.uploadsContainerTitle = this.progressDialogTitleKey;
+         }
+         if (this.widgetsButtons && this.widgetsButtons.length) {
+            array.forEach(this.widgetsButtons, function(dialogButton) {
+               if(dialogButton.assignTo) {
+                  dialogButton.assignToScope = this;
+               }
+            }, this);
          }
          this.inherited(arguments);
       },

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -88,6 +88,29 @@ define(["dojo/_base/declare",
       uploadsContainerTitleUpdateTopic: topics.DIALOG_CHANGE_TITLE,
 
       /**
+       * The buttons to use in the dialog. Note that if this is overridden then be cautious of re-using
+       * the "assignTo/assignToScope" properties, and to only use them if you fully understand their
+       * purpose.
+       *
+       * @instance
+       * @type {object[]}
+       * @since 1.0.57
+       */
+      widgetsButtons: [
+         {
+            id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
+            name: "alfresco/buttons/AlfButton",
+            assignTo: "dialogButton",
+            assignToScope: this,
+            config: {
+               label: "progress-dialog.cancel-button.label",
+               publishTopic: topics.UPLOAD_CANCELLATION,
+               additionalCssClasses: "call-to-action"
+            }
+         }
+      ],
+
+      /**
        * This defines the JSON structure for the widgets to be displayed in the progress dialog. This
        * can be overridden by extending widgets to render a different display in the dialog
        *
@@ -180,10 +203,12 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload containing the original upload request
        * @since 1.0.52
        */
-      onUploadsBatchComplete: function alfresco_services__BaseUploadService__onUploadsBatchComplete(/*jshint unused:false*/ payload) {
+      onUploadsBatchComplete: function alfresco_services__BaseUploadService__onUploadsBatchComplete( /*jshint unused:false*/ payload) {
          this.inherited(arguments);
-         this.dialogButton.setLabel(this.message("progress-dialog.ok-button.label"));
-         this.dialogButton.publishTopic = topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT;
+         if (this.dialogButton) {
+            this.dialogButton.setLabel(this.message("progress-dialog.ok-button.label"));
+            this.dialogButton.publishTopic = topics.UPLOAD_COMPLETION_ACKNOWLEDGEMENT;
+         }
       },
 
       /**
@@ -222,17 +247,7 @@ define(["dojo/_base/declare",
                publishTopic: dialogDisplayedTopic
             }],
             widgetsContent: this.widgetsForUploadDisplay,
-            widgetsButtons: [{
-               id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
-               name: "alfresco/buttons/AlfButton",
-               assignTo: "dialogButton",
-               assignToScope: this,
-               config: {
-                  label: this.message("progress-dialog.cancel-button.label"),
-                  publishTopic: topics.UPLOAD_CANCELLATION,
-                  additionalCssClasses: "call-to-action"
-               }
-            }]
+            widgetsButtons: this.widgetsButtons
          });
          return dfd.promise;
       }

--- a/aikau/src/test/resources/alfresco/upload/UploadTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadTest.js
@@ -87,7 +87,7 @@ define(["intern!object",
          beforeEach: function() {
             browser.end();
          },
-         
+
          "Test bad file data": function () {
             // Simulate providing a zero byte file and check the output...
             return browser.findById("BAD_FILE_DATA_label")
@@ -217,6 +217,13 @@ define(["intern!object",
                })
             .end()
             
+            .findByCssSelector("[widgetid=\"ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION\"] .dijitButtonNode")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "OK", "Button label didn't change after uploads complete");
+               })
+            .end()
+
             .findById("ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
                .click()
             .end()
@@ -225,6 +232,35 @@ define(["intern!object",
 
             // Check that alfResponseTopic is published on completion
             .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED");
+         },
+
+         // NOTE: Upload does NOT work here because of scoping, however scoping is only used
+         // to have multiple upload services on one page, something which is not expected
+         // to happen in the wild. If it does, then we will address that problem when it occurs.
+         "Dialog button-label and title can be customised": function() {
+            return browser.findByCssSelector("[widgetid=\"SINGLE_UPLOAD_CUSTOM_BUTTON\"] .dijitButtonNode")
+               .click()
+            .end()
+
+            .findByCssSelector("#ALF_UPLOAD_PROGRESS_DIALOG_title")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "Custom Title", "Dialog title not updated");
+               })
+            .end()
+
+            .findByCssSelector(".dialogDisplayed #ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION_label")
+               .getVisibleText()
+               .then(function(visibleText){
+                  assert.equal(visibleText, "Custom Label", "Button label not updated");
+               })
+            .end()
+
+            .findByCssSelector("[widgetid=\"ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION\"] .dijitButtonNode")
+               .click()
+            .end()
+
+            .waitForDeletedByCssSelector(".dialogDisplayed");   
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/Upload.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/Upload.get.js
@@ -18,7 +18,25 @@ model.jsonModel = {
          }
       },
       "alfresco/services/DialogService",
-      "alfresco/services/UploadService"
+      "alfresco/services/UploadService",
+      {
+         name: "alfresco/services/UploadService",
+         config: {
+            pubSubScope: "CUSTOM_BUTTON_",
+            uploadsContainerTitle: "Custom Title",
+            widgetsButtons: [
+               {
+                  id: "ALF_UPLOAD_PROGRESS_DIALOG_CANCELLATION",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Custom Label",
+                     publishTopic: "ALF_UPLOAD_DIALOG_CANCEL_CLICK",
+                     additionalCssClasses: "call-to-action"
+                  }
+               }
+            ]
+         }
+      }
    ],
    widgets: [
       {
@@ -65,6 +83,26 @@ model.jsonModel = {
          name: "alfresco/buttons/AlfButton",
          config: {
             label: "Single File Upload",
+            publishTopic: "ALF_UPLOAD_REQUEST",
+            publishPayload: {
+               files: [
+                  {
+                     size: 100,
+                     name: "100 Bytes File"
+                  }
+               ],
+               targetData: {
+                  destination: "some://fake/node"
+               }
+            }
+         }
+      },
+      {
+         id: "SINGLE_UPLOAD_CUSTOM_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Single File Upload (Custom Button Label)",
+            pubSubScope: "CUSTOM_BUTTON_",
             publishTopic: "ALF_UPLOAD_REQUEST",
             publishPayload: {
                files: [


### PR DESCRIPTION
This PR addresses issue [AKU-853](https://issues.alfresco.com/jira/browse/AKU-853), by permitting the customisation of the dialog buttons by overriding the `widgetsButtons` property in the `UploadService`. Regression tests have been added and full suite run.