### PR TITLE
AKU-846: Form dialog support for "dialogEnableTopic" for button disabling

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -258,6 +258,17 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Returns a promise to provide an array of all the buttons in the dialog.
+       * 
+       * @instance
+       * @return {promise} An array of the buttons widgets for the dialog
+       * @since 1.0.58
+       */
+      getButtons: function alfresco_dialogs_AlfDialog__getButtons() {
+         return this.getProcessedWidgets("BUTTONS");
+      },
+
+      /**
        * Extends the superclass implementation to set the dialog as not closeable (by clicking an "X"
        * in the corner).
        * 
@@ -599,7 +610,7 @@ define(["dojo/_base/declare",
                   button.publishPayload.dialogContent = [];
                }
                button.publishPayload.dialogRef = this; // Add a reference to the dialog itself so that it can be destroyed
-            });
+            }, this);
          }
       },
       

--- a/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
@@ -1,2 +1,11 @@
-# Use to find the confirmation button on a form dialog
+# A disabled confirmation button on a form dialog
+disabled.form.dialog.confirmation.button=#{0} .footer .confirmationButton.dijitButtonDisabled .dijitButtonNode
+
+# The confirmation button on a form dialog
 form.dialog.confirmation.button=#{0} .footer .confirmationButton .dijitButtonNode
+
+# A hidden dialog
+hidden.dialog=#{0}.dialogHidden
+
+# A displayed dialog
+visible.dialog=#{0}.dialogDisplayed

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -134,8 +134,8 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/buttons/AlfButton",
          id: "LAUNCH_FAILURE_DIALOG",
+         name: "alfresco/buttons/AlfButton",
          config: {
             label: "Launch Failing Form Dialog",
             publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
@@ -158,6 +158,33 @@ model.jsonModel = {
             }
          }
       }, 
+      {
+         id: "LAUNCH_FAILURE_DIALOG_2",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Launch Failing Form Dialog (DISABLE BUTTONS)",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Failure Test Dialog",
+               dialogId: "FD4",
+               formSubmissionTopic: "POST_FORM_DIALOG",
+               dialogCloseTopic: "FORM_POST_SUCCESS",
+               dialogEnableTopic: "FORM_POST_FAILURE",
+               widgets: [
+                  {
+                     id: "TB4",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        name: "text",
+                        label: "Enter some text",
+                        description: "The service will fail when value is 'fail'"
+                     }
+                  }
+               ]
+            }
+         }
+      }, 
+      
       {
          name: "alfresco/buttons/AlfButton",
          id: "LAUNCH_CUSTOM_BUTTON_ID_DIALOG",

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormDialogMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormDialogMockService.js
@@ -49,10 +49,18 @@ define(["dojo/_base/declare",
             this.alfPublish("ALF_DISPLAY_PROMPT", {
                message: "Post failure"
             });
+
+            // Intentionally wait before publishing failure message so that the unit test can detect the
+            // disabled buttons.
+            var _this = this;
+            setTimeout(function() {
+               _this.alfPublish(payload.alfPublishScope + "FORM_POST_FAILURE");
+            }, 2000);
+            
          }
          else
          {
-            this.alfPublish(payload.alfPublishScope + "FORM_POST_SUCCESS", {});
+            this.alfPublish(payload.alfPublishScope + "FORM_POST_SUCCESS");
          }
       }
    });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-846 to add support for a new parameter when requesting form dialogs: 'dialogEnableTopic'. When this option is used it will result in all the buttons in the dialog being disabled when data is submitted. The topic is subscribed to in order to re-enable the buttons. Using this new feature requires the developer to ensure that the topic is published when failure occurs so that the buttons can be re-enabled to give the user the opportunity to submit valid data.