### PR TITLE
Additional v1 upload API support - relativePath upload parameter.

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -649,7 +649,7 @@ define(["dojo/_base/declare",
                   
                   // get a dir reader and cleanup file path
                   var reader = directory.createReader(),
-                      relativePath = directory.fullPath.replace(/^\//, "").replace(/(.+?)\/?$/, "$1/");
+                      relativePath = directory.fullPath.replace(/^\//, "");
                   reader.readEntries(function(entries) {
                      callback.pending--;
                      array.forEach(entries, function(entry) {
@@ -659,7 +659,7 @@ define(["dojo/_base/declare",
                            entry.file(function(File) {
                               // add the relativePath property to each file - this can be used to rebuild the contents of
                               // a nested tree folder structure if an appropriate API is available to do so
-                              File.relativePath = relativePath + File.name;
+                              File.relativePath = relativePath;
                               callback.files.push(File);
                               if (callback.limit && callback.files.length > callback.limit)
                               {

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -312,7 +312,7 @@ define(["alfresco/core/CoreXhr",
             destination: destination,
             siteId: targetData.siteId,
             containerId: targetData.containerId,
-            uploaddirectory: targetData.uploadDirectory,
+            uploaddirectory: targetData.uploadDirectory || file.relativePath,
             majorVersion: targetData.majorVersion ? targetData.majorVersion : "true",
             updateNodeRef: targetData.updateNodeRef,
             description: targetData.description,
@@ -674,6 +674,9 @@ define(["alfresco/core/CoreXhr",
                formData.append("fileData", uploadData.filedata);
                formData.append("fileName", uploadData.filename);
                formData.append("autoRename", !uploadData.overwrite);
+               if (uploadData.uploaddirectory) {
+                  formData.append("relativePath", uploadData.uploaddirectory);
+               }
                
                break;
             }


### PR DESCRIPTION
This PR addresses the final requirements for SFS-210 - addition of relativePath parameter to uploadData handling. Refactor of passing the value now final v1 API is available.