### PR TITLE
AKU-820: Uploader progress bars

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -334,6 +334,9 @@
 @upload-monitor-status-color-inprogress: #ccc;
 @upload-monitor-status-color-successful: #090;
 @upload-monitor-status-color-unsuccessful: #c00;
+@upload-monitor-progress-bar-height: 2px;
+@upload-monitor-progress-bar-background: #6bf;
+@upload-monitor-progress-bar-box-shadow: 0 0 2px 1px #dff;
 
 // Filters
 @filter-hover-color: @list-hover-color;

--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -36,9 +36,10 @@ define(["alfresco/core/FileSizeMixin",
         "dojo/_base/lang", 
         "dojo/dom-class", 
         "dojo/dom-construct",
+        "dojo/dom-style",
         "dojo/when", 
         "dojo/text!./templates/UploadMonitor.html"], 
-        function(FileSizeMixin, CoreWidgetProcessing, topics, _UploadsDisplayMixin, array, declare, lang, domClass, domConstruct, when, template) {
+        function(FileSizeMixin, CoreWidgetProcessing, topics, _UploadsDisplayMixin, array, declare, lang, domClass, domConstruct, domStyle, when, template) {
 
    return declare([FileSizeMixin, CoreWidgetProcessing, _UploadsDisplayMixin], {
 
@@ -273,7 +274,15 @@ define(["alfresco/core/FileSizeMixin",
             }, itemRow),
             itemActions = domConstruct.create("td", {
                className: this.baseClass + "__item__actions"
-            }, itemRow);
+            }, itemRow),
+            progressRow = domConstruct.create("tr", {}, this.inProgressItemsNode),
+            progressCell = domConstruct.create("td", {
+               colspan: 4,
+               className: this.baseClass + "__item__progress-cell"
+            }, progressRow),
+            progressBar = domConstruct.create("div", {
+               className: this.baseClass + "__item__progress-bar"
+            }, progressCell);
 
          // Add localised status messages
          domConstruct.create("span", {
@@ -305,7 +314,9 @@ define(["alfresco/core/FileSizeMixin",
                row: itemRow,
                name: itemNameContent,
                errorIcon: errorIconNode,
-               progress: itemProgressContent
+               progress: itemProgressContent,
+               progressRow: progressRow,
+               progressBar: progressBar
             }
          };
 
@@ -393,6 +404,7 @@ define(["alfresco/core/FileSizeMixin",
 
             // Mark as completed and move to successful section
             upload.completed = true;
+            upload.nodes.progressBar.parentNode.removeChild(upload.nodes.progressBar);
             upload.nodes.progress.textContent = this.displayUploadPercentage ? "100%" : "";
             domConstruct.place(upload.nodes.row, this.successfulItemsNode, "first");
 
@@ -444,6 +456,7 @@ define(["alfresco/core/FileSizeMixin",
 
             // Move the item to the unsuccessful items section and update the properties accordingly
             upload.completed = true;
+            upload.nodes.progressBar.parentNode.removeChild(upload.nodes.progressBar);
             domConstruct.place(upload.nodes.row, this.unsuccessfulItemsNode, "first");
             upload.nodes.progress.textContent = "";
             
@@ -506,6 +519,7 @@ define(["alfresco/core/FileSizeMixin",
          if (upload) {
             if (!upload.completed) {
                upload.nodes.progress.textContent = percentageComplete + "%";
+               domStyle.set(upload.nodes.progressBar, "width", percentageComplete + "%");
             }
          } else {
             this.alfLog("warn", "Attempt to update upload that is not being tracked (id=" + fileId + ")");

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -8,7 +8,6 @@
       border-spacing: 0;
       position: relative;
       table-layout: fixed;
-      top: -1px;
       width: 100%;
       td {
          padding: 0;
@@ -55,6 +54,17 @@
       }
       &__action {
          display: none;
+      }
+      &__progress-cell {
+         font-size: 0;
+         padding: 0;
+      }
+      &__progress-bar {
+         background: #6bf;
+         box-shadow: 0 0 2px 1px #dff;
+         height: 2px;
+         width: 0;
+         transition: width .3s ease;
       }
    }
    &__inprogress-items {

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -60,9 +60,9 @@
          padding: 0;
       }
       &__progress-bar {
-         background: #6bf;
-         box-shadow: 0 0 2px 1px #dff;
-         height: 2px;
+         background: @upload-monitor-progress-bar-background;
+         box-shadow: @upload-monitor-progress-bar-box-shadow;
+         height: @upload-monitor-progress-bar-height;
          width: 0;
          transition: width .3s ease;
       }

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -25,6 +25,11 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, TestCommon) {
 
+   function getTextContent(selector) {
+      var elem = document.querySelector(selector);
+      return elem && elem.textContent;
+   }
+
    registerSuite(function() {
       var browser;
 
@@ -48,8 +53,7 @@ define(["intern!object",
 
             .findByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-upload-UploadMonitor__unsuccessful-items .alfresco-upload-UploadMonitor__item")
 
-               .findByCssSelector(".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title")
-                  .getProperty("innerHTML")
+               .execute(getTextContent, [".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title"])
                   .then(function(text) {
                      assert.equal(text, "The file ''This file is empty.txt'' could not be uploaded for the following reason. 0kb files can't be uploaded");
                   })
@@ -131,11 +135,38 @@ define(["intern!object",
                .click()
             .end()
 
-            .findByCssSelector(".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title")
-               .getProperty("innerHTML")
+            .execute(getTextContent, [".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title"])
                .then(function(text) {
                   assert.equal(text, "The file ''Tiny dataset.csv'' could not be uploaded for the following reason. The upload was cancelled");
-               });
+               })
+            .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_STICKY_PANEL_CLOSED");
+         },
+
+         "Progress bar displayed when upload in-progress": function() {
+            return browser.findById("SINGLE_UPLOAD_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(".alfresco-upload-UploadMonitor__item__progress-bar")
+            .end()
+
+            .getLastPublish("UPLOAD_COMPLETE_OR_CANCELLED", 5000)
+
+            .waitForDeletedByCssSelector(".alfresco-upload-UploadMonitor__item__progress-bar")
+            .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_STICKY_PANEL_CLOSED");
          },
 
          "Post Coverage Results": function() {


### PR DESCRIPTION
This addresses [AKU-820](https://issues.alfresco.com/jira/browse/AKU-820) and adds visual progress bars to the uploads in the UploadMonitor widget. A regression test has been added and a full suite run.