### PR TITLE
AKU-871: Accessibility updates for AlfMenuBarSelectItems

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -34,6 +34,15 @@ define(["dojo/_base/declare",
    return declare([AlfMenuBarSelect], {
       
       /**
+       * An array of the i18n files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/AlfMenuBarSelectItems.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/AlfMenuBarSelectItems.properties"}],
+   
+      /**
        * Sets an initial iconClass. This ensures that the iconNode is created.
        * 
        * @instance
@@ -96,6 +105,7 @@ define(["dojo/_base/declare",
          this.inherited(arguments);
          if (this.iconNode)
          {
+            this.iconNode.setAttribute("alt", this.message("menubarselectitems.none.selected"));
             on(this.iconNode, "click", lang.hitch(this, this.handleIconClick));
          }
       },
@@ -216,6 +226,7 @@ define(["dojo/_base/declare",
             domClass.remove(this.iconNode, this._currentIconClass);
             this._currentIconClass = "alf-allselected-icon";
             domClass.add(this.iconNode, this._currentIconClass);
+            this.iconNode.setAttribute("alt", this.message("menubarselectitems.all.selected"));
          }
          this._itemsSelected = this._ALL;
       },
@@ -229,6 +240,7 @@ define(["dojo/_base/declare",
             domClass.remove(this.iconNode, this._currentIconClass);
             this._currentIconClass = "alf-someselected-icon";
             domClass.add(this.iconNode, this._currentIconClass);
+            this.iconNode.setAttribute("alt", this.message("menubarselectitems.some.selected"));
          }
          this._itemsSelected = this._SOME;
       },
@@ -242,6 +254,7 @@ define(["dojo/_base/declare",
             domClass.remove(this.iconNode, this._currentIconClass);
             this._currentIconClass = "alf-noneselected-icon";
             domClass.add(this.iconNode, this._currentIconClass);
+            this.iconNode.setAttribute("alt", this.message("menubarselectitems.none.selected"));
          }
          this._itemsSelected = this._NONE;
       }

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -39,6 +39,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {object[]}
        * @default [{i18nFile: "./i18n/AlfMenuBarSelectItems.properties"}]
+       * @since 1.0.59
        */
       i18nRequirements: [{i18nFile: "./i18n/AlfMenuBarSelectItems.properties"}],
    

--- a/aikau/src/main/resources/alfresco/menus/i18n/AlfMenuBarSelectItems.properties
+++ b/aikau/src/main/resources/alfresco/menus/i18n/AlfMenuBarSelectItems.properties
@@ -1,0 +1,3 @@
+menubarselectitems.all.selected=All of the items are currently selected, click this icon remove all selections
+menubarselectitems.some.selected=Some of the items are currently selected, click this icon to select all items
+menubarselectitems.none.selected=None of the items are currently selected, click this icon to select all of the items

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectItemsTest.js
@@ -121,7 +121,11 @@ registerSuite(function(){
          .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-someselected-icon")
             .then(null, function() {
                assert(false, "Expected CSS class not found on checkbox");
-            });
+            })
+            .getAttribute("alt")
+               .then(function(text) {
+                  assert.equal(text, "Some of the items are currently selected, click this icon to select all items");
+               });
       },
             
       "Click checkbox to go from some to all": function() {
@@ -189,7 +193,11 @@ registerSuite(function(){
          .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-allselected-icon")
             .then(null, function() {
                assert(false, "Expected CSS class not found on checkbox");
-            });
+            })
+            .getAttribute("alt")
+               .then(function(text) {
+                  assert.equal(text, "All of the items are currently selected, click this icon remove all selections");
+               });
       },
 
       "Click 'Select None' menu item": function() {
@@ -212,7 +220,11 @@ registerSuite(function(){
          .findByCssSelector("#MENU_BAR_SELECT_ITEMS>img.alf-noneselected-icon")
             .then(null, function() {
                assert(false, "Expected CSS class not found on checkbox");
-            });
+            })
+            .getAttribute("alt")
+               .then(function(text) {
+                  assert.equal(text, "None of the items are currently selected, click this icon to select all of the items");
+               });
       },
 
       "Click checkbox to go from none to all": function() {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-871 to improve the accessibility of the AlfMenuBarSelectItems widget. Some accessibility issues had been addressed by previous PRs ( #913 ) but this ensures that the alt text is more meaningful.