### PR TITLE
AKU-816: Finish JSHint fixes

### DIFF
--- a/aikau/resources/grunt/coverage.js
+++ b/aikau/resources/grunt/coverage.js
@@ -130,6 +130,7 @@ module.exports = function(grunt) {
    // Merge individual coverage reports in the node coverage server
    // TODO: Give the report a sensible name (e.g. with a timestamp)
    grunt.registerTask("sub-merge-reports", "A task for merging code coverage reports", function() {
+      /*jshint loopfunc:true*/
       var done = this.async();
       
       var mergeArgs;

--- a/aikau/resources/grunt/testing.js
+++ b/aikau/resources/grunt/testing.js
@@ -12,6 +12,7 @@ var networkInterfaces = os.networkInterfaces(),
 interfaceNames.forEach(function(interfaceName) {
    var lowerName = interfaceName && interfaceName.toLowerCase();
    networkInterfaces[interfaceName].forEach(function(interface) {
+      /*jshint noempty:false*/
       if (interface.family === "IPv4" && !interface.internal) {
          if (!lowerName) {
             // Ignore unnamed interfaces (for the moment)

--- a/aikau/src/main/resources/alfresco/accessibility/_SemanticWrapperMixin.js
+++ b/aikau/src/main/resources/alfresco/accessibility/_SemanticWrapperMixin.js
@@ -78,7 +78,7 @@ define(["dojo/_base/declare",
        * @param {element} innerNode The DOM node that should be moved into the created semantic wrapper
        */
       generateSemanticWrapper: function alfresco_accessibility__SemanticWrapperMixin__generateSemanticWrapper(outerNode, innerNode) {
-         if(this.semanticWrapper && array.indexOf(this._semanticWrapperOptions, this.semanticWrapper) != -1)
+         if(this.semanticWrapper && array.indexOf(this._semanticWrapperOptions, this.semanticWrapper) !== -1)
          {
             var wrapper = domConstruct.create(this.semanticWrapper, null, outerNode, "first");
             if(innerNode)

--- a/aikau/src/main/resources/alfresco/buttons/DropDownButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/DropDownButton.js
@@ -153,7 +153,7 @@ define(["dojo/_base/declare",
        */
       hideDropDown: function alfresco_buttons_DropDownButton__hideDropDown() {
          // NOTE: Tried this using dijit/popup dependency and it didn't work...
-         dijit.popup.close(this._dropDownDisplay)
+         dijit.popup.close(this._dropDownDisplay);
       },
 
       /**
@@ -186,7 +186,7 @@ define(["dojo/_base/declare",
          this._dropDownButton = new DropDownButton({
             id: this.id + "_DROP_DOWN_BUTTON",
             label: this.label ? this.message(this.label) : "",
-            dropDown: this._dropDownDisplay,
+            dropDown: this._dropDownDisplay
          });
 
          this._dropDownButton.placeAt(this.domNode);

--- a/aikau/src/main/resources/alfresco/charts/ccc/BarChart.js
+++ b/aikau/src/main/resources/alfresco/charts/ccc/BarChart.js
@@ -30,8 +30,6 @@ define(["dojo/_base/declare",
    "alfresco/charts/ccc/Chart"],
       function(declare, AlfCore, I18nUtils, Chart) {
 
-         var i18nScope = "alfresco.reports.BarChart";
-
          return declare([Chart], {
 
             /**

--- a/aikau/src/main/resources/alfresco/charts/ccc/Chart.js
+++ b/aikau/src/main/resources/alfresco/charts/ccc/Chart.js
@@ -1,3 +1,5 @@
+/*globals pvc*/
+
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *
@@ -329,11 +331,14 @@ define(["dojo/_base/declare",
                config.colors = styles.backgroundColor;
 
                // Set any additional chart options
-               if (typeof this.chartConfig == "object")
+               if (typeof this.chartConfig === "object")
                {
                   for (var p in this.chartConfig)
                   {
-                     config[p] = this.chartConfig[p];
+                     if (this.chartConfig.hasOwnProperty(p))
+                     {
+                        config[p] = this.chartConfig[p];
+                     }
                   }
                }
 
@@ -455,9 +460,9 @@ define(["dojo/_base/declare",
                try {
                   var style = domStyle.getComputedStyle(this.domNode);
                   var s = domGeom.getContentBox(this.domNode, style);
-                  var w = (s.w + "").split('.')[0];
-                  w = w.split('px')[0];
-                  w = parseInt(w);
+                  var w = (s.w + "").split(".")[0];
+                  w = w.split("px")[0];
+                  w = parseInt(w, 10);
                   return w;
                }
                catch(e) {
@@ -479,7 +484,7 @@ define(["dojo/_base/declare",
              *
              * @param payload {object}
              */
-            onDataLoadFailure: function(payload){
+            onDataLoadFailure: function(/*jshint unused:false*/payload){
                this.showData({}, {});
             }
 

--- a/aikau/src/main/resources/alfresco/charts/ccc/ChartsView.js
+++ b/aikau/src/main/resources/alfresco/charts/ccc/ChartsView.js
@@ -192,6 +192,7 @@ define(["dojo/_base/declare",
              * @param dataDescriptor {object} Metadata describing data
              */
             onDataRequestTopic: function(data, dataDescriptor) {
+               /*jshint eqnull:true*/
                var chart = this._chartMap[this._currentlySelectedChart];
                if (chart != null) {
                   chart.showData(data, dataDescriptor);
@@ -246,7 +247,7 @@ define(["dojo/_base/declare",
                     return startDate;
                 };
                 var getEndDate = function(timePeriod) {
-                   if (timePeriod == "CUSTOM") {
+                   if (timePeriod === "CUSTOM") {
                       return endDate;
                    } else {
                       return now;
@@ -275,7 +276,7 @@ define(["dojo/_base/declare",
                   var chartName = name;
 
                   // Check if this is the initially requested chart...
-                  if (chartName == this._chart || (!this._currentlySelectedChart && !this._chart))
+                  if (chartName === this._chart || (!this._currentlySelectedChart && !this._chart))
                   {
                      this._currentlySelectedChart = chartName;
                   }

--- a/aikau/src/main/resources/alfresco/charts/ccc/DonutChart.js
+++ b/aikau/src/main/resources/alfresco/charts/ccc/DonutChart.js
@@ -37,7 +37,7 @@ define(["dojo/_base/declare",
              *
              * @instance
              */
-            explodedSliceRadius: '1%',
+            explodedSliceRadius: "1%",
 
             /**
              * Adds a margin into the centre of the pie chart, making it look like a donut instead.
@@ -45,7 +45,7 @@ define(["dojo/_base/declare",
              * @instance
              */
             extensionPoints: {
-               slice_innerRadiusEx: '20%'
+               slice_innerRadiusEx: "20%"
             }
 
          });

--- a/aikau/src/main/resources/alfresco/core/ArrayUtils.js
+++ b/aikau/src/main/resources/alfresco/core/ArrayUtils.js
@@ -24,8 +24,7 @@
  * @module alfresco/core/ArrayUtils
  * @author Dave Draper
  */
-define(["dojo/_base/lang"], 
-        function(lang) {
+define([], function() {
    
    return {
       
@@ -82,6 +81,7 @@ define(["dojo/_base/lang"],
        * @returns {integer} -1 if not found, other wise the index
        */
       arrayIndex: function alfresco_core_ArrayUtils__arrayIndex(arr, value, attr) {
+         /*jshint eqeqeq:false*/
          if (arr)
          {
             for (var i = 0, ii = arr.length; i < ii; i++)

--- a/aikau/src/main/resources/alfresco/core/CoreData.js
+++ b/aikau/src/main/resources/alfresco/core/CoreData.js
@@ -71,12 +71,15 @@ define(["dojo/_base/declare",
          {
             for (var key in obj)
             {
+               if (obj.hasOwnProperty(key))
+               {
                   var procData = { id: uuid(), 
                                    label: key, 
                                    type: "path" };
                   var rawData = obj[key];
                   procData.children = this.getDataItems(rawData._alfValue);
                   items.push(procData);
+               }
             }
          }
          else
@@ -91,6 +94,7 @@ define(["dojo/_base/declare",
    
    var instance; 
    DataModel.getSingleton = function() {
+      /*jshint eqnull:true*/
       if (instance == null)
       {
          instance = new DataModel(); 

--- a/aikau/src/main/resources/alfresco/core/CoreRwd.js
+++ b/aikau/src/main/resources/alfresco/core/CoreRwd.js
@@ -68,6 +68,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_core_CoreRwd__postCreate() {
+         /*jshint eqnull:true*/
          this.inherited(arguments);
          
          if (this.domNode != null && (this.minRwdWidth != null || this.maxRwdWidth != null))
@@ -88,6 +89,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       applyRwd: function alfresco_core_CoreRwd__applyRwd() {
+         /*jshint eqnull:true*/
          var winBox = win.getBox();
          if ((this.minRwdWidth == null && winBox.w < this.maxRwdWidth) ||
              (this.maxRwdWidth == null && winBox.w > this.minRwdWidth) ||

--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -316,6 +316,7 @@ define(["dojo/_base/declare",
        * @param {boolean} negate Whether or not to negate the evaluated rule
        */
       setupVisibilityConfigProcessing: function alfresco_core_CoreWidgetProcessing__setupVisibilityConfigProcessing(widget, negate) {
+         /*jshint eqnull:true*/
          // Set a default for negation if not provided...
          negate = (negate != null) ? negate : false;
 
@@ -475,6 +476,7 @@ define(["dojo/_base/declare",
        * @deprecated Since 1.0.44 - See [setupVisibilityConfigProcessing]{@link module:alfresco/core/CoreWidgetProcessing#setupVisibilityConfigProcessing} source code for current technique for evaluating visibility
        */
       visibilityRuleComparator: function alfresco_core_CoreWidgetProcessing__visibilityRuleComparator(targetValue, widget, useCurrentItem, currValue) {
+         /*jshint eqnull:true*/
          if (targetValue == null && currValue == null)
          {
             return true;
@@ -672,7 +674,7 @@ define(["dojo/_base/declare",
          // The use of indirection is done so modules will not rolled into a build (should we do one)
          var requires = [widget.name];
          require(requires, function(WidgetType) {
-            // jshint maxcomplexity:false
+            /* jshint maxcomplexity:false,maxstatements:false*/
             // Just to be sure, check that no widget doesn't already exist with that id and
             // if it does, generate a new one...
             if (typeof WidgetType === "function")

--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -212,11 +212,12 @@ define(["dojo/_base/declare",
                }, function(response) {
 
                   // Handle authentication failure (401) or Session timeout
+                  var callbackScope;
                   if (response.response && response.response.status === 401)
                   {
                      if (typeof config.authenticationFailureCallback === "function")
                      {
-                        var callbackScope = config.failureCallbackScope || config.callbackScope || _this;
+                        callbackScope = config.failureCallbackScope || config.callbackScope || _this;
                         config.authenticationFailureCallback.call(callbackScope, response, config);
                      }
                      else
@@ -261,7 +262,7 @@ define(["dojo/_base/declare",
                   }
                   if (typeof config.failureCallback === "function")
                   {
-                     var callbackScope = config.failureCallbackScope || config.callbackScope || _this;
+                     callbackScope = config.failureCallbackScope || config.callbackScope || _this;
                      config.failureCallback.call(callbackScope, response, config);
                   }
                   else
@@ -427,8 +428,8 @@ define(["dojo/_base/declare",
          // Build up the Accept-Language header value
          var languages = navigator.languages;
          if (languages) {
-            languages = array.map(languages, function(lang) {
-               return lang.toLowerCase();
+            languages = array.map(languages, function(nextLang) {
+               return nextLang.toLowerCase();
             }).join(", ");
          } else {
             languages = (navigator.language || navigator.userLanguage).toLowerCase();

--- a/aikau/src/main/resources/alfresco/core/DomElementUtils.js
+++ b/aikau/src/main/resources/alfresco/core/DomElementUtils.js
@@ -52,7 +52,7 @@ define(["dojo/_base/declare",
          var start = 0, end = 0, normalizedValue, range,
          textInputRange, len, endRange;
 
-         if (typeof el.selectionStart == "number" && typeof el.selectionEnd == "number") 
+         if (typeof el.selectionStart === "number" && typeof el.selectionEnd === "number") 
          {
             start = el.selectionStart;
             end = el.selectionEnd;
@@ -61,7 +61,7 @@ define(["dojo/_base/declare",
          {
             range = document.selection.createRange();
    
-            if (range && range.parentElement() == el) 
+            if (range && range.parentElement() === el) 
             {
                len = el.value.length;
                normalizedValue = el.value.replace(/\r\n/g, "\n");
@@ -123,7 +123,7 @@ define(["dojo/_base/declare",
          else if (el.createTextRange) 
          { 
              var range = el.createTextRange();
-             range.moveStart('character', position); 
+             range.moveStart("character", position); 
              range.select(); 
          }
       },
@@ -194,11 +194,11 @@ define(["dojo/_base/declare",
                }
 
                // Operator
-               if (this.domCalculationOperators[c["operator"]]) {
-                  result = this.domCalculationOperators[c["operator"]].call(this, result, tmp);
+               if (this.domCalculationOperators[c.operator]) {
+                  result = this.domCalculationOperators[c.operator].call(this, result, tmp);
                }
                else {
-                  throw new Error("Failed calculation due to missing operator " + c["operator"]);
+                  throw new Error("Failed calculation due to missing operator " + c.operator);
                }
             }
          }
@@ -259,7 +259,8 @@ define(["dojo/_base/declare",
        *    values to ignore).
        */
       resolveCssStyles: function(prefix, names, styleProperties, cache){
-         cache = typeof cache == "boolean" ? cache : true;
+         /*jshint maxcomplexity:false,maxstatements:false*/
+         cache = typeof cache === "boolean" ? cache : true;
 
          var result;
          if (cache) {
@@ -283,30 +284,32 @@ define(["dojo/_base/declare",
             computedStyle = domStyle.getComputedStyle(el);
             stylePropertiesPerName = {};
             for (var s in styleProperties) {
-               styleProperty = computedStyle[s];
+               if(styleProperties.hasOwnProperty(s)) {
+                  styleProperty = computedStyle[s];
 
-               // Make sure there is an array to store result in
-               if (!result[s]) {
-                  result[s] = [];
-               }
+                  // Make sure there is an array to store result in
+                  if (!result[s]) {
+                     result[s] = [];
+                  }
 
-               // Make sure we are not adding a valu that shall be ignored
-               if (lang.isArray(styleProperties[s])) {
-                  if (array.indexOf(styleProperties[s], styleProperty) == -1) {
+                  // Make sure we are not adding a valu that shall be ignored
+                  if (lang.isArray(styleProperties[s])) {
+                     if (array.indexOf(styleProperties[s], styleProperty) === -1) {
+                        result[s].push(styleProperty);
+                     }
+                  }
+                  else if (styleProperty !== styleProperties) {
                      result[s].push(styleProperty);
                   }
-               }
-               else if (styleProperty != styleProperties) {
-                  result[s].push(styleProperty);
-               }
 
-               // Store style property value on a per name basis as well
-               stylePropertiesPerName[s] = styleProperty;
+                  // Store style property value on a per name basis as well
+                  stylePropertiesPerName[s] = styleProperty;
+               }
             }
             result.byName.push({
                name: names[i],
                style: stylePropertiesPerName
-            })
+            });
          }
 
          if (cache) {

--- a/aikau/src/main/resources/alfresco/core/FileIconUtils.js
+++ b/aikau/src/main/resources/alfresco/core/FileIconUtils.js
@@ -146,12 +146,12 @@ define(["dojo/_base/lang",
                prefix = extns[extn];
             }
          }
-         else if (typeof type == "undefined")
+         else if (typeof type === "undefined")
          {
             if (fileParentType !== null)
             {
                type = this.fileIconTypes[fileParentType];
-               if (typeof type == "undefined")
+               if (typeof type === "undefined")
                {
                   type = "file";
                }

--- a/aikau/src/main/resources/alfresco/core/FileIconUtils.js
+++ b/aikau/src/main/resources/alfresco/core/FileIconUtils.js
@@ -281,6 +281,7 @@ define(["dojo/_base/lang",
        * @return {string} File extension or null
        */
       getFileExtension: function alfresco_core_FileIconUtils(filePath) {
+         /*jshint eqnull:true*/
          if (filePath != null)
          {
             var match = filePath.match(/^.*\.([^\.]*)$/);

--- a/aikau/src/main/resources/alfresco/core/I18nUtils.js
+++ b/aikau/src/main/resources/alfresco/core/I18nUtils.js
@@ -34,7 +34,7 @@ define(["alfresco/core/Core"], function(AlfCore){
     * @param key
     * @returns {*}
     */
-   function msg(i18nScope, key){
+   function msg(i18nScope, /*jshint unused:false*/ key){
       var msgArgs = [];
       if (arguments.length > 1)
       {

--- a/aikau/src/main/resources/alfresco/creation/DragPalette.js
+++ b/aikau/src/main/resources/alfresco/creation/DragPalette.js
@@ -91,6 +91,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       creator: function alfresco_creation_DragWidgetPalette__creator(item, hint) {
+         /*jshint eqnull:true*/
          this.alfLog("log", "Creating", item, hint);
          var node = domConstruct.toDom(stringUtil.substitute(WidgetTemplate, {
             title: (item.name != null) ? item.name : "",

--- a/aikau/src/main/resources/alfresco/creation/DropZone.js
+++ b/aikau/src/main/resources/alfresco/creation/DropZone.js
@@ -97,6 +97,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_creation_DropZone__postCreate() {
+         /*jshint eqnull:true*/
          if (this.acceptTypes == null)
          {
             this.acceptTypes = ["widget"];
@@ -148,7 +149,7 @@ define(["dojo/_base/declare",
 
          if (this.value != null && this.value !== "")
          {
-            array.forEach(this.value, function(widget, i) {
+            array.forEach(this.value, function(widget) {
                var data = {
                   name: widget.name,
                   module: widget.module,
@@ -167,27 +168,31 @@ define(["dojo/_base/declare",
        * @returns {object[]} The currently available fields.
        */
       getAvailableFields: function alfresco_creation_DropZone__getAvailableFields() {
+         /*jshint eqnull:true*/
          var currentFields = [];
          for (var key in this.previewTarget.map)
          {
-            var currentField = this.previewTarget.map[key];
-            
-            // Get the field name to use as the label (this can change) and the id (which should remain
-            // static once created) to populate an individual option.
-            var fieldName = lang.getObject("updatedConfig.defaultConfig.name", false, currentField.data);
-            if (fieldName == null)
+            if (this.previewTarget.map.hasOwnProperty(key))
             {
-               fieldName = lang.getObject("defaultConfig.name", false, currentField.data);
+               var currentField = this.previewTarget.map[key];
+               
+               // Get the field name to use as the label (this can change) and the id (which should remain
+               // static once created) to populate an individual option.
+               var fieldName = lang.getObject("updatedConfig.defaultConfig.name", false, currentField.data);
+               if (fieldName == null)
+               {
+                  fieldName = lang.getObject("defaultConfig.name", false, currentField.data);
+               }
+               var fieldId = lang.getObject("updatedConfig.defaultConfig.fieldId", false, currentField.data);
+               if (fieldId == null)
+               {
+                  fieldId = lang.getObject("defaultConfig.fieldId", false, currentField.data);
+               }
+               currentFields.push({
+                  label: fieldName,
+                  value: fieldId
+               });
             }
-            var fieldId = lang.getObject("updatedConfig.defaultConfig.fieldId", false, currentField.data);
-            if (fieldId == null)
-            {
-               fieldId = lang.getObject("defaultConfig.fieldId", false, currentField.data);
-            }
-            currentFields.push({
-               label: fieldName,
-               value: fieldId
-            });
          }
          return currentFields;
       },
@@ -209,6 +214,7 @@ define(["dojo/_base/declare",
        * @param {object} evt The event.
        */
       deleteItem: function alfresco_creation_DropZone__deleteItem(evt) {
+         /*jshint eqnull:true*/
          this.alfLog("log", "Delete widget request detected", evt);
          
          if (evt.target != null && 
@@ -255,12 +261,13 @@ define(["dojo/_base/declare",
        * @instance
        */
       updateItem: function alfresco_creation_DropZone__updateItem(payload) {
+         /*jshint eqnull:true,maxstatements:false,maxcomplexity:false*/
          // Check that the updated item belongs to this DropZone instance (this is done to prevent
          // multiple DropZone instances trying to modify the wrong objects)...
          if (payload.node != null)
          {
-            var myNode = array.some(this.previewTarget.getAllNodes(), function(node, i) {
-               return payload.node.id == node.id;
+            var myNode = array.some(this.previewTarget.getAllNodes(), function(node) {
+               return payload.node.id === node.id;
             });
             if (myNode === true)
             {
@@ -294,17 +301,23 @@ define(["dojo/_base/declare",
                   var v;
                   for (var key in payload.updatedConfig.defaultConfig)
                   {
-                     v = payload.updatedConfig.defaultConfig[key];
-                     config.widgetConfig[itemConfigKey][key] = v;
-                     lang.setObject(key, v, config.updatedConfig.defaultConfig);
+                     if (payload.updatedConfig.defaultConfig.hasOwnProperty(key))
+                     {
+                        v = payload.updatedConfig.defaultConfig[key];
+                        config.widgetConfig[itemConfigKey][key] = v;
+                        lang.setObject(key, v, config.updatedConfig.defaultConfig);
+                     }
                   }
 
                   // Set additional config...
                   for (key in payload.updatedConfig.additionalConfig)
                   {
-                     v = payload.updatedConfig.additionalConfig[key];
-                     config.widgetConfig[key] = v;
-                     lang.setObject(key, v, config.updatedConfig.additionalConfig);
+                     if (payload.updatedConfig.additionalConfig.hasOwnProperty(key))
+                     {
+                        v = payload.updatedConfig.additionalConfig[key];
+                        config.widgetConfig[key] = v;
+                        lang.setObject(key, v, config.updatedConfig.additionalConfig);
+                     }
                   }
 
                   array.forEach(config.widgetsForConfig, lang.hitch(this, this.updateWidgetConfig, payload.updatedConfig));
@@ -322,7 +335,7 @@ define(["dojo/_base/declare",
                // Remove any existing widgets associated with the currently selected node,
                // however preserve the DOM so that it can be used as a reference for adding
                // the replacement widget (it will be removed afterwards)...
-               array.forEach(this.previewTarget.getSelectedNodes(), function(node, i) {
+               array.forEach(this.previewTarget.getSelectedNodes(), function(node) {
                   var widget = registry.byNode(node);
                   if (widget)
                   {
@@ -363,6 +376,7 @@ define(["dojo/_base/declare",
        * @param {string} childIdToRemove The ID of the child to remove
        */
       removeReferencesFromParent: function alfresco_creation_DropZone__removeReferencesFromParent(parentId, childIdToRemove) {
+         /*jshint eqnull:true*/
          if (parentId != null)
          {
             // The current item already has a parent - this means that we're doing a move...
@@ -372,8 +386,8 @@ define(["dojo/_base/declare",
             {
                // Filter out the current child...
                // TODO: This should ONLY be done on drop - not drag !!
-               oldParentConfig.children = array.filter(oldParentConfig.children, function(childId, index) {
-                  return childId != childIdToRemove;
+               oldParentConfig.children = array.filter(oldParentConfig.children, function(childId) {
+                  return childId !== childIdToRemove;
                }, this);
             }
             else
@@ -389,6 +403,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       creator: function alfresco_creation_DropZone__creator(item, hint) {
+         /*jshint maxcomplexity:false,maxstatements:false,eqnull:true*/
          this.alfLog("log", "Creating", item, hint);
          
          var node = domConstruct.create("div");
@@ -425,8 +440,11 @@ define(["dojo/_base/declare",
                clonedItem.widgetConfig[itemConfigKey] = {};
                for (var key in clonedItem.defaultConfig)
                {
-                  var v = clonedItem.defaultConfig[key];
-                  clonedItem.widgetConfig[itemConfigKey][key] = v;
+                  if (clonedItem.defaultConfig.hasOwnProperty(key))
+                  {
+                     var v = clonedItem.defaultConfig[key];
+                     clonedItem.widgetConfig[itemConfigKey][key] = v;
+                  }
                }
 
                // Initialise widgets for display...
@@ -462,7 +480,7 @@ define(["dojo/_base/declare",
                if (savedConfig != null && savedConfig.updatedConfig != null)
                {
                   // Update the normal config values with the latest saved data...
-                  array.forEach(clonedItem.originalConfigWidgets, function(widget, i) {
+                  array.forEach(clonedItem.originalConfigWidgets, function(widget) {
                      if (widget.config.name)
                      {
                         this.updateWidgetConfig(savedConfig.updatedConfig, widget, 0);
@@ -506,7 +524,7 @@ define(["dojo/_base/declare",
             }
 
             // Update the pubSubScope so that they can request available fields on the correct pubSubScope...
-            array.forEach(clonedItem.widgetsForConfig, function(widget, index) {
+            array.forEach(clonedItem.widgetsForConfig, function(widget) {
                lang.setObject("config.pubSubScope", this.childPubSubScope, widget);
             }, this);
 
@@ -569,7 +587,8 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget to update
        * @param {number} i The index of the widget
        */
-      updateWidgetConfig: function alfresco_creation_DropZone__updateValues(configToUpdateFrom, widget, i) {
+      updateWidgetConfig: function alfresco_creation_DropZone__updateValues(configToUpdateFrom, widget, /*jshint unused:false*/ i) {
+         /*jshint eqnull:true*/
          if (widget.config.name)
          {
             var updatedValue = lang.getObject(widget.config.name, false, configToUpdateFrom);
@@ -591,6 +610,7 @@ define(["dojo/_base/declare",
        * @return {string} The UUID of the widget associated with this DropZone.
        */
       getMyUuid: function alfresco_creation_DropZone__getMyUuid() {
+         /*jshint eqnull:true*/
          // Update the configuration to set the ID of the parent...
          // The ID is either that of the parent DropZoneWrapper or the actual ID if there is no DropZoneWrapper
          // There won't be a DropZoneWrapper if this is the root DropZone (e.g. one created by a DropZoneFormControl)...
@@ -609,7 +629,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} e The selection event
        */
-      onWidgetSelected: function alfresco_creation_DropZone__onWidgetSelected(e) {
+      onWidgetSelected: function alfresco_creation_DropZone__onWidgetSelected(/*jshint unused:false*/ e) {
+         /*jshint eqnull:true*/
          var selectedNodes = this.previewTarget.getSelectedNodes();
          if (selectedNodes.length > 0 && selectedNodes[0] != null)
          {
@@ -631,6 +652,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       refreshChildren: function alfresco_creation_DropZone__refreshChildren() {
+         /*jshint eqnull:true*/
          this.alfLog("log", "Widgets updated");
          
          var myUuid = this.getMyUuid();
@@ -656,7 +678,7 @@ define(["dojo/_base/declare",
          // matches the current order of the nodes representing each data item...
          var items = [];
          var updatedChildren = [];
-         array.forEach(myConfig.children, function (item, index) {
+         array.forEach(myConfig.children, function (item) {
             var itemData = this.alfGetData(item);
             var id = lang.getObject("updatedConfig.defaultConfig.fieldId", false, itemData);
             if (id == null)

--- a/aikau/src/main/resources/alfresco/creation/DropZoneWrapper.js
+++ b/aikau/src/main/resources/alfresco/creation/DropZoneWrapper.js
@@ -31,11 +31,8 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/DropZoneWrapper.html",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
-        "dojo/on",
-        "dijit/registry",
-        "dojo/_base/lang",
-        "dojo/_base/array"], 
-        function(declare, _Widget, _Templated, template, AlfCore, CoreWidgetProcessing, on, registry, lang, array) {
+        "dojo/on"], 
+        function(declare, _Widget, _Templated, template, AlfCore, CoreWidgetProcessing, on) {
    
    return declare([_Widget, _Templated, AlfCore, CoreWidgetProcessing], {
       
@@ -73,6 +70,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_creation_DropZoneWrapper__postCreate() {
+         /*jshint eqnull:true*/
          if (this.widgets != null)
          {
             this.processWidgets(this.widgets, this.controlNode);
@@ -87,7 +85,8 @@ define(["dojo/_base/declare",
        * @param {object} widgetConfig The configuration for the widget to be created
        * @param {number} index The index of the widget configuration in the array that it was taken from
        */
-      processWidget: function alfresco_creation_DropZoneWrapper__processWidget(rootNode, widgetConfig, index) {
+      processWidget: function alfresco_creation_DropZoneWrapper__processWidget(rootNode, widgetConfig, /*jshint unused:false*/ index) {
+         /*jshint eqnull:true*/
          if (widgetConfig != null && widgetConfig.config != null)
          {
             widgetConfig.config._dropZoneWrapperId = this.fieldId;
@@ -101,7 +100,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event that triggers the delete.
        */
-      onWidgetDelete: function alfresco_creation_DropZoneWrapper__onWidgetDelete(evt) {
+      onWidgetDelete: function alfresco_creation_DropZoneWrapper__onWidgetDelete(/*jshint unused:false*/ evt) {
          on.emit(this.domNode, "onWidgetDelete", {
             bubbles: true,
             cancelable: true,

--- a/aikau/src/main/resources/alfresco/creation/WidgetConfig.js
+++ b/aikau/src/main/resources/alfresco/creation/WidgetConfig.js
@@ -32,10 +32,8 @@ define(["dojo/_base/declare",
         "alfresco/forms/Form",
         "dojo/_base/lang",
         "dijit/registry",
-        "dojo/_base/array",
-        "dijit/form/Button",
-        "dojo/dom-class"], 
-        function(declare, _Widget, _Templated, template, AlfCore, Form, lang, registry, array, Button, domClass) {
+        "dojo/_base/array"], 
+        function(declare, _Widget, _Templated, template, AlfCore, Form, lang, registry, array) {
    
    return declare([_Widget, _Templated, AlfCore], {
       
@@ -111,6 +109,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       saveWidgetConfig: function alfresco_creation_WidgetConfig__saveWidgetConfig() {
+         /*jshint eqnull:true*/
          if (this.currentWidgetConfig != null)
          {
             // Get the values for the current widgets...
@@ -155,6 +154,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       displayWidgetConfig: function alfresco_creation_WidgetConfig__displayWidgetConfig(payload) {
+         /*jshint eqnull:true*/
          
          // Clear the previous widgets...
          this.clearCurrentDisplay();
@@ -196,7 +196,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object[]} widgets The widgets that have been created.
        */
-      allWidgetsProcessed: function alfresco_creation_WidgetConfig__allWidgetsProcessed(widgets) {
+      allWidgetsProcessed: function alfresco_creation_WidgetConfig__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
          this.alfLog("log", "Widget config processed");
       },
       
@@ -208,7 +208,7 @@ define(["dojo/_base/declare",
        * @param {object} The widget to destroy
        * @param {number} The index of the widget in the config panel
        */
-      destroyOldConfigWidget: function alfresco_creation_WidgetConfig__destroyOldConfigWidget(widget, index) {
+      destroyOldConfigWidget: function alfresco_creation_WidgetConfig__destroyOldConfigWidget(widget, /*jshint unused:false*/ index) {
          widget.destroyRecursive(false);
       }
    });

--- a/aikau/src/main/resources/alfresco/creation/WidgetDragWrapper.js
+++ b/aikau/src/main/resources/alfresco/creation/WidgetDragWrapper.js
@@ -66,6 +66,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_creation_WidgetDragWrapper__postCreate() {
+         /*jshint eqnull:true*/
          if (this.widgets != null)
          {
             this.processWidgets(this.widgets, this.controlNode);
@@ -78,7 +79,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event that triggers the delete.
        */
-      onWidgetDelete: function alfresco_creation_WidgetDragWrapper__onWidgetDelete(evt) {
+      onWidgetDelete: function alfresco_creation_WidgetDragWrapper__onWidgetDelete(/*jshint unused:false*/ evt) {
          on.emit(this.domNode, "onWidgetDelete", {
             bubbles: true,
             cancelable: true,
@@ -105,7 +106,8 @@ define(["dojo/_base/declare",
        * @param {object} widget The current widget to inspect for widget defintions
        * @param {number} index The index of the current widget to inspect.
        */
-      getSubWidgetDefinitions: function alfresco_creation_WidgetDragWrapper__getSubWidgetDefinitions(widgetDefs, widget, index) {
+      getSubWidgetDefinitions: function alfresco_creation_WidgetDragWrapper__getSubWidgetDefinitions(widgetDefs, widget, /*jshint unused:false*/ index) {
+         /*jshint eqnull:true*/
          if (typeof widget.getWidgetDefinitions === "function")
          {
             var defs = widget.getWidgetDefinitions();

--- a/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
+++ b/aikau/src/main/resources/alfresco/dashlets/Dashlet.js
@@ -1,3 +1,4 @@
+/*jshint maxlen:false*/
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *

--- a/aikau/src/main/resources/alfresco/dashlets/SiteContentReportDashlet.js
+++ b/aikau/src/main/resources/alfresco/dashlets/SiteContentReportDashlet.js
@@ -30,7 +30,6 @@ define(["dojo/_base/declare",
    "alfresco/dashlets/Dashlet"],
       function(declare, AlfCore, I18nUtils, Dashlet) {
 
-         var i18nScope = "alfresco.reports.SiteContentReportDashlet";
          return declare([Dashlet], {
 
             /**

--- a/aikau/src/main/resources/alfresco/debug/CoreDataDebugger.js
+++ b/aikau/src/main/resources/alfresco/debug/CoreDataDebugger.js
@@ -83,7 +83,7 @@ define(["dojo/_base/declare",
             model: myModel,
             showRoot: false,
             getIconClass: function(item, opened) {
-               return (item.type == "value" ? "dijitLeaf" : (opened ? "dijitFolderOpened" : "dijitFolderClosed"));
+               return (item.type === "value" ? "dijitLeaf" : (opened ? "dijitFolderOpened" : "dijitFolderClosed"));
             }
          });
          tree.placeAt(this.treeNode);

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfCloudSyncFilteredMenuBarItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfCloudSyncFilteredMenuBarItem.js
@@ -34,9 +34,8 @@ define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarItem",
         "alfresco/menus/_AlfDisplayFilterMixin",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
-        "dojo/_base/lang",
-        "dojo/_base/array"], 
-        function(declare, AlfMenuBarItem, _AlfDisplayFilterMixin, _AlfDocumentListTopicMixin, lang, array) {
+        "dojo/_base/lang"], 
+        function(declare, AlfMenuBarItem, _AlfDisplayFilterMixin, _AlfDocumentListTopicMixin, lang) {
    
    return declare([AlfMenuBarItem, _AlfDisplayFilterMixin, _AlfDocumentListTopicMixin], {
       

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfViewSelectionGroup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfViewSelectionGroup.js
@@ -68,6 +68,7 @@ define(["dojo/_base/declare",
        * @param {Object} menuItem The menu item to add.
        */
       addViewSelectionMenuItem: function alfresco_documentlibrary_AlfViewSelectionGroup__addViewSelectionMenuItem(payload) {
+         /*jshint eqnull:true*/
          if (payload == null || !payload.menuItem.isInstanceOf(AlfCheckableMenuItem))
          {
             this.alfLog("warn", "A request was made to register a view selection menu item that was not an instance of 'alfresco/documentlibrary/AlfCheckableMenuItem'", payload.menuItem);

--- a/aikau/src/main/resources/alfresco/documentlibrary/ViewPreferencesGroup.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/ViewPreferencesGroup.js
@@ -176,7 +176,7 @@ define(["dojo/_base/declare",
             this._setDefaultMenuItem.publishPayload = {
                prop_app_defaultViewId: this.currentView,
                nodeRef: nodeRef
-            }
+            };
                
             // If the user is either the site manager or the creator of the container...
             if (folderView)
@@ -201,7 +201,7 @@ define(["dojo/_base/declare",
                this._removeDefaultMenuItem.publishPayload = {
                   prop_app_defaultViewId: "",
                   nodeRef: nodeRef
-               }
+               };
             }
             else
             {

--- a/aikau/src/main/resources/alfresco/forms/CrudForm.js
+++ b/aikau/src/main/resources/alfresco/forms/CrudForm.js
@@ -87,13 +87,13 @@ define(["dojo/_base/declare",
 
          if (this.showInfoTopics)
          {
-            array.forEach(this.showInfoTopics, function(topic, i) {
+            array.forEach(this.showInfoTopics, function(topic) {
                this.alfSubscribe(topic, lang.hitch(this, this.onShowInfo));
             }, this);
          }
          if (this.showFormTopics)
          {
-            array.forEach(this.showFormTopics, function(topic, i) {
+            array.forEach(this.showFormTopics, function(topic) {
                this.alfSubscribe(topic, lang.hitch(this, this.onShowForm));
             }, this);
          }
@@ -150,7 +150,8 @@ define(["dojo/_base/declare",
        * @instance
        * @param {array} widgets The created form controls
        */
-      allWidgetsProcessed: function alfresco_forms_CrudForm__allWidgetsProcessed(widgets) {
+      allWidgetsProcessed: function alfresco_forms_CrudForm__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
+         /*jshint eqnull:true*/
          if (this.__creatingInfoWidgets === true)
          {
             this.__creatingInfoWidgets = false;
@@ -166,7 +167,7 @@ define(["dojo/_base/declare",
 
             // Collect the initial set of form data...
             var startingFormData = {};
-            array.forEach(this._form.getChildren(), function(entry, i) {
+            array.forEach(this._form.getChildren(), function(entry) {
                lang.setObject(entry.get("name"), entry.getValue(), startingFormData);
             });
 
@@ -189,6 +190,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       createButtons: function alfresco_forms_CrudForm__createButtons() {
+         /*jshint eqnull:true*/
          
          // Clear the default buttonsNode...
          domConstruct.empty(this.buttonsNode);
@@ -252,7 +254,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The details of the create state
        */
-      onShowCreateState: function alfresco_forms_CrudForm__onShowCreateState(payload) {
+      onShowCreateState: function alfresco_forms_CrudForm__onShowCreateState(/*jshint unused:false*/ payload) {
          // Update the form to display the default data.
          this.setValue(this.defaultData);
 

--- a/aikau/src/main/resources/alfresco/forms/controls/DojoRadioButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DojoRadioButtons.js
@@ -23,6 +23,4 @@
  * @author Dave Draper
  * @deprecated Since 1.0.3 - Use [alfresco/forms/controls/RadioButtons]{@link module:alfresco/forms/controls/RadioButtons} instead
  */
-define(["dojo/_base/declare",
-        "alfresco/forms/controls/RadioButtons"], 
-        function(declare, RadioButtons) {});
+define([], function() {});

--- a/aikau/src/main/resources/alfresco/forms/controls/DojoRadioButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DojoRadioButtons.js
@@ -23,4 +23,8 @@
  * @author Dave Draper
  * @deprecated Since 1.0.3 - Use [alfresco/forms/controls/RadioButtons]{@link module:alfresco/forms/controls/RadioButtons} instead
  */
-define([], function() {});
+define(["dojo/_base/declare",
+        "alfresco/forms/controls/RadioButtons"],
+        function(declare, RadioButtons) {
+   return declare([RadioButtons], {});
+});

--- a/aikau/src/main/resources/alfresco/forms/controls/DropZoneControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DropZoneControl.js
@@ -59,7 +59,8 @@ define(["alfresco/forms/controls/BaseFormControl",
       /**
        * @instance
        */
-      createFormControl: function alfresco_forms_controls_DropZoneControl__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_DropZoneControl__createFormControl(config, /*jshint unused:false*/ domNode) {
+         /*jshint eqnull:true*/
          // Set the value in the data model (this is so that it can be updated with dropped child references)
          // ...see DropZone.creator() function...
          this.alfSetData(config.id, (config.value != null) ? config.value : {});
@@ -81,6 +82,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @returns {string} The widgets defined in the preview pane
        */
       onUpdateValue: function alfresco_forms_controls_DropZoneControl__onUpdateValue() {
+         /*jshint eqnull:true*/
          this.alfLog("log", "Updating DropZoneControl value...");
          var value = {
             editorConfig: "",
@@ -130,7 +132,8 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {string} child The UUID of the child to retrieve the configuration for
        * @param {number} index The index of the child in the parent array
        */
-      processChildren: function alfresco_forms_controls_DropZoneControl__processChildren(childData, child, index) {
+      processChildren: function alfresco_forms_controls_DropZoneControl__processChildren(childData, child, /*jshint unused:false*/ index) {
+         /*jshint eqnull:true*/
          var childConfig = this.alfGetData(child);
          var subChildData = [];
          array.forEach(childConfig.children, lang.hitch(this, "processChildren", subChildData));

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryCreator.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryCreator.js
@@ -189,14 +189,14 @@ define(["dojo/_base/declare",
       getDNDAvatarWidget: function alfresco_forms_controls_MultipleEntryCreator__getDNDAvatarWidget(item) {
          var widget = null;
          var selectedNodes = this._dndSource.getSelectedNodes();
-         array.forEach(selectedNodes, function(node, index) {
+         array.forEach(selectedNodes, function(node) {
             var wrapper = registry.byNode(node);
             
             // This ultra-cautious - but to avoid potential errors we're going to check that
             // the data structure we expect is in place. We're looking to check that the item
             // is the represented by the current selected node.
             if (wrapper && wrapper.widget && wrapper.widget.value && 
-                item._alfMultipleElementId == wrapper.widget.value._alfMultipleElementId)
+                item._alfMultipleElementId === wrapper.widget.value._alfMultipleElementId)
             {
                widget = wrapper.widget;
             }
@@ -240,7 +240,8 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_forms_controls_MultipleEntryCreator__postMixInProperties() {
-         if (this.addEntryImageSrc == null || this.addEntryImageSrc == "")
+         /*jshint eqnull:true*/
+         if (this.addEntryImageSrc == null || this.addEntryImageSrc === "")
          {
             this.addEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.addEntryImage);
          }
@@ -306,6 +307,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       createEntries: function alfresco_forms_controls_MultipleEntryCreator__createEntries(elements) {
+         /*jshint eqnull:true*/
          if (elements == null) 
          {
             elements = [];
@@ -318,7 +320,7 @@ define(["dojo/_base/declare",
          {
             // Iterate over the list of elements and create a wrapper containing each element...
             this.alfLog("log", "Creating entries for MultipleEntryCreator", elements);
-            array.forEach(elements, function(element, index) {
+            array.forEach(elements, function(element) {
                if (element != null)
                {
                   var wrapper = this.createElementWrapper(element, true);
@@ -358,7 +360,7 @@ define(["dojo/_base/declare",
          var wrapper = new MultipleEntryElementWrapper({creator: this,
                                                         previouslyExisted: previouslyExisted, 
                                                         widget: elementWidget});
-         aspect.after(wrapper, "blurWrapper", function(deferred) {
+         aspect.after(wrapper, "blurWrapper", function(/*jshint unused:false*/ deferred) {
             _this.alfLog("log", "Wrapper 'blurWrapper' function processed");
             _this.validationRequired();
          });
@@ -448,7 +450,7 @@ define(["dojo/_base/declare",
       getValue: function alfresco_forms_controls_MultipleEntryCreator__getValue() {
          var value = [];
          var wrappers = registry.findWidgets(this.currentEntries);
-         array.forEach(wrappers, function(wrapper, index) {
+         array.forEach(wrappers, function(wrapper) {
             var widget = wrapper.widget;
             if (typeof widget.getValue === "function")
             {
@@ -470,10 +472,10 @@ define(["dojo/_base/declare",
          // Destroy all the wrapper widgets
          this.alfLog("log", "Setting value of MultipleEntryCreator", this, value);
          var wrappers = registry.findWidgets(this.currentEntries);
-         array.forEach(wrappers, function(wrapper, index) {
+         array.forEach(wrappers, function(wrapper) {
             wrapper.destroyRecursive();
          });
-         if (!value instanceof Array)
+         if (!(value instanceof Array))
          {
             this.alfLog("warn", "The value provided to the MultipleEntryCreator setValue was not an array:", value);
          }
@@ -491,8 +493,7 @@ define(["dojo/_base/declare",
       validate: function alfresco_forms_controls_MultipleEntryCreator__validate() {
          var valid = true;
          var wrappers = registry.findWidgets(this.currentEntries);
-         var _this = this;
-         array.forEach(wrappers, function(wrapper, index) {
+         array.forEach(wrappers, function(wrapper) {
             valid = valid && wrapper.widget.validate();
          });
          return valid;

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryCreator.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryCreator.js
@@ -107,7 +107,7 @@ define(["dojo/_base/declare",
          // The supplied value should correspond to the JSON that we want to represent...
          // We need to construct the element configuration from this...
          
-         if (typeof this.value == "undefined" || this.value == null)
+         if (typeof this.value === "undefined" || this.value === null)
          {
             // If no value has been set then we can just make the value an empty array and
             // also make the elements attribute an empty array.
@@ -450,7 +450,7 @@ define(["dojo/_base/declare",
          var wrappers = registry.findWidgets(this.currentEntries);
          array.forEach(wrappers, function(wrapper, index) {
             var widget = wrapper.widget;
-            if (typeof widget.getValue == "function")
+            if (typeof widget.getValue === "function")
             {
                value.push(widget.getValue());
             }

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElement.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElement.js
@@ -181,7 +181,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      setFormValue: function alfresco_forms_controls_MultipleEntryElement__setFormValue(value) {
+      setFormValue: function alfresco_forms_controls_MultipleEntryElement__setFormValue(/*jshint unused:false*/ value) {
          this.form.setValue(this.elementValue);
       },
       

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElementWrapper.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElementWrapper.js
@@ -294,7 +294,7 @@ define(["dojo/_base/declare",
          this.alfLog("log", "Edit element clicked", {});
          
          // Switch the widget into edit mode...
-         if (this.widget && typeof this.widget.editMode == "function")
+         if (this.widget && typeof this.widget.editMode === "function")
          {
             this.widget.editMode(true);
             

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElementWrapper.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryElementWrapper.js
@@ -38,9 +38,8 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/MultipleEntryElementWrapper.html",
         "alfresco/core/Core",
         "dojo/_base/array",
-        "dojo/dom-class",
-        "dijit/focus"], 
-        function(declare, _Widget, _Templated, _OnDijitClickMixin, _FocusMixin, template, AlfCore, array, domClass, focusUtil) {
+        "dojo/dom-class"], 
+        function(declare, _Widget, _Templated, _OnDijitClickMixin, _FocusMixin, template, AlfCore, array, domClass) {
    
    return declare([_Widget, _Templated, _OnDijitClickMixin, _FocusMixin, AlfCore], {
       
@@ -201,22 +200,23 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_forms_controls_MultipleEntryElementWrapper__postMixInProperties() {
-         if (this.saveEntryImageSrc == null || this.saveEntryImageSrc == "")
+         /*jshint eqnull:true*/
+         if (this.saveEntryImageSrc == null || this.saveEntryImageSrc === "")
          {
             this.saveEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.saveEntryImage);
          }
          this.saveEntryAltText = this.message(this.saveEntryAltText);
-         if (this.cancelEditImageSrc == null || this.cancelEditImageSrc == "")
+         if (this.cancelEditImageSrc == null || this.cancelEditImageSrc === "")
          {
             this.cancelEditImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.cancelEditImage);
          }
          this.cancelEditAltText = this.message(this.cancelEditAltText);
-         if (this.deleteEntryImageSrc == null || this.deleteEntryImageSrc == "")
+         if (this.deleteEntryImageSrc == null || this.deleteEntryImageSrc === "")
          {
             this.deleteEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.deleteEntryImage);
          }
          this.deleteEntryAltText = this.message(this.deleteEntryAltText);
-         if (this.editEntryImageSrc == null || this.editEntryImageSrc == "")
+         if (this.editEntryImageSrc == null || this.editEntryImageSrc === "")
          {
             this.editEntryImageSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.editEntryImage);
          }
@@ -236,6 +236,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_forms_controls_MultipleEntryElementWrapper__postCreate() {
+         /*jshint eqnull:true*/
          
          // Check that a widget has been provided and then add it into the correct node...
          if (this.widget != null)
@@ -321,7 +322,7 @@ define(["dojo/_base/declare",
       /**
        * @instance
        */
-      deleteElement: function alfresco_forms_controls_MultipleEntryElementWrapper__deleteElement(e) {
+      deleteElement: function alfresco_forms_controls_MultipleEntryElementWrapper__deleteElement(/*jshint unused:false*/ e) {
          this.alfLog("log", "Delete element clicked", {});
          
          // When the delete button is clicked the wrapper should be removed and it's data should also be removed from

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleEntryFormControl.js
@@ -83,7 +83,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @instance
        * @returns {object} A new alfresco/forms/controls/MultipleEntryCreator
        */
-      createFormControl: function alfresco_forms_controls_MultipleEntryFormControl__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_MultipleEntryFormControl__createFormControl(config, /*jshint unused:false*/ domNode) {
          return this.createWidget({
             name: "alfresco/forms/controls/MultipleEntryCreator",
             config: config
@@ -114,7 +114,7 @@ define(["alfresco/forms/controls/BaseFormControl",
          // same scope so that they can modify their appearance/behaviour as necessary)...
          if (this.wrappedWidget)
          {
-            aspect.after(this.wrappedWidget, "validationRequired", function(deferred) {
+            aspect.after(this.wrappedWidget, "validationRequired", function(/*jshint unused:false*/ deferred) {
                _this.alfLog("log", "Wrapper 'validationRequired' function processed");
                _this.validate();
             });

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleKeyValuePairElement.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleKeyValuePairElement.js
@@ -23,13 +23,8 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/forms/controls/MultipleEntryElement", 
-        "dijit/form/TextBox",
-        "dojo/_base/lang",
-        "dojo/dom-construct",
-        "dojo/dom-class",
-        "dijit/registry"], 
-        function(declare, MultipleEntryElement, TextBox, lang, domConstruct, domClass, registry) {
+        "alfresco/forms/controls/MultipleEntryElement"], 
+        function(declare, MultipleEntryElement) {
    
    return declare([MultipleEntryElement], {
       

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleKeyValuePairElement.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleKeyValuePairElement.js
@@ -23,7 +23,10 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/forms/controls/MultipleEntryElement"], 
+        "alfresco/forms/controls/MultipleEntryElement",
+
+        // Below classes needed for build purposes only
+        "alfresco/forms/controls/DojoValidationTextBox"], 
         function(declare, MultipleEntryElement) {
    
    return declare([MultipleEntryElement], {

--- a/aikau/src/main/resources/alfresco/forms/controls/MultipleKeyValuePairFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultipleKeyValuePairFormControl.js
@@ -27,9 +27,8 @@
  */
 define(["alfresco/forms/controls/MultipleEntryFormControl",
         "dojo/_base/declare",
-        "alfresco/forms/controls/MultipleKeyValuePairCreator",
-        "dojo/_base/array"], 
-        function(MultipleEntryFormControl, declare, MultipleKeyValuePairCreator, array) {
+        "alfresco/forms/controls/MultipleKeyValuePairCreator"], 
+        function(MultipleEntryFormControl, declare, MultipleKeyValuePairCreator) {
    
    return declare([MultipleEntryFormControl], {
       
@@ -40,8 +39,8 @@ define(["alfresco/forms/controls/MultipleEntryFormControl",
        * @param {Element} domNode
        * @returns A new [MultipleKeyValuePairCreator]{@link module:alfresco/forms/controls/MultipleKeyValuePairCreator}
        */
-      createFormControl: function(config, domNode) {
+      createFormControl: function(config, /*jshint unused:false*/ domNode) {
          return new MultipleKeyValuePairCreator(config);
       }
-   })
+   });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/SimpleMultipleEntryElement.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/SimpleMultipleEntryElement.js
@@ -43,6 +43,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       determineKeyAndValue: function alfresco_forms_controls_SimpleMultipleEntryElement__determineKeyAndValue() {
+         /*jshint eqnull:true*/
          this.alfLog("log", "DetermineKeyAndValue", this);
          if (ObjectTypeUtils.isString(this.elementConfig))
          {
@@ -74,7 +75,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      setFormValue: function alfresco_forms_controls_SimpleMultipleEntryElement__setFormValue(value) {
+      setFormValue: function alfresco_forms_controls_SimpleMultipleEntryElement__setFormValue(/*jshint unused:false*/ value) {
          this.form.setValue({
             value: this.elementValue
          });
@@ -87,6 +88,7 @@ define(["dojo/_base/declare",
        * @returns {object[]}
        */
       getFormWidgets: function alfresco_forms_controls_SimpleMultipleEntryElement__getFormWidgets() {
+         /*jshint eqnull:true*/
          if (this.widgets != null)
          {
             return this.widgets;
@@ -115,6 +117,7 @@ define(["dojo/_base/declare",
        * @returns {object}
        */
       getValue: function alfresco_forms_controls_SimpleMultipleEntryElement__getValue() {
+         /*jshint eqnull:true*/
          var value = "";
          if (this.form != null) 
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/SimplePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/SimplePicker.js
@@ -31,11 +31,12 @@ define(["alfresco/forms/controls/BaseFormControl",
         "dojo/_base/lang",
         "dojo/_base/array",
         "alfresco/core/ObjectTypeUtils",
+
+        // Following items required in order to be built into the bundle, but not used directly
         "alfresco/pickers/Picker",
         "alfresco/pickers/PropertyPicker",
         "alfresco/pickers/PickedItems"], 
-        function(BaseFormControl, declare, CoreWidgetProcessing, ObjectProcessingMixin, lang, array, ObjectTypeUtils, 
-                 Picker, PropertyPicker, PickedItems) {
+        function(BaseFormControl, declare, CoreWidgetProcessing, ObjectProcessingMixin, lang, array, ObjectTypeUtils) {
    
    return declare([BaseFormControl, CoreWidgetProcessing, ObjectProcessingMixin], {
       
@@ -53,7 +54,7 @@ define(["alfresco/forms/controls/BaseFormControl",
       /**
        * @instance
        */
-      createFormControl: function alfresco_forms_controls_SimplePicker__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_SimplePicker__createFormControl(/*jshint unused:false*/ config, /*jshint unused:false*/ domNode) {
          this.lastValue = ObjectTypeUtils.isArray(this.value) ? this.value : [];
 
          // Create a specific item selection scope to ensure that the picker publications don't interfere

--- a/aikau/src/main/resources/alfresco/forms/controls/TextArea.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TextArea.js
@@ -72,7 +72,8 @@ define(["alfresco/forms/controls/BaseFormControl",
       /**
        * @instance
        */
-      createFormControl: function alfresco_forms_controls_TextArea__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_controls_TextArea__createFormControl(config, /*jshint unused:false*/ domNode) {
+         /*jshint eqnull:true*/
          var textArea = new Textarea(config);
          // Handle adding classes
          var additionalCssClasses = "";

--- a/aikau/src/main/resources/alfresco/forms/controls/TextBoxControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TextBoxControl.js
@@ -26,57 +26,52 @@
  * @author Martin Doyle
  * @since 1.0.45
  */
-define([
-      "alfresco/core/Core",
-      "dijit/form/ValidationTextBox",
-      "dojo/_base/declare",
-      "dojo/_base/lang",
-      "dojo/dom-construct",
-      "dojo/on"
-   ],
-   function(Core, ValidationTextBox, declare, lang, domConstruct, on) {
+define(["alfresco/core/Core", 
+        "dijit/form/ValidationTextBox", 
+        "dojo/_base/declare"], 
+        function(Core, ValidationTextBox, declare) {
 
-      // We only want to run this once
-      var supportsPlaceholder = document.createElement("input").placeholder === "";
+   // We only want to run this once
+   var supportsPlaceholder = document.createElement("input").placeholder === "";
 
-      return declare([ValidationTextBox], {
+   return declare([ValidationTextBox], {
 
-         /**
-          * Whether to enable autocomplete on the textbox. Further details available against the
-          * [alfresco/forms/controls/TextBox property]{@link module:alfresco/forms/controls/TextBox#autocomplete}.
-          *
-          * @instance
-          * @type {string}
-          * @default
-          */
-         autocomplete: null,
+      /**
+       * Whether to enable autocomplete on the textbox. Further details available against the
+       * [alfresco/forms/controls/TextBox property]{@link module:alfresco/forms/controls/TextBox#autocomplete}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      autocomplete: null,
 
-         /**
-          * Run after the widget has been created.
-          *
-          * @instance
-          * @override
-          */
-         postCreate: function alfresco_forms_controls_TextBoxControl__postCreate() {
-            this.inherited(arguments);
-            if(this.autocomplete) {
-               this.textbox && this.textbox.setAttribute("autocomplete", this.autocomplete);
-            }
-         },
-
-         /**
-          * If we can use native placeholder, use it instead of the Dojo one.
-          *
-          * @instance
-          * @override
-          * @param {string} placeholderValue The placeholder value.
-          */
-         _setPlaceHolderAttr: function alfresco_forms_controls_TextBoxControl___setPlaceHolderAttr(placeholderValue) {
-            if (supportsPlaceholder) {
-               this.textbox.placeholder = placeholderValue;
-            } else {
-               this.inherited(arguments);
-            }
+      /**
+       * Run after the widget has been created.
+       *
+       * @instance
+       * @override
+       */
+      postCreate: function alfresco_forms_controls_TextBoxControl__postCreate() {
+         this.inherited(arguments);
+         if(this.autocomplete) {
+            this.textbox && this.textbox.setAttribute("autocomplete", this.autocomplete);
          }
-      });
+      },
+
+      /**
+       * If we can use native placeholder, use it instead of the Dojo one.
+       *
+       * @instance
+       * @override
+       * @param {string} placeholderValue The placeholder value.
+       */
+      _setPlaceHolderAttr: function alfresco_forms_controls_TextBoxControl___setPlaceHolderAttr(placeholderValue) {
+         if (supportsPlaceholder) {
+            this.textbox.placeholder = placeholderValue;
+         } else {
+            this.inherited(arguments);
+         }
+      }
    });
+});

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/IconMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/IconMixin.js
@@ -48,6 +48,7 @@ define(["dojo/_base/declare",
        * @param {object} control The form control to manipulate
        */
       addIcon: function alfresco_forms_controls_utilities_IconMixin__addIcon(control) {
+         /*jshint eqnull:true*/
          if (this.iconClass != null && lang.trim(this.iconClass) !== "")
          {
             domConstruct.create("span", {

--- a/aikau/src/main/resources/alfresco/forms/creation/FormRulesConfigCreator.js
+++ b/aikau/src/main/resources/alfresco/forms/creation/FormRulesConfigCreator.js
@@ -24,11 +24,8 @@
  */
 define(["alfresco/forms/controls/MultipleEntryCreator",
         "alfresco/forms/creation/FormRulesConfigCreatorElement",
-        "dojo/_base/declare",
-        "dojo/_base/array",
-        "dijit/registry",
-        "dojo/_base/lang"], 
-        function(MultipleEntryCreator, FormRulesConfigCreatorElement, declare, array, registry, lang) {
+        "dojo/_base/declare"], 
+        function(MultipleEntryCreator, FormRulesConfigCreatorElement, declare) {
    
    return declare([MultipleEntryCreator], {
       /**

--- a/aikau/src/main/resources/alfresco/forms/creation/PublicationConfigControl.js
+++ b/aikau/src/main/resources/alfresco/forms/creation/PublicationConfigControl.js
@@ -45,7 +45,7 @@ define(["alfresco/forms/controls/MultipleEntryFormControl",
       /**
        * @instance
        */
-      createFormControl: function alfresco_forms_creation_PublicationConfigControl__createFormControl(config, domNode) {
+      createFormControl: function alfresco_forms_creation_PublicationConfigControl__createFormControl(config, /*jshint unused:false*/ domNode) {
          return new PublicationConfigCreator(config);
       }
    });

--- a/aikau/src/main/resources/alfresco/forms/creation/PublicationConfigCreatorElement.js
+++ b/aikau/src/main/resources/alfresco/forms/creation/PublicationConfigCreatorElement.js
@@ -24,14 +24,11 @@
  */
 define(["alfresco/forms/controls/MultipleEntryElement",
         "dojo/_base/declare",
-        "alfresco/forms/PublishForm",
-        "alfresco/core/ObjectTypeUtils",
-        "dojo/_base/lang",
-        "dojo/_base/array",
+
+        // Following required for build purposes only
         "alfresco/forms/controls/DojoValidationTextBox",
-        "alfresco/forms/controls/Select",
-        "alfresco/forms/controls/MultipleEntryFormControl"], 
-        function(MultipleEntryElement, declare, PublishForm, ObjectTypeUtils, lang, array, DojoValidationTextBox, DojoSelect, MultipleEntryFormControl) {
+        "alfresco/forms/controls/MultipleKeyValuePairFormControl"], 
+        function(MultipleEntryElement, declare) {
    
    return declare([MultipleEntryElement], {
       

--- a/aikau/src/main/resources/alfresco/header/AlfCascadingMenu.js
+++ b/aikau/src/main/resources/alfresco/header/AlfCascadingMenu.js
@@ -24,9 +24,8 @@
  */
 define(["dojo/_base/declare",
         "alfresco/menus/AlfCascadingMenu",
-        "dojo/dom-class",
-        "dojo/dom-construct"], 
-        function(declare, AlfCascadingMenu, domClass, domConstruct) {
+        "dojo/dom-class"], 
+        function(declare, AlfCascadingMenu, domClass) {
    
    return declare([AlfCascadingMenu], {
       

--- a/aikau/src/main/resources/alfresco/header/AlfSitesMenu.js
+++ b/aikau/src/main/resources/alfresco/header/AlfSitesMenu.js
@@ -554,7 +554,7 @@ define(["dojo/_base/declare",
          var item = this.createWidget({
             name: "alfresco/header/AlfMenuItem",
             config: widget.config
-         })
+         });
          group.addChild(item);
       },
       

--- a/aikau/src/main/resources/alfresco/html/Heading.js
+++ b/aikau/src/main/resources/alfresco/html/Heading.js
@@ -151,6 +151,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_html_Label__postMixInProperties() {
+         /*jshint eqnull:true*/
          if (this.subscriptionTopic != null && lang.trim(this.subscriptionTopic) !== "")
          {
             this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.onHeadingUpdate));
@@ -163,6 +164,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the label update
        */
       onHeadingUpdate: function alfresco_html_Heading__onHeadingUpdate(payload) {
+         /*jshint eqnull:true*/
          var update = lang.getObject("label", false, payload);
          if (update != null)
          {

--- a/aikau/src/main/resources/alfresco/html/Spacer.js
+++ b/aikau/src/main/resources/alfresco/html/Spacer.js
@@ -89,6 +89,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_html_Spacer__postCreate() {
+         /*jshint eqnull:true*/
          if (this.additionalCssClasses != null)
          {
             domClass.add(this.domNode, this.additionalCssClasses);

--- a/aikau/src/main/resources/alfresco/integration/MessageClient.js
+++ b/aikau/src/main/resources/alfresco/integration/MessageClient.js
@@ -38,7 +38,7 @@
                name: name
             };
 
-            if (typeof value != 'undefined')
+            if (typeof value !== "undefined")
             {
                message.value = value;
             }
@@ -92,7 +92,7 @@
 
       _addEventListener: function(el, event, callback)
       {
-         if (typeof el.addEventListener == 'function')
+         if (typeof el.addEventListener === "function")
          {
             el.addEventListener(event, this._bind(callback), false);
          }

--- a/aikau/src/main/resources/alfresco/integration/MessageClient.js
+++ b/aikau/src/main/resources/alfresco/integration/MessageClient.js
@@ -15,15 +15,15 @@
    {
       if (!otherWindow || !origin || !channel)
       {
-         throw new Error('MessageClient constructor requires all ("otherWindow", "origin" and "channel") ' +
-               'parameters to be set');
+         throw new Error("MessageClient constructor requires all (\"otherWindow\", \"origin\" and \"channel\") " +
+               "parameters to be set");
       }
       this._otherWindow = otherWindow;
       this._origin = origin;
       this._channel = channel;
 
       this._callbacks = {};
-      this._addEventListener(window, 'message', this._receiveMessage);
+      this._addEventListener(window, "message", this._receiveMessage);
    }
 
    MessageClient.prototype = {
@@ -69,11 +69,11 @@
          {
             var callback = this._callbacks[data.callback];
             delete this._callbacks[data.callback];
-            if (data.success && typeof callback[0] == "function")
+            if (data.success && typeof callback[0] === "function")
             {
                callback[0](data.result);
             }
-            else if (data.failure && typeof callback[1] == "function")
+            else if (data.failure && typeof callback[1] === "function")
             {
                callback[1](data.code, data.message);
             }
@@ -84,10 +84,10 @@
       {
          var args = Array.prototype.slice.call(arguments).slice(2);
          var me = this;
-         return (function()
+         return function()
          {
             return fn.apply(me, args.concat(Array.prototype.slice.call(arguments)));
-         });
+         };
       },
 
       _addEventListener: function(el, event, callback)
@@ -98,7 +98,7 @@
          }
          else
          {
-            el.attachEvent('on' + event, this._bind(callback));
+            el.attachEvent("on" + event, this._bind(callback));
          }
       }
 

--- a/aikau/src/main/resources/alfresco/integration/MessageServer.js
+++ b/aikau/src/main/resources/alfresco/integration/MessageServer.js
@@ -72,7 +72,7 @@
             {
                var name = data.name;
                var fn = this._messageHandlerResolver(name);
-               if (typeof fn == 'function')
+               if (typeof fn === "function")
                {
                   fn(data.value, function(result){
                      var message = {
@@ -121,7 +121,7 @@
 
       _addEventListener: function(el, event, callback)
       {
-         if (typeof el.addEventListener == 'function')
+         if (typeof el.addEventListener === "function")
          {
             el.addEventListener(event, this._bind(callback), false);
          }

--- a/aikau/src/main/resources/alfresco/integration/MessageServer.js
+++ b/aikau/src/main/resources/alfresco/integration/MessageServer.js
@@ -16,13 +16,13 @@
    {
       if (!origins || !channel)
       {
-         throw new Error('MessageServer constructor requires all ("origins" and "channel") ' +
-               'parameters to be set');
+         throw new Error("MessageServer constructor requires all (\"origins\" and \"channel\") " +
+               "parameters to be set");
       }
 
       if (CHANNELS[channel])
       {
-         throw new Error('Cannot construct MessageServer since channel "' + channel + '"already is in use');
+         throw new Error("Cannot construct MessageServer since channel \"" + channel + "\"already is in use");
       }
 
       CHANNELS[channel] = true;
@@ -31,7 +31,7 @@
       this._channel = channel;
       this._messageHandlerResolver = messageHandlerResolver || this._messageHandlerResolver;
 
-      this._addEventListener(window, 'message', this._receiveMessage);
+      this._addEventListener(window, "message", this._receiveMessage);
    }
 
    MessageServer.prototype = {
@@ -57,7 +57,7 @@
          var allowed = false;
          for (var i = 0, il = this._origins.length; i < il; i++)
          {
-            if (event.origin == this._origins[i])
+            if (event.origin === this._origins[i])
             {
                allowed = true;
                break;
@@ -68,7 +68,7 @@
          {
             // event.source
             var data = JSON.parse(event.data);
-            if (data.name && data.channel == this._channel)
+            if (data.name && data.channel === this._channel)
             {
                var name = data.name;
                var fn = this._messageHandlerResolver(name);
@@ -83,14 +83,14 @@
                      message = JSON.stringify(message);
                      event.source.postMessage(message, event.origin);
                   }, function(code, message){
-                     var message = {
+                     var messageToPost = {
                         callback: data.callback,
                         failure: true,
                         code: code,
                         message: message
                      };
-                     message = JSON.stringify(message);
-                     event.source.postMessage(message, event.origin);
+                     messageToPost = JSON.stringify(messageToPost);
+                     event.source.postMessage(messageToPost, event.origin);
                   });
                }
                else
@@ -100,7 +100,7 @@
                      callback: data.callback,
                      failure: true,
                      code: 1,
-                     message: 'Message named "' + name + '" was not recognized.'
+                     message: "Message named \"" + name + "\" was not recognized."
                   };
                   message = JSON.stringify(message);
                   event.source.postMessage(message, event.origin);
@@ -113,10 +113,10 @@
       {
          var args = Array.prototype.slice.call(arguments).slice(2);
          var me = this;
-         return (function()
+         return function()
          {
             return fn.apply(me, args.concat(Array.prototype.slice.call(arguments)));
-         });
+         };
       },
 
       _addEventListener: function(el, event, callback)
@@ -127,7 +127,7 @@
          }
          else
          {
-            el.attachEvent('on' + event, this._bind(callback));
+            el.attachEvent("on" + event, this._bind(callback));
          }
       }
    };

--- a/aikau/src/main/resources/alfresco/layout/AbsoluteCenterWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/AbsoluteCenterWidgets.js
@@ -57,8 +57,9 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       allWidgetsProcessed: function alfresco_layout_AbsoluteCenterWidgets__allWidgetsProcessed(widgets) {
+         /*jshint eqnull:true*/
          var heightRequired = 0;
-         array.forEach(widgets, function(widget, index) {
+         array.forEach(widgets, function(widget) {
             var computedStyle = domStyle.getComputedStyle(widget.domNode);
             var output = domGeom.getMarginBox(widget.domNode, computedStyle);
             heightRequired += output.h;

--- a/aikau/src/main/resources/alfresco/layout/AlfAccordionContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfAccordionContainer.js
@@ -84,7 +84,7 @@ define(["dojo/_base/declare",
        * @param {object} widget The widget to add
        * @param {integer} index The index of the widget
        */
-      addWidget: function alfresco_layout_AlfAccordionContainer__addWidget(widget, index) {
+      addWidget: function alfresco_layout_AlfAccordionContainer__addWidget(widget, /*jshint unused:false*/ index) {
          var domNode = domConstruct.create("div", {});
          var widgetNode = this.createWidgetDomNode(widget, domNode);
          var w = this.createWidget(widget, widgetNode);

--- a/aikau/src/main/resources/alfresco/layout/CenteredWidgets.js
+++ b/aikau/src/main/resources/alfresco/layout/CenteredWidgets.js
@@ -54,10 +54,8 @@ define(["alfresco/core/ProcessWidgets",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-style",
-        "dojo/dom-geometry",
-        "dojo/on",
-        "alfresco/core/ObjectTypeUtils"], 
-        function(ProcessWidgets, declare, template, lang, array, domConstruct, domStyle, domGeom, on, ObjectTypeUtils) {
+        "dojo/dom-geometry"], 
+        function(ProcessWidgets, declare, template, lang, array, domConstruct, domStyle, domGeom) {
    
    return declare([ProcessWidgets], {
       
@@ -108,7 +106,7 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        * @param {object} evt The resize event.
        */
-      onResize: function alfresco_layout_CenteredWidgets__onResize(evt) {
+      onResize: function alfresco_layout_CenteredWidgets__onResize(/*jshint unused:false*/ evt) {
          this.alfLog("log", "Resizing");
 
          // TODO: Implement to resize when the window changes...
@@ -126,7 +124,8 @@ define(["alfresco/core/ProcessWidgets",
        * @param {string} rootClassName A string containing one or more space separated CSS classes to set on the DOM node
        * @returns {element} A new DOM node for the widget to be attached to
        */
-      createWidgetDomNode: function alfresco_layout_CenteredWidgets__createWidgetDomNode(widget, rootNode, rootClassName) {
+      createWidgetDomNode: function alfresco_layout_CenteredWidgets__createWidgetDomNode(widget, /*jshint unused:false*/ rootNode, /*jshint unused:false*/ rootClassName) {
+         /*jshint eqnull:true*/
 
          var marginLeft =  (this.widgetMarginLeft != null && !isNaN(this.widgetMarginLeft)) ? this.widgetMarginLeft: 0;
          var marginRight =  (this.widgetMarginRight != null && !isNaN(this.widgetMarginRight)) ? this.widgetMarginRight: 0;
@@ -135,8 +134,8 @@ define(["alfresco/core/ProcessWidgets",
          var style = {
             "marginLeft": marginLeft + "px",
             "marginRight": marginRight + "px"
-         }
-         if (widget.widthCalc != 0)
+         };
+         if (widget.widthCalc !== 0)
          {
             style.width = widget.widthCalc + "px";
          }
@@ -158,7 +157,7 @@ define(["alfresco/core/ProcessWidgets",
          // Calculate the total width and the max height of all the contained widgets
          var calcWidth = 0;
          var maxHeight = 0;
-         array.forEach(widgets, function(widget, i) {
+         array.forEach(widgets, function(widget) {
             calcWidth = calcWidth + this.overallWidth(widget.domNode);
             var thisHeight = this.overallHeight(widget.domNode);
             maxHeight = maxHeight > thisHeight?maxHeight:thisHeight;
@@ -171,17 +170,15 @@ define(["alfresco/core/ProcessWidgets",
 
          // Otherwise set the containerNode width
          }else{
-            var style = {
+            domStyle.set(this.containerNode, {
                "width": calcWidth + "px"
-            }
-            domStyle.set(this.containerNode, style);
+            });
          }
 
          // Set max height for the domNode
-         var style = {
+         domStyle.set(this.domNode, {
             "height": maxHeight + "px"
-         }
-         domStyle.set(this.domNode, style);
+         });
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/SlideOverlay.js
+++ b/aikau/src/main/resources/alfresco/layout/SlideOverlay.js
@@ -141,10 +141,10 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_layout_SlideOverlay__postCreate() {
          
          // Set up all the subscription and event handlers...
-         array.forEach(this.showTopics, function(topic, i) {
+         array.forEach(this.showTopics, function(topic) {
             this.alfSubscribe(topic, lang.hitch(this, "showOverlay"));
          }, this);
-         array.forEach(this.hideTopics, function(topic, i) {
+         array.forEach(this.hideTopics, function(topic) {
             this.alfSubscribe(topic, lang.hitch(this, "hideOverlay"));
          }, this);
          array.forEach(this.showEvents, function(eventName) {
@@ -153,7 +153,7 @@ define(["dojo/_base/declare",
          array.forEach(this.hideEvents, function(eventName) {
             on(this.domNode, eventName, lang.hitch(this, "hideOverlay"));
          }, this);
-         array.forEach(this.adjustHeightTopics, function(topic, i) {
+         array.forEach(this.adjustHeightTopics, function(topic) {
             this.alfSubscribe(topic, lang.hitch(this, "adjustHeight"));
          }, this);
          array.forEach(this.adjustHeightEvents, function(eventName) {
@@ -186,11 +186,11 @@ define(["dojo/_base/declare",
        * @param {object} widgetConfig
        * @param {number} index
        */
-      processWidget: function alfresco_layout_SlideOverlay__processWidget(rootNode, widgetConfig, index) {
+      processWidget: function alfresco_layout_SlideOverlay__processWidget(rootNode, widgetConfig, /*jshint unused:false*/ index) {
          if (this.filterWidget(widgetConfig))
          {
             var domNode = null;
-            if (widgetConfig.align == "overlay")
+            if (widgetConfig.align === "overlay")
             {
                domNode = this.createWidgetDomNode(widgetConfig, this.overlayNode, widgetConfig.className);
             }

--- a/aikau/src/main/resources/alfresco/layout/SlidingTabs.js
+++ b/aikau/src/main/resources/alfresco/layout/SlidingTabs.js
@@ -116,13 +116,14 @@ define(["dojo/_base/declare",
        * @instance
        * @param {Element} rootNode
        * @param {object} widgetConfig
-       * @param {number} index
+       * @param {number} idx
        */
-      processWidget: function alfresco_layout_SlidingTabs__processWidget(rootNode, widgetConfig, index) {
+      processWidget: function alfresco_layout_SlidingTabs__processWidget(rootNode, widgetConfig, /*jshint unused:false*/ idx) {
+         /*jshint eqnull:true*/
          if (this.filterWidget(widgetConfig))
          {
             // Only add the widget if it has a title...
-            if (widgetConfig.title != null && widgetConfig.title != "")
+            if (widgetConfig.title != null && widgetConfig.title !== "")
             {
                // Increment the count of tabs...
                this.tabCount++;
@@ -179,7 +180,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      allWidgetsProcessed: function alfresco_layout_SlidingTabs__allWidgetsProcessed(widgets) {
+      allWidgetsProcessed: function alfresco_layout_SlidingTabs__allWidgetsProcessed(/*jshint unused:false*/ widgets) {
          // Initially set the first and second tabs as "selected" and "next"...
          // TODO: Set these based on a # filter...
          query(".navigation", this.domNode).children().first().addClass("selected").next().addClass("next");

--- a/aikau/src/main/resources/alfresco/layout/TitleDescriptionAndContent.js
+++ b/aikau/src/main/resources/alfresco/layout/TitleDescriptionAndContent.js
@@ -78,11 +78,11 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_layout_TitleDescriptionAndContent__postMixInProperties() {
-         if (this.title != "")
+         if (this.title !== "")
          {
             this.title = this.message(this.title);
          }
-         if (this.description != "")
+         if (this.description !== "")
          {
             this.description = this.message(this.description);
          }
@@ -94,6 +94,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_layout_TitleDescriptionAndContent__postCreate() {
+         /*jshint eqnull:true*/
          if (this.widgets != null)
          {
             this.processWidgets(this.widgets, this.contentNode);

--- a/aikau/src/main/resources/alfresco/lists/views/_AlfAdditionalViewControlMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/_AlfAdditionalViewControlMixin.js
@@ -67,6 +67,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload published on the filter topic 
        */
       filter: function alfresco_lists_views__AlfAdditionalViewControlMixin__filter(payload) {
+         /*jshint eqnull:true*/
          if (this.relatedViewName == null)
          {
             this.alfLog("warn", "Unable to filter additional view control due to the 'relatedViewName' not being configured", this);

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Column.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Column.js
@@ -76,7 +76,7 @@ define(["dojo/_base/declare",
        * @param {String} rootClassName A string containing one or more space separated CSS classes to set on the DOM node
        * @returns {element} A new DOM node for a processed widget to attach to
        */
-      createWidgetDomNode: function alfresco_renderers_Column__createWidgetDomNode(widget, rootNode, rootClassName) {
+      createWidgetDomNode: function alfresco_renderers_Column__createWidgetDomNode(widget, rootNode, /*jshint unused:false*/ rootClassName) {
          var nodeToAdd = domConstruct.create("TR", {}, rootNode);
          return domConstruct.create("TD", {}, nodeToAdd);
       }

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
@@ -212,7 +212,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onSortClick: function alfresco_lists_views_layouts_HeaderCell__onSortClick(evt) {
+      onSortClick: function alfresco_lists_views_layouts_HeaderCell__onSortClick(/*jshint unused:false*/ evt) {
          if (this.sortable === true)
          {
             this.alfLog("log", "Sort request received");

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
@@ -202,6 +202,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       renderData: function alfresco_lists_views_layout___MultiItemRendererMixin__renderData() {
+         /*jshint eqnull:true*/
          
          // Ensure that an array is created to hold the root widget subscriptions...
          if (!this.rootWidgetSubscriptions)
@@ -295,6 +296,7 @@ define(["dojo/_base/declare",
        * @param {string} processWidgetsId An optional ID that might have been provided to map the results of multiple calls to [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        */
       allWidgetsProcessed: function alfresco_lists_views_layout___MultiItemRendererMixin__allWidgetsProcessed(widgets, processWidgetsId) {
+         /*jshint eqnull:true*/
          if (!processWidgetsId || processWidgetsId === "RENDER_APPENDIX_SENTINEL")
          {
             // Push the processed widgets for the last item into the array of rendered widgets...

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarToggle.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarToggle.js
@@ -66,9 +66,8 @@ define(["dojo/_base/declare",
         "dojo/dom-class",
         "dojo/dom-attr",
         "dojo/_base/lang",
-        "alfresco/util/hashUtils",
-        "dojo/io-query"], 
-        function(declare, AlfMenuBarItem, _AlfDocumentListTopicMixin, domConstruct, domClass, domAttr, lang, hashUtils, ioQuery) {
+        "alfresco/util/hashUtils"], 
+        function(declare, AlfMenuBarItem, _AlfDocumentListTopicMixin, domConstruct, domClass, domAttr, lang, hashUtils) {
    
    
    return declare([AlfMenuBarItem, _AlfDocumentListTopicMixin], {
@@ -127,6 +126,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       constructor: function alfresco_menus_AlfMenuBarToggle__constructor(args) {
+         /*jshint eqnull:true*/
          
          this.alfLog("log", "Create toggle", args);
          
@@ -255,7 +255,7 @@ define(["dojo/_base/declare",
          if (newConfig && newConfig.label)
          {
             this.label = newConfig.label;
-            this.set('label', this.message(newConfig.label));
+            this.set("label", this.message(newConfig.label));
             this.title = newConfig.title;
          }
 
@@ -264,7 +264,7 @@ define(["dojo/_base/declare",
          {
             this.title = newConfig.title;
             var title = this.message(newConfig.title);
-            this.set('title', title);
+            this.set("title", title);
             domAttr.set(this.iconNode, "title", title);
          }
 
@@ -328,10 +328,11 @@ define(["dojo/_base/declare",
        * @instance
        */
       setState: function alfresco_menus_AlfMenuBarToggle__setState(payload) {
+         /*jshint eqnull:true*/
          if (payload && payload[this.subscriptionAttribute] != null)
          {
             this.alfLog("log", "Setting toggle state", payload, this);
-            this.checked = (this.checkedValue == payload[this.subscriptionAttribute]);
+            this.checked = (this.checkedValue === payload[this.subscriptionAttribute]);
             if (this.checked)
             {
                this.renderToggle(this.onConfig, this.offConfig);

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuGroup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuGroup.js
@@ -191,6 +191,7 @@ define(["dojo/_base/declare",
        * @return Either null if a menu bar cannot be found or a menu bar widget.
        */
       findMenuBarAncestor: function alfresco_menus_AlfMenuGroup__findMenuBarAncestor(currentMenu) {
+         /*jshint eqnull:true*/
          var reachedMenuTop = false;
          while (!reachedMenuTop && !currentMenu._isMenuBar)
          {

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuItemWrapper.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuItemWrapper.js
@@ -147,7 +147,7 @@ define(["dojo/_base/declare",
        */
       onClick: function alfresco_menus_AlfMenuItemWrapper__onClick(evt){
          this.alfLog("log", "Item Wrapper onClick", evt);
-         if (this.item && typeof this.item.onClick == "function")
+         if (this.item && typeof this.item.onClick === "function")
          {
             this.item.onClick(evt);
          }

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuTextForClipboard.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuTextForClipboard.js
@@ -103,6 +103,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_menus_AlfMenuTextForClipboard__postMixInProperties() {
+         /*jshint eqnull:true*/
          if (this.label != null)
          {
             this.label = this.encodeHTML(this.message(this.label));

--- a/aikau/src/main/resources/alfresco/menus/AlfVerticalMenuBar.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfVerticalMenuBar.js
@@ -66,7 +66,7 @@ define(["dojo/_base/declare",
        */
       allWidgetsProcessed: function alfresco_menus_AlfMenuBar__allWidgetsProcessed(widgets) {
          var _this = this;
-         array.forEach(widgets, function(entry, i) {
+         array.forEach(widgets, function(entry) {
             _this._menuBar.addChild(entry);
          });
          this._menuBar.placeAt(this.containerNode);

--- a/aikau/src/main/resources/alfresco/menus/_AlfDisplayFilterMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfDisplayFilterMixin.js
@@ -53,6 +53,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfMenuItem__postCreate() {
+         /*jshint eqnull:true*/
          if (this.filterTopic != null)
          {
             this.alfSubscribe(this.filterTopic, lang.hitch(this, "filter"));
@@ -70,7 +71,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload The payload published on the filter topic 
        */
-      filter: function alfresco_menus_AlfFilteringMenuItem__filter(payload) {
+      filter: function alfresco_menus_AlfFilteringMenuItem__filter(/*jshint unused:false*/ payload) {
          this.inherited(arguments);
       },
       

--- a/aikau/src/main/resources/alfresco/menus/_AlfPopupCloseMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfPopupCloseMixin.js
@@ -29,9 +29,8 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "dojo/on",
         "dojo/_base/lang",
-        "dijit/popup",
-        "dijit/focus"], 
-        function(declare, AlfCore, on, lang, popup, focusUtil) {
+        "dijit/popup"], 
+        function(declare, AlfCore, on, lang, popup) {
    
    return declare([AlfCore], {
 
@@ -73,6 +72,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       closePopupMenu: function alfresco_menus__AlfPopupCloseMixin__closePopupMenu() {
+         /*jshint eqnull:true*/
          if (this.popup)
          {
             // Focus the main node again (this is require for keyboard accessibility)

--- a/aikau/src/main/resources/alfresco/navigation/Link.js
+++ b/aikau/src/main/resources/alfresco/navigation/Link.js
@@ -100,7 +100,8 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_navigation_Link__postMixInProperties() {
-         if (this.label != null && this.label != "")
+         /*jshint eqnull:true*/
+         if (this.label != null && this.label !== "")
          {
             this.label = this.message(this.label);
          }
@@ -109,7 +110,7 @@ define(["dojo/_base/declare",
             this.label = "";
             this.alfLog("warn", "No sensible 'label' attribute set for a link", this);
          }
-         if (this.title != null && this.title != "")
+         if (this.title != null && this.title !== "")
          {
             this.title = this.message(this.title);
          }
@@ -122,7 +123,7 @@ define(["dojo/_base/declare",
          {
             this.publishPayload = {};
          }
-         if (this.publishTopic == null || this.publishTopic == "")
+         if (this.publishTopic == null || this.publishTopic === "")
          {
             this.alfLog("warn", "A link has been created without a 'publishTopic' attribute, clicking it will have no effect", this);
          }
@@ -135,6 +136,7 @@ define(["dojo/_base/declare",
        * @param {object} evt The click event
        */
       onClick: function alfresco_navigation_Link__onClick(evt) {
+         /*jshint eqnull:true*/
          event.stop(evt);
          if (this.publishTopic != null)
          {

--- a/aikau/src/main/resources/alfresco/pickers/PropertyPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/PropertyPicker.js
@@ -81,7 +81,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload
        */
-      onFolderClick: function alfresco_pickers_PropertyPicker__onFolderClick(payload) {
+      onFolderClick: function alfresco_pickers_PropertyPicker__onFolderClick(/*jshint unused:false*/ payload) {
          // No action.
       },
 
@@ -92,7 +92,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} payload
        */
-      onDocumentClick: function alfresco_pickers_PropertyPicker__onFolderClick(payload) {
+      onDocumentClick: function alfresco_pickers_PropertyPicker__onFolderClick(/*jshint unused:false*/ payload) {
          // No action.
       },
 

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/DocumentPage.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/DocumentPage.js
@@ -66,14 +66,14 @@ define(["dojo/_base/declare",
        * @instance
        */
       render: function alfresco_preview_PdfJs_DocumentPage__render() {
-         var div = document.createElement('div');
-         div.id = this.parent.id + '-pageContainer-' + this.id;
+         var div = document.createElement("div");
+         div.id = this.parent.id + "-pageContainer-" + this.id;
          domClass.add(div, "page");
          this.parent.viewer.appendChild(div);
 
          // Create the loading indicator div
-         var loadingIconDiv = document.createElement('div');
-         domClass.add(loadingIconDiv, 'loadingIcon');
+         var loadingIconDiv = document.createElement("div");
+         domClass.add(loadingIconDiv, "loadingIcon");
          div.appendChild(loadingIconDiv);
 
          this.container = div;
@@ -101,7 +101,7 @@ define(["dojo/_base/declare",
        * @instance
        * @returns The vertical position of the page relative to the top of the parent element
        */
-      getVPos: function alfresco_preview_PdfJs_DocumentPage__getVPos(page) {
+      getVPos: function alfresco_preview_PdfJs_DocumentPage__getVPos(/*jshint unused:false*/ page) {
          return this.container.getBoundingClientRect().top + $(document).scrollTop() - this.parent.viewerRegion.t;
       },
 
@@ -112,8 +112,8 @@ define(["dojo/_base/declare",
        */
       renderContent: function alfresco_preview_PdfJs_DocumentPage__renderContent() {
          var region = this.getRegion(),
-             canvas = document.createElement('canvas');
-         canvas.id = this.container.id.replace('-pageContainer-', '-canvas-');
+             canvas = document.createElement("canvas");
+         canvas.id = this.container.id.replace("-pageContainer-", "-canvas-");
          canvas.mozOpaque = true;
          this.container.appendChild(canvas);
 
@@ -130,8 +130,8 @@ define(["dojo/_base/declare",
          var textLayerDiv = null;
          if (!this.parent.disableTextLayer)
          {
-            textLayerDiv = document.createElement('div');
-            textLayerDiv.className = 'textLayer';
+            textLayerDiv = document.createElement("div");
+            textLayerDiv.className = "textLayer";
             this.container.appendChild(textLayerDiv);
          }
          this.textLayerDiv = textLayerDiv;
@@ -139,7 +139,7 @@ define(["dojo/_base/declare",
 
          var content = this.content,
              // view = content.view,
-             ctx = canvas.getContext('2d');
+             ctx = canvas.getContext("2d");
 
          // Render the content itself
          var renderContext = {

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/Outline.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/Outline.js
@@ -56,6 +56,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_preview_PdfJs_Outline__postCreate() {
+         /*jshint eqnull:true*/
          domClass.add(this.domNode, "alfresco-preview-PdfJs-Outline");
          if (this.pdfJsPlugin != null && this.pdfJsPlugin.pdfDocument != null)
          {
@@ -85,8 +86,8 @@ define(["dojo/_base/declare",
                for (i = 0; i < n; i++)
                {
                   var item = levelData.items[i];
-                  var div = document.createElement('div');
-                  div.className = 'outlineItem';
+                  var div = document.createElement("div");
+                  div.className = "outlineItem";
                   var a = domConstruct.create("a", {
                      href: "#",
                      innerHTML: item.title
@@ -95,8 +96,8 @@ define(["dojo/_base/declare",
                   div.appendChild(a);
 
                   if (item.items.length > 0) {
-                     var itemsDiv = document.createElement('div');
-                     itemsDiv.className = 'outlineItems';
+                     var itemsDiv = document.createElement("div");
+                     itemsDiv.className = "outlineItems";
                      div.appendChild(itemsDiv);
                      queue.push({parent: itemsDiv, items: item.items});
                   }
@@ -117,7 +118,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} dest The destination to navigate to within the PDF
        */
-      onOutlineClick: function alfresco_preview_PdfJs_Outline__onOutlineClick(dest, evt) {
+      onOutlineClick: function alfresco_preview_PdfJs_Outline__onOutlineClick(dest, /*jshint unused:false*/ evt) {
          this.pdfJsPlugin._navigateTo(dest);
       },
 

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/PDFFindController.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/PDFFindController.js
@@ -267,8 +267,8 @@ define(["dojo/_base/declare",
                   var textItems = textContent.items;
                   var str = "";
 
-                  for (var i = 0; i < textItems.length; i++) {
-                     str += textItems[i].str;
+                  for (var j = 0; j < textItems.length; j++) {
+                     str += textItems[j].str;
                   }
 
                   // Store the pageContent as a string.

--- a/aikau/src/main/resources/alfresco/preview/PdfJs/TextLayerBuilder.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/TextLayerBuilder.js
@@ -67,11 +67,11 @@ define(["dojo/_base/declare",
          this.isViewerInPresentationMode = false;
          // END ALFRESCO CHANGES
 
-         if (typeof this.pdfJsPlugin._findController === 'undefined') {
+         if (typeof this.pdfJsPlugin._findController === "undefined") {
            this.pdfJsPlugin._findController = null;
          } 
 
-         if (typeof this.lastScrollSource === 'undefined') {
+         if (typeof this.lastScrollSource === "undefined") {
            this.lastScrollSource = null;
          }
       },
@@ -83,8 +83,8 @@ define(["dojo/_base/declare",
        */
       renderLayer: function alfresco_preview_PdfJs_TextLayerBuilder__renderLayer() {
          var textDivs = this.textDivs;
-         var canvas = document.createElement('canvas');
-         var ctx = canvas.getContext('2d');
+         var canvas = document.createElement("canvas");
+         var ctx = canvas.getContext("2d");
 
          // No point in rendering so many divs as it'd make the browser unusable
          // even after the divs are rendered
@@ -95,30 +95,30 @@ define(["dojo/_base/declare",
 
          for (var i = 0, ii = textDivs.length; i < ii; i++) {
             var textDiv = textDivs[i];
-            if ('isWhitespace' in textDiv.dataset) {
+            if ("isWhitespace" in textDiv.dataset) {
                continue;
             }
 
-            ctx.font = textDiv.style.fontSize + ' ' + textDiv.style.fontFamily;
+            ctx.font = textDiv.style.fontSize + " " + textDiv.style.fontFamily;
             var width = ctx.measureText(textDiv.textContent).width;
 
             if (width > 0) {
                this.textLayerFrag.appendChild(textDiv);
                var textScale = textDiv.dataset.canvasWidth / width;
                var rotation = textDiv.dataset.angle;
-               var transform = 'scale(' + textScale + ', 1)';
-               transform = 'rotate(' + rotation + 'deg) ' + transform;
+               var transform = "scale(" + textScale + ", 1)";
+               transform = "rotate(" + rotation + "deg) " + transform;
 
                // ALFRESCO CHANGES
                // Share extras changed to use Yahoo dom.
                // TODO: Work out some more efficient way of determining
                // prefix as original method do, instead of setting all.
-               domStyle.set(textDiv, '-ms-transform', 'scale(' + textScale + ', 1)');
-               domStyle.set(textDiv, '-webkit-transform', 'scale(' + textScale + ', 1)');
-               domStyle.set(textDiv, '-moz-transform', 'scale(' + textScale + ', 1)');
-               domStyle.set(textDiv, '-ms-transformOrigin', '0% 0%');
-               domStyle.set(textDiv, '-webkit-transformOrigin', '0% 0%');
-               domStyle.set(textDiv, '-moz-transformOrigin', '0% 0%');
+               domStyle.set(textDiv, "-ms-transform", "scale(" + textScale + ", 1)");
+               domStyle.set(textDiv, "-webkit-transform", "scale(" + textScale + ", 1)");
+               domStyle.set(textDiv, "-moz-transform", "scale(" + textScale + ", 1)");
+               domStyle.set(textDiv, "-ms-transformOrigin", "0% 0%");
+               domStyle.set(textDiv, "-webkit-transformOrigin", "0% 0%");
+               domStyle.set(textDiv, "-moz-transformOrigin", "0% 0%");
                // END ALFRESCO CHANGES
             }
          }
@@ -166,7 +166,7 @@ define(["dojo/_base/declare",
        */
       appendText: function alfresco_preview_PdfJs_TextLayerBuilder__appendText(geom, styles) {
           var style = styles[geom.fontName];
-          var textDiv = document.createElement('div');
+          var textDiv = document.createElement("div");
           this.textDivs.push(textDiv);
           if (!/\S/.test(geom.str)) {
             textDiv.dataset.isWhitespace = true;
@@ -181,10 +181,10 @@ define(["dojo/_base/declare",
           var fontAscent = (style.ascent ? style.ascent * fontHeight :
             (style.descent ? (1 + style.descent) * fontHeight : fontHeight));
 
-          textDiv.style.position = 'absolute';
-          textDiv.style.left = (tx[4] + (fontAscent * Math.sin(angle))) + 'px';
-          textDiv.style.top = (tx[5] - (fontAscent * Math.cos(angle))) + 'px';
-          textDiv.style.fontSize = fontHeight + 'px';
+          textDiv.style.position = "absolute";
+          textDiv.style.left = (tx[4] + (fontAscent * Math.sin(angle))) + "px";
+          textDiv.style.top = (tx[5] - (fontAscent * Math.cos(angle))) + "px";
+          textDiv.style.fontSize = fontHeight + "px";
           textDiv.style.fontFamily = style.fontFamily;
 
           textDiv.textContent = geom.str;
@@ -220,6 +220,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       convertMatches: function alfresco_preview_PdfJs_TextLayerBuilder__convertMatches(matches) {
+         /*jshint devel:true*/
           var i = 0;
           var iIndex = 0;
           var bidiTexts = this.textContent.items;
@@ -241,8 +242,8 @@ define(["dojo/_base/declare",
             }
 
             // TODO: Do proper handling here if something goes wrong.
-            if (i == bidiTexts.length) {
-              console.error('Could not find matching mapping');
+            if (i === bidiTexts.length) {
+              console.error("Could not find matching mapping");
             }
 
             var match = {
@@ -278,6 +279,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       renderMatches: function alfresco_preview_PdfJs_TextLayerBuilder__renderMatches(matches) {
+         /*jshint maxcomplexity:false,maxstatements:false*/
           // Early exit if there is nothing to render.
           if (matches.length === 0) {
             return;
@@ -300,30 +302,30 @@ define(["dojo/_base/declare",
             offset: undefined
           };
 
-          function beginText(begin, className) {
-            var divIdx = begin.divIdx;
-            var div = textDivs[divIdx];
-            div.textContent = '';
-            appendTextToDiv(divIdx, 0, begin.offset, className);
-          }
-
-          function appendText(from, to, className) {
-            appendTextToDiv(from.divIdx, from.offset, to.offset, className);
-          }
-
           function appendTextToDiv(divIdx, fromOffset, toOffset, className) {
             var div = textDivs[divIdx];
 
             var content = bidiTexts[divIdx].str.substring(fromOffset, toOffset);
             var node = document.createTextNode(content);
             if (className) {
-              var span = document.createElement('span');
+              var span = document.createElement("span");
               span.className = className;
               span.appendChild(node);
               div.appendChild(span);
               return;
             }
             div.appendChild(node);
+          }
+
+          function beginText(begin, className) {
+            var divIdx = begin.divIdx;
+            var div = textDivs[divIdx];
+            div.textContent = "";
+            appendTextToDiv(divIdx, 0, begin.offset, className);
+          }
+
+          function appendText(from, to, className) {
+            appendTextToDiv(from.divIdx, from.offset, to.offset, className);
           }
 
           function highlightDiv(divIdx, className) {
@@ -346,7 +348,7 @@ define(["dojo/_base/declare",
             var end = match.end;
 
             var isSelected = isSelectedPage && i === selectedMatchIdx;
-            var highlightSuffix = (isSelected ? ' selected' : '');
+            var highlightSuffix = (isSelected ? " selected" : "");
             if (isSelected && !this.isViewerInPresentationMode) {
               // ALFRESCO - change reference to select correct pageIdx
               this.pdfJsPlugin.documentView.pages[this.pageIdx].scrollIntoView(textDivs[begin.divIdx],
@@ -367,13 +369,13 @@ define(["dojo/_base/declare",
             }
 
             if (begin.divIdx === end.divIdx) {
-              appendText(begin, end, 'highlight' + highlightSuffix);
+              appendText(begin, end, "highlight" + highlightSuffix);
             } else {
-              appendText(begin, infty, 'highlight begin' + highlightSuffix);
+              appendText(begin, infty, "highlight begin" + highlightSuffix);
               for (var n = begin.divIdx + 1; n < end.divIdx; n++) {
-                highlightDiv(n, 'highlight middle' + highlightSuffix);
+                highlightDiv(n, "highlight middle" + highlightSuffix);
               }
-              beginText(end, 'highlight end' + highlightSuffix);
+              beginText(end, "highlight end" + highlightSuffix);
             }
             prevEnd = end;
           }
@@ -407,7 +409,7 @@ define(["dojo/_base/declare",
             for (var n = begin; n <= match.end.divIdx; n++) {
                var div = textDivs[n];
                div.textContent = bidiTexts[n].str;
-               div.className = '';
+               div.className = "";
             }
             clearedUntilDivIdx = match.end.divIdx + 1;
          }

--- a/aikau/src/main/resources/alfresco/prototyping/Preview.js
+++ b/aikau/src/main/resources/alfresco/prototyping/Preview.js
@@ -245,10 +245,10 @@ define(["dojo/_base/declare",
          {
             // Find the the template...
             var loadedTemplate;
-            array.forEach(parameters.config.templates, function(template) {
-               if (template.name === parameters.object)
+            array.forEach(parameters.config.templates, function(nextTemplate) {
+               if (nextTemplate.name === parameters.object)
                {
-                  var parsedContent = JSON.parse(template.content);
+                  var parsedContent = JSON.parse(nextTemplate.content);
                   loadedTemplate = parsedContent.widgets[0];
                }
             });

--- a/aikau/src/main/resources/alfresco/quadds/QuaddsWidgets.js
+++ b/aikau/src/main/resources/alfresco/quadds/QuaddsWidgets.js
@@ -53,6 +53,7 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       postCreate: function alfresco_quadds_QuaddsWidgets__postCreate() {
+         /*jshint eqnull:true*/
 
          if (this.quadds != null)
          {
@@ -73,21 +74,25 @@ define(["alfresco/core/ProcessWidgets",
       /**
        * @instance
        */
-      updatePage: function alfresco_prototyping_Preview__updatePage(response, originalRequestConfig) {
+      updatePage: function alfresco_prototyping_Preview__updatePage(response, /*jshint unused:false*/ originalRequestConfig) {
+         /*jshint devel:true*/
          // Iterate over the CSS map and append a new <link> element into the <head> element to ensure that all the
          // widgets CSS dependencies are loaded... 
          for (var media in response.cssMap)
          {
-            // TODO: query for the node outside of the loop
-            // TODO: keep a reference to each node appended and then remove it when the preview is regenerated
-            query("head").append('<link rel="stylesheet" type="text/css" href="' + appContext + response.cssMap[media] + '" media="' + media + '">');
+            if (response.cssMap.hasOwnProperty(media))
+            {
+               // TODO: query for the node outside of the loop
+               // TODO: keep a reference to each node appended and then remove it when the preview is regenerated
+               query("head").append("<link rel=\"stylesheet\" type=\"text/css\" href=\"" + appContext + response.cssMap[media] + "\" media=\"" + media + "\">");
+            }
          }
 
          
          // Build in the i18n properties into the global object...
          for (var scope in response.i18nMap)
          {
-            if (typeof window[response.i18nGlobalObject].messages.scope[scope] == "undefined")
+            if (typeof window[response.i18nGlobalObject].messages.scope[scope] === "undefined")
             {
                // If the scope hasn't already been used then we can just assign it directly...
                window[response.i18nGlobalObject].messages.scope[scope] = response.i18nMap[scope];
@@ -149,7 +154,8 @@ define(["alfresco/core/ProcessWidgets",
        * Extract any widget configuration from the QuADDS item and add it to the supplied array.
        * @instance
        */
-      processQuaddsItem: function alfresco_quadds_QuaddsWidgets__processQuaddsItem(widgets, quaddsItem, index) {
+      processQuaddsItem: function alfresco_quadds_QuaddsWidgets__processQuaddsItem(widgets, quaddsItem, /*jshint unused:false*/ index) {
+         /*jshint eqnull:true*/
          var widgetConfig = lang.getObject("data.widget", false, quaddsItem);
          if (widgetConfig != null)
          {

--- a/aikau/src/main/resources/alfresco/renderers/Banner.js
+++ b/aikau/src/main/resources/alfresco/renderers/Banner.js
@@ -84,7 +84,8 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_renderers_Banner__postCreate() {
-         if (this.bannerMessage != null && this.bannerMessage != "")
+         /*jshint eqnull:true*/
+         if (this.bannerMessage != null && this.bannerMessage !== "")
          {
             domClass.remove(this.bannerNode, "hidden");
          }

--- a/aikau/src/main/resources/alfresco/renderers/Boolean.js
+++ b/aikau/src/main/resources/alfresco/renderers/Boolean.js
@@ -120,8 +120,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_Boolean__postMixInProperties() {
+         /*jshint maxcomplexity:false*/
 
-         if(typeof this.displayTypeOptions.get(this.displayType) == "undefined")
+         if(typeof this.displayTypeOptions.get(this.displayType) === "undefined")
          {
             this.alfLog("log", "Unknown displayType '" + this.displayType + "'. Please select displayType from: " + this.displayTypeOptions.enums, this);
             this.renderedValue = "";

--- a/aikau/src/main/resources/alfresco/renderers/EditTag.js
+++ b/aikau/src/main/resources/alfresco/renderers/EditTag.js
@@ -82,6 +82,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_EditTag__postMixInProperties() {
+         /*jshint eqnull:true*/
          if (this.tagName != null)
          {
             this.tagName = this.encodeHTML(this.tagName);
@@ -105,7 +106,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event
        */
-      onRemoveTag: function alfresco_renderers_EditTag__onRemoveTag(evt) {
+      onRemoveTag: function alfresco_renderers_EditTag__onRemoveTag(/*jshint unused:false*/ evt) {
          on.emit(this.domNode, "ALF_REMOVE_TAG", { bubbles: true, cancelable: true });
       },
       

--- a/aikau/src/main/resources/alfresco/renderers/FileType.js
+++ b/aikau/src/main/resources/alfresco/renderers/FileType.js
@@ -79,6 +79,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_FileType__postMixInProperties() {
+         /*jshint eqnull:true*/
          // Mix the custom type mappings into the default type mappings
          var typeMappings = this.defaultTypeMappings;
          if (this.customTypeMappings != null)
@@ -109,6 +110,7 @@ define(["dojo/_base/declare",
        * @returns {string} The string representing the type.
        */
       getImageType: function alfresco_renderers_FileType__getImageType(typeMappings) {
+         /*jshint eqnull:true*/
          var type = "file";
          var itemType = lang.getObject("node.type", false, this.currentItem);
          if (itemType != null && typeMappings[itemType] != null)
@@ -125,10 +127,11 @@ define(["dojo/_base/declare",
        * @returns {string} The extension for the current item
        */
       getExtension: function alfresco_renderers_FileType__getExtensions() {
+         /*jshint eqnull:true*/
          var extn = "";
          if (this.currentItem != null &&
              this.currentItem.fileName != null &&
-             this.currentItem.fileName.lastIndexOf(".") != -1)
+             this.currentItem.fileName.lastIndexOf(".") !== -1)
          {
             extn = this.currentItem.fileName.substring(this.currentItem.fileName.lastIndexOf(".") + 1).toLowerCase();
          }
@@ -165,17 +168,17 @@ define(["dojo/_base/declare",
        */
       getImageSize: function alfresco_renderers_FileType__getImageSize() {
          var size = "48";
-         if (this.size == "large")
+         if (this.size === "large")
          {
             // Leave as default, no action required.
          }
-         else if (this.size == "medium")
+         else if (this.size === "medium")
          {
             size = "32";
          }
-         else if (this.size == "small")
+         else if (this.size === "small")
          {
-            size = "16"
+            size = "16";
          }
          return size;
       },

--- a/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
@@ -33,10 +33,11 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dojo/dom-class",
         "alfresco/layout/LeftAndRight",
+
+        // These items required for building only
         "alfresco/renderers/Selector",
-        "alfresco/renderers/MoreInfo",
-        "service/constants/Default"], 
-        function(declare, Thumbnail, template, lang, domStyle, domClass, LeftAndRight, Selector, MoreInfo, AlfConstants) {
+        "alfresco/renderers/MoreInfo"], 
+        function(declare, Thumbnail, template, lang, domStyle, domClass, LeftAndRight) {
 
    return declare([Thumbnail], {
       

--- a/aikau/src/main/resources/alfresco/renderers/Like.js
+++ b/aikau/src/main/resources/alfresco/renderers/Like.js
@@ -106,6 +106,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_Like__postMixInProperties() {
+         /*jshint eqnull:true*/
          // Set up the toggle topics..
          // If no instantiation overrides have been provided then just default to the standard topics
          // provided by the "alfresco/services/_RatingsServiceTopicMixin" class...

--- a/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
+++ b/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
@@ -132,6 +132,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_MoreInfo__postMixInProperties() {
+         /*jshint eqnull:true*/
          if (this.altText == null)
          {
             this.altText = "";
@@ -172,6 +173,7 @@ define(["dojo/_base/declare",
        * @param {object} evt The click event.
        */
       onMoreInfo: function alfresco_renderers_MoreInfo__onMoreInfo(evt) {
+         /*jshint eqnull:true*/
          event.stop(evt);
          if (this.moreInfoDialog == null)
          {

--- a/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
@@ -38,10 +38,9 @@ define(["dojo/_base/declare",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/forms/controls/Select",
         "dojo/_base/lang",
-        "dojo/dom-class",
-        "dojo/on"],
+        "dojo/dom-class"],
         function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, template, AlfCore, ObjectTypeUtils, 
-                 Select, lang, domClass, on) {
+                 Select, lang, domClass) {
 
    return declare([_WidgetBase, _OnDijitClickMixin, _TemplatedMixin, AlfCore, _PublishPayloadMixin], {
 

--- a/aikau/src/main/resources/alfresco/renderers/QuickShare.js
+++ b/aikau/src/main/resources/alfresco/renderers/QuickShare.js
@@ -121,6 +121,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_QuickShare__postMixInProperties() {
+         /*jshint eqnull:true*/
          // Set up the toggle topics..
          // If no instantiation overrides have been provided then just default to the standard topics
          // provided by the "alfresco/services/_RatingsServiceTopicMixin" class...
@@ -157,6 +158,7 @@ define(["dojo/_base/declare",
        * @returns {boolean} Indicating the initial state of the toggle.
        */
       getInitialState: function alfresco_renderers_QuickShare__getInitialState() {
+         /*jshint eqnull:true*/
          return (lang.getObject(this.propertyToRender, false, this.currentItem) != null);
       },
       
@@ -231,7 +233,8 @@ define(["dojo/_base/declare",
        * Called whenever the "toggleOffSuccessTopic" attribute is published on
        * @instance
        */
-      onToggleOffSuccess: function alfresco_renderers_QuickShare__onToggleOffSuccess(payload) {
+      onToggleOffSuccess: function alfresco_renderers_QuickShare__onToggleOffSuccess(/*jshint unused:false*/ payload) {
+         /*jshint eqnull:true*/
          this.inherited(arguments);
          if (this.onNode.children != null && this.onNode.children.length > 0)
          {
@@ -314,7 +317,7 @@ define(["dojo/_base/declare",
                   ]
                }
             }
-         ]
+         ];
          return widgets;
       }
    });

--- a/aikau/src/main/resources/alfresco/renderers/Reorder.js
+++ b/aikau/src/main/resources/alfresco/renderers/Reorder.js
@@ -168,11 +168,12 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_Reorder__postMixInProperties() {
-         if (this.upArrowImageSrc == null || this.upArrowImageSrc == "")
+         /*jshint eqnull:true*/
+         if (this.upArrowImageSrc == null || this.upArrowImageSrc === "")
          {
             this.upArrowImageSrc = require.toUrl("alfresco/renderers/css/images/" + this.upArrowImg);
          }
-         if (this.downArrowImageSrc == null || this.downArrowImageSrc == "")
+         if (this.downArrowImageSrc == null || this.downArrowImageSrc === "")
          {
             this.downArrowImageSrc = require.toUrl("alfresco/renderers/css/images/" + this.downArrowImg);
          }
@@ -212,7 +213,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event object
        */
-      onUpClick: function alfresco_renderers_Reorder__onUpClick(evt) {
+      onUpClick: function alfresco_renderers_Reorder__onUpClick(/*jshint unused:false*/ evt) {
          this.alfLog("log", "Moving item up", this);
          var payload = this.generatePayload(this.moveUpPublishPayload, 
                                             this.currentItem, 
@@ -236,7 +237,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event object
        */
-      onDownClick: function alfresco_renderers_Reorder__onDownClick(evt) {
+      onDownClick: function alfresco_renderers_Reorder__onDownClick(/*jshint unused:false*/ evt) {
          this.alfLog("log", "Moving item down", this);
          var payload = this.generatePayload(this.moveDownPublishPayload, 
                                             this.currentItem, 

--- a/aikau/src/main/resources/alfresco/reports/SiteContentReport.js
+++ b/aikau/src/main/resources/alfresco/reports/SiteContentReport.js
@@ -65,23 +65,23 @@ define(["dojo/_base/declare",
                         site: Alfresco.constants.SITE // todo replace with $$SITE$$ once supported
                      },
                      readers: [
-                        { names: 'category', indexes: 0 },
-                        { names: 'value', indexes: 2 }
+                        { names: "category", indexes: 0 },
+                        { names: "value", indexes: 2 }
                      ],
                      explodedSliceRadius: null,
                      selectable: false,
                      hoverable:  true,
                      extensionPoints: {
-                        slice_innerRadiusEx: '55%',
-                        slice_strokeStyle: 'white'
+                        slice_innerRadiusEx: "55%",
+                        slice_strokeStyle: "white"
                      },
                      tooltip: {
                         format: function(scene){
-                           var tooltip = '<div style="text-align: left;">';
-                           tooltip += '<strong>' + Alfresco.util.encodeHTML(scene.datum.atoms.category.value) + '</strong><br/>';
-                           tooltip += I18nUtils.msg(i18nScope, "count", Alfresco.util.encodeHTML(scene.datum.atoms.value.value), Alfresco.util.encodeHTML(scene.vars.value.percent.label)) + '<br/>';
+                           var tooltip = "<div style=\"text-align: left;\">";
+                           tooltip += "<strong>" + Alfresco.util.encodeHTML(scene.datum.atoms.category.value) + "</strong><br/>";
+                           tooltip += I18nUtils.msg(i18nScope, "count", Alfresco.util.encodeHTML(scene.datum.atoms.value.value), Alfresco.util.encodeHTML(scene.vars.value.percent.label)) + "<br/>";
                            tooltip += I18nUtils.msg(i18nScope, "sum", Alfresco.util.encodeHTML(Alfresco.util.formatFileSize(scene.datum.atoms.value2.value)));
-                           tooltip += '</div>';
+                           tooltip += "</div>";
                            return tooltip;
                         }
                      }

--- a/aikau/src/main/resources/alfresco/reports/TopSiteContributorReport.js
+++ b/aikau/src/main/resources/alfresco/reports/TopSiteContributorReport.js
@@ -61,7 +61,7 @@ define(["dojo/_base/declare",
              return startDate;
          };
          var getEndDate = function() {
-            if (timePeriod == "CUSTOM") {
+            if (timePeriod === "CUSTOM") {
                return endDate;
             } else {
                return now;
@@ -233,30 +233,29 @@ define(["dojo/_base/declare",
                            name: "alfresco/charts/ccc/PieChart",
                            config: {
                               readers: [
-                                 { names: 'category', indexes: 0 },
-                                 { names: 'value', indexes: 2 }
+                                 { names: "category", indexes: 0 },
+                                 { names: "value", indexes: 2 }
                               ],
                               explodedSliceRadius: null,
                               selectable: false,
                               hoverable:  true,
                               extensionPoints: {
-                                 slice_innerRadiusEx: '55%',
-                                 slice_strokeStyle: 'white'
+                                 slice_innerRadiusEx: "55%",
+                                 slice_strokeStyle: "white"
                               },
                               clickTopic: "REPORT_ITEM_CLICKED",
                               tooltip: {
                                  format: function(scene){
-                                    var avatarUrl = Alfresco.constants.PROXY_URI + "slingshot/profile/avatar/" + encodeURIComponent(scene.datum.atoms.category.value) + "/thumbnail/avatar32";
-                                    var tooltip = '';
-                                    tooltip += '<table><tr><td>';
-                                    tooltip += '<img class="avatar" src="' + avatarUrl + '" alt="avatar"><br>';
-                                    tooltip += '</td><td>';
-                                    tooltip += '<div style="text-align: left;">';
-                                    tooltip += '<strong>' + Alfresco.util.encodeHTML(scene.datum.atoms.category.value) + '</strong><br/>';
-                                    tooltip += I18nUtils.msg(i18nScope, "count", Alfresco.util.encodeHTML(scene.datum.atoms.value.value), Alfresco.util.encodeHTML(scene.vars.value.percent.label)) + '<br/>';
+                                    var tooltip = "";
+                                    tooltip += "<table><tr><td>";
+                                    tooltip += "<img class=\"avatar\" src=\"\" + avatarUrl + \"\" alt=\"avatar\"><br>";
+                                    tooltip += "</td><td>";
+                                    tooltip += "<div style=\"text-align: left;\">";
+                                    tooltip += "<strong>" + Alfresco.util.encodeHTML(scene.datum.atoms.category.value) + "</strong><br/>";
+                                    tooltip += I18nUtils.msg(i18nScope, "count", Alfresco.util.encodeHTML(scene.datum.atoms.value.value), Alfresco.util.encodeHTML(scene.vars.value.percent.label)) + "<br/>";
                                     tooltip += I18nUtils.msg(i18nScope, "sum", Alfresco.util.encodeHTML(Alfresco.util.formatFileSize(scene.datum.atoms.value2.value)));
-                                    tooltip += '</div>';
-                                    tooltip += '</td></tr></table>';
+                                    tooltip += "</div>";
+                                    tooltip += "</td></tr></table>";
                                     return tooltip;
                                  }
                               }

--- a/aikau/src/main/resources/alfresco/search/NoSearchResults.js
+++ b/aikau/src/main/resources/alfresco/search/NoSearchResults.js
@@ -58,13 +58,14 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_documentlibrary_views_AlfSearchListView_NoSearchResultsTemplate__postCreate() {
+         /*jshint eqnull:true*/
          if (this.title != null)
          {
             this.titleNode.innerHTML = this.message(this.title);
          }
          if (this.suggestions != null)
          {
-            array.forEach(this.suggestions, function(suggestion, index) {
+            array.forEach(this.suggestions, function(suggestion) {
                domConstruct.create("li", {
                   innerHTML: this.message(suggestion),
                   className: "suggestion"

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnail.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnail.js
@@ -28,9 +28,8 @@
  */
 define(["dojo/_base/declare",
         "alfresco/renderers/Thumbnail",
-        "alfresco/search/SearchThumbnailMixin",
-        "dojo/dom-class"], 
-        function(declare, Thumbnail, SearchThumbnailMixin, domClass) {
+        "alfresco/search/SearchThumbnailMixin"], 
+        function(declare, Thumbnail, SearchThumbnailMixin) {
 
    return declare([Thumbnail, SearchThumbnailMixin], {
 

--- a/aikau/src/main/resources/alfresco/services/BaseService.js
+++ b/aikau/src/main/resources/alfresco/services/BaseService.js
@@ -1,3 +1,4 @@
+/*jshint maxlen:false*/
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *

--- a/aikau/src/main/resources/alfresco/services/LoginService.js
+++ b/aikau/src/main/resources/alfresco/services/LoginService.js
@@ -50,6 +50,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       doLogin: function alfresco_services_LoginService__doLogout(payload) {
+         /*jshint eqnull:true*/
          // Publish an event to indicate that a login attempt is about to begin, this is done so that
          // the login page has the opportunity to clear previously displayed messages and display
          // an indication that login has begun...
@@ -83,6 +84,7 @@ define(["dojo/_base/declare",
        * @param {object} originalRequestConfig The configuration passed on the original request
        */
       onLoginSuccess: function alfresco_services_LoginService__onLoginSuccess(response, originalRequestConfig) {
+         /*jshint eqnull:true*/
          this.alfLog("info", "Login success");
          var url = lang.getObject("data.successUrl", false, originalRequestConfig);
          if (url != null)
@@ -102,7 +104,7 @@ define(["dojo/_base/declare",
        * @param {object} response The response from the request
        * @param {object} originalRequestConfig The configuration passed on the original request
        */
-      onLoginFailure: function alfresco_services_LoginService__onLoginFailure(response, originalRequestConfig) {
+      onLoginFailure: function alfresco_services_LoginService__onLoginFailure(/*jshint unused:false*/ response, /*jshint unused:false*/ originalRequestConfig) {
          this.alfLog("info", "Login failure");
          this.alfPublish("ALF_LOGIN_STATUS", {
             status: "FAILURE"

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -121,6 +121,7 @@ define(["dojo/_base/declare",
        * @since 1.0.48
        */
       onDisplayStickyPanel: function alfresco_services_NotificationService__onDisplayStickyPanel(payload) {
+         /*jshint maxcomplexity:false*/
 
          // Setup variables
          var panelConfig = {},

--- a/aikau/src/main/resources/alfresco/services/OptionsService.js
+++ b/aikau/src/main/resources/alfresco/services/OptionsService.js
@@ -60,6 +60,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onOptionsRequest: function alfresco_services_OptionsService__onOptionsRequest(payload) {
+         /*jshint eqnull:true*/
          if (payload.url != null &&
              payload.itemsAttribute != null &&
              payload.labelAttribute != null &&
@@ -123,7 +124,8 @@ define(["dojo/_base/declare",
        * @param {object} item The current item to process as an option
        * @param {number} index The index of the item in the items list
        */
-      processOptions: function alfresco_services_OptionsService__processOptions(options, config, item, index) {
+      processOptions: function alfresco_services_OptionsService__processOptions(options, config, item, /*jshint unused:false*/ index) {
+         /*jshint eqnull:true*/
          var label = lang.getObject(config.labelAttribute, false, item);
          var value = lang.getObject(config.valueAttribute, false, item);
          if (label == null && value == null)

--- a/aikau/src/main/resources/alfresco/services/PreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/PreviewService.js
@@ -50,18 +50,20 @@ define(["dojo/_base/declare",
        * @instance
        */
       generateDependencies: function alfresco_services_PreviewService__generateDependencies(payload) {
+         /*jshint eqnull:true*/
          if (payload != null && payload.model != null)
          {
-            var pageDefObject = dojoJson.parse(payload.model);
-            var data = {
-               jsonContent: pageDefObject,
-               widgets: payload.model
-            };
+            // This block (and query below) commented out because JSHint said they were unused .... why unused though? Why are they here?
+            // var pageDefObject = JSON.parse(payload.model);
+            // var data = {
+            //    jsonContent: pageDefObject,
+            //    widgets: payload.model
+            // };
             
             this.serviceXhr({
                url: AlfConstants.URL_SERVICECONTEXT + "/service/surf/dojo/xhr/dependencies",
                method: "POST",
-               query: query,
+               query: undefined,//query,
                successCallback: this.generateDependenciesSuccess,
                failureCallback: this.generateDependenciesFailure,
                callbackScope: this

--- a/aikau/src/main/resources/alfresco/services/QuickShareService.js
+++ b/aikau/src/main/resources/alfresco/services/QuickShareService.js
@@ -75,6 +75,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onAddQuickShare: function alfresco_services_QuickShareService__onAddRating(payload) {
+         /*jshint eqnull:true*/
          var url = lang.getObject("node.jsNode.nodeRef.uri", false, payload);
          if (url != null)
          {
@@ -94,6 +95,7 @@ define(["dojo/_base/declare",
        * @param {object} payload
        */
       onRemoveQuickShare: function alfresco_services_QuickShareService__onRemoveQuickShare(payload) {
+         /*jshint eqnull:true*/
          var quickShareId = lang.getObject("node.jsNode.properties.qshare:sharedId", false, payload);
          if (quickShareId != null)
          {

--- a/aikau/src/main/resources/alfresco/services/ReportService.js
+++ b/aikau/src/main/resources/alfresco/services/ReportService.js
@@ -64,6 +64,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the request
        */
       getSiteContentReport: function alfresco_services_ReportService__getSiteContentReport(payload) {
+         /*jshint eqnull:true*/
          var alfTopic = (payload.alfResponseTopic != null) ? payload.alfResponseTopic : "ALF_RETRIEVE_SITE_CONTENT_REPORT";
          var url = AlfConstants.PROXY_URI + "api/solrstats";
          if (payload.site) {
@@ -100,6 +101,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the request
        */
       getTopSiteContributorReport: function alfresco_services_ReportService__getTopSiteContributorReport(payload) {
+         /*jshint eqnull:true*/
          var alfTopic = (payload.alfResponseTopic != null) ? payload.alfResponseTopic : "ALF_RETRIEVE_TOP_SITE_CONTRIBUTOR_REPORT";
          var url = AlfConstants.PROXY_URI + "api/solrstats";
          if (payload.site)

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -608,7 +608,7 @@ define(["alfresco/core/CoreXhr",
        * @param {object} Contains info about the file and its request.
        */
       startFileUpload: function alfresco_services__BaseUploadService__startFileUpload(fileInfo) {
-         /*jshint maxstatements:false*/
+         /*jshint maxstatements:false,maxcomplexity:false*/
 
          // Ensure we only upload the maximum allowed at a time
          if (this._numUploadsInProgress === this.maxSimultaneousUploads) {

--- a/aikau/src/main/resources/alfresco/upload/AlfFileDrop.js
+++ b/aikau/src/main/resources/alfresco/upload/AlfFileDrop.js
@@ -72,7 +72,7 @@ define(["dojo/_base/declare",
       /**
        * @instance
        */
-      onDndDragEnter: function alfresco_upload_AlfFileDrop__onDndDragEnter(evt) {
+      onDndDragEnter: function alfresco_upload_AlfFileDrop__onDndDragEnter(/*jshint unused:false*/ evt) {
         
       },
 

--- a/aikau/src/main/resources/alfresco/util/objectUtils.js
+++ b/aikau/src/main/resources/alfresco/util/objectUtils.js
@@ -37,6 +37,7 @@ define([
 
          // See API below
          evaluateRules: function alfresco_util_objectUtils__evaluateRules(rules, successHandler, failureHandler) {
+            /*jshint devel:true*/
 
             // Setup variables
             var testValue = lang.getObject(rules.attribute, false, rules.testObject),

--- a/aikau/src/main/resources/lib/3rd-party/spin.js
+++ b/aikau/src/main/resources/lib/3rd-party/spin.js
@@ -148,7 +148,7 @@
 
   /** The constructor */
   function Spinner(o) {
-    if (typeof this == 'undefined') return new Spinner(o)
+    if (typeof this === "undefined") return new Spinner(o)
     this.opts = merge(o || {}, Spinner.defaults, defaults)
   }
 


### PR DESCRIPTION
This addresses [AKU-816](https://issues.alfresco.com/jira/browse/AKU-816) and removes almost all of the remaining JSHint errors. A full regression suite has been run successfully.

The following errors remain, and will need addressing at some point.

__`'Alfresco' is not defined`__
This is legacy usage of the `Alfresco` global and is present in the following files:
* `src/main/resources/alfresco/core/JsNode.js`
* `src/main/resources/alfresco/reports/SiteContentReport.js`
* `src/main/resources/alfresco/reports/TopSiteContributorReport.js`
* `src/main/resources/alfresco/services/LightboxService.js`

__`'Promise' is not defined`__
This is usage of ES6 code, which even if we used Babel to transpile to ES5 would still fail on older versions of IE. As it is, this will not work on any version of IE. It is present in the following files:
* `src/main/resources/alfresco/preview/PdfJs/PDFFindController.js`
* `src/main/resources/alfresco/preview/PdfJs/PdfJs.js`
