### PR TITLE
AKU-832: Allow a tooltip to be set for the minimize button on the Upload Monitor

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -344,6 +344,9 @@ define([],function() {
        * @event
        * @property {object[]} widgets The widgets to appear in the panel
        * @property {string} [title=default.title] The title to display (uses i18n)
+       * @property {string} [closeButtonLabel=Close this panel] The text-label that decorates the close button for accessibility reasons
+       * @property {string} [minimiseButtonLabel=Minimize this panel] The text-label that decorates the minimise button for accessibility reasons
+       * @property {string} [restoreButtonLabel=Restore this panel] The text-label that decorates the restore button for accessibility reasons
        * @property {number} [padding=10] The padding to be applied to the widgets area
        * @property {string|number} [width=50%] The width of the panel (CSS dimension or number of pixels)
        * @property {boolean} [warnIfOpen=true] Whether to put a warning in the console if the panel is

--- a/aikau/src/main/resources/alfresco/layout/StickyPanel.js
+++ b/aikau/src/main/resources/alfresco/layout/StickyPanel.js
@@ -83,6 +83,26 @@ define(["alfresco/core/Core",
       baseClass: "alfresco-layout-StickyPanel",
 
       /**
+       * The label to display on the minimise button for accessibility reasons
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       */
+      closeButtonLabel: "button.close.label",
+
+      /**
+       * The label to display on the minimise button for accessibility reasons
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       */
+      minimiseButtonLabel: "button.minimise.label",
+
+      /**
        * The width of the panel. Can be provided as a CSS dimension (e.g. 50%, 100px)
        * or a pure number, which will be treated as pixels.
        *
@@ -91,6 +111,16 @@ define(["alfresco/core/Core",
        * @default
        */
       panelWidth: "50%",
+
+      /**
+       * The label to display on the minimise button for accessibility reasons
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       */
+      restoreButtonLabel: "button.restore.label",
 
       /**
        * The title to display in the title-bar of the panel
@@ -146,6 +176,14 @@ define(["alfresco/core/Core",
             domStyle.set(this.widgetsNode, "padding", this.widgetsPadding + "px");
          }
          this.sizePanel();
+
+         // Setup mouse-hover and screenreader text labels for the panel buttons
+         this.minimiseButtonNode.setAttribute("title", this.message(this.minimiseButtonLabel));
+         this.restoreButtonNode.setAttribute("title", this.message(this.restoreButtonLabel));
+         this.closeButtonNode.setAttribute("title", this.message(this.closeButtonLabel));
+         this.minimiseButtonNode.setAttribute("aria-label", this.message(this.minimiseButtonLabel));
+         this.restoreButtonNode.setAttribute("aria-label", this.message(this.restoreButtonLabel));
+         this.closeButtonNode.setAttribute("aria-label", this.message(this.closeButtonLabel));
       },
 
       /**
@@ -197,9 +235,22 @@ define(["alfresco/core/Core",
        * Handle clicks on the minimise or restore buttons.
        *
        * @instance
+       * @since 1.0.58
        */
-      onClickMinimiseRestore: function alfresco_layout_StickyPanel__onClickMinimiseRestore() {
-         this.toggleMinimised();
+      onClickMinimise: function alfresco_layout_StickyPanel__onClickMinimise() {
+         this.setMinimised(true);
+         this.restoreButtonNode.focus();
+      },
+
+      /**
+       * Handle clicks on the minimise or restore buttons.
+       *
+       * @instance
+       * @since 1.0.58
+       */
+      onClickRestore: function alfresco_layout_StickyPanel__onClickRestore() {
+         this.setMinimised(false);
+         this.minimiseButtonNode.focus();
       },
 
       /**
@@ -218,8 +269,8 @@ define(["alfresco/core/Core",
          this.alfSubscribe(topics.STICKY_PANEL_SET_TITLE, lang.hitch(this, this.setTitle));
          this.alfSubscribe(topics.STICKY_PANEL_DISABLE_CLOSE, lang.hitch(this, this.disableCloseButton));
          this.alfSubscribe(topics.STICKY_PANEL_ENABLE_CLOSE, lang.hitch(this, this.enableCloseButton));
-         this.alfSubscribe(topics.STICKY_PANEL_RESTORE, lang.hitch(this, this.toggleMinimised, "restore"));
-         this.alfSubscribe(topics.STICKY_PANEL_MINIMISE, lang.hitch(this, this.toggleMinimised, "minimise"));
+         this.alfSubscribe(topics.STICKY_PANEL_RESTORE, lang.hitch(this, this.setMinimised, false));
+         this.alfSubscribe(topics.STICKY_PANEL_MINIMISE, lang.hitch(this, this.setMinimised, true));
       },
 
       /**
@@ -252,17 +303,14 @@ define(["alfresco/core/Core",
       },
 
       /**
-       * Toggle between minimised/restored states.
+       * Set the minimised state
        *
        * @instance
-       * @param {string} [forceTo] This can be used to force the panel to either "minimise" or "restore".
-       * @since 1.0.55
+       * @param {boolean} minimise Whether to minimise the panel (true will minimise, false will restore)
+       * @since 1.0.58
        */
-      toggleMinimised: function alfresco_layout_StickyPanel__toggleMinimised(forceTo) {
-         var doOpen = (forceTo === "restore"),
-            doMinimise = (forceTo === "minimise"),
-            funcName = doOpen ? "remove" : doMinimise ? "add" : "toggle";
-         domClass[funcName](this.domNode, this.baseClass + "--minimised");
+      setMinimised: function alfresco_layout_StickyPanel__setMinimised(minimise) {
+         domClass[minimise ? "add" : "remove"](this.domNode, this.baseClass + "--minimised");
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/i18n/StickyPanel.properties
+++ b/aikau/src/main/resources/alfresco/layout/i18n/StickyPanel.properties
@@ -1,1 +1,6 @@
 default.title=Information Panel
+
+# Note that these string values are used as defaults within the JSDoc for alfresco/core/topics#DISPLAY_STICKY_PANEL
+button.close.label=Close this panel
+button.minimise.label=Minimize this panel
+button.restore.label=Restore this panel

--- a/aikau/src/main/resources/alfresco/layout/templates/StickyPanel.html
+++ b/aikau/src/main/resources/alfresco/layout/templates/StickyPanel.html
@@ -2,8 +2,8 @@
    <div class="${baseClass}__panel" data-dojo-attach-point="panelNode">
       <div class="${baseClass}__title-bar">
          <div class="${baseClass}__title-bar__title" data-dojo-attach-point="titleNode"></div>
-         <div class="${baseClass}__title-bar__minimise" tabindex="0" data-dojo-attach-point="minimiseButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
-         <div class="${baseClass}__title-bar__restore" tabindex="0" data-dojo-attach-point="restoreButtonNode" data-dojo-attach-event="dijitClick:onClickMinimiseRestore">&ndash;</div>
+         <div class="${baseClass}__title-bar__minimise" tabindex="0" data-dojo-attach-point="minimiseButtonNode" data-dojo-attach-event="dijitClick:onClickMinimise">&ndash;</div>
+         <div class="${baseClass}__title-bar__restore" tabindex="0" data-dojo-attach-point="restoreButtonNode" data-dojo-attach-event="dijitClick:onClickRestore">&ndash;</div>
          <div class="${baseClass}__title-bar__close" tabindex="0" data-dojo-attach-point="closeButtonNode" data-dojo-attach-event="dijitClick:onClickClose">&times;</div>
       </div>
       <div class="${baseClass}__widgets" data-dojo-attach-point="widgetsNode"></div>

--- a/aikau/src/main/resources/alfresco/services/FileUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/FileUploadService.js
@@ -41,6 +41,45 @@ define(["alfresco/core/topics",
    return declare([_BaseUploadService], {
 
       /**
+       * An array of the i18n files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @since 1.0.58
+       */
+      i18nRequirements: [{i18nFile: "./i18n/FileUploadService.properties"}],
+
+      /**
+       * The label to display on the minimise button for accessibility reasons
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       */
+      closeButtonLabel: "upload-panel.close.label",
+
+      /**
+       * The label to display on the minimise button for accessibility reasons
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       */
+      minimiseButtonLabel: "upload-panel.minimise.label",
+
+      /**
+       * The label to display on the minimise button for accessibility reasons
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       */
+      restoreButtonLabel: "upload-panel.restore.label",
+
+      /**
        * This is the topic on which to publish updates to the title container.
        *
        * @instance
@@ -104,6 +143,9 @@ define(["alfresco/core/topics",
          var widgetsForUploadDisplay = this.processWidgetsForUploadDisplay();
          this.alfServicePublish(topics.DISPLAY_STICKY_PANEL, {
             title: this.message(this.uploadsContainerTitle, 0),
+            closeButtonLabel: this.message(this.closeButtonLabel),
+            minimiseButtonLabel: this.message(this.minimiseButtonLabel),
+            restoreButtonLabel: this.message(this.restoreButtonLabel),
             padding: 0,
             widgets: widgetsForUploadDisplay,
             callback: lang.hitch(this, function(panel) {

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -148,6 +148,15 @@ define(["dojo/_base/declare",
             if (payload.padding || payload.padding === 0) {
                panelConfig.widgetsPadding = payload.padding;
             }
+            if (payload.closeButtonLabel) {
+               panelConfig.closeButtonLabel = payload.closeButtonLabel;
+            }
+            if (payload.minimiseButtonLabel) {
+               panelConfig.minimiseButtonLabel = payload.minimiseButtonLabel;
+            }
+            if (payload.restoreButtonLabel) {
+               panelConfig.restoreButtonLabel = payload.restoreButtonLabel;
+            }
 
             // Create the panel
             theStickyPanel = new StickyPanel(panelConfig);

--- a/aikau/src/main/resources/alfresco/services/i18n/FileUploadService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/FileUploadService.properties
@@ -1,0 +1,3 @@
+upload-panel.close.label=Close the upload window
+upload-panel.minimise.label=Minimize the upload window
+upload-panel.restore.label=Restore the upload window

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -61,6 +61,51 @@ define(["intern!object",
                .click();
          },
 
+         "Panel buttons carry correct attributes": function() {
+            return browser.findById("BAD_FILE_DATA_label")
+               .click()
+            .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__minimise")
+               .getAttribute("title")
+               .then(function(attrValue){
+                  assert.equal(attrValue, "Minimize the upload window", "Minimise button does not have correct title attribute");
+               })
+               .getAttribute("aria-label")
+               .then(function(attrValue){
+                  assert.equal(attrValue, "Minimize the upload window", "Minimise button does not have correct aria-label attribute");
+               })
+            .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__restore")
+               .getAttribute("title")
+               .then(function(attrValue){
+                  assert.equal(attrValue, "Restore the upload window", "Restore button does not have correct title attribute");
+               })
+               .getAttribute("aria-label")
+               .then(function(attrValue){
+                  assert.equal(attrValue, "Restore the upload window", "Restore button does not have correct aria-label attribute");
+               })
+            .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .getAttribute("title")
+               .then(function(attrValue){
+                  assert.equal(attrValue, "Close the upload window", "Close button does not have correct title attribute");
+               })
+               .getAttribute("aria-label")
+               .then(function(attrValue){
+                  assert.equal(attrValue, "Close the upload window", "Close button does not have correct aria-label attribute");
+               })
+            .end()
+
+            .findByCssSelector(".alfresco-layout-StickyPanel__title-bar__close")
+               .click()
+            .end()
+
+            .getLastPublish("ALF_STICKY_PANEL_CLOSED");
+         },
+
          "Single file upload succeeds": function() {
             return browser.findById("SINGLE_UPLOAD_label")
                .click()


### PR DESCRIPTION
This addresses [AKU-832](https://issues.alfresco.com/jira/browse/AKU-832) and sets up button labels for the minimise, restore and close buttons on the StickyPanel with requested overrides for the UploadMonitor. A regression test has been added.

Mentioning @andyhealey26 so that he can review the properties file changes.