### PR TITLE
AKU-840: Ensure plugin overrides are placed at beginning of the array.

### DIFF
--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
@@ -378,7 +378,7 @@ define(["dojo/_base/declare",
          else
          {
             // The condition provided does not already exist so add it now...
-            this.pluginConditions.push(condition);
+            this.pluginConditions.splice(0, 0, condition);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
+++ b/aikau/src/main/resources/alfresco/preview/AlfDocumentPreview.js
@@ -378,7 +378,7 @@ define(["dojo/_base/declare",
          else
          {
             // The condition provided does not already exist so add it now...
-            this.pluginConditions.splice(0, 0, condition);
+            this.pluginConditions.unshift(condition);
          }
       },
 


### PR DESCRIPTION
This is a further enhancement to the changes made for https://issues.alfresco.com/jira/browse/AKU-840. The issue that the customer was having was that new plugin conditions were being placed at the end of the condition array and the catch-all "imgpreview" thumbnail condition was being matched before the additional condition. This was resulting in the image previewer being used instead of the video previewer. This change ensures that all new conditions will be evaluated first.