### PR TITLE
AKU-840: Remove type from video source

### DIFF
--- a/aikau/src/main/resources/alfresco/preview/Video.js
+++ b/aikau/src/main/resources/alfresco/preview/Video.js
@@ -129,10 +129,9 @@ define(["dojo/_base/declare",
          {
             src = this.attributes.src ? this.previewManager.getThumbnailUrl(this.attributes.src) : this.previewManager.getContentUrl();
          }
-         var mimeType = this.attributes.srcMimeType ? this.attributes.srcMimeType : this.previewManager.mimeType;
          var str = "";
          str += "<video controls alt=\"" + this.previewManager.name  + "\" title=\"" + this.previewManager.name  + "\">";
-         str += "   <source src=\"" + src + "\"  type=\"" + mimeType + "\">";
+         str += "   <source src=\"" + src + "\"  >";
          str += "</video>";
          return str;
       }


### PR DESCRIPTION
This is a further update to https://issues.alfresco.com/jira/browse/AKU-840 and related video playback issues. Working with the customer we've discovered that the an incorrect "type" attribute on the source element in the video element is causing the video to fail to play. Removing this attribute instructs the browser to check the type itself, see the following quote from https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML5_audio_and_video 

"If the type attribute isn't specified, the media's type is retrieved from the server and checked to see if the browser can handle it; if it can't be rendered, the next source is checked. If none of the specified source elements can be used, an error event is dispatched to the video element. If the type attribute is specified, it's compared against the types the browser can play, and if it's not recognized, the server doesn't even get queried; instead, the next source is checked at once."

