### PR TITLE
AKU-852: Update UploadMonitor to show accessible error icons

### DIFF
--- a/aikau/src/main/resources/alfresco/html/svg/error.svg
+++ b/aikau/src/main/resources/alfresco/html/svg/error.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+   <symbol id="error" viewBox="0 0 21 19"><path d="M18.47,16.37H2.53l8-13.68h0Z" fill="#d13332" stroke="#d13333" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/><circle cx="10.5" cy="16.37" r="1.5" fill="#fff"/><rect x="9.5" y="4.23" width="2" height="9.14" fill="#fff"/></symbol>
+</svg>

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -29,19 +29,12 @@
             padding-right: @upload-monitor-item-padding-right;
          }
       }
-      &__name__error {
-         color: @upload-monitor-error-message-color;
-         display: none;
-         line-height: @upload-monitor-error-message-line-height;
-         position: relative;
-         top: @upload-monitor-error-message-top;
-      }
       &__progress {
          width: @upload-monitor-progress-column-width;
       }
       &__status {
          width: @upload-monitor-status-column-width;
-         &__inprogress, &__successful, &__unsuccessful {
+         &__inprogress, &__successful, &__unsuccessful, &__unsuccessful_icon {
             display: none;
          }
          &__inprogress {
@@ -62,13 +55,6 @@
       }
       &__action {
          display: none;
-      }
-      &--has-error {
-         .alfresco-upload-UploadMonitor {
-            &__item__name__error {
-               display: block;
-            }
-         }
       }
    }
    &__inprogress-items {
@@ -108,6 +94,11 @@
             }
             &__action__unsuccessful {
                display: inline-block;
+            }
+            &__status__unsuccessful_icon {
+               display: inline-block;
+               margin-left: 10px;
+               vertical-align: middle;
             }
          }
       }

--- a/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
+++ b/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
@@ -2,4 +2,7 @@ upload.status.inprogress=In progress
 upload.status.successful=Successful
 upload.status.unsuccessful=Unsuccessful
 upload.failure.unknown-reason=Failed for unknown reason
-upload.cancelled=Upload cancelled
+upload.cancelled=The upload was cancelled
+
+upload.failure.icon.title=The file ''{0}'' could not be uploaded for the following reason. {1}
+upload.failure.icon.description=A picture of a warning triangle.

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -48,13 +48,14 @@ define(["intern!object",
 
             .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
 
-            .findByCssSelector(".alfresco-upload-UploadMonitor__item__name__error")
-               .getVisibleText()
-               .then(function(visibleText) {
-                  assert.equal(visibleText, "0kb files can't be uploaded");
-               })
+               .findByCssSelector(".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title")
+                  .getProperty("innerHTML")
+                  .then(function(text) {
+                     assert.equal(text, "The file ''This file is empty.txt'' could not be uploaded for the following reason. 0kb files can't be uploaded");
+                  })
                .end()
-               .end() // Escape previous extra nesting
+
+            .end() // Escape previous extra nesting
 
             .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
                .click();
@@ -130,10 +131,10 @@ define(["intern!object",
                .click()
             .end()
 
-            .findByCssSelector(".alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item__name__error")
-               .getVisibleText()
-               .then(function(visibleText) {
-                  assert.equal(visibleText, "Upload cancelled");
+            .findByCssSelector(".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title")
+               .getProperty("innerHTML")
+               .then(function(text) {
+                  assert.equal(text, "The file ''Tiny dataset.csv'' could not be uploaded for the following reason. The upload was cancelled");
                });
          },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-852 to change the UploadMonitor so that error messages are replaced with an error icon.