### PR TITLE
AKU-851: Update "widgetsForUploadDisplay" config handling in upload services

### DIFF
--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -101,10 +101,11 @@ define(["alfresco/core/topics",
        */
       showUploadsWidget: function alfresco_services_FileUploadService__showUploadsWidget() {
          var dfd = new Deferred();
+         var widgetsForUploadDisplay = this.processWidgetsForUploadDisplay();
          this.alfServicePublish(topics.DISPLAY_STICKY_PANEL, {
             title: this.message(this.uploadsContainerTitle, 0),
             padding: 0,
-            widgets: this.widgetsForUploadDisplay,
+            widgets: widgetsForUploadDisplay,
             callback: lang.hitch(this, function(panel) {
                this.uploadsContainer = panel;
                dfd.resolve();

--- a/aikau/src/main/resources/alfresco/services/UploadService.js
+++ b/aikau/src/main/resources/alfresco/services/UploadService.js
@@ -241,18 +241,20 @@ define(["dojo/_base/declare",
        */
       showUploadsWidget: function alfresco_services_UploadService__showUploadsWidget() {
          var dfd = new Deferred(),
-            dialogDisplayedTopic = "PROGRESS_DIALOG_DISPLAYED",
-            displayedSubHandle = this.alfSubscribe(dialogDisplayedTopic, lang.hitch(this, function() {
+             dialogDisplayedTopic = "PROGRESS_DIALOG_DISPLAYED",
+             displayedSubHandle = this.alfSubscribe(dialogDisplayedTopic, lang.hitch(this, function() {
                this.alfUnsubscribe(displayedSubHandle);
                dfd.resolve();
-            }));
+             }));
+
+         var widgetsForUploadDisplay = this.processWidgetsForUploadDisplay();
          this.alfServicePublish(topics.CREATE_DIALOG, {
             dialogId: "ALF_UPLOAD_PROGRESS_DIALOG",
             dialogTitle: this.createProgressDialogTitle(),
             publishOnShow: [{
                publishTopic: dialogDisplayedTopic
             }],
-            widgetsContent: this.widgetsForUploadDisplay,
+            widgetsContent: widgetsForUploadDisplay,
             widgetsButtons: this.widgetsButtons
          });
          return dfd.promise;

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -258,16 +258,6 @@ define(["alfresco/core/CoreXhr",
        */
       initService: function alfresco_services__BaseUploadService__initService() {
          this.inherited(arguments);
-         this.widgetsForUploadDisplay = lang.clone(this.widgetsForUploadDisplay);
-         var widgets = this.widgetsForUploadDisplay;
-         if (widgets && widgets.constructor === Array && widgets.length === 1) {
-            lang.mixin(widgets[0], {
-               assignTo: "uploadDisplayWidget",
-               assignToScope: this
-            });
-         } else {
-            this.alfLog("error", "Must define a widget for displaying upload progress in property 'widgetsForUploadDisplay'");
-         }
          this.reset();
       },
 
@@ -523,6 +513,30 @@ define(["alfresco/core/CoreXhr",
             this.uploadDisplayWidget.handleFailedUpload(fileId, evt, fileInfo.request);
             this.onUploadFinished(fileId);
          }
+      },
+
+      /**
+       * This function can be called when creating the upload display. It ensures that the root widget is correctly
+       * configured to be assigned to the [widgetsForUploadDisplay]{@link module:alfresco/services/_BaseUploadService#widgetsForUploadDisplay}
+       * reference. Care should be taken When overriding the 
+       * [showUploadsWidget]{@link module:alfresco/services/_BaseUploadService#showUploadsWidget} to ensure that any model
+       * is correctly setup by calling this function.
+       * 
+       * @return {object[]} The object model for rendering the upload display
+       * @instance 1.0.57
+       */
+      processWidgetsForUploadDisplay: function alfresco_services__BaseUploadService__processWidgetsForUploadDisplay() {
+         var widgets = lang.clone(this.widgetsForUploadDisplay);
+         if (widgets && widgets.constructor === Array && widgets.length === 1) {
+            lang.mixin(widgets[0], {
+               assignTo: "uploadDisplayWidget",
+               assignToScope: this
+            });
+         } 
+         else {
+            this.alfLog("error", "Must define a widget for displaying upload progress in property 'widgetsForUploadDisplay'");
+         }
+         return widgets;
       },
 
       /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/Upload.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/Upload.get.js
@@ -18,7 +18,14 @@ model.jsonModel = {
          }
       },
       "alfresco/services/DialogService",
-      "alfresco/services/UploadService",
+      {
+         name: "alfresco/services/UploadService",
+         config: {
+            widgetsForUploadDisplay: [{
+               name: "alfresco/upload/AlfUploadDisplay"
+           }]
+         }
+      },
       {
          name: "alfresco/services/UploadService",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-851 to ensure that it is possible to configure the widgetsForUploadDisplay in the upload services. The UploadService unit test page has been updated to verify that configuration can be overridden.