### PR TITLE
AKU-874: Checkbox string values

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/CheckBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/CheckBox.js
@@ -33,7 +33,7 @@ define(["alfresco/forms/controls/BaseFormControl",
         "dojo/_base/lang",
         "dojo/dom-class"], 
         function(BaseFormControl, declare, CheckBox, lang, domClass) {
-   
+
    return declare([BaseFormControl], {
       
       /**
@@ -46,14 +46,78 @@ define(["alfresco/forms/controls/BaseFormControl",
       cssRequirements: [{cssFile:"./css/CheckBox.css"}],
 
       /**
+       * The value to be returned when the checkbox is not selected. If not specified, the default value is false.
+       * If this value is provided then [onValue]{@link module:alfresco/forms/controls/CheckBox#onValue} must also
+       * be provided.
+       *
+       * @instance
+       * @type {*}
+       * @default
+       * @since 1.0.59
+       */
+      offValue: undefined,
+
+      /**
+       * The value to be returned when the checkbox is selected. If not specified, the default value is true.
+       * If this value is provided then [offValue]{@link module:alfresco/forms/controls/CheckBox#offValue}
+       * must also be provided.
+       *
+       * @instance
+       * @type {*}
+       * @default
+       * @since 1.0.59
+       */
+      onValue: undefined,
+
+      /**
+       * Private state variable to store whether custom on/off values were provided.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.59
+       */
+      _hasCustomValues: false,
+
+      /**
+       * This is called after the properties have been mixed into the widget.
+       *
+       * @instance
+       * @override
+       * @since 1.0.59
+       */
+      postMixInProperties: function alfresco_forms_controls_CheckBox__postMixInProperties() {
+
+         // Call overridden method
+         this.inherited(arguments);
+
+         // Check the configured properties
+         if (typeof this.offValue === "undefined" && typeof this.onValue !== "undefined") {
+            this.alfLog("error", "When providing an 'onValue' for a checkbox, must also provide an 'offValue'", this);
+         } else if (typeof this.onValue === "undefined" && typeof this.offValue !== "undefined") {
+            this.alfLog("error", "When providing an 'offValue' for a checkbox, must also provide an 'onValue'", this);
+         } else if (typeof this.onValue !== "undefined" && typeof this.offValue !== "undefined") {
+            this._hasCustomValues = true;
+         }
+
+         // Apply defaults
+         if (typeof this.offValue === "undefined") {
+            this.offValue = false;
+         }
+         if (typeof this.onValue === "undefined") {
+            this.onValue = true;
+         }
+      },
+
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_CheckBox__getWidgetConfig() {
          // Return the configuration for the widget
+         // NOTE: setValue will always be called after creation, so let that determine the checked state, especially because the logic is messy!
          return {
             id : this.generateUuid(),
-            name: this.name,
-            checked: this.value === "true" || this.value === true
+            name: this.name
          };
       },
       
@@ -77,16 +141,13 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @returns {boolean} The checked state of the checkbox
        */
       getValue: function alfresco_forms_controls_CheckBox__getValue() {
-         var value = null;
+         var value = null,
+            checked;
          if (this.wrappedWidget)
          {
-            value = this.wrappedWidget.get("checked");
-            if (value === "")
-            {
-               value = this.value;
-            }
+            checked = this.wrappedWidget.get("checked");
+            value = checked ? this.onValue : this.offValue;
          }
-         value = this.convertStringValuesToBoolean(value);
          this.alfLog("log", "Returning value for field: '" + this.name + "': ", value);
          return value;
       },
@@ -107,7 +168,17 @@ define(["alfresco/forms/controls/BaseFormControl",
             this.alfLog("log", "Setting field: '" + this.name + "' with value: ", value);
             if (this.wrappedWidget)
             {
-               this.wrappedWidget.set("checked", value);
+               if (this._hasCustomValues) {
+                  if (value === this.onValue) {
+                     this.wrappedWidget.set("checked", true);
+                  } else if (value === this.offValue) {
+                     this.wrappedWidget.set("checked", false);
+                  } else {
+                     this.alfLog("warn", "Specified value '" + value + "' (" + typeof value + ") does not match possible values of '" + this.onValue + "' (" + typeof this.onValue + ") or '" + this.offValue + "' (" + typeof this.offValue + ")", this);
+                  }
+               } else {
+                  this.wrappedWidget.set("checked", !!value);
+               }
             }
          }
       },

--- a/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
@@ -34,13 +34,21 @@ define(["intern!object",
 
    var selectors = {
       checkBoxes: {
-         canBuild: {
-            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["CAN_BUILD"]),
-            label: TestCommon.getTestSelector(formControlSelectors, "label", ["CAN_BUILD"])
+         default: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["DEFAULT_CHECKBOX"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["DEFAULT_CHECKBOX"])
+         },
+         o1: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["O1_CHECKBOX"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["O1_CHECKBOX"])
+         },
+         offon: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["OFFON_CHECKBOX"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["OFFON_CHECKBOX"])
          }
       },
       buttons: {
-         uncheck: TestCommon.getTestSelector(buttonSelectors, "button.label", ["UNCHECK_CHECKBOX"])
+         updateCheckboxes: TestCommon.getTestSelector(buttonSelectors, "button.label", ["UPDATE_CHECKBOXES"])
       },
       form: {
          confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["CHECKBOX_FORM"])
@@ -62,32 +70,62 @@ define(["intern!object",
             browser.end();
          },
 
-         "Initial value is set correctly": function() {
-            return browser.findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
+         "Initial values are set correctly": function() {
+            return browser.findByCssSelector(selectors.checkBoxes.default.checkBox)
                .isSelected()
                .then(function(isSelected) {
-                  assert.isTrue(isSelected, "Checkbox not selected at startup");
+                  assert.isTrue(isSelected, "Default checkbox not selected at startup");
+               })
+            .end()
+
+            .findByCssSelector(selectors.checkBoxes.o1.checkBox)
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isFalse(isSelected, "0/1 checkbox selected at startup");
+               })
+            .end()
+
+            .findByCssSelector(selectors.checkBoxes.offon.checkBox)
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isTrue(isSelected, "on/off checkbox not selected at startup");
                });
          },
 
-         "Value can be updated by publish": function() {
-            return browser.findByCssSelector(selectors.buttons.uncheck)
+         "Values are correctly updated by publish": function() {
+            return browser.findByCssSelector(selectors.buttons.updateCheckboxes)
                .click()
             .end()
 
-            .findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
+            .findByCssSelector(selectors.checkBoxes.default.checkBox)
                .isSelected()
                .then(function(isSelected) {
-                  assert.isFalse(isSelected, "Checkbox not deselected by publish");
+                  assert.isFalse(isSelected, "Default checkbox not deselected by publish");
+               })
+            .end()
+
+            .findByCssSelector(selectors.checkBoxes.o1.checkBox)
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isTrue(isSelected, "0/1 checkbox not selected by publish");
+               })
+            .end()
+
+            .findByCssSelector(selectors.checkBoxes.offon.checkBox)
+               .isSelected()
+               .then(function(isSelected) {
+                  assert.isTrue(isSelected, "on/off checkbox incorrectly modified by publish");
                });
          },
 
          "Keyboard navigation and selection is supported": function() {
-            return browser.pressKeys(keys.TAB)
+            return browser.findByCssSelector(selectors.buttons.updateCheckboxes)
+               .click()
+               .tabToElement(selectors.checkBoxes.default.checkBox)
                .pressKeys(keys.SPACE)
             .end()
 
-            .findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
+            .findByCssSelector(selectors.checkBoxes.default.checkBox)
                .isSelected()
                .then(function(isSelected) {
                   assert.isTrue(isSelected, "Checkbox value not changed by keyboard");
@@ -95,11 +133,11 @@ define(["intern!object",
          },
 
          "Can modify checkbox value with mouse": function() {
-            return browser.findByCssSelector(selectors.checkBoxes.canBuild.label)
+            return browser.findByCssSelector(selectors.checkBoxes.default.label)
                .click()
             .end()
 
-            .findByCssSelector(selectors.checkBoxes.canBuild.checkBox)
+            .findByCssSelector(selectors.checkBoxes.default.checkBox)
                .isSelected()
                .then(function(isSelected) {
                   assert.isFalse(isSelected, "Checkbox value not changed by mouse");
@@ -113,7 +151,9 @@ define(["intern!object",
 
             .getLastPublish("POST_FORM")
                .then(function(payload) {
-                  assert.deepPropertyVal(payload, "canbuild", false, "Failed to submit checkbox value correctly");
+                  assert.propertyVal(payload, "defaultCheckbox", false);
+                  assert.propertyVal(payload, "o1", 1);
+                  assert.propertyVal(payload, "offon", "on");
                });
          },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CheckBox.get.js
@@ -15,12 +15,14 @@ model.jsonModel = {
    widgets: [
       {
          name: "alfresco/buttons/AlfButton",
+         id: "UPDATE_CHECKBOXES",
          config: {
-            id: "UNCHECK_CHECKBOX",
-            label: "Uncheck checkbox",
+            label: "Update checkboxes",
             publishTopic: "SET_FORM_VALUE",
             publishPayload: {
-               canbuild: false
+               defaultCheckbox: false,
+               o1: 1,
+               offon: "false"
             }
          }
       },
@@ -38,16 +40,37 @@ model.jsonModel = {
             setValueTopic: "SET_FORM_VALUE",
             scopeFormControls: false,
             value: {
-               canbuild: true
+               defaultCheckbox: true
             },
             widgets: [
                {
                   name: "alfresco/forms/controls/CheckBox",
+                  id: "DEFAULT_CHECKBOX",
                   config: {
-                     name: "canbuild",
-                     id: "CAN_BUILD",
-                     label: "Yes we can",
-                     description: "Can we build it?"
+                     name: "defaultCheckbox",
+                     label: "Possible values default (true/false), initial value true (via form values-object)"
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/CheckBox",
+                  id: "O1_CHECKBOX",
+                  config: {
+                     name: "o1",
+                     label: "Possible values 0 (unchecked) or 1 (checked), initial value \"1\"",
+                     offValue: 0,
+                     onValue: 1,
+                     value: "1"
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/CheckBox",
+                  id: "OFFON_CHECKBOX",
+                  config: {
+                     name: "offon",
+                     label: "Possible values \"off\" (unchecked) or \"on\" (checked), initial value \"on\"",
+                     offValue: "off",
+                     onValue: "on",
+                     value: "on"
                   }
                }
             ]


### PR DESCRIPTION
This addresses [AKU-874](https://issues.alfresco.com/jira/browse/AKU-874) and adds support for custom values for a checkbox (through the `onValue` and `offValue` properties). Additionally it consolidates the handling of value-setting. Unit-tests have been added and a full regression suite run.