### PR TITLE
AKU-837: Correct the name of the MultiSelectInput selectors properties file

### DIFF
--- a/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MultiSelectInputTest.js
@@ -27,7 +27,7 @@ define(["intern!object",
    function(registerSuite, assert, TestCommon, keys) {
 
       // Get the selectors for the MultiInputSelect widget...
-      var MultiSelectInputSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/MultiInputSelect");
+      var MultiSelectInputSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/MultiSelectInput");
       var FormSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
       var DialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
 

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/MultiSelectInput.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/MultiSelectInput.properties
@@ -25,7 +25,7 @@ nth.choice.content=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice:n
 # The delete button on a specific choice
 nth.choice.delete=#{0} .alfresco-forms-controls-utilities-ChoiceMixin__choice:nth-child({1}) .alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button
 
-# A specific choice in the drop-down
+# A specific result in the drop-down
 nth.result=#{0}_CONTROL_RESULTS .alfresco-forms-controls-MultiSelect__results__result:nth-child({1})
 
 # All results rendered in the drop-down


### PR DESCRIPTION
This is an update to #876 for https://issues.alfresco.com/jira/browse/AKU-837 to set the correct name for the MultiSelectInput widget properties file