### PR TITLE
AKU-870: Ensure list sorting without useHash or infinite scroll

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1301,17 +1301,6 @@ define([],function() {
       TINYMCE_EDITOR_FOCUSED: "ALF_TINYMCE_EDITOR_FOCUSED",
 
       /**
-       * This topic can be used to publish a request to change the title of a page. It is subscribed to by the
-       * [Title widget]{@link module:alfresco/header/Title} and published by the 
-       * [SetTitle widget]{@link module:alfresco/header/SetTitle}
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      UPDATE_PAGE_TITLE: "ALF_UPDATE_PAGE_TITLE",
-
-      /**
        * This can be published to change the current field being used to sort lists.
        * 
        * @instance
@@ -1326,6 +1315,17 @@ define([],function() {
        * @property {object}  [requester] The widget making the request (include to avoid cycling publications).
        */
       UPDATE_LIST_SORT_FIELD: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+
+      /**
+       * This topic can be used to publish a request to change the title of a page. It is subscribed to by the
+       * [Title widget]{@link module:alfresco/header/Title} and published by the 
+       * [SetTitle widget]{@link module:alfresco/header/SetTitle}
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      UPDATE_PAGE_TITLE: "ALF_UPDATE_PAGE_TITLE",
 
       /**
        * This topic is published when the user acknowledges the completion of uploading files to the

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1148,6 +1148,22 @@ define([],function() {
       SMART_DOWNLOAD: "ALF_SMART_DOWNLOAD",
 
       /**
+       * This can be published to request that a [list]{@link module:alfresco/lists/AlfSortablePaginatedList}
+       * changes the way that its data is sorted.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.59
+       *
+       * @event
+       * @property {string} direction Either "ascending" or "descending"
+       * @property {string} value The field to sort on
+       * @property {object} [requester] The widget making the request (include to avoid cycling publications).
+       */
+      SORT_LIST: "ALF_DOCLIST_SORT",
+
+      /**
        * This can be called to close the StickyPanel.
        *
        * @instance
@@ -1294,6 +1310,22 @@ define([],function() {
        * @default
        */
       UPDATE_PAGE_TITLE: "ALF_UPDATE_PAGE_TITLE",
+
+      /**
+       * This can be published to change the current field being used to sort lists.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.59
+       *
+       * @event
+       * @property {string}  direction Either "ascending" or "descending"
+       * @property {string}  [label] A label that represents the field to be sorted on
+       * @property {boolean} [sortable] Whether or not this field can be have the sort direction changed on it
+       * @property {object}  [requester] The widget making the request (include to avoid cycling publications).
+       */
+      UPDATE_LIST_SORT_FIELD: "ALF_DOCLIST_SORT_FIELD_SELECTION",
 
       /**
        * This topic is published when the user acknowledges the completion of uploading files to the

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -220,17 +220,17 @@ define(["dojo/_base/declare",
        * @event sortRequestTopic
        * @instance
        * @type {string} 
-       * @default
+       * @default [SORT_LIST]{@link module:alfresco/core/topics#SORT_LIST}
        */
-      sortRequestTopic: "ALF_DOCLIST_SORT",
+      sortRequestTopic: topics.SORT_LIST,
       
       /**
        * @event
        * @instance
        * @type {string} 
-       * @default
+       * @default [UPDATE_LIST_SORT_FIELD]{@link module:alfresco/core/topics#UPDATE_LIST_SORT_FIELD}
        */
-      sortFieldSelectionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+      sortFieldSelectionTopic: topics.UPDATE_LIST_SORT_FIELD,
       
       /**
        * @event showFoldersTopic

--- a/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/views/AlfTableView.js
@@ -167,11 +167,13 @@ define(["dojo/_base/declare",
             config: {
                widgets: [
                   {
+                     id: "TABLE_SELECTOR_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_SELECTOR",
                               name: "alfresco/renderers/Selector",
                               config: {
                                  itemKey: "node.nodeRef"
@@ -181,22 +183,26 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_INDICATORS_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_INDICATORS",
                               name: "alfresco/renderers/Indicators"
                            }
                         ]
                      }
                   },
                   {
+                     id: "TABLE_NAME_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_NAME",
                               name: "alfresco/renderers/InlineEditPropertyLink",
                               config: {
                                  propertyToRender: "node.properties.cm:name",
@@ -209,11 +215,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_TITLE_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_TITLE",
                               name: "alfresco/renderers/InlineEditProperty",
                               config: {
                                  propertyToRender: "node.properties.cm:title",
@@ -227,11 +235,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_DESCRIPTION_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_DESCRIPTION",
                               name: "alfresco/renderers/InlineEditProperty",
                               config: {
                                  propertyToRender: "node.properties.cm:description",
@@ -245,11 +255,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_CREATOR_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_CREATOR",
                               name: "alfresco/renderers/PropertyLink",
                               config: {
                                  propertyToRender: "node.properties.cm:creator",
@@ -269,11 +281,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_CREATED_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_CREATED",
                               name: "alfresco/renderers/Property",
                               config: {
                                  propertyToRender: "node.properties.cm:created",
@@ -284,11 +298,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_MODIFIER_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_MODIFIER",
                               name: "alfresco/renderers/PropertyLink",
                               config: {
                                  propertyToRender: "node.properties.cm:modifier",
@@ -308,11 +324,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_MODIFIED_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_MODIFIED",
                               name: "alfresco/renderers/Property",
                               config: {
                                  propertyToRender: "node.properties.cm:modified",
@@ -323,11 +341,13 @@ define(["dojo/_base/declare",
                      }
                   },
                   {
+                     id: "TABLE_ACTIONS_CELL",
                      name: "alfresco/lists/views/layouts/Cell",
                      config: {
                         additionalCssClasses: "mediumpad",
                         widgets: [
                            {
+                              id: "TABLE_ACTIONS",
                               name: "alfresco/renderers/Actions"
                            }
                         ]

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -32,10 +32,11 @@
 define(["dojo/_base/declare",
         "alfresco/lists/AlfHashList",
         "alfresco/services/_PreferenceServiceTopicMixin",
+        "alfresco/core/topics",
         "dojo/_base/lang",
         "alfresco/util/hashUtils",
         "dojo/io-query"],
-        function(declare, AlfHashList, _PreferenceServiceTopicMixin, lang, hashUtils, ioQuery) {
+        function(declare, AlfHashList, _PreferenceServiceTopicMixin, topics, lang, hashUtils, ioQuery) {
 
    return declare([AlfHashList, _PreferenceServiceTopicMixin], {
 
@@ -104,6 +105,28 @@ define(["dojo/_base/declare",
        * @default
        */
       sortField: "cm:name",
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#showView} to set the sort data for
+       * any [HeaderCell]{@link module:alfresco/lists/views/layouts/HeaderCell} widgets that might be included in the
+       * view.
+       * 
+       * @instance
+       * @since 1.0.59
+       * @fires module:alfresco/core/topics#SORT_LIST
+       */
+      showView: function alfresco_lists_AlfSortablePaginatedList__showView() {
+         this.inherited(arguments);
+         if (!this.useHash)
+         {
+            this.alfLog("info", "Really should publish sort data");
+            this.alfPublish(topics.SORT_LIST, {
+               direction: (this.sortAscending) ? "ascending" : "descending",
+               value: this.sortField,
+               requester: this
+            });
+         }
+      },
 
       /**
        * Extends the [inherited function]{@link module:alfresco/lists/AlfList#postMixInProperties}
@@ -208,7 +231,7 @@ define(["dojo/_base/declare",
        */
       onSortRequest: function alfresco_lists_AlfSortablePaginatedList__onSortRequest(payload) {
          this.alfLog("log", "Sort requested: ", payload);
-         if (payload && payload.direction !== null || payload.value !== null)
+         if (payload && payload.requester !== this && (payload.direction !== null || payload.value !== null))
          {
             if (payload.direction)
             {

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
@@ -30,12 +30,13 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dojo/text!./templates/HeaderCell.html",
         "alfresco/core/Core",
+        "alfresco/core/topics",
         "alfresco/util/hashUtils",
         "dojo/_base/lang",
         "dojo/dom-class",
         "dojo/query",
         "dojo/dom-attr"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, hashUtils, lang, domClass, query, domAttr) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, topics, hashUtils, lang, domClass, query, domAttr) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
 
@@ -156,6 +157,8 @@ define(["dojo/_base/declare",
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        * 
        * @instance postCreate
+       * @listens module:alfresco/core/topics#SORT_LIST
+       * @listens module:alfresco/core/topics#UPDATE_LIST_SORT_FIELD
        */
       postCreate: function alfresco_lists_views_layouts_HeaderCell__postCreate() {
          if (this.useHash && this.sortable)
@@ -168,8 +171,8 @@ define(["dojo/_base/declare",
             }
          }
 
-         this.alfSubscribe("ALF_DOCLIST_SORT", lang.hitch(this, this.onExternalSortRequest));
-         this.alfSubscribe("ALF_DOCLIST_SORT_FIELD_SELECTION", lang.hitch(this, this.onExternalSortRequest));
+         this.alfSubscribe(topics.SORT_LIST, lang.hitch(this, this.onExternalSortRequest));
+         this.alfSubscribe(topics.UPDATE_LIST_SORT_FIELD, lang.hitch(this, this.onExternalSortRequest));
 
          domAttr.set(this.ascendingSortNode, "alt", this.sortAscAlt ? this.sortAscAlt : "");
          domAttr.set(this.descendingSortNode, "alt", this.sortDescAlt ? this.sortDescAlt : "");
@@ -212,7 +215,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onSortClick: function alfresco_lists_views_layouts_HeaderCell__onSortClick(evt) {
+      onSortClick: function alfresco_lists_views_layouts_HeaderCell__onSortClick(/*jshint unused:false*/ evt) {
          if (this.sortable === true)
          {
             this.alfLog("log", "Sort request received");
@@ -244,9 +247,10 @@ define(["dojo/_base/declare",
 
       /**
        * @instance
+       * @fires module:alfresco/core/topics#SORT_LIST
        */
       publishSortRequest: function alfresco_lists_views_layouts_HeaderCell__publishSortRequest() {
-         this.alfPublish("ALF_DOCLIST_SORT", {
+         this.alfPublish(topics.SORT_LIST, {
             direction: (this.sortedAscending) ? "ascending" : "descending",
             value: this.sortValue,
             requester: this

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
@@ -45,7 +45,7 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget configuration build configuration for
        * @return {object} The arguments that can be used when instantiating the widget configuration processed
        */
-      processWidgetConfig: function alfresco_lists_views_layouts_Cell__processWidgetConfig(widget) {
+      processWidgetConfig: function alfresco_lists_views_layouts__LayoutMixin__processWidgetConfig(widget) {
          if (widget.id)
          {
             widget.id = widget.id + "_ITEM_" + this.currentItem.index;

--- a/aikau/src/main/resources/alfresco/renderers/CommentsList.js
+++ b/aikau/src/main/resources/alfresco/renderers/CommentsList.js
@@ -36,8 +36,9 @@
 define(["dojo/_base/declare",
         "alfresco/core/ProcessWidgets",
         "alfresco/core/ObjectProcessingMixin",
+        "alfresco/core/topics",
         "dojo/_base/lang"], 
-        function(declare, ProcessWidgets, ObjectProcessingMixin, lang) {
+        function(declare, ProcessWidgets, ObjectProcessingMixin, topics, lang) {
 
    return declare([ProcessWidgets, ObjectProcessingMixin], {
 
@@ -145,14 +146,14 @@ define(["dojo/_base/declare",
                         checked: true,
                         onConfig: {
                            iconClass: "alf-sort-ascending-icon",
-                           publishTopic: "ALF_DOCLIST_SORT",
+                           publishTopic: topics.SORT_LIST,
                            publishPayload: {
                               direction: "ascending"
                            }
                         },
                         offConfig: {
                            iconClass: "alf-sort-descending-icon",
-                           publishTopic: "ALF_DOCLIST_SORT",
+                           publishTopic: topics.SORT_LIST,
                            publishPayload: {
                               direction: "descending"
                            }

--- a/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
@@ -25,6 +25,26 @@ define(["intern!object",
         "alfresco/TestCommon"], 
         function (registerSuite, assert, TestCommon) {
 
+   var rowSelectors = TestCommon.getTestSelectors("alfresco/lists/views/layouts/Row");
+   var headerCellSelectors = TestCommon.getTestSelectors("alfresco/lists/views/layouts/HeaderCell");
+
+   var selectors = {
+      rows: {
+         all:  TestCommon.getTestSelector(rowSelectors, "row")
+      },
+      headerCells: {
+         all: {
+            indicators: TestCommon.getTestSelector(headerCellSelectors, "all.indicators")
+         },
+         name: {
+            indicators: TestCommon.getTestSelector(headerCellSelectors, "indicator", ["TABLE_VIEW_NAME_HEADING"]),
+            ascending: TestCommon.getTestSelector(headerCellSelectors, "ascending.indicator", ["TABLE_VIEW_NAME_HEADING"]),
+            descending: TestCommon.getTestSelector(headerCellSelectors, "descending.indicator", ["TABLE_VIEW_NAME_HEADING"]),
+            label: TestCommon.getTestSelector(headerCellSelectors, "label", ["TABLE_VIEW_NAME_HEADING"])
+         }
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -41,7 +61,7 @@ define(["intern!object",
          },
 
          "No initial sorting indicated": function() {
-            return browser.findDisplayedByCssSelector(".alfresco-lists-views-layouts-HeaderCell img")
+            return browser.findDisplayedByCssSelector(selectors.headerCells.all.indicators)
                .then(function() {
                   assert(false, "Should not have found any displayed sort indicators");
                },
@@ -55,14 +75,14 @@ define(["intern!object",
 
             .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
-            .findAllByCssSelector(".alfresco-lists-views-layouts-Row")
+            .findAllByCssSelector(selectors.rows.all)
                .then(function(elements) {
                   assert.lengthOf(elements, 4);
                });
          },
 
          "Sort on name, check four results are still shown": function() {
-            return browser.findByCssSelector("#TABLE_VIEW_NAME_HEADING .label")
+            return browser.findByCssSelector(selectors.headerCells.name.label)
                .clearLog()
                .click()
             .end()
@@ -70,7 +90,7 @@ define(["intern!object",
             .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
             .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
-            .findAllByCssSelector(".alfresco-lists-views-layouts-Row")
+            .findAllByCssSelector(selectors.rows.all)
                .then(function(elements) {
                   assert.lengthOf(elements, 4);
                });
@@ -84,10 +104,103 @@ define(["intern!object",
             return browser.refresh().findByCssSelector("body").end()
             .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
-            .findDisplayedByCssSelector("#TABLE_VIEW_NAME_HEADING img");
+            .findDisplayedByCssSelector(selectors.headerCells.all.indicators);
          },
 
          "Post Coverage Results (1)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfDocumentList Sorting Tests (no hash, no infinite scroll)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollDocumentList?useHash=false&useInfiniteScroll=false", "AlfDocumentList Sorting Tests (no hash, no infinite scroll)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "No initial sorting indicated": function() {
+            return browser.findDisplayedByCssSelector(selectors.headerCells.all.indicators)
+               .then(function() {
+                  assert(false, "Should not have found any displayed sort indicators");
+               },
+               function() {
+                  assert(true);
+               });
+         },
+
+         "Four results shown initially": function() {
+            return browser.findByCssSelector("body").end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findAllByCssSelector(selectors.rows.all)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4);
+               });
+         },
+
+         "Sort on name, check four results are still shown": function() {
+            return browser.findByCssSelector(selectors.headerCells.name.label)
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findAllByCssSelector(selectors.rows.all)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4);
+               });
+         },
+
+         "Ascending icon is shown": function() {
+            return browser.findDisplayedByCssSelector(selectors.headerCells.name.ascending);
+         },
+
+         "Change sort order of name": function() {
+            return browser.findByCssSelector(selectors.headerCells.name.label)
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "sortAscending", false);
+               })
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findDisplayedByCssSelector(selectors.headerCells.name.descending);
+         },
+
+         "Change sort order again": function() {
+            return browser.findByCssSelector(selectors.headerCells.name.label)
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "sortAscending", true);
+               })
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findDisplayedByCssSelector(selectors.headerCells.name.ascending);
+         },
+
+         "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);
          }
       };

--- a/aikau/src/test/resources/test-selectors/alfresco/lists/views/layouts/HeaderCell.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/lists/views/layouts/HeaderCell.properties
@@ -1,0 +1,14 @@
+# All indicators, not for any specific identifier header cell
+all.indicators=.alfresco-lists-views-layouts-HeaderCell img
+
+# Indicator (either ascending or descending, hidden or visible)
+indicator=#{0}.alfresco-lists-views-layouts-HeaderCell img
+
+# Ascending indicator
+ascending.indicator=#{0}.alfresco-lists-views-layouts-HeaderCell img.ascendingSort
+
+# Descending indicator
+descending.indicator=#{0}.alfresco-lists-views-layouts-HeaderCell img.descendingSort
+
+# Label
+label=#{0}.alfresco-lists-views-layouts-HeaderCell .label

--- a/aikau/src/test/resources/test-selectors/alfresco/lists/views/layouts/Row.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/lists/views/layouts/Row.properties
@@ -1,0 +1,5 @@
+# All rows in a table
+row=.alfresco-lists-views-layouts-Row
+
+# Nth row
+nth.row=.alfresco-lists-views-layouts-Row:nth-child({0})

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
@@ -30,12 +30,21 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         name: "alfresco/html/Label",
+         config: {
+            label: "Use ?useHash=false&useInfiniteScroll=false request parameters to disable infinite scroll and hashing"
+         }
+      },
+      {
+         id: "DOCUMENT_LIST",
          name: "alfresco/documentlibrary/AlfDocumentList",
          config: {
+            sortField: null,
             useHash: useHash,
             useInfiniteScroll: useInfiniteScroll,
              widgets: [
                {
+                  id: "TABLE_VIEW",
                   name: "alfresco/documentlibrary/views/AlfTableView"
                }
             ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-870 to ensure that sorting of lists works when using HeaderCell widgets with useHash set to false.