### PR TITLE
AKU-838: Form control selectors

### DIFF
--- a/aikau/src/test/resources/alfresco/forms/controls/AsyncFormControlLoadingTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/AsyncFormControlLoadingTest.js
@@ -25,6 +25,30 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+   var baseFormControlSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/BaseFormControl");
+   var tabSelectors = TestCommon.getTestSelectors("alfresco/layout/AlfTabContainer");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+
+   var selectors = {
+      buttons: {
+         create: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_DIALOG_BUTTON"])
+      },
+      dialogs: {
+         dialog1: {
+            visible: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["DIALOG1"])
+         }
+      },
+      tabs: {
+         tab1: TestCommon.getTestSelector(tabSelectors, "identified.tab", ["TABS","DYNAMIC"])
+      },
+      checkBoxes: {
+         initialVisibility: {
+            label: TestCommon.getTestSelector(baseFormControlSelectors, "label", ["INITIALLY_VISIBLE"])
+         }
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -42,24 +66,20 @@ define(["intern!object",
 
          "Check that controls all load": function() {
             // Open the dialog...
-            return browser.findById("CREATE_DILAOG_BUTTON_label")
+            return browser.findByCssSelector(selectors.buttons.create)
                .click()
             .end()
 
             // ...wait for it to be displayed...
-            .findByCssSelector("#DIALOG1.dialogDisplayed")
+            .findByCssSelector(selectors.dialogs.dialog1.visible)
             .end()
 
             // Select the "DYNAMIC" tab...
-            .findById("TABS_TABCONTAINER_tablist_TABS_DYNAMIC")
+            .findByCssSelector(selectors.tabs.tab1)
                .click()
             .end()
 
-            .findByCssSelector("#DIALOG1 #DYNAMIC .alfresco-forms-controls-CheckBox .label")
-               .isDisplayed()
-               .then(function(displayed) {
-                  assert.isTrue(displayed, "The form control label should have been displayed");
-               });
+            .findDisplayedByCssSelector(selectors.checkBoxes.initialVisibility.label);
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
@@ -23,145 +23,133 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"], 
-        function (registerSuite, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var selectSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/Select");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
 
-   return {
-      name: "Auto Set Form Rules Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AutoSet", "Auto Set Form Rules Tests").end();
+   var selectors = {
+      form: {
+         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["FORM"])
       },
-
-      beforeEach: function() {
-         browser.end();
+      select: {
+         firstOption: TestCommon.getTestSelector(selectSelectors, "nth.option.label", ["SOURCE","1"]),
+         openIcon: TestCommon.getTestSelector(selectSelectors, "open.menu.icon", ["SOURCE"]),
+         secondOption: TestCommon.getTestSelector(selectSelectors, "nth.option.label", ["SOURCE","2"]),
+         thirdOption: TestCommon.getTestSelector(selectSelectors, "nth.option.label", ["SOURCE","3"])
       },
-
-      "Check the initial post (source field)": function () {
-         return browser.findByCssSelector(".confirmationButton > span")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "source", "1"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Source field not posted correctly");
-            });
-      },
-
-      "Check the initial post (target field)": function () {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "target", ""))
-            .then(function(elements) {
-               assert(elements.length === 1, "Target field not posted correctly");
-            });
-      },
-
-      "Check the initial post (hidden field)": function () {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden", ""))
-            .then(function(elements) {
-               assert(elements.length === 1, "Hidden field not posted correctly");
-            });
-      },
-
-      "Check the initial post (hidden field without auto set config)": function () {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden2", "initial value"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Second hidden field not posted correctly");
-            });
-      },
-
-      "Check the updated post (source field)": function () {
-         return browser.findByCssSelector("#SOURCE .dijitArrowButtonInner")
-            .click()
-         .end()
-         .findByCssSelector("#SOURCE_CONTROL_dropdown table tr:nth-child(2) td.dijitMenuItemLabel")
-            .click()
-         .end()
-
-         // Post the form, check the hidden field is set and the visible field isn't
-         .findByCssSelector(".confirmationButton > span")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "source", "2"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Source field not posted correctly");
-            });
-      },
-
-       "Check the updated post (target field)": function () {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "target", ""))
-            .then(function(elements) {
-               assert(elements.length === 1, "Target field not posted correctly");
-            });
-      },
-
-      "Check complex data": function() {
-         return browser.findByCssSelector(TestCommon.pubDataNestedValueCssSelector("POST_FORM","something","quite","complex"))
-            .then(null, function() {
-               assert(false, "Couldn't find complex data in initial form value publication");
-            });
-      },
-
-      "Check the hidden field is not set and the visible field is": function() {
-         // Set the drop-down to 2...
-         return browser.findByCssSelector("#SOURCE .dijitArrowButtonInner")
-            .click()
-         .end()
-         .findByCssSelector("#SOURCE_CONTROL_dropdown table tr:nth-child(2) td.dijitMenuItemLabel")
-            .click()
-         .end()
-
-         // Set the drop-down to 3...
-         .findByCssSelector("#SOURCE .dijitArrowButtonInner")
-            .click()
-         .end()
-         .findByCssSelector("#SOURCE_CONTROL_dropdown table tr:nth-child(3) td.dijitMenuItemLabel")
-            .click()
-         .end()
-
-         // Post the form, check the hidden field is not set and the visible field is...
-         .findByCssSelector(".confirmationButton > span")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "source", "3"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Source field not posted correctly");
-            });
-      },
-
-      "Check target field": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "target", "Updated"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Target field not posted correctly");
-            });
-      },
-
-      "Check hidden field": function() {
-         return browser.findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden", ""))
-            .then(function(elements) {
-               assert(elements.length === 1, "Hidden field not posted correctly");
-            });
-      },
-
-      "Check that hidden field value can be set by form value update": function() {
-         return browser.findByCssSelector("#SET_FORM_VALUE")
-            .click()
-         .end()
-         .findByCssSelector(".confirmationButton > span")
-            .click()
-         .end()
-         .findAllByCssSelector(TestCommon.pubSubDataCssSelector("last", "hidden2", "Value Set"))
-            .then(function(elements) {
-               assert(elements.length === 1, "Second hidden field not posted correctly");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
+      button: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE"])
    };
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Auto Set Form Rules Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AutoSet", "Auto Set Form Rules Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check the initial post (source field)": function () {
+            return browser.findByCssSelector(selectors.form.confirmationButton)
+               .click()
+            .end()
+
+            .getLastPublish("POST_FORM")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "source", "1", "Source field not posted correctly");
+                  assert.propertyVal(payload, "target", "", "Target field not posted correctly");
+                  assert.propertyVal(payload, "hidden", "", "Hidden field not posted correctly");
+                  assert.propertyVal(payload, "hidden2", "initial value", "Second hidden field not posted correctly");
+               });
+         },
+
+         "Check the updated post (source field)": function () {
+            return browser.findByCssSelector(selectors.select.openIcon)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.select.secondOption)
+               .click()
+            .end()
+
+            .clearLog()
+
+            // Post the form, check the hidden field is set and the visible field isn't
+            .findByCssSelector(selectors.form.confirmationButton)
+               .click()
+            .end()
+
+            .getLastPublish("POST_FORM")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "source", "2", "Source field not posted correctly");
+                  assert.propertyVal(payload, "target", "", "Target field not posted correctly");
+                  assert.deepPropertyVal(payload, "hidden.something.quite", "complex", "Couldn't find complex data in initial form value publication");
+               });
+         },
+
+         "Check the hidden field is not set and the visible field is": function() {
+            // Set the drop-down to 2...
+            return browser.findByCssSelector(selectors.select.openIcon)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.select.secondOption)
+               .click()
+            .end()
+
+            // Set the drop-down to 3...
+            .findByCssSelector(selectors.select.openIcon)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.select.thirdOption)
+               .click()
+            .end()
+
+            .clearLog()
+
+            // Post the form, check the hidden field is not set and the visible field is...
+            .findByCssSelector(selectors.form.confirmationButton)
+               .click()
+            .end()
+
+            .getLastPublish("POST_FORM")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "source", "3", "Source field not posted correctly");
+                  assert.propertyVal(payload, "target", "Updated", "Target field not posted correctly");
+                  assert.propertyVal(payload, "hidden", "", "Hidden field not posted correctly");
+               });
+         },
+
+         "Check that hidden field value can be set by form value update": function() {
+            return browser.findByCssSelector(selectors.button)
+               .click()
+            .end()
+
+            .clearLog()
+
+            .findByCssSelector(selectors.form.confirmationButton)
+               .click()
+            .end()
+
+            .getLastPublish("POST_FORM")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "hidden2", "Value Set", "Second hidden field not posted correctly");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/BaseFormTest.js
@@ -29,6 +29,50 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function(registerSuite, assert, keys, TestCommon) {
 
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+
+   var selectors = {
+      forms: {
+         basic: {
+            confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["BASIC_FORM"]),
+            cancelButton: TestCommon.getTestSelector(formSelectors, "cancellation.button", ["BASIC_FORM"]),
+            hiddenConfirmationButton: TestCommon.getTestSelector(formSelectors, "hidden.confirmation.button", ["BASIC_FORM"]),
+            hiddenCancelButton: TestCommon.getTestSelector(formSelectors, "hidden.cancellation.button", ["BASIC_FORM"])
+         },
+         autoSave: {
+            confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["AUTOSAVE_FORM"]),
+            cancelButton: TestCommon.getTestSelector(formSelectors, "cancellation.button", ["AUTOSAVE_FORM"])
+         },
+         enterForm: {
+            confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["ENTER_FORM"]),
+         }
+      },
+      textBoxes: {
+         basic: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["FORM_FIELD"])
+         },
+         autoSave: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["AUTOSAVE_FORM_FIELD"])
+         },
+         invalidAutoSave: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["AUTOSAVE_INVALID_FORM_FIELD"])
+         },
+         submitOnEnter: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["ENTER_TEXT_FIELD"])
+         }
+      },
+      buttons: {
+         setValue1: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE_1"]),
+         setValue2: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE_2"]),
+         setValue3: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE_3"]),
+         setValue4: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE_4"]),
+         setValue5: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE_5"]),
+         clearAutoSave: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CLEAR_AUTOSAVE_1"])
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -45,7 +89,7 @@ define(["intern!object",
          },
 
          "Checking the form field is initially empty": function() {
-            return browser.findByCssSelector("div#FORM_FIELD div.control input[name='control']")
+            return browser.findByCssSelector(selectors.textBoxes.basic.input)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "", "Form field not initially empty");
@@ -53,11 +97,11 @@ define(["intern!object",
          },
 
          "No payload does not update value": function() {
-            return browser.findById("SET_FORM_VALUE_1")
+            return browser.findByCssSelector(selectors.buttons.setValue1)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+            .findByCssSelector(selectors.textBoxes.basic.input)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "", "No payload published but field value updated");
@@ -65,11 +109,11 @@ define(["intern!object",
          },
 
          "Invalid field name does not update value": function() {
-            return browser.findById("SET_FORM_VALUE_2")
+            return browser.findByCssSelector(selectors.buttons.setValue2)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+            .findByCssSelector(selectors.textBoxes.basic.input)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "", "Invalid field name provided but value updated");
@@ -77,11 +121,11 @@ define(["intern!object",
          },
 
          "Setting string value updates field appropriately": function() {
-            return browser.findById("SET_FORM_VALUE_3")
+            return browser.findByCssSelector(selectors.buttons.setValue3)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+            .findByCssSelector(selectors.textBoxes.basic.input)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "this is the new value", "Field value not updated to published string value");
@@ -89,11 +133,11 @@ define(["intern!object",
          },
 
          "Setting number value updates field appropriately": function() {
-            return browser.findById("SET_FORM_VALUE_4")
+            return browser.findByCssSelector(selectors.buttons.setValue4)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+            .findByCssSelector(selectors.textBoxes.basic.input)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "3.14159265", "Field value not updated to published numeric value");
@@ -101,11 +145,11 @@ define(["intern!object",
          },
 
          "Setting boolean value updates field appropriately": function() {
-            return browser.findById("SET_FORM_VALUE_5")
+            return browser.findByCssSelector(selectors.buttons.setValue5)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("div#FORM_FIELD div.control input[name=\"control\"]")
+            .findByCssSelector(selectors.textBoxes.basic.input)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "true", "Field value not updated to published boolean value");
@@ -113,20 +157,20 @@ define(["intern!object",
          },
 
          "Autosave on a form removes OK/Cancel buttons": function() {
-            return browser.findAllByCssSelector("#BASIC_FORM .confirmationButton, #BASIC_FORM .cancelButton")
+            return browser.findAllByCssSelector(selectors.forms.basic.confirmationButton+ ", " + selectors.forms.basic.cancelButton)
                .then(function(elements) {
                   assert.lengthOf(elements, 2, "OK/Cancel buttons not found on basic form");
                })
                .end()
 
-            .findAllByCssSelector("#AUTOSAVE_FORM .confirmationButton, #AUTOSAVE_FORM .cancelButton")
+            .findAllByCssSelector(selectors.forms.autoSave.confirmationButton+ ", " + selectors.forms.autoSave.cancelButton)
                .then(function(elements) {
                   assert.lengthOf(elements, 0, "OK/Cancel buttons found on autosave form");
                });
          },
 
          "Updating autosave value publishes form": function() {
-            return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD .dijitInputInner")
+            return browser.findByCssSelector(selectors.textBoxes.autoSave.input)
                .clearValue()
                .type("wibble")
                .getLastPublish("AUTOSAVE_FORM_1")
@@ -137,7 +181,7 @@ define(["intern!object",
          },
 
          "Updating to invalid value does not autosave form": function() {
-            return browser.findById("CLEAR_AUTOSAVE_1")
+            return browser.findByCssSelector(selectors.buttons.clearAutoSave)
                .click()
                .clearLog()
                .getAllPublishes("AUTOSAVE_FORM_1")
@@ -147,7 +191,7 @@ define(["intern!object",
          },
 
          "Autosave on invalid flag publishes invalid form": function() {
-            return browser.findByCssSelector("#AUTOSAVE_INVALID_FORM_FIELD .dijitInputInner")
+            return browser.findByCssSelector(selectors.textBoxes.invalidAutoSave.input)
                .clearLog()
                .clearValue()
                .pressKeys(keys.BACKSPACE) // Need to trigger an update!
@@ -159,7 +203,7 @@ define(["intern!object",
          },
 
          "Autosaving with defined payload mixes payload into form values": function(){
-            return browser.findByCssSelector("#AUTOSAVE_FORM_FIELD") // Need to get session to check for publish
+            return browser.findByCssSelector("body") // Need to get session to check for publish
                .getLastPublish("AUTOSAVE_FORM_2")
                .then(function(payload) {
                   assert.propertyVal(payload, "customProperty", "awooga", "Did not mix custom payload into form values");
@@ -167,14 +211,14 @@ define(["intern!object",
          },
 
          "Ensure hidden button inputs have value": function() {
-            return browser.findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(1) input[type=\"button\"]")
+            return browser.findByCssSelector(selectors.forms.basic.hiddenConfirmationButton)
                .getAttribute("value")
                .then(function(value) {
                   assert.equal(value, "OK");
                })
                .end()
 
-            .findByCssSelector("#BASIC_FORM .alfresco-buttons-AlfButton:nth-child(2) input[type=\"button\"]")
+            .findByCssSelector(selectors.forms.basic.hiddenCancelButton)
                .getAttribute("value")
                .then(function(value) {
                   assert.equal(value, "CANCEL");
@@ -184,21 +228,21 @@ define(["intern!object",
          "Enter key can submit form": function() {
             var firstPublish;
 
-            return browser.findByCssSelector("#ENTER_TEXT_FIELD .dijitInputInner")
+            return browser.findByCssSelector(selectors.textBoxes.submitOnEnter.input)
                .clearLog()
                .type("wibble")
                .pressKeys(keys.ENTER)
-               .end()
+            .end()
 
             .getLastPublish("FORM_PUBLISH")
                .then(function(payload) {
                   firstPublish = payload;
                })
 
-            .findByCssSelector("#ENTER_FORM .confirmationButton .dijitButtonNode")
+            .findByCssSelector(selectors.forms.enterForm.confirmationButton)
                .clearLog()
                .click()
-               .end()
+            .end()
 
             .getLastPublish("FORM_PUBLISH")
                .then(function(payload) {

--- a/aikau/src/test/resources/alfresco/forms/controls/ButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ButtonsTest.js
@@ -22,9 +22,8 @@
  */
 define(["intern!object",
         "intern/chai!assert", 
-        "alfresco/TestCommon", 
-        "intern/dojo/node!leadfoot/keys"],
-        function(registerSuite, assert, TestCommon, keys) {
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, TestCommon) {
 
    registerSuite(function() {
       var browser;

--- a/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
@@ -22,17 +22,35 @@
  * @author Dave Draper
  */
 define(["intern!object",
-      "intern/chai!assert",
-      "require",
-      "alfresco/TestCommon",
-      "intern/dojo/node!leadfoot/keys"
-   ],
-   function(registerSuite, assert, require, TestCommon, keys) {
+        "intern/chai!assert",
+        "alfresco/TestCommon",
+        "intern/dojo/node!leadfoot/keys"],
+   function(registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var formControlSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/BaseFormControl");
+   var checkBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/CheckBox");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
 
-   return {
+   var selectors = {
+      checkBoxes: {
+         canBuild: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["CAN_BUILD"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["CAN_BUILD"])
+         }
+      },
+      buttons: {
+         uncheck: TestCommon.getTestSelector(buttonSelectors, "button.label", ["UNCHECK_CHECKBOX"])
+      },
+      form: {
+         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["CHECKBOX_FORM"])
+      }
+   };
+
+   registerSuite(function(){
+      var browser;
+
+      return {
          name: "CheckBox Tests",
 
          setup: function() {
@@ -45,7 +63,7 @@ registerSuite(function(){
          },
 
          "Initial value is set correctly": function() {
-            return browser.findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+            return browser.findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
                .isSelected()
                .then(function(isSelected) {
                   assert.isTrue(isSelected, "Checkbox not selected at startup");
@@ -53,11 +71,11 @@ registerSuite(function(){
          },
 
          "Value can be updated by publish": function() {
-            return browser.findById("UNCHECK_CHECKBOX")
+            return browser.findByCssSelector(selectors.buttons.uncheck)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+            .findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
                .isSelected()
                .then(function(isSelected) {
                   assert.isFalse(isSelected, "Checkbox not deselected by publish");
@@ -67,9 +85,9 @@ registerSuite(function(){
          "Keyboard navigation and selection is supported": function() {
             return browser.pressKeys(keys.TAB)
                .pressKeys(keys.SPACE)
-               .end()
+            .end()
 
-            .findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+            .findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
                .isSelected()
                .then(function(isSelected) {
                   assert.isTrue(isSelected, "Checkbox value not changed by keyboard");
@@ -77,11 +95,11 @@ registerSuite(function(){
          },
 
          "Can modify checkbox value with mouse": function() {
-            return browser.findByCssSelector("#CAN_BUILD label")
+            return browser.findByCssSelector(selectors.checkBoxes.canBuild.label)
                .click()
-               .end()
+            .end()
 
-            .findByCssSelector("#CAN_BUILD .dijitCheckBox input")
+            .findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
                .isSelected()
                .then(function(isSelected) {
                   assert.isFalse(isSelected, "Checkbox value not changed by mouse");
@@ -89,9 +107,9 @@ registerSuite(function(){
          },
 
          "Form correctly posts value": function() {
-            return browser.findByCssSelector("#CHECKBOX_FORM > .buttons > .confirmationButton .dijitButtonNode")
+            return browser.findByCssSelector(selectors.form.confirmationButton)
                .click()
-               .end()
+            .end()
 
             .getLastPublish("POST_FORM")
                .then(function(payload) {
@@ -103,5 +121,5 @@ registerSuite(function(){
             TestCommon.alfPostCoverageResults(this, browser);
          }
       };
-      });
    });
+});

--- a/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TextBoxTest.js
@@ -23,345 +23,347 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   var baseFormControlSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/BaseFormControl");
+   var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
 
-   return {
-      name: "Text Box Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/TextBox", "Text Box Tests").end();
-      },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      // teardown: function() {
-      //    browser.end();
-      // },
-      
-     "Check that label is rendered correctly": function () {
-         return browser.findByCssSelector("#BASIC .label")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert(resultText === "Basic", "The label was not rendered correctly: " + resultText);
-            });
-      },
-
-      "Check that units are rendered correctly": function() {
-         return browser.findByCssSelector("#UNITS_AND_DESCRIPTION .units")
-            .getVisibleText()
-            .then(function(resultText) {
-               assert(resultText === "Some unit", "The units was not rendered correctly: " + resultText);
-            });
-      },
-
-      "Check that initial value is set correctly": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE1 .dijitInputContainer input")
-            .getProperty("value")
-            .then(function(resultText) {
-               assert(resultText === "Val1", "The initial value was not set correctly: " + resultText);
-            });
-      },
-
-      "Check that SINGLE_POSITIVE_RULES widget is displayed": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES")
-            .then(
-               function() {
-                  // No action;
-               }, 
-               function() {
-                  assert(false, "Widget not displayed as expected");
-               }
-            );
-      },
-
-      "Check that SINGLE_NEGATIVE_RULES widget is hidden": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Widget displayed unexpectedly");
-            });
-      },
-
-      "Check that SINGLE_POSITIVE_RULES widget requirement indicator is shown": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Requirement indicator not displayed as expected");
-            });
-      },
-
-      "Check requirement indicator": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Requirement indicator displayed unexpectedly");
-            });
-      },
-
-      "Check field is disabled": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === false, "Field should have been disabled");
-            });
-      },
-
-      "Check field is enabled": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === true, "Field should have been enabled");
-            });
-      },
-
-      "Check widget is hidden": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE1 .dijitInputContainer input")
-            .type(keys.BACKSPACE)
-         .end()
-         .findByCssSelector("#SINGLE_POSITIVE_RULES")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Widget displayed unexpectedly after processing positive rules");
-            });
-      },
-
-      "Check widget is displayed": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES")
-            .then(function() {}, function() {
-               assert(false, "Widget not displayed as expected after processing negative rules");
-            });
-      },
-
-      "Check requirement indicator is displayed": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE2 .dijitInputContainer input")
-            .type(keys.BACKSPACE)
-         .end()
-         .findByCssSelector("#SINGLE_NEGATIVE_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Requirement indicator not displayed as expected");
-            });
-      },
-
-      "Check requirement indicator is hidden": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Requirement indicator displayed unexpectedly");
-            });
-      },
-
-      "Check field is disabled on backspace": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE3 .dijitInputContainer input")
-            .type(keys.BACKSPACE)
-         .end()
-         .findByCssSelector("#SINGLE_NEGATIVE_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === false, "Field should have been disabled");
-            });
-      },
-
-      "Check field is enabled on backspace": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === true, "Field should have been enabled");
-            });
-      },
-
-      "Check widget displayed": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE1 .dijitInputContainer input")
-            .type("1")
-         .end()
-         .findByCssSelector("#INITIAL_VALUE2 .dijitInputContainer input")
-            .type("2")
-         .end()
-         .findByCssSelector("#INITIAL_VALUE3 .dijitInputContainer input")
-            .type("3")
-         .end()
-         .findByCssSelector("#SINGLE_POSITIVE_RULES")
-            .then(function() {}, function() {
-               assert(false, "Widget not displayed as expected");
-            });
-      },
-
-      "Check widget hidden": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Widget displayed unexpectedly");
-            });
-      },
-
-      "Check requirement indicator displayed": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Requirement indicator not displayed as expected");
-            });
-      },
-
-      "Check requirement indicate hidden": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Requirement indicator displayed unexpectedly");
-            });
-      },
-
-      "Check field is disabled (SINGLE_POSITIVE_RULES)": function() {
-         return browser.findByCssSelector("#SINGLE_POSITIVE_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === false, "Field should have been disabled");
-            });
-      },
-
-      "Check field is enabled (SINGLE_NEGATIVE_RULES)": function() {
-         return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES .dijitInputContainer input")
-               .isEnabled()
-               .then(function(result) {
-                  assert(result === true, "Field should have been enabled");
-               });
-      },
-
-      "Check widget is hidden (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#MULTIPLE_MIXED_RULES")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Multiple mixed rule widget displayed unexpectedly");
-            });
-      },
-
-      "Check widget is displayed (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE2 .dijitInputContainer input")
-            .type("x")
-         .end()
-         .findByCssSelector("#MULTIPLE_MIXED_RULES")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result !== "none", "Multiple mixed rule widget should be displayed");
-            });
-      },
-
-      "Check widget is hidden again (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE1 .dijitInputContainer input")
-            .type("x")
-         .end()
-         .findByCssSelector("#MULTIPLE_MIXED_RULES")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Multiple mixed should be hidden again");
-            });
-      },
-
-      "Check requirement indicator was hidden (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE1 .dijitInputContainer input")
-            .type(keys.BACKSPACE)
-         .end()
-         // Requirement should be ON
-         .findByCssSelector("#MULTIPLE_MIXED_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Multiple mixed requirement indicator was not displayed");
-            });
-      },
-
-      "Check widget is disabled (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#MULTIPLE_MIXED_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === false, "Multiple mixed should have been disabled");
-            });
-      },
-
-      "Check requirement indicator is hidden (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#INITIAL_VALUE3 .dijitInputContainer input")
-            .type("x")
-         .end()
-         .findByCssSelector("#MULTIPLE_MIXED_RULES span.requirementIndicator")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "none", "Multiple mixed requirement indicator displayed unexpectedly");
-            });
-      },
-
-      "Check widget is enabled (MULTIPLE_MIXED_RULES)": function() {
-         return browser.findByCssSelector("#MULTIPLE_MIXED_RULES .dijitInputContainer input")
-            .isEnabled()
-            .then(function(result) {
-               assert(result === true, "Multiple mixed should have been enabled");
-            });
-      },
-
-      "Check validation error indicator": function() {
-         return browser.findByCssSelector("#HAS_VALIDATION_CONFIG.alfresco-forms-controls-BaseFormControl--invalid");
-      },
-
-      "Check validation error message": function() {
-         return browser.findByCssSelector("#HAS_VALIDATION_CONFIG span.validation-message")
-            .getComputedStyle("display")
-            .then(function(result) {
-               assert(result === "inline-block", "Validation error message should be displayed");
-            })
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Value must be a number", "Validation error message not set correctly");
-            });
-      },
-
-      "Check validation error indicator is displayed (non-numeric)": function() {
-         return browser.findByCssSelector("#HAS_VALIDATION_CONFIG .dijitInputContainer input")
-            .type("x")
-         .end()
-         .findByCssSelector("#HAS_VALIDATION_CONFIG.alfresco-forms-controls-BaseFormControl--invalid");
-      },
-
-      "Check validation indicator is hidden (non-numeric)": function() {
-         return browser.findByCssSelector("#HAS_VALIDATION_CONFIG .dijitInputContainer input")
-            .type(keys.BACKSPACE)
-            .type("1234")
-         .end()
-         .findAllByCssSelector("#HAS_VALIDATION_CONFIG.alfresco-forms-controls-BaseFormControl--invalid")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0);
-            });
-      },
-
-      "Check invalid configuration": function() {
-         // TODO: Need assertions here...
-         return browser.findByCssSelector("#INVALID_VALIDATION_CONFIG_1")
-            .isDisplayed()
-            .end()
-         .findByCssSelector("#INVALID_VALIDATION_CONFIG_2")
-            .isDisplayed();
-      },
-
-      "Check textbox with help is displayed": function() {
-         return browser.findByCssSelector("#FORM_FIELD_WITH_HELP img.inlineHelp")
-            .then(
-               function() {
-                  // No action;
-               }, 
-               function() {
-                  assert(false, "Textbox with help is not displayed");
-               }
-            );
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
+   var selectors = {
+      textBoxes: {
+         basic: {
+            label: TestCommon.getTestSelector(baseFormControlSelectors, "label", ["BASIC"])
+         },
+         hasValidationConfig: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["HAS_VALIDATION_CONFIG"]),
+            invalid: TestCommon.getTestSelector(baseFormControlSelectors, "invalid.state", ["HAS_VALIDATION_CONFIG"]),
+            validationMessage: TestCommon.getTestSelector(baseFormControlSelectors, "validation.message", ["HAS_VALIDATION_CONFIG"])
+         },
+         initialValue1: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["INITIAL_VALUE1"])
+         },
+         initialValue2: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["INITIAL_VALUE2"])
+         },
+         initialValue3: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["INITIAL_VALUE3"])
+         },
+         multipleMixedRules: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["MULTIPLE_MIXED_RULES"]),
+            requirementIndicator: TestCommon.getTestSelector(baseFormControlSelectors, "requirement.indicator", ["MULTIPLE_MIXED_RULES"])
+         },
+         singleNegativeRules: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["SINGLE_NEGATIVE_RULES"]),
+            requirementIndicator: TestCommon.getTestSelector(baseFormControlSelectors, "requirement.indicator", ["SINGLE_NEGATIVE_RULES"])
+         },
+         singlePostitiveRules: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["SINGLE_POSITIVE_RULES"]),
+            requirementIndicator: TestCommon.getTestSelector(baseFormControlSelectors, "requirement.indicator", ["SINGLE_POSITIVE_RULES"])
+         },
+         unitsAndDescription: {
+            units: TestCommon.getTestSelector(baseFormControlSelectors, "units", ["UNITS_AND_DESCRIPTION"])
+         },
+         withHelp: {
+            helpIndicator: TestCommon.getTestSelector(baseFormControlSelectors, "help.indicator", ["FORM_FIELD_WITH_HELP"])
+         }
       }
    };
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Text Box Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/TextBox", "Text Box Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+        "Check that label is rendered correctly": function () {
+            return browser.findByCssSelector(selectors.textBoxes.basic.label)
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Basic");
+               });
+         },
+
+         "Check that units are rendered correctly": function() {
+            return browser.findByCssSelector(selectors.textBoxes.unitsAndDescription.units)
+               .getVisibleText()
+               .then(function(resultText) {
+                  assert.equal(resultText, "Some unit");
+               });
+         },
+
+         "Check that initial value is set correctly": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue1.input)
+               .getProperty("value")
+               .then(function(resultText) {
+                  assert.equal(resultText,"Val1");
+               });
+         },
+
+         "Check that SINGLE_POSITIVE_RULES widget is displayed": function() {
+            return browser.findDisplayedByCssSelector("#SINGLE_POSITIVE_RULES");
+         },
+
+         "Check that SINGLE_NEGATIVE_RULES widget is hidden": function() {
+            return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES")
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none");
+               });
+         },
+
+         "Check that SINGLE_POSITIVE_RULES widget requirement indicator is shown": function() {
+            return browser.findDisplayedByCssSelector(selectors.textBoxes.singlePostitiveRules.requirementIndicator);
+         },
+
+         "Check requirement indicator": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singleNegativeRules.requirementIndicator)
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result,"none");
+               });
+         },
+
+         "Check field is disabled": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singlePostitiveRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         "Check field is enabled": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singleNegativeRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isTrue(result);
+               });
+         },
+
+         "Check widget is dynamically hidden": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue1.input)
+               .type(keys.BACKSPACE)
+            .end()
+
+            .findByCssSelector("#SINGLE_POSITIVE_RULES")
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none", "Widget displayed unexpectedly after processing positive rules");
+               });
+         },
+
+         "Check widget is displayed": function() {
+            return browser.findDisplayedByCssSelector("#SINGLE_NEGATIVE_RULES");
+         },
+
+         "Check requirement indicator is displayed": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue2.input)
+               .type(keys.BACKSPACE)
+            .end()
+
+            .findDisplayedByCssSelector(selectors.textBoxes.singleNegativeRules.requirementIndicator);
+         },
+
+         "Check requirement indicator is hidden": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singlePostitiveRules.requirementIndicator)
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none", "Requirement indicator displayed unexpectedly");
+               });
+         },
+
+         "Check field is disabled on backspace": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue3.input)
+               .type(keys.BACKSPACE)
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.singleNegativeRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         "Check field is enabled on backspace": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singlePostitiveRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isTrue(result);
+               });
+         },
+
+         "Check widget displayed": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue1.input)
+               .type("1")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.initialValue2.input)
+               .type("2")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.initialValue3.input)
+               .type("3")
+            .end()
+
+            .findDisplayedByCssSelector("#SINGLE_POSITIVE_RULES");
+         },
+
+         "Check widget hidden": function() {
+            return browser.findByCssSelector("#SINGLE_NEGATIVE_RULES")
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none");
+               });
+         },
+
+         "Check requirement indicator displayed": function() {
+            return browser.findDisplayedByCssSelector(selectors.textBoxes.singlePostitiveRules.requirementIndicator);
+         },
+
+         "Check requirement indicate hidden": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singleNegativeRules.requirementIndicator)
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none");
+               });
+         },
+
+         "Check field is disabled (SINGLE_POSITIVE_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singlePostitiveRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         "Check field is enabled (SINGLE_NEGATIVE_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.singleNegativeRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isTrue(result);
+               });
+         },
+
+         "Check widget is hidden (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector("#MULTIPLE_MIXED_RULES")
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none");
+               });
+         },
+
+         "Check widget is displayed (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue2.input)
+               .type("x")
+            .end()
+
+            .findDisplayedByCssSelector("#MULTIPLE_MIXED_RULES");
+         },
+
+         "Check widget is hidden again (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue1.input)
+               .type("x")
+            .end()
+
+            .findByCssSelector("#MULTIPLE_MIXED_RULES")
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none");
+               });
+         },
+
+         "Check requirement indicator was displayed (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue1.input)
+               .type(keys.BACKSPACE)
+            .end()
+
+            // Requirement should be ON
+            .findDisplayedByCssSelector(selectors.textBoxes.multipleMixedRules.requirementIndicator);
+         },
+
+         "Check widget is disabled (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.multipleMixedRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isFalse(result, "Multiple mixed should have been disabled");
+               });
+         },
+
+         "Check requirement indicator is hidden (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.initialValue3.input)
+               .type("x")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.multipleMixedRules.requirementIndicator)
+               .getComputedStyle("display")
+               .then(function(result) {
+                  assert.equal(result, "none");
+               });
+         },
+
+         "Check widget is enabled (MULTIPLE_MIXED_RULES)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.multipleMixedRules.input)
+               .isEnabled()
+               .then(function(result) {
+                  assert.isTrue(result);
+               });
+         },
+
+         "Check validation error indicator": function() {
+            return browser.findByCssSelector(selectors.textBoxes.hasValidationConfig.invalid);
+         },
+
+         "Check validation error message": function() {
+            return browser.findDisplayedByCssSelector(selectors.textBoxes.hasValidationConfig.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Value must be a number");
+               });
+         },
+
+         "Check validation error indicator is displayed (non-numeric)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.hasValidationConfig.input)
+               .type("x")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.hasValidationConfig.invalid);
+         },
+
+         "Check validation indicator is hidden (non-numeric)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.hasValidationConfig.input)
+               .type(keys.BACKSPACE)
+               .type("1234")
+            .end()
+
+            .findAllByCssSelector(selectors.textBoxes.hasValidationConfig.invalid)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               });
+         },
+
+         "Check invalid configuration": function() {
+            return browser.findDisplayedByCssSelector("#INVALID_VALIDATION_CONFIG_1")
+            .end()
+
+            .findDisplayedByCssSelector("#INVALID_VALIDATION_CONFIG_2");
+         },
+
+         "Check textbox with help is displayed": function() {
+            return browser.findDisplayedByCssSelector(selectors.textBoxes.withHelp.helpIndicator);
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
@@ -23,285 +23,307 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon"],
-        function (registerSuite, assert, require, TestCommon) {
+        function (registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
-
-   return {
-      name: "Advanced Form Validation Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/Validation", "Advanced Form Validation Tests").end();
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
+   var formControlSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/BaseFormControl");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   
+   var selectors = {
+      form: {
+         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["TEST_FORM"]),
+         disabledConfirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button.disabled", ["TEST_FORM"])
       },
-
-      beforeEach: function() {
-         browser.end();
+      textBoxes: {
+         threeLettersOrMore: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TEST_CONTROL"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["TEST_CONTROL"]),
+            validating: TestCommon.getTestSelector(formControlSelectors, "validating.state", ["TEST_CONTROL"])
+         },
+         invert: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TEST_CONTROL_INVERT"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["TEST_CONTROL_INVERT"])
+         },
+         topicValidation: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TOPIC_VALIDATION"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["TOPIC_VALIDATION"])
+         },
+         matchTarget: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["MATCH_TARGET"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["MATCH_TARGET"])
+         },
+         matchSource: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["MATCH_SOURCE"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["MATCH_SOURCE"])
+         }
       },
-
-      // teardown: function() {
-      //    browser.end();
-      // },
-
-     "Check that the form is initially invalid": function () {
-         return browser.findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be initially disabled");
-            });
-      },
-
-      "Check the initial error messages (1)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL .validation-message")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Too short, Letters only", "The initial error message is incorrect: " + text);
-            });
-      },
-
-      "Check the initial error messages (2)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL_INVERT .validation-message")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Too short", "The initial error message is incorrect: " + text);
-            });
-      },
-
-      "Check the in-progress indicator isn't shown": function() {
-         return browser.findByCssSelector(".validationInProgress")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "Test", "The in progress indicator is displayed incorrectly");
-            });
-      },
-
-      // Add 3 letters to both controls (make sure errors are cleared and form can be posted)...
-      "Check form confirmation button is enabled": function () {
-         return browser.findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .type("abc")
-         .end()
-         .findByCssSelector("#TEST_CONTROL_INVERT .dijitInputContainer input")
-            .type("abc")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The forms confirmation button should be enabled");
-            });
-      },
-
-      "Check that error message has been removed (1)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL .validation-message")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "The error message was displayed incorrectly");
-            });
-      },
-
-      "Check that error message has been removed (2)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL_INVERT .validation-message")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "The error message was displayed incorrectly");
-            });
-      },
-
-      // Add 6 letters to control 1 (make sure field is invalid and message is correct)...
-      "Test confirmation button disabled (too many chars)": function () {
-         return browser.findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .clearValue()
-            .type("abcdef")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test error message (too many chars)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL .validation-message")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Too long", "The initial error message is incorrect: " + text);
-            });
-      },
-
-      // Add numbers to control 1 (make sure field is invalid and message is correct)...
-      "Test confirmation button disabled (invalid chars)": function () {
-         return browser.findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .clearValue()
-            .type("123")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test error message (invalid chars)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL .validation-message")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Letters only", "The initial error message is incorrect: " + text);
-            });
-      },
-
-      // Add a value to control 1 that is used (make sure field is invalid and message is correct)...
-      "Test confirmation button disabled (duplicate value)": function () {
-         return browser.findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .clearValue()
-            .type("One")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test error message (duplicate value)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL .validation-message")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "Already used", "The initial error message is incorrect: " + text);
-            });
-      },
-
-      // Add a value to control 2 that contains illegal characters (make sure field is invalid and message is correct)...
-      "Test confirmation button is disabled (more illegal chars)": function () {
-         return browser.findByCssSelector("#TEST_CONTROL_INVERT .dijitInputContainer input")
-            .clearValue()
-            .type("abc>def/")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test error message (more illegal chars)": function() {
-         return browser.findByCssSelector("#TEST_CONTROL_INVERT .validation-message")
-            .getVisibleText()
-            .then(function(text) {
-               assert(text === "No illegal characters", "The initial error message is incorrect: " + text);
-            });
-      },
-
-      // Check asynchoronous behaviour...
-      "Test asynchoronous validation indicator gets displayed": function () {
-         return browser.findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .clearValue()
-         .end()
-         .findByCssSelector("#BLOCK_RESPONSE_label")
-            .click()
-         .end()
-         .findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .type("O")
-         .end()
-         .findByCssSelector(".validationInProgress")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === true, "The in progress indicator isn't visible");
-            });
-      },
-
-      "Test progress indicator is removed": function() {
-         return browser.findByCssSelector("#UNBLOCK_RESPONSE_label")
-            .click()
-            .click() // Needs the 2nd click!
-         .end()
-         .findByCssSelector(".validationInProgress")
-            .isDisplayed()
-            .then(function(result) {
-               assert(result === false, "The in progress indicator is visible");
-            });
-      },
-
-      // Need to make the form valid before the next test!
-      "Test confirmation button gets enabled": function () {
-         return browser.findByCssSelector("#TEST_CONTROL .dijitInputContainer input")
-            .clearValue()
-            .type("abc")
-         .end()
-         .findByCssSelector("#TEST_CONTROL_INVERT .dijitInputContainer input")
-            .clearValue()
-            .type("abc")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The forms confirmation button should be enabled");
-            });
-      },
-
-      "Test validationTopic returns a failure": function() {
-         return browser.findByCssSelector("#TOPIC_VALIDATION .dijitInputContainer input")
-            .clearValue()
-            .type("#fail")
-            .end()
-            .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function (elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test validationTopic returns success": function () {
-         return browser.findByCssSelector("#TOPIC_VALIDATION .dijitInputContainer input")
-            .clearValue()
-            .type("success")
-            .end()
-            .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function (elements) {
-               assert(elements.length === 0, "The forms confirmation button should be enabled");
-            });
-      },
-
-      "Test Match Validation - Source Change": function () {
-         return browser.findByCssSelector("#MATCH_TARGET .dijitInputContainer input")
-            .clearValue()
-            .type("ABC")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test Match Validation - Target Match": function () {
-         return browser.findByCssSelector("#MATCH_SOURCE .dijitInputContainer input")
-            .clearValue()
-            .type("ABC")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The forms confirmation button should be enabled");
-            });
-      },
-
-      "Test Match Validation - Target Mismatch": function () {
-         return browser.findByCssSelector("#MATCH_SOURCE .dijitInputContainer input")
-            .clearValue()
-            .type("AB")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 1, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Test Match Validation - Source Match Again": function () {
-         return browser.findByCssSelector("#MATCH_TARGET .dijitInputContainer input")
-            .clearValue()
-            .type("AB")
-         .end()
-         .findAllByCssSelector(".confirmationButton.dijitDisabled")
-            .then(function(elements) {
-               assert(elements.length === 0, "The forms confirmation button should be disabled");
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
+      buttons: {
+         blockResponse: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BLOCK_RESPONSE"]),
+         unblockResponse: TestCommon.getTestSelector(buttonSelectors, "button.label", ["UNBLOCK_RESPONSE"])
       }
    };
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Advanced Form Validation Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Validation", "Advanced Form Validation Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Check that the form is initially invalid": function () {
+            return browser.findCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Check the initial error messages (1)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Too short, Letters only");
+               });
+         },
+
+         "Check the initial error messages (2)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.invert.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Too short");
+               });
+         },
+
+         "Check the in-progress indicator isn't shown": function() {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.validating)
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         // Add 3 letters to both controls (make sure errors are cleared and form can be posted)...
+         "Check form confirmation button is enabled": function () {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .type("abc")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.invert.input)
+               .type("abc")
+            .end()
+
+            .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The forms confirmation button should be enabled");
+               });
+         },
+
+         "Check that error message has been removed (1)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.validationMessage)
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         "Check that error message has been removed (2)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.invert.validationMessage)
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         // Add 6 letters to control 1 (make sure field is invalid and message is correct)...
+         "Test confirmation button disabled (too many chars)": function () {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .clearValue()
+               .type("abcdef")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test error message (too many chars)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Too long");
+               });
+         },
+
+         // Add numbers to control 1 (make sure field is invalid and message is correct)...
+         "Test confirmation button disabled (invalid chars)": function () {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .clearValue()
+               .type("123")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test error message (invalid chars)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Letters only");
+               });
+         },
+
+         // Add a value to control 1 that is used (make sure field is invalid and message is correct)...
+         "Test confirmation button disabled (duplicate value)": function () {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .clearValue()
+               .type("One")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test error message (duplicate value)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Already used");
+               });
+         },
+
+         // Add a value to control 2 that contains illegal characters (make sure field is invalid and message is correct)...
+         "Test confirmation button is disabled (more illegal chars)": function () {
+            return browser.findByCssSelector(selectors.textBoxes.invert.input)
+               .clearValue()
+               .type("abc>def/")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test error message (more illegal chars)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.invert.validationMessage)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "No illegal characters");
+               });
+         },
+
+         // Check asynchoronous behaviour...
+         "Test asynchoronous validation indicator gets displayed": function () {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .clearValue()
+            .end()
+
+            .findByCssSelector(selectors.buttons.blockResponse)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .type("O")
+            .end()
+
+            .findDisplayedByCssSelector(selectors.textBoxes.threeLettersOrMore.validating);
+         },
+
+         "Test progress indicator is removed": function() {
+            return browser.findByCssSelector(selectors.buttons.unblockResponse)
+               .click()
+               .click() // Needs the 2nd click!
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.threeLettersOrMore.validating)
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result);
+               });
+         },
+
+         // Need to make the form valid before the next test!
+         "Test confirmation button gets enabled": function () {
+            return browser.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
+               .clearValue()
+               .type("abc")
+            .end()
+            .findByCssSelector(selectors.textBoxes.invert.input)
+               .clearValue()
+               .type("abc")
+            .end()
+            .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The forms confirmation button should be enabled");
+               });
+         },
+
+         "Test validationTopic returns a failure": function() {
+            return browser.findByCssSelector(selectors.textBoxes.topicValidation.input)
+               .clearValue()
+               .type("#fail")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test validationTopic returns success": function () {
+            return browser.findByCssSelector(selectors.textBoxes.topicValidation.input)
+               .clearValue()
+               .type("success")
+            .end()
+
+            .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+               .then(function (elements) {
+                  assert.lengthOf(elements, 0, "The forms confirmation button should be enabled");
+               });
+         },
+
+         "Test Match Validation - Source Change": function () {
+            return browser.findByCssSelector(selectors.textBoxes.matchTarget.input)
+               .clearValue()
+               .type("ABC")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test Match Validation - Target Match": function () {
+            return browser.findByCssSelector(selectors.textBoxes.matchSource.input)
+               .clearValue()
+               .type("ABC")
+            .end()
+
+            .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The forms confirmation button should be enabled");
+               });
+         },
+
+         "Test Match Validation - Target Mismatch": function () {
+            return browser.findByCssSelector(selectors.textBoxes.matchSource.input)
+               .clearValue()
+               .type("AB")
+            .end()
+
+            .findByCssSelector(selectors.form.disabledConfirmationButton);
+         },
+
+         "Test Match Validation - Source Match Again": function () {
+            return browser.findByCssSelector(selectors.textBoxes.matchSource.input)
+               .clearValue()
+               .type("AB")
+            .end()
+
+            .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "The forms confirmation button should be disabled");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/Form.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/Form.properties
@@ -1,5 +1,14 @@
+# Use to find the cancellation button of the form
+cancellation.button=#{0} .cancelButton .dijitButtonNode
+
 # Use to find the confirmation button of the form
 confirmation.button=#{0} .confirmationButton .dijitButtonNode
 
 # Use to find the disabled confirmation button in the form
 confirmation.button.disabled=#{0} .confirmationButton.dijitDisabled
+
+# A button displayed outside of the viewport for accessibility reasons
+hidden.confirmation.button=#{0} .alfresco-buttons-AlfButton:nth-child(1) input[type="button"]
+
+# A button displayed outside of the viewport for accessibility reasons
+hidden.cancellation.button=#{0} .alfresco-buttons-AlfButton:nth-child(2) input[type="button"]

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/BaseFormControl.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/BaseFormControl.properties
@@ -1,0 +1,20 @@
+# Help indicator
+help.indicator=#{0} img.inlineHelp
+
+# A control that is currently in the invalid state
+invalid.state=#{0}.alfresco-forms-controls-BaseFormControl--invalid
+
+# Label
+label=#{0}.alfresco-forms-controls-BaseFormControl .label
+
+# Requirement indicator icon
+requirement.indicator=#{0} span.requirementIndicator
+
+# Units
+units=#{0}.alfresco-forms-controls-BaseFormControl .units
+
+# A control that is currently being asynchronously validated
+validating.state=#{0}.alfresco-forms-controls-BaseFormControl .validationInProgress
+
+# Validation message
+validation.message=#{0} span.validation-message

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/CheckBox.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/CheckBox.properties
@@ -1,0 +1,2 @@
+# Checkbox
+checkbox=#{0} .dijitCheckBox input

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/Select.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/Select.properties
@@ -1,0 +1,5 @@
+# Open drop-down arrow icon
+open.menu.icon=#{0} .dijitArrowButtonInner
+
+# nth option label
+nth.option.label=#{0}_CONTROL_dropdown table tr:nth-child({1}) td.dijitMenuItemLabel

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/TextBox.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/TextBox.properties
@@ -1,0 +1,2 @@
+# Input field
+input=#{0} .dijitInputContainer input

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/AsyncFormControlLoading.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/AsyncFormControlLoading.get.js
@@ -274,6 +274,7 @@ function getFormControlConfigWidgets() {
                   config: {
                      widgets: [
                         {
+                           id: "INITIALLY_VISIBLE",
                            name: "alfresco/forms/controls/CheckBox",
                            config: {
                               name: "config.visibilityConfig.initialValue",
@@ -449,7 +450,7 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         id: "CREATE_DILAOG_BUTTON",
+         id: "CREATE_DIALOG_BUTTON",
          name: "alfresco/buttons/AlfButton",
          config: {
             label: "Create form dialog",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/AutoSet.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/AutoSet.get.js
@@ -26,6 +26,7 @@ model.jsonModel = {
          }
       },
       {
+         id: "FORM",
          name: "alfresco/forms/Form",
          config: {
             okButtonPublishTopic: "POST_FORM",
@@ -106,7 +107,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/BaseForm.get.js
@@ -15,18 +15,18 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         id: "SET_FORM_VALUE_1",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "SET_FORM_VALUE_1",
             label: "Publish update without payload",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_"
          }
       },
       {
+         id: "SET_FORM_VALUE_2",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "SET_FORM_VALUE_2",
             label: "Incorrect fieldname in update payload",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
@@ -36,9 +36,9 @@ model.jsonModel = {
          }
       },
       {
+         id: "SET_FORM_VALUE_3",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "SET_FORM_VALUE_3",
             label: "Update and set string value",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
@@ -48,9 +48,9 @@ model.jsonModel = {
          }
       },
       {
+         id: "SET_FORM_VALUE_4",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "SET_FORM_VALUE_4",
             label: "Update and set number value",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",
@@ -60,9 +60,9 @@ model.jsonModel = {
          }
       },
       {
+         id: "SET_FORM_VALUE_5",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "SET_FORM_VALUE_5",
             label: "Update and set boolean value",
             publishTopic: "SET_FORM_CONTROL_VALUE",
             pubSubScope: "TEST_SCOPE_",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/TextBox.get.js
@@ -405,10 +405,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -16,8 +16,8 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         name: "alfresco/forms/Form",
          id: "TEST_FORM",
+         name: "alfresco/forms/Form",
          config: {
             widgets: [
                {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-838 to externalise test selectors for form controls. The base form control selectors have been added, as well as some other specific selectors. Not all the tests have been updated, but a significant chunk have been addressed to ensure the most common selectors are provided.