### PR TITLE
AKU-865: Unable to interact with elements in the same row as a notification while it is visible.

### DIFF
--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -1,11 +1,10 @@
 /* Centering technique from http://www.smashingmagazine.com/2013/08/09/absolute-horizontal-vertical-centering-css */
 .alfresco-notifications-AlfNotification {
+   height: 0;
    left: 0;
-   opacity: 0;
    position: fixed;
    right: 0;
-   top: 22.5%;
-   transition: all .2s ease-out;
+   top: 0;
    z-index: 9999; /* This isn't ideal, but searching all z-indexes is even worse (better solution possible?) */
    &__container {
       background: @notification-background;
@@ -13,8 +12,11 @@
       box-shadow: @standard-box-shadow;
       box-sizing: border-box;
       margin: 0 auto;
+      opacity: 0;
       padding: 20px 30px 20px 20px;
       position: relative;
+      top: 22.5vh;
+      transition: all .2s ease-out;
       width: @notification-width;
    }
    &__close {
@@ -36,7 +38,11 @@
       line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
    }
    &--visible {
-      opacity: 1;
-      top: 20%;
+      .alfresco-notifications-AlfNotification {
+         &__container {
+            opacity: 1;
+            top: 20vh;
+         }
+      }
    }
 }

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -172,7 +172,41 @@ registerSuite(function(){
             .getVisibleText()
             .then(function(visibleText) {
                assert.equal(visibleText, "<img src=\"1\" onerror=\"window.hackedPanel=true\">");
-            });
+            })
+            .end()
+
+         .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("ALF_STICKY_PANEL_CLOSED");
+      },
+
+      "Notification does not prevent clicking to sides": function(){
+         return browser.findByCssSelector("[widgetid=\"NOTIFICATION_BUTTON_LARGE\"] .dijitButtonNode")
+            .click()
+            .clearLog()
+         .end()
+
+         .findByCssSelector("[widgetid=\"LEFT_BUTTON\"] .dijitButtonNode")
+            .click()
+         .end()
+
+         .getLastPublish("LEFT_BUTTON_PUSHED")
+
+         .findByCssSelector("[widgetid=\"RIGHT_BUTTON\"] .dijitButtonNode")
+            .click()
+         .end()
+
+         .getLastPublish("RIGHT_BUTTON_PUSHED")
+
+         .findByCssSelector(".alfresco-notifications-AlfNotification__close")
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("ALF_NOTIFICATION_CLOSED");
       },
       
       "Post Coverage Results": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -35,10 +35,13 @@ define({
       "src/test/resources/alfresco/upload/UploadMonitorTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
-      // "src/test/resources/alfresco/dnd/NestedConfigurationTest",
-      // "src/test/resources/alfresco/layout/AlfTabContainerTest",
-      // "src/test/resources/alfresco/preview/PdfJsPreviewTest",
-      // "src/test/resources/alfresco/services/actions/DownloadAsZipTest",
+      // "src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest",
+      // "src/test/resources/alfresco/documentlibrary/views/FilmStripViewTest",
+      // "src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest",
+      // "src/test/resources/alfresco/forms/controls/ContainerPickerTest",
+      // "src/test/resources/alfresco/forms/controls/SitePickerTest",
+      // "src/test/resources/alfresco/renderers/CommentsListTest",
+      // "src/test/resources/alfresco/services/DialogServiceTest"
    ],
 
    /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -16,6 +16,37 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "20vh"
+         }
+      },
+      {
+         name: "alfresco/layout/LeftAndRight",
+         config: {
+            widgetsLeft: [
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  id: "LEFT_BUTTON",
+                  config: {
+                     label: "Left button",
+                     publishTopic: "LEFT_BUTTON_PUSHED"
+                  }
+               }
+            ],
+            widgetsRight: [
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  id: "RIGHT_BUTTON",
+                  config: {
+                     label: "Right button",
+                     publishTopic: "RIGHT_BUTTON_PUSHED"
+                  }
+               }
+            ]
+         }
+      },
+      {
          name: "alfresco/buttons/AlfButton",
          id: "NOTIFICATION_BUTTON_SMALL",
          config: {


### PR DESCRIPTION
This addresses PR [AKU-865](https://issues.alfresco.com/jira/browse/AKU-865), however by using a slightly different technique than when fixing the same issue on the StickyPanel (because the notification is not stuck to the bottom of the screen), this fix should work in all browsers. Regression test added and full suite run successfully (however have updated the list of regularly-failing tests).