### PR TITLE
Normalise the filename timestamp

### DIFF
--- a/aikau/src/test/resources/intern_bamboo.js
+++ b/aikau/src/test/resources/intern_bamboo.js
@@ -23,7 +23,7 @@ define(["./config/Suites"],
       });
 
       // Define "constants"
-      var isoTimestamp = (new Date()).toISOString(),
+      var isoTimestamp = (new Date()).toISOString().replace(/\D/g, ""),
          settings = {
             project: "Aikau",
             name: "[AKU] BrowserStack Tests @ " + isoTimestamp,


### PR DESCRIPTION
Normalise the timestamp used when naming the JUnit test result file so that it has only digits in it (prevent filesystem problems).