### PR TITLE
Fixed loading order of lightbox 'loading' image into init method

### DIFF
--- a/aikau/src/main/resources/alfresco/services/LightboxService.js
+++ b/aikau/src/main/resources/alfresco/services/LightboxService.js
@@ -45,6 +45,21 @@ define(["dojo/_base/declare",
        * @type {String[]}
        */
       nonAmdDependencies: ["/js/lib/3rd-party/lightbox.js"],
+      
+      /**
+       * If a service needs to act upon its post-mixed-in state before registering subscriptions then
+       * this is where it should be done. It is comparable to postMixInProperties in a widget in the
+       * class lifecycle.
+       * 
+       * @instance
+       */
+      initService: function alfresco_services_LightboxService__initService() {
+         
+         Alfresco.AikauLightbox.init({
+            loadingImage: require.toUrl("alfresco/services/css/images/loading.gif"),
+            closeButton: require.toUrl("alfresco/services/css/images/close.gif")
+         });
+      },
 
       /**
        * Sets up the subscriptions for the LightboxService
@@ -53,6 +68,7 @@ define(["dojo/_base/declare",
        * @since 1.0.32
        */
       registerSubscriptions: function alfresco_services_LightboxService__registerSubscriptions() {
+         
          this.alfSubscribe("ALF_DISPLAY_LIGHTBOX", lang.hitch(this, this.onDisplayLightbox));
       },
       
@@ -63,6 +79,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the image.
        */
       onDisplayLightbox: function alfresco_services_LightboxService__onDisplayLightbox(payload) {
+         
          var src = lang.getObject("src", false, payload),
              title = lang.getObject("title", false, payload);
          if (!src)
@@ -74,9 +91,7 @@ define(["dojo/_base/declare",
             // call the non-AMD Lightbox JS to perform the actual work of displaying the image in a lightbox
             Alfresco.AikauLightbox.show({
                src: src,
-               title: title,
-               loadingImage: require.toUrl("alfresco/services/css/images/loading.gif"),
-               closeButton: require.toUrl("alfresco/services/css/images/close.gif")
+               title: title
             });
          }
       }

--- a/aikau/src/main/resources/lib/3rd-party/lightbox.js
+++ b/aikau/src/main/resources/lib/3rd-party/lightbox.js
@@ -126,9 +126,6 @@ Alfresco.AikauLightbox = (function() {
    //
    var showLightbox = function showLightbox(objLink)
    {
-      loadingImage = objLink.loadingImage;
-      closeButton = objLink.closeButton;
-
       // prep objects
       var objOverlay = document.getElementById("aikauOverlay");
       var objLightbox = document.getElementById("aikauLightbox");
@@ -153,8 +150,7 @@ Alfresco.AikauLightbox = (function() {
 
       // preload image
       imgPreload = new Image();
-   
-      imgPreload.onload=function(){
+      imgPreload.onload = function() {
          objImage.src = objLink.href || objLink.src;
    
          // center lightbox and make sure that the top and left values are not negative
@@ -188,15 +184,21 @@ Alfresco.AikauLightbox = (function() {
             // An HTMLELement weas passed in
             title = objLink.getAttribute("title");
          }
-         if (title){
+         if (title)
+         {
             objCaption.style.display = "block";
             //objCaption.style.width = imgPreload.width + "px";
             objCaption.innerHTML = title;
-         } else {
+         }
+         else
+         {
             objCaption.style.display = "none";
          }
    
-         if (objLoadingImage) {  objLoadingImage.style.display = "none"; }
+         if (objLoadingImage)
+         {
+            objLoadingImage.style.display = "none";
+         }
    
          objLightbox.style.display = "block";
    
@@ -219,31 +221,6 @@ Alfresco.AikauLightbox = (function() {
       };
    
       imgPreload.src = objLink.href || objLink.src;
-
-      // preload and create close button image
-      if (!document.getElementById("aikauCloseButton") && document.getElementById("aikauLink"))
-      {
-         var imgPreloadCloseButton = new Image();
-   
-         // if close button image found, 
-         imgPreloadCloseButton.onload=function(){
-      
-            var objCloseButton = document.createElement("img");
-            objCloseButton.src = closeButton;
-            objCloseButton.setAttribute("id","aikauCloseButton");
-            if (Alfresco && Alfresco.util && typeof Alfresco.util.message === "function")
-            {
-               objCloseButton.setAttribute("alt",Alfresco.util.message.call(this, "lightbox.close"));
-            }
-            objCloseButton.style.position = "absolute";
-            objCloseButton.style.zIndex = "200";
-            objCloseButton.style.right = "8px";
-            document.getElementById("aikauLink").appendChild(objCloseButton);
-            return false;
-         };
-      
-         imgPreloadCloseButton.src = closeButton;
-      }
    };
    
    
@@ -278,8 +255,11 @@ Alfresco.AikauLightbox = (function() {
    // The function also inserts html markup at the top of the page which will be used as a
    // container for the overlay pattern and the inline image.
    //
-   var initLightbox = function initLightbox()
+   var initLightbox = function initLightbox(config)
    {
+      loadingImage = config.loadingImage;
+      closeButton = config.closeButton;
+      
       var objBody = document.getElementsByTagName("body").item(0);
       
       // create overlay div and hardcode some functional styles (aesthetic styles are in CSS file)
@@ -303,11 +283,11 @@ Alfresco.AikauLightbox = (function() {
       var imgPreloader = new Image();
       
       // if loader image found, create link to hide lightbox and create loadingimage
-      imgPreloader.onload=function(){
-   
+      imgPreloader.onload = function() {
+         
          var objLoadingImageLink = document.createElement("a");
          objLoadingImageLink.setAttribute("href","#");
-         objLoadingImageLink.onclick = function () {
+         objLoadingImageLink.onclick = function() {
             hideLightbox(); return false;
          };
          objOverlay.appendChild(objLoadingImageLink);
@@ -317,17 +297,17 @@ Alfresco.AikauLightbox = (function() {
          objLoadingImage.setAttribute("id","aikauLoadingImage");
          if (Alfresco && Alfresco.util && typeof Alfresco.util.message === "function")
          {
-            objLoadingImage.setAttribute("alt",Alfresco.util.message.call(this, "lightbox.loading"));
+            objLoadingImage.setAttribute("alt", Alfresco.util.message.call(this, "lightbox.loading"));
          }
          objLoadingImage.style.position = "absolute";
          objLoadingImage.style.zIndex = "150";
          objLoadingImageLink.appendChild(objLoadingImage);
-   
+         
          imgPreloader.onload=function(){};   // clear onLoad, as IE will flip out w/animated gifs
-   
+         
          return false;
       };
-   
+      
       imgPreloader.src = loadingImage;
    
       // create lightbox div, same note about styles as above
@@ -348,6 +328,25 @@ Alfresco.AikauLightbox = (function() {
          return false;
       };
       objLightbox.appendChild(objLink);
+      
+      // create close button image
+      var imgPreloadCloseButton = new Image();
+      imgPreloadCloseButton.onload = function() {
+         
+         var objCloseButton = document.createElement("img");
+         objCloseButton.src = closeButton;
+         objCloseButton.setAttribute("id","aikauCloseButton");
+         if (Alfresco && Alfresco.util && typeof Alfresco.util.message === "function")
+         {
+            objCloseButton.setAttribute("alt",Alfresco.util.message.call(this, "lightbox.close"));
+         }
+         objCloseButton.style.position = "absolute";
+         objCloseButton.style.zIndex = "200";
+         objCloseButton.style.right = "8px";
+         objLink.appendChild(objCloseButton);
+         return false;
+      };
+      imgPreloadCloseButton.src = closeButton;
    
       // create image
       var objImage = document.createElement("img");
@@ -367,16 +366,8 @@ Alfresco.AikauLightbox = (function() {
       objLightboxDetails.appendChild(objCaption);
    };
    
-   if (window.addEventListener)
-   {
-      window.addEventListener("load", initLightbox, false);
-   }
-   else
-   {
-      window.attachEvent("onload", initLightbox);
-   }
-   
    return {
+       init: initLightbox,
        show: showLightbox
    };
 })();


### PR DESCRIPTION
Fixed loading order of lightbox 'loading' image into init method for LightboxService.

Fixes the issue where the "loading" spinner image is never actually loaded (you can see this on the Aikau sandbox page with clickable thumbnails).

Also removes the need for a cheeky window.load event handler to be injected from the non-amd code. The old Lightbox non-amd code is horrible, and needs a rewrite but for a later time...