### PR TITLE
AKU-860: "Request to join a moderated site multiple times"

### DIFF
--- a/aikau/src/main/resources/alfresco/core/NotificationUtils.js
+++ b/aikau/src/main/resources/alfresco/core/NotificationUtils.js
@@ -25,9 +25,10 @@
  * @deprecated Since 1.0.17 - use the [NotificationService]{@link module:alfresco/services/NotificationService} instead.
  */
 define(["dojo/_base/declare",
+        "dojo/_base/lang",
         "alfresco/core/topics",
         "alfresco/core/Core"],
-        function(declare, topics, AlfCore) {
+        function(declare, lang, topics, AlfCore) {
 
    return declare([AlfCore], {
 
@@ -35,13 +36,22 @@ define(["dojo/_base/declare",
        * This function handles displaying popup messages. 
        *
        * @instance
-       * @param msg {String} The message to be displayed.
+       * @param {string} msg The message to be displayed.
+       * @param {object} postMessagePublish A publication to occur after the message has displayed, provided as a mixin to the payload.
+       * @param {string} postMessagePublish.publishTopic The topic to publish
+       * @param {string} postMessagePublish.publishPayload The payload to publish
+       * @param {string} postMessagePublish.publishGlobal Whether to publish globally
+       * @param {string} postMessagePublish.publishToParent Whether to publish to parent
        * @fires module:alfresco/core/topics#DISPLAY_NOTIFICATION
        */
-      displayMessage: function alfresco_core_Core__displayMessage(msg) {
-         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, {
+      displayMessage: function alfresco_core_Core__displayMessage(msg, postMessagePublish) {
+         var payload = {
             message: msg
-         });
+         };
+         if (postMessagePublish) {
+            lang.mixin(payload, postMessagePublish);
+         }
+         this.alfServicePublish(topics.DISPLAY_NOTIFICATION, payload);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -115,6 +115,18 @@ define([],function() {
       CANCEL_INPROGRESS_UPLOAD: "CANCEL_INPROGRESS_UPLOAD",
 
       /**
+       * Cancel a request to join a site.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.58
+       *
+       * @event
+       */
+      CANCEL_JOIN_SITE_REQUEST: "ALF_CANCEL_JOIN_SITE_REQUEST",
+
+      /**
        * This topic is published to request the options to change the type of a node. It doesn't perform the
        * actual change, but simply provides the type change options in a dialog.
        *

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -123,6 +123,10 @@ define([],function() {
        * @since 1.0.58
        *
        * @event
+       * @property {string} siteId The ID of the site
+       * @property {string} siteTitle The "friendly" name of the site
+       * @property {object} pendingInvite The object describing the pending invite
+       * @property {string} pendingInvite.id The ID of the pending site-join request
        */
       CANCEL_JOIN_SITE_REQUEST: "ALF_CANCEL_JOIN_SITE_REQUEST",
 

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -130,7 +130,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe("ALF_REMOVE_FAVOURITE_SITE", lang.hitch(this, this.removeSiteFromFavourites));
          this.alfSubscribe("ALF_GET_RECENT_SITES", lang.hitch(this, this.getRecentSites));
          this.alfSubscribe("ALF_GET_FAVOURITE_SITES", lang.hitch(this, this.getFavouriteSites));
-         this.alfSubscribe("ALF_CANCEL_JOIN_SITE_REQUEST", lang.hitch(this, this.cancelJoinSiteRequest));
+         this.alfSubscribe(topics.CANCEL_JOIN_SITE_REQUEST, lang.hitch(this, this.cancelJoinSiteRequest));
 
          // Make sure that the edit-site.js file is loaded. This is required for as it handles legacy site
          // editing. At some stage this will not be needed when a new edit site dialog is provided.

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -624,6 +624,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} response The response from the XHR request to join the site.
        * @param {object} originalRequestConfig The original configuration passed when the request was made.
+       * @since 1.0.58
        */
       siteMembershipRequestFailed: function alfresco_services_SiteService__siteMembershipRequestFailed(response, originalRequestConfig) {
          this.alfLog("warn", "Request to join site failed:", originalRequestConfig);

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -528,6 +528,7 @@ define(["dojo/_base/declare",
             this.serviceXhr({url : url,
                              method: "POST",
                              site: config.site,
+                             siteTitle: config.siteTitle,
                              user: config.user,
                              data: data,
                              successCallback: this.siteMembershipRequestComplete,
@@ -558,7 +559,7 @@ define(["dojo/_base/declare",
          this.alfLog("log", "User has successfully requested to join a moderated site", response, originalRequestConfig);
          this.alfServicePublish(topics.CREATE_DIALOG, {
             dialogTitle: this.message("message.request-join-success-title"),
-            textContent: this.message("message.request-join-success", {"0": originalRequestConfig.user, "1": originalRequestConfig.site}),
+            textContent: this.message("message.request-join-success", {"0": originalRequestConfig.user, "1": originalRequestConfig.siteTitle || originalRequestConfig.site}),
             widgetsButtons: [
                {
                   name: "alfresco/buttons/AlfButton",

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -130,6 +130,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe("ALF_REMOVE_FAVOURITE_SITE", lang.hitch(this, this.removeSiteFromFavourites));
          this.alfSubscribe("ALF_GET_RECENT_SITES", lang.hitch(this, this.getRecentSites));
          this.alfSubscribe("ALF_GET_FAVOURITE_SITES", lang.hitch(this, this.getFavouriteSites));
+         this.alfSubscribe("ALF_CANCEL_JOIN_SITE_REQUEST", lang.hitch(this, this.cancelJoinSiteRequest));
 
          // Make sure that the edit-site.js file is loaded. This is required for as it handles legacy site
          // editing. At some stage this will not be needed when a new edit site dialog is provided.
@@ -532,6 +533,7 @@ define(["dojo/_base/declare",
                              user: config.user,
                              data: data,
                              successCallback: this.siteMembershipRequestComplete,
+                             failureCallback: this.siteMembershipRequestFailed,
                              callbackScope: this});
          }
          else
@@ -546,6 +548,44 @@ define(["dojo/_base/declare",
                this.alfLog("error", "A request was made to join a site but no user was specified", config);
             }
          }
+      },
+
+      /**
+       * Cancel a pending request to join a site
+       *
+       * @instance
+       * @param {object} payload The publication payload
+       * @since 1.0.58
+       */
+      cancelJoinSiteRequest: function alfresco_services_SiteService__cancelJoinSiteRequest(payload) {
+         var siteId = payload.siteId,
+            siteTitle = payload.siteTitle,
+            encodedSiteId = encodeURIComponent(siteId),
+            pendingInvite = encodeURIComponent(payload.pendingInvite.id),
+            url = AlfConstants.PROXY_URI + "api/sites/" + encodedSiteId + "/invitations/" + pendingInvite;
+         this.serviceXhr({
+            url: url,
+            siteTitle: siteTitle || siteId,
+            method: "DELETE",
+            successCallback: this._cancelJoinSiteRequestSuccess,
+            callbackScope: this
+         });
+      },
+
+      /**
+       * Success-handler for the request to cancel a join-site request.
+       *
+       * @instance
+       * @param {object} response The response object
+       * @param {object} originalRequestConfig The original configuration passed when the request was made
+       * @since 1.0.58
+       */
+      _cancelJoinSiteRequestSuccess: function alfresco_services_SiteService___cancelJoinSiteRequestSuccess(response, originalRequestConfig) {
+         this.displayMessage(this.message("message.cancel-join-request-success", {
+            "0": originalRequestConfig.siteTitle
+         }), {
+            publishTopic: topics.RELOAD_PAGE // This is more reliable than an arbitrary timeout in ensuring the message will be displayed before reloading
+         });
       },
 
       /**
@@ -576,6 +616,22 @@ define(["dojo/_base/declare",
                }
             ]
          });
+      },
+
+      /**
+       * Callback that occurs after a request to join a moderated site has failed.
+       *
+       * @instance
+       * @param {object} response The response from the XHR request to join the site.
+       * @param {object} originalRequestConfig The original configuration passed when the request was made.
+       */
+      siteMembershipRequestFailed: function alfresco_services_SiteService__siteMembershipRequestFailed(response, originalRequestConfig) {
+         this.alfLog("warn", "Request to join site failed:", originalRequestConfig);
+         var responseMessage = lang.getObject("response.text", false, response),
+            requestPendingMessage = "A request to join this site is in pending", // NOTE: This is a string-literal in Share's "Site.java" file
+            failedBecausePending = responseMessage && responseMessage.indexOf(requestPendingMessage) !== -1,
+            failureMessage = failedBecausePending ? "message.request-join-site-pending-failure" : "message.request-join-site-failure";
+         this.displayMessage(this.message(failureMessage));
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -45,3 +45,8 @@ edit-site.saving=Site details are being saved...
 create-site.failure.dialog.title=We couldn't create the site
 edit-site.failure.dialog.title=We couldn't save the site info
 error.duplicateShortName=We couldn't create the site because the URL is already used
+
+# Following four messages added as part of AKU-860
+message.cancel-join-request-success=Successfully cancelled request to join site {0}
+message.request-join-site-pending-failure=A request to join this site is already pending
+message.request-join-site-failure=The request to join the site failed

--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -15,8 +15,6 @@ button.leave-site.cancel-label=Cancel
 
 message.request-joining=Requesting to add user {0} to site {1}...
 message.request-join-success-title=Request Sent
-message.request-join-success=Request to join site {1} successfully sent. You'll now be returned to your personal dashboard.
-message.request-join-failure=We couldn't make the request to add user {0} to site {1}.
 
 message.delete-site-confirm-title=Delete Site
 message.delete-site-prompt=If you delete site '{0}' all its content will also be deleted?

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -159,6 +159,56 @@ define(["alfresco/TestCommon",
             .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible");
          },
 
+         "Requesting to join site with request already pending displays suitable error message": function() {
+            return browser.findById("REQUEST_SITE_MEMBERSHIP_ALREADY_PENDING_label")
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(".alfresco-notifications-AlfNotification__message")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "A request to join this site is already pending");
+               })
+            .end()
+
+            .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification");
+         },
+
+         "Error occurring when requesting to join site displays error message": function() {
+            return browser.findById("REQUEST_SITE_MEMBERSHIP_ERROR_label")
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(".alfresco-notifications-AlfNotification__message")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "The request to join the site failed");
+               })
+            .end()
+
+            .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification");
+         },
+
+         "Can cancel request to join site": function() {
+            return browser.findById("CANCEL_PENDING_REQUEST_label")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastXhr("api/sites/my-site/invitations/foo")
+
+            .findDisplayedByCssSelector(".alfresco-notifications-AlfNotification__message")
+               .getVisibleText()
+               .then(function(visibleText) {
+                  assert.equal(visibleText, "Successfully cancelled request to join site My Site");
+               })
+            .end()
+
+            .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification")
+
+            .getLastPublish("ALF_RELOAD_PAGE");
+         },
+
          "Leave site and confirm user home page override works": function(){
             return browser.findById("LEAVE_SITE_label")
                .click()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -16,38 +16,23 @@ model.jsonModel = {
             legacyMode: false
          }
       },
-      {
-         name: "alfresco/services/DialogService"
-      },
-      {
-         name: "alfresco/services/SiteService",
-         config: {
-            pubSubScope: "NORMAL_USER_"
-         }
-      },
-      {
-         name: "alfresco/services/SiteService",
-         config: {
-            pubSubScope: "ADMIN_USER_"
-         }
-      },
+      "alfresco/services/DialogService",
       "alfresco/services/NotificationService",
       "alfresco/services/ErrorReporter"
    ],
    widgets:[
-
       {
          name: "alfresco/buttons/AlfButton",
+         id: "CREATE_SITE",
          config: {
-            id: "CREATE_SITE",
             label: "Create Site",
             publishTopic: "ALF_CREATE_SITE"
          }
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "EDIT_SITE",
          config: {
-            id: "EDIT_SITE",
             label: "Edit Site",
             publishTopic: "ALF_EDIT_SITE",
             publishPayload: {
@@ -55,194 +40,10 @@ model.jsonModel = {
             }
          }
       },
-
       {
          name: "alfresco/buttons/AlfButton",
+         id: "BECOME_SITE_MANAGER",
          config: {
-            id: "GET_SITE_DETAILS",
-            label: "Get Site Details",
-            publishTopic: "ALF_GET_SITE_DETAILS",
-            publishPayload: {
-               site: "swsdp",
-               responseTopic: "ALF_PROCESS_SITE_DETAILS"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_DETAILS_BAD1",
-            label: "Get Site Details Bad 1",
-            publishTopic: "ALF_GET_SITE_DETAILS"
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_DETAILS_BAD2",
-            label: "Get Site Details Bad 2",
-            publishTopic: "ALF_GET_SITE_DETAILS",
-            publishPayload: {
-               site: "swsdp"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_DETAILS_BAD3",
-            label: "Get Site Details Bad 3",
-            publishTopic: "ALF_GET_SITE_DETAILS",
-            publishPayload: {
-               responseTopic: "ALF_PROCESS_SITE_DETAILS"
-            }
-         }
-      },
-
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "ADD_FAVOURITE_SITE",
-            label: "Add Favourite Site",
-            publishTopic: "ALF_ADD_FAVOURITE_SITE",
-            publishPayload: {
-               site: "swsdp",
-               user: "admin"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "ADD_FAVOURITE_SITE_BAD1",
-            label: "Add Favourite Site Bad 1",
-            publishTopic: "ALF_ADD_FAVOURITE_SITE",
-            publishPayload: {
-               user: "admin"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "ADD_FAVOURITE_SITE_BAD2",
-            label: "Add Favourite Site Bad 2",
-            publishTopic: "ALF_ADD_FAVOURITE_SITE",
-            publishPayload: {
-               site: "swsdp"
-            }
-         }
-      },
-
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "REMOVE_FAVOURITE_SITE",
-            label: "Remove Favourite Site",
-            publishTopic: "ALF_REMOVE_FAVOURITE_SITE",
-            publishPayload: {
-               site: "swsdp",
-               user: "admin"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "REMOVE_FAVOURITE_SITE_BAD1",
-            label: "Remove Favourite Site Bad 1",
-            publishTopic: "ALF_REMOVE_FAVOURITE_SITE",
-            publishPayload: {
-               site: "swsdp"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "REMOVE_FAVOURITE_SITE_BAD2",
-            label: "Remove Favourite Site Bad 2",
-            publishTopic: "ALF_REMOVE_FAVOURITE_SITE",
-            publishPayload: {
-               user: "admin"
-            }
-         }
-      },
-
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_MEMBERSHIPS",
-            label: "Get Site Memberships",
-            publishTopic: "ALF_GET_SITE_MEMBERSHIPS",
-            publishPayload: {
-               site: "swsdp",
-               responseTopic: "ALF_PROCESS_SITE_MEMBERSHIPS"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_MEMBERSHIPS_BAD1",
-            label: "Get Site Memberships Bad 1",
-            publishTopic: "ALF_GET_SITE_MEMBERSHIPS"
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_MEMBERSHIPS_BAD2",
-            label: "Get Site Memberships Bad 2",
-            publishTopic: "ALF_GET_SITE_MEMBERSHIPS",
-            publishPayload: {
-               site: "swsdp"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_SITE_MEMBERSHIPS_BAD3",
-            label: "Get Site Memberships Bad 3",
-            publishTopic: "ALF_GET_SITE_MEMBERSHIPS",
-            publishPayload: {
-               responseTopic: "ALF_PROCESS_SITE_MEMBERSHIPS"
-            }
-         }
-      },
-
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "UPDATE_SITE_DETAILS",
-            label: "Update Site Details",
-            publishTopic: "ALF_UPDATE_SITE_DETAILS",
-            publishPayload: {
-               shortName: "swsdp",
-               responseTopic: "ALF_PROCESS_UPDATE_SITE_DETAILS"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "UPDATE_SITE_DETAILS_BAD1",
-            label: "Update Site Details Bad 1",
-            publishTopic: "ALF_UPDATE_SITE_DETAILS",
-            publishPayload: {
-               responseTopic: "ALF_PROCESS_UPDATE_SITE_DETAILS"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "BECOME_SITE_MANAGER",
             label: "Become Site Manager",
             publishTopic: "ALF_BECOME_SITE_MANAGER",
             publishPayload: {
@@ -254,43 +55,7 @@ model.jsonModel = {
       },
       {
          name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "BECOME_SITE_MANAGER_BAD1",
-            label: "Become Site Manager Bad 1",
-            publishTopic: "ALF_BECOME_SITE_MANAGER",
-            publishPayload: {
-               role: "SiteCollaborator",
-               user: "admin"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "BECOME_SITE_MANAGER_BAD2",
-            label: "Become Site Manager Bad 2",
-            publishTopic: "ALF_BECOME_SITE_MANAGER",
-            publishPayload: {
-               site: "swsdp",
-               user: "admin"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "BECOME_SITE_MANAGER_BAD3",
-            label: "Become Site Manager Bad 3",
-            publishTopic: "ALF_BECOME_SITE_MANAGER",
-            publishPayload: {
-               site: "swsdp",
-               role: "SiteCollaborator"
-            }
-         }
-      },
-      {
          id: "BECOME_SITE_MANAGER_PAGE_RELOAD",
-         name: "alfresco/buttons/AlfButton",
          config: {
             label: "Become Site Manager (reload page)",
             publishTopic: "ALF_BECOME_SITE_MANAGER",
@@ -303,8 +68,8 @@ model.jsonModel = {
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "REQUEST_SITE_MEMBERSHIP",
          config: {
-            id: "REQUEST_SITE_MEMBERSHIP",
             label: "Request Site Membership",
             publishTopic: "ALF_REQUEST_SITE_MEMBERSHIP",
             publishPayload: {
@@ -317,286 +82,57 @@ model.jsonModel = {
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "REQUEST_SITE_MEMBERSHIP_ALREADY_PENDING",
          config: {
-            id: "REQUEST_SITE_MEMBERSHIP_BAD1",
-            label: "Request Site Membership Bad 1",
+            label: "Request Site Membership (Already pending)",
             publishTopic: "ALF_REQUEST_SITE_MEMBERSHIP",
             publishPayload: {
+               site: "swsdp",
                user: "admin",
                role: "SiteCollaborator",
-               comments: "Just for fun"
+               comments: "Request pending"
             }
          }
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "REQUEST_SITE_MEMBERSHIP_ERROR",
          config: {
-            id: "REQUEST_SITE_MEMBERSHIP_BAD2",
-            label: "Request Site Membership Bad 2",
+            label: "Request Site Membership (Other error)",
             publishTopic: "ALF_REQUEST_SITE_MEMBERSHIP",
             publishPayload: {
                site: "swsdp",
+               user: "admin",
                role: "SiteCollaborator",
-               comments: "Just for fun"
+               comments: "Error"
             }
          }
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "CANCEL_PENDING_REQUEST",
          config: {
-            id: "REQUEST_SITE_MEMBERSHIP_BAD3",
-            label: "Request Site Membership Bad 3",
-            publishTopic: "ALF_REQUEST_SITE_MEMBERSHIP",
+            label: "Cancel pending join-site request",
+            publishTopic: "ALF_CANCEL_JOIN_SITE_REQUEST",
             publishPayload: {
-               site: "swsdp",
-               user: "admin",
-               comments: "Just for fun"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "REQUEST_SITE_MEMBERSHIP_BAD4",
-            label: "Request Site Membership Bad 4",
-            publishTopic: "ALF_REQUEST_SITE_MEMBERSHIP",
-            publishPayload: {
-               site: "swsdp",
-               user: "admin",
-               role: "SiteCollaborator"
-            }
-         }
-      },
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_RECENT_SITES",
-            label: "Get Recent Sites",
-            publishTopic: "ALF_GET_RECENT_SITES",
-            publishPayload: {
-               alfResponseTopic: "ALF_PROCESS_RECENT_SITES"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_RECENT_SITES_BAD1",
-            label: "Get Recent Sites Bad 1",
-            publishTopic: "ALF_GET_RECENT_SITES"
-         }
-      },
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_FAVOURITE_SITES",
-            label: "Get Favourite Sites",
-            publishTopic: "ALF_GET_FAVOURITE_SITES",
-            publishPayload: {
-               alfResponseTopic: "ALF_PROCESS_FAVOURITE_SITES"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "GET_FAVOURITE_SITES_BAD1",
-            label: "Get Favourite Sites Bad 1",
-            publishTopic: "ALF_GET_FAVOURITE_SITES"
-         }
-      },
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "DELETE_SITE",
-            label: "Delete Site",
-            publishTopic: "ALF_DELETE_SITE",
-            publishPayload: {
-               document: {
-                  shortName: "swsdp"
+               siteId: "my-site",
+               siteTitle: "My Site",
+               pendingInvite: {
+                  id: "foo"
                }
             }
          }
       },
-
       {
          name: "alfresco/buttons/AlfButton",
+         id: "LEAVE_SITE",
          config: {
-            id: "JOIN_SITE",
-            label: "Join Site",
-            publishTopic: "ALF_JOIN_SITE",
-            publishPayload: {
-               site: "swsdp",
-               user: "admin",
-               role: "SiteCollaborator"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "JOIN_SITE_BAD1",
-            label: "Join Site Bad 1",
-            publishTopic: "ALF_JOIN_SITE",
-            publishPayload: {
-               user: "admin",
-               role: "SiteCollaborator"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "JOIN_SITE_BAD2",
-            label: "Join Site Bad 2",
-            publishTopic: "ALF_JOIN_SITE",
-            publishPayload: {
-               site: "swsdp",
-               role: "SiteCollaborator"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "JOIN_SITE_BAD3",
-            label: "Join Site Bad 3",
-            publishTopic: "ALF_JOIN_SITE",
-            publishPayload: {
-               site: "swsdp",
-               user: "admin"
-            }
-         }
-      },
-
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "LEAVE_SITE",
             label: "Leave Site",
             publishTopic: "ALF_LEAVE_SITE",
             publishPayload: {
                site: "swsdp",
                user: "admin@alfresco.com"
             }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "LEAVE_SITE_BAD1",
-            label: "Leave Site Bad 1",
-            publishTopic: "ALF_LEAVE_SITE",
-            publishPayload: {
-               user: "admin"
-            }
-         }
-      },
-      {
-         name: "alfresco/buttons/AlfButton",
-         config: {
-            id: "LEAVE_SITE_BAD2",
-            label: "Leave Site Bad 2",
-            publishTopic: "ALF_LEAVE_SITE",
-            publishPayload: {
-               site: "swsdp"
-            }
-         }
-      },
-
-      {
-         id: "SITES_LIST",
-         name: "alfresco/documentlibrary/AlfSitesList",
-         config: {
-            dataRequestTopic: "ALF_GET_SITES",
-            pubSubScope: "NORMAL_USER_",
-            widgets: [
-               {
-                  name: "alfresco/lists/views/AlfListView",
-                  config: {
-                     itemKey: "shortName",
-                     widgetsForHeader: [
-                        {
-                           name: "alfresco/lists/views/layouts/HeaderCell",
-                           config: {
-                              label: "Site"
-                           }
-                        }
-                     ],
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/layouts/Row",
-                           config: {
-                              widgets: [
-                                 {
-                                    name: "alfresco/lists/views/layouts/Cell",
-                                    config: {
-                                       widgets: [
-                                          {
-                                             name: "alfresco/renderers/Property",
-                                             config: {
-                                                propertyToRender: "title"
-                                             }
-                                          }
-                                       ]
-                                    }
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  }
-               }
-            ]
-         }
-      },
-      {
-         id: "ADMIN_SITES_LIST",
-         name: "alfresco/documentlibrary/AlfSitesList",
-         config: {
-            dataRequestTopic: "ALF_GET_SITES_ADMIN",
-            pubSubScope: "ADMIN_USER_",
-            widgets: [
-               {
-                  name: "alfresco/lists/views/AlfListView",
-                  config: {
-                     itemKey: "shortName",
-                     widgetsForHeader: [
-                        {
-                           name: "alfresco/lists/views/layouts/HeaderCell",
-                           config: {
-                              label: "Site"
-                           }
-                        }
-                     ],
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/layouts/Row",
-                           config: {
-                              widgets: [
-                                 {
-                                    name: "alfresco/lists/views/layouts/Cell",
-                                    config: {
-                                       widgets: [
-                                          {
-                                             name: "alfresco/renderers/Property",
-                                             config: {
-                                                propertyToRender: "title"
-                                             }
-                                          }
-                                       ]
-                                    }
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  }
-               }
-            ]
          }
       },
       {


### PR DESCRIPTION
This addresses [AKU-860](https://issues.alfresco.com/jira/browse/AKU-860) (clone of [MNT-15642](https://issues.alfresco.com/jira/browse/MNT-15642)) to add functionality to deal with site-membership requests failing because of an existing request and the ability to cancel a previously created site-membership request. Regression tests have been added and a full regression suite run. Also, the SiteService test files have had redundant elements removed.