### PR TITLE
AKU-834: Update to provide opt-in configuration

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/FileSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FileSelect.js
@@ -31,6 +31,18 @@ define(["alfresco/forms/controls/BaseFormControl",
    return declare([BaseFormControl], {
       
       /**
+       * Configuring this attribute to be true will result in the wrapped [FileInput]{@link module:alfresco/html/FileInput}
+       * widget being recreated each time that file or files are selected. This option was added to support a specific
+       * use case, see https://issues.alfresco.com/jira/browse/AKU-834 for details.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.57
+       */
+      recreateControlOnSelect: false,
+
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_FileSelect__getWidgetConfig() {
@@ -86,7 +98,10 @@ define(["alfresco/forms/controls/BaseFormControl",
       onFilesSelected: function alfresco_forms_controls_FileSelect__onFilesSelected(evt) {
          this.alfLog("log", "Files selected", evt, this);
          this.onValueChangeEvent(this.name, this.lastValue, this.wrappedWidget.getValue());
-         this.recreateControl(); // This is needed to fix AKU-834
+         if (this.recreateControlOnSelect)
+         {
+            this.recreateControl(); // This is needed to fix AKU-834
+         }
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FileSelect.get.js
@@ -35,6 +35,19 @@ model.jsonModel = {
                                  initialValue: true
                               }
                            }
+                        },
+                        {
+                           id: "FILE_SELECT",
+                           name: "alfresco/forms/controls/FileSelect",
+                           config: {
+                              label: "File(s) selector (clear on select)",
+                              name: "files_field",
+                              value: "",
+                              recreateControlOnSelect: true,
+                              requirementConfig: {
+                                 initialValue: true
+                              }
+                           }
                         }
                      ]
                   }


### PR DESCRIPTION
This PR updates the previous PR #865 to address https://issues.alfresco.com/jira/browse/AKU-834 as the previous update meant that the selected files were not displayed in the form control. This would be a regression in previous behaviour so we now create an opt-in configuration to enable the behaviour rather than it being the default