### PR TITLE
AKU-872: Improve AlfCheckableMenuItem accessibility

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -80,6 +80,7 @@ define(["dojo/_base/declare",
 
       /**
        * A reference to the cell that will be created by postCreate to handle toggling selection
+       * 
        * @instance
        * @type {object}
        * @default
@@ -88,6 +89,7 @@ define(["dojo/_base/declare",
 
       /**
        * Indicates whether or not the menu item is selected or not
+       * 
        * @instance
        * @type {boolean}
        * @default
@@ -96,11 +98,12 @@ define(["dojo/_base/declare",
 
       /**
        * The class to apply to render some checked indicator
+       * 
        * @instance
        * @type {string}
        * @default
        */
-      checkedIconClass: "alf-selected-icon",
+      checkedIconClass: "alfresco-menus-AlfCheckableMenuItem--checked",
 
       /**
        * If this is set then it indicates that this item is a member of a group. When in a group this cannot be unselected. Unselection
@@ -147,6 +150,22 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_menus_AlfCheckableMenuItem__postCreate() {
+         domClass.add(this.domNode, "alfresco-menus-AlfCheckableMenuItem");
+
+         // Set the correct role...
+         if (this.group)
+         {
+            // If a group has been assigned then only one menu item will be checkable at a time within the group
+            // so assign the role of "menuitemradio" (https://www.w3.org/TR/wai-aria/roles#menuitemradio)
+            this.domNode.setAttribute("role", "menuitemradio");
+         }
+         else
+         {
+            // If a group has NOT been assigned then this menu item can be toggled on and off independently so it
+            // should be given the role of "menuitemcheckbox" (https://www.w3.org/TR/wai-aria/roles#menuitemcheckbox)
+            this.domNode.setAttribute("role", "menuitemcheckbox");
+         }
+         
          if (!this.publishPayload)
          {
             this.publishPayload = {};
@@ -174,10 +193,11 @@ define(["dojo/_base/declare",
          }
 
          this.alfLog("log", "Create checkable cell");
-         this.checkCell = domConstruct.create("td", { className: "alf-checkable-menu-item", innerHTML: "&nbsp;"}, this.focusNode, "first");
+         this.checkCell = domConstruct.create("td", { className: "alfresco-menus-AlfCheckableMenuItem__icon", innerHTML: "&nbsp;"}, this.focusNode, "first");
+
          if (this.checked)
          {
-            domClass.add(this.checkCell, this.checkedIconClass);
+            domClass.add(this.domNode, this.checkedIconClass);
          }
 
          if (this.group)
@@ -199,6 +219,9 @@ define(["dojo/_base/declare",
          {
             this.subscriptionHandle = this.alfSubscribe(this.publishTopic, lang.hitch(this, this.onPublishTopicEvent));
          }
+
+         // Set the appropriate initial aria-state for the role type...
+         this.domNode.setAttribute(this.group ? "aria-selected": "aria-checked", this.checked);
       },
 
       /**
@@ -266,6 +289,7 @@ define(["dojo/_base/declare",
 
          if (this.group)
          {
+
             // If this is the member of a group we need to handle things a bit differently...
             if (!this.checked)
             {
@@ -276,6 +300,9 @@ define(["dojo/_base/declare",
                this.render();
                this.publishSelection();
             }
+
+            // Set the appropriate aria-state for the role type...
+            this.domNode.setAttribute("aria-selected", this.checked);
          }
          else
          {
@@ -283,6 +310,9 @@ define(["dojo/_base/declare",
             this.checked = !this.checked;
             this.render();
             this.publishSelection();
+
+            // Set the appropriate aria-state for the role type...
+            this.domNode.setAttribute(this.group ? "aria-selected": "aria-checked", this.checked);
          }
 
          // Clicking on the check cell will result in the menu item being marked as selected
@@ -303,11 +333,11 @@ define(["dojo/_base/declare",
       render: function alfresco_menus_AlfCheckableMenuItem__render() {
          if (this.checked)
          {
-            domClass.add(this.checkCell, this.checkedIconClass);
+            domClass.add(this.domNode, this.checkedIconClass);
          }
          else
          {
-            domClass.remove(this.checkCell, this.checkedIconClass);
+            domClass.remove(this.domNode, this.checkedIconClass);
          }
       },
 
@@ -338,6 +368,7 @@ define(["dojo/_base/declare",
       onGroupSelection: function alfresco_menus_AlfCheckableMenuItem__toggleSelection(payload) {
          if (payload.value !== this.value)
          {
+            this.domNode.setAttribute("aria-selected", false);
             this.checked = false;
             this.render();
          } 

--- a/aikau/src/main/resources/alfresco/menus/css/AlfCheckableMenuItem.css
+++ b/aikau/src/main/resources/alfresco/menus/css/AlfCheckableMenuItem.css
@@ -1,12 +1,24 @@
-.alf-checkable-menu-item {
-  height: 12px;
-  width: 12px;
+.@{alfresco} {
+
+   .dijitMenu {
+      .alfresco-menus-AlfCheckableMenuItem {
+         &__icon {
+            height: 16px;
+            width: 16px;
+         }
+
+         &--checked {
+            .alfresco-menus-AlfCheckableMenuItem {
+               &__icon{
+                  background-repeat: no-repeat;
+                  background-position: 4px 4px;
+                  background-image: url("./images/12x12-selected-icon.png");
+               }
+            }
+         }
+      }
+   }
 }
 
-.@{alfresco} .dijitMenu .alf-checkable-menu-item.alf-selected-icon {
-   background: url("./images/12x12-selected-icon.png");
-   background-repeat: no-repeat;
-   background-position: 4px 4px;
-   height: 16px;
-   width: 16px;
-}
+
+

--- a/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/PaginationTest.js
@@ -73,7 +73,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .findAllByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown .alf-checkable-menu-item")
+            .findAllByCssSelector("#CUSTOM_PAGE_SIZE_PAGINATOR_RESULTS_PER_PAGE_SELECTOR_dropdown .alfresco-menus-AlfCheckableMenuItem")
                .then(function(elements) {
                   assert.lengthOf(elements, 3, "The wrong number of custom page sizes was found");
                });
@@ -273,7 +273,7 @@ define(["intern!object",
                .click()
                .end()
 
-            .findAllByCssSelector("#MENU_BAR_POPUP_dropdown tr:nth-child(4) td.alf-selected-icon")
+            .findAllByCssSelector("#MENU_BAR_POPUP_dropdown .alfresco-menus-AlfCheckableMenuItem--checked")
                .then(function(elements) {
                   assert(elements.length === 1, "Results per page widget check box not highlighted correctly");
                });

--- a/aikau/src/test/resources/alfresco/menus/AlfCheckableMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfCheckableMenuItemTest.js
@@ -24,253 +24,409 @@
  */
 define(["intern!object",
         "intern/chai!assert",
-        "require",
         "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"], 
-        function (registerSuite, assert, require, TestCommon, keys) {
+        function (registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   var checkableMenuItemSelectors = TestCommon.getTestSelectors("alfresco/menus/AlfCheckableMenuItem");
+   var menuBarPopupSelectors = TestCommon.getTestSelectors("alfresco/menus/AlfMenuBarPopup");
 
-   return {
-      name: "Checkable Menu Item Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/AlfCheckableMenuItem", "Checkable Menu Item Tests").end();
+   var selectors = {
+      checkableMenuItems: {
+         ungrouped1: {
+            checked: TestCommon.getTestSelector(checkableMenuItemSelectors, "checked.item", ["CHECKABLE_1"]),
+            item: TestCommon.getTestSelector(checkableMenuItemSelectors, "item", ["CHECKABLE_1"])
+         },
+         ungrouped2: {
+            checked: TestCommon.getTestSelector(checkableMenuItemSelectors, "checked.item", ["CHECKABLE_2"]),
+            item: TestCommon.getTestSelector(checkableMenuItemSelectors, "item", ["CHECKABLE_2"])
+         },
+         ungrouped3: {
+            checked: TestCommon.getTestSelector(checkableMenuItemSelectors, "checked.item", ["CHECKABLE_3"]),
+            item: TestCommon.getTestSelector(checkableMenuItemSelectors, "item", ["CHECKABLE_3"])
+         },
+         grouped1: {
+            checked: TestCommon.getTestSelector(checkableMenuItemSelectors, "checked.item", ["GROUPED_CHECKABLE_1"]),
+            item: TestCommon.getTestSelector(checkableMenuItemSelectors, "item", ["GROUPED_CHECKABLE_1"])
+         },
+         grouped2: {
+            checked: TestCommon.getTestSelector(checkableMenuItemSelectors, "checked.item", ["GROUPED_CHECKABLE_2"]),
+            item: TestCommon.getTestSelector(checkableMenuItemSelectors, "item", ["GROUPED_CHECKABLE_2"])
+         },
+         grouped3: {
+            checked: TestCommon.getTestSelector(checkableMenuItemSelectors, "checked.item", ["GROUPED_CHECKABLE_3"]),
+            item: TestCommon.getTestSelector(checkableMenuItemSelectors, "item", ["GROUPED_CHECKABLE_3"])
+         }
       },
+      popupMenu: {
+         label: TestCommon.getTestSelector(menuBarPopupSelectors, "label", ["CHECKABLE_MENU_ITEMS_DROPDOWN"]),
+         popup: TestCommon.getTestSelector(menuBarPopupSelectors, "popup", ["CHECKABLE_MENU_ITEMS_DROPDOWN"])
+      }
+   };
 
-      beforeEach: function() {
-         browser.end();
-      },
+   registerSuite(function(){
+      var browser;
 
-      // Count the number of subscriptions to for the grouped checkable items, there should be 
-      // 3 subscriptions - one for each item in the group...
-      "Test registered subscription count": function () {
-         return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_CHECKABLE_MENU_ITEM__CHECKABLE_GROUP"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 3, "A subscription for each grouped checkable menu item was expected.");
-            });
-      },
+      return {
+         name: "Checkable Menu Item Tests",
 
-      // Check that there is a subscription for checkable items with a publishTopic
-      // (this is so that they can respond to external publications)
-      "Test subscription for each checkable item with publishTopic": function() {
-         return browser.findByCssSelector(TestCommon.topicSelector("CHECKABLE_1"))
-            .then(null, function() {
-               assert(false, "Test #2 - A subcription could not be found for a checkable menu item with a publish topic");
-            });
-      },
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfCheckableMenuItem", "Checkable Menu Item Tests").end();
+         },
 
-      // Check that there is NOT a subcription for checkable items WITHOUT a publishTopic
-      "Test there is no subscription for checkable item WITHOUT a publishTopic": function() {
-         return browser.findByCssSelector(TestCommon.topicSelector("CHECKABLE_3"))
-            .then(
-               function() {
-                  // FOUND (error)
-                  assert(false, "An unexpected subcription was found for a checkable menu item");
-               },
-               function() {
-                  // DIDN'T FIND (success)
-                  assert(true, "Did NOT find menu item as expected");
+         beforeEach: function() {
+            browser.end();
+         },
+
+         // Count the number of subscriptions to for the grouped checkable items, there should be 
+         // 3 subscriptions - one for each item in the group...
+         "Test registered subscription count": function () {
+            return browser.findAllByCssSelector(TestCommon.topicSelector("ALF_CHECKABLE_MENU_ITEM__CHECKABLE_GROUP"))
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3, "A subscription for each grouped checkable menu item was expected.");
                });
-      },
+         },
 
-      "Test that first checkable item is not initially checked": function() {
-         return browser.execute("return dijit.registry.byId('CHECKABLE_1').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The menu item was NOT checked on page load");
-            });
-      },
-
-      "Test that second checkable item IS initially checked": function() {
-         return browser.execute("return dijit.registry.byId('CHECKABLE_2').checked")
-            .then(function(result) {
-               assert.isTrue(result, "The menu item SHOULD HAVE BEEN checked on page load");
-            });
-      },
-
-      "Test that first grouped checkable menu item IS checked on page load": function() {
-         return browser.execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
-            .then(function(result) {
-               assert.isTrue(result, "The first GROUPED menu item SHOULD HAVE BEEN checked on page load");
-            });
-      },
-
-      "Test that second grouped checkable item is NOT checked on page load": function() {
-         return browser.execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The second GROUPED menu item was NOT checked on page load");
-            });
-      },
-
-      "Test that third grouped checkable item is NOT checked on page load": function() {
-         return browser.execute("return dijit.registry.byId('GROUPED_CHECKABLE_3').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The first GROUPED menu item was NOT checked on page load");
-            });
-      },
-
-      "Test that a checked menu item has a tick displayed": function() {
-         return browser.findByCssSelector("tr#CHECKABLE_2 > td.alf-selected-icon")
-            .then(null, function() {
-               assert(false, "A checked menu item should have the alf-selected-icon class applied to it");
-            });
-      },
-
-      "Test that an unchecked menu item does NOT have a tick displayed": function() {
-         return browser.findByCssSelector("tr#CHECKABLE_1>td.alf-selected-icon")
-            .then(
-               function() {
-                  // FOUND == ERROR
-                  assert(false, "An UNCHECKED menu item should NOT have the alf-selected-icon class applied to it");
-               },
-               function() {
-                  // NOT FOUND == SUCCESS
-                  assert(true, "Not found as expected");
+         // Check that there is a subscription for checkable items with a publishTopic
+         // (this is so that they can respond to external publications)
+         "Test subscription for each checkable item with publishTopic": function() {
+            return browser.findByCssSelector(TestCommon.topicSelector("CHECKABLE_1"))
+               .then(null, function() {
+                  assert(false, "Test #2 - A subcription could not be found for a checkable menu item with a publish topic");
                });
-      },
+         },
 
-      "Test that an externally published topic can set a check box": function() {
-         return browser.findByCssSelector("#SET_CHECKABLE_1_label")
-            .click()
-         .end()
-         .execute("return dijit.registry.byId('CHECKABLE_1').checked")
-            .then(function(result) {
-               assert(result === "true", "The first menu item has not been CHECKED following an external publish");
-            });
-      },
+         // Check that there is NOT a subcription for checkable items WITHOUT a publishTopic
+         "Test there is no subscription for checkable item WITHOUT a publishTopic": function() {
+            return browser.findByCssSelector(TestCommon.topicSelector("CHECKABLE_3"))
+               .then(
+                  function() {
+                     // FOUND (error)
+                     assert(false, "An unexpected subcription was found for a checkable menu item");
+                  },
+                  function() {
+                     // DIDN'T FIND (success)
+                     assert(true, "Did NOT find menu item as expected");
+                  });
+         },
 
-      "Test than an externally published topic can unset a check box": function() {
-         return browser.findByCssSelector("#UNSET_CHECKABLE_1_label")
-            .click()
-         .end()
-         .execute("return dijit.registry.byId('CHECKABLE_1').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The first menu item have been UNCHECKED following an external publish");
-            });
-      },
+         "Test that first checkable item is not initially checked": function() {
+            return browser.execute("return dijit.registry.byId('CHECKABLE_1').checked")
+               .then(function(result) {
+                  assert.isFalse(result, "The menu item was NOT checked on page load");
+               });
+         },
 
-      "Test that externally published topic updates a group": function() {
-         return browser.findByCssSelector("#SET_GROUPED_CHECKABLE_2_label")
-            .click()
-         .end()
-         .execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The first GROUPED menu item have been UNCHECKED following an external publish");
-            })
-         .execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
-            .then(function(result) {
-               assert.isTrue(result, "The second GROUPED menu item have been CHECKED following an external publish");
-            });
-      },
+         "Test that second checkable item IS initially checked": function() {
+            return browser.execute("return dijit.registry.byId('CHECKABLE_2').checked")
+               .then(function(result) {
+                  assert.isTrue(result, "The menu item SHOULD HAVE BEEN checked on page load");
+               });
+         },
 
-      "Test checking a menu item publishes topic correctly (mouse)": function() {
-         return browser.findByCssSelector("#CHECKABLE_MENU_ITEMS_DROPDOWN")
-            .click()
-         .end()
-         .findByCssSelector("#CHECKABLE_1")
-            .click()
-         .end()
-         .findByCssSelector(TestCommon.topicSelector("CHECKABLE_1", "publish", "last"))
-            .then(null, function() {
-               assert(false, "Mouse selection of CHECKABLE_1 didn't publish correctly (missing publish topic)");
-            })
-         .end()
-         .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selected", "true"))
-            .then(null, function() {
-               assert(false, "Mouse selection of CHECKABLE_1 didn't publish correctly (incorrect 'selected' payload attribute");
-            });
-      },
+         "Test that first grouped checkable menu item IS checked on page load": function() {
+            return browser.execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
+               .then(function(result) {
+                  assert.isTrue(result, "The first GROUPED menu item SHOULD HAVE BEEN checked on page load");
+               });
+         },
 
-      "Test unchecking a menu item publishes topic correctly (mouse)": function() {
-         return browser.findByCssSelector("#CHECKABLE_MENU_ITEMS_DROPDOWN")
-            .click()
-         .end()
-         .findByCssSelector("#CHECKABLE_1")
-            .click()
-         .end()
-         .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selected", "false"))
-            .then(null, function() {
-               assert(false, "Mouse de-selection of CHECKABLE_1 didn't publish correctly (incorrect 'selected' payload attribute");
-            });
-      },
+         "Test that second grouped checkable item is NOT checked on page load": function() {
+            return browser.execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
+               .then(function(result) {
+                  assert.isFalse(result, "The second GROUPED menu item was NOT checked on page load");
+               });
+         },
 
-      "Test checking a menu item publishes topic correctly (keyboard)": function() {
-         return browser.pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .sleep(1000)
-            .pressKeys(keys.SPACE)
-            .findByCssSelector(TestCommon.topicSelector("CHECKABLE_2", "publish", "last"))
-               .then(null, function() {
-                  assert(false, "Keyboard selection of CHECKABLE_2 didn't publish correctly");
-               })
-            .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selected", "false"))
-               .then(null, function() {
-                  assert(false, "Keyboard selection of CHECKABLE_2 didn't publish correctly (incorrect 'selected' payload attribute");
-               })
-            .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "clicked", "CHECKABLE_2"))
-               .then(null, function() {
-                  assert(false, "Keyboard selection of CHECKABLE_2 didn't publish additional payload attribute");
-               })
-            .end();
-      },
+         "Test that third grouped checkable item is NOT checked on page load": function() {
+            return browser.execute("return dijit.registry.byId('GROUPED_CHECKABLE_3').checked")
+               .then(function(result) {
+                  assert.isFalse(result, "The first GROUPED menu item was NOT checked on page load");
+               });
+         },
 
-      "Test checking grouped item using keyboard": function() {
-         return browser.pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .pressKeys(keys.ARROW_DOWN)
-            .sleep(1000)
-            .pressKeys(keys.RETURN)
-            .findByCssSelector(TestCommon.topicSelector("ALF_CHECKABLE_MENU_ITEM__CHECKABLE_GROUP", "publish"))
-               .then(null, function() {
-                  assert(false, "Test #14 - Keyboard selection of grouped item didn't publish to group");
-               })
-         .execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
-            .then(function(result) {
-               assert.isTrue(result, "The first GROUPED menu item should have been CHECKED following keyboard navigation");
-            })
-         .execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The second GROUPED menu item should have been UNCHECKED following keyboard navigation");
-            })
-         .execute("return dijit.registry.byId('GROUPED_CHECKABLE_3').checked")
-            .then(function(result) {
-               assert.isFalse(result, "The third GROUPED menu item should have been UNCHECKED following keyboard navigation");
-            });
-      },
+         "Test that a checked menu item has a tick displayed": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.ungrouped2.checked);
+         },
 
-      "Test checking groups item using mouse": function() {
-         return browser.findByCssSelector("#CHECKABLE_MENU_ITEMS_DROPDOWN")
+         "Test that an unchecked menu item does NOT have a tick displayed": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.ungrouped1.checked)
+               .then(
+                  function() {
+                     // FOUND == ERROR
+                     assert(false, "An UNCHECKED menu item should NOT have the alf-selected-icon class applied to it");
+                  },
+                  function() {
+                     // NOT FOUND == SUCCESS
+                     assert(true, "Not found as expected");
+                  });
+         },
+
+         "Test that an externally published topic can set a check box": function() {
+            return browser.findByCssSelector("#SET_CHECKABLE_1_label")
                .click()
             .end()
-            .findByCssSelector("#GROUPED_CHECKABLE_3")
+            .execute("return dijit.registry.byId('CHECKABLE_1').checked")
+               .then(function(result) {
+                  assert(result === "true", "The first menu item has not been CHECKED following an external publish");
+               });
+         },
+
+         "Test than an externally published topic can unset a check box": function() {
+            return browser.findByCssSelector("#UNSET_CHECKABLE_1_label")
                .click()
             .end()
-            .findByCssSelector(TestCommon.topicSelector("ALF_CHECKABLE_MENU_ITEM__CHECKABLE_GROUP", "publish"))
-               .then(null, function() {
-                  assert(false, "Test #15 - Mouse selection of grouped item didn't publish to group");
-               })
+            .execute("return dijit.registry.byId('CHECKABLE_1').checked")
+               .then(function(result) {
+                  assert.isFalse(result, "The first menu item have been UNCHECKED following an external publish");
+               });
+         },
+
+         "Test that externally published topic updates a group": function() {
+            return browser.findByCssSelector("#SET_GROUPED_CHECKABLE_2_label")
+               .click()
+            .end()
             .execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
                .then(function(result) {
-                  assert.isFalse(result, "The first GROUPED menu item should have been UNCHECKED following mouse navigation");
+                  assert.isFalse(result, "The first GROUPED menu item have been UNCHECKED following an external publish");
                })
             .execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
                .then(function(result) {
-                  assert.isFalse(result, "The second GROUPED menu item should have been UNCHECKED following mouse navigation");
+                  assert.isTrue(result, "The second GROUPED menu item have been CHECKED following an external publish");
+               });
+         },
+
+         "Test checking a menu item publishes topic correctly (mouse)": function() {
+            return browser.findByCssSelector("#CHECKABLE_MENU_ITEMS_DROPDOWN")
+               .click()
+            .end()
+            .findByCssSelector("#CHECKABLE_1")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.topicSelector("CHECKABLE_1", "publish", "last"))
+               .then(null, function() {
+                  assert(false, "Mouse selection of CHECKABLE_1 didn't publish correctly (missing publish topic)");
+               })
+            .end()
+            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selected", "true"))
+               .then(null, function() {
+                  assert(false, "Mouse selection of CHECKABLE_1 didn't publish correctly (incorrect 'selected' payload attribute");
+               });
+         },
+
+         "Test unchecking a menu item publishes topic correctly (mouse)": function() {
+            return browser.findByCssSelector("#CHECKABLE_MENU_ITEMS_DROPDOWN")
+               .click()
+            .end()
+            .findByCssSelector("#CHECKABLE_1")
+               .click()
+            .end()
+            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selected", "false"))
+               .then(null, function() {
+                  assert(false, "Mouse de-selection of CHECKABLE_1 didn't publish correctly (incorrect 'selected' payload attribute");
+               });
+         },
+
+         "Test checking a menu item publishes topic correctly (keyboard)": function() {
+            return browser.pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .sleep(1000)
+               .pressKeys(keys.SPACE)
+               .findByCssSelector(TestCommon.topicSelector("CHECKABLE_2", "publish", "last"))
+                  .then(null, function() {
+                     assert(false, "Keyboard selection of CHECKABLE_2 didn't publish correctly");
+                  })
+               .end()
+               .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "selected", "false"))
+                  .then(null, function() {
+                     assert(false, "Keyboard selection of CHECKABLE_2 didn't publish correctly (incorrect 'selected' payload attribute");
+                  })
+               .end()
+               .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "clicked", "CHECKABLE_2"))
+                  .then(null, function() {
+                     assert(false, "Keyboard selection of CHECKABLE_2 didn't publish additional payload attribute");
+                  })
+               .end();
+         },
+
+         "Test checking grouped item using keyboard": function() {
+            return browser.pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .pressKeys(keys.ARROW_DOWN)
+               .sleep(1000)
+               .pressKeys(keys.RETURN)
+               .findByCssSelector(TestCommon.topicSelector("ALF_CHECKABLE_MENU_ITEM__CHECKABLE_GROUP", "publish"))
+                  .then(null, function() {
+                     assert(false, "Test #14 - Keyboard selection of grouped item didn't publish to group");
+                  })
+            .execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
+               .then(function(result) {
+                  assert.isTrue(result, "The first GROUPED menu item should have been CHECKED following keyboard navigation");
+               })
+            .execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
+               .then(function(result) {
+                  assert.isFalse(result, "The second GROUPED menu item should have been UNCHECKED following keyboard navigation");
                })
             .execute("return dijit.registry.byId('GROUPED_CHECKABLE_3').checked")
                .then(function(result) {
-                  assert.isTrue(result, "The third GROUPED menu item should have been CHECKED following mouse navigation");
+                  assert.isFalse(result, "The third GROUPED menu item should have been UNCHECKED following keyboard navigation");
                });
-      },
+         },
 
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
-   };
+         "Test checking groups item using mouse": function() {
+            return browser.findByCssSelector("#CHECKABLE_MENU_ITEMS_DROPDOWN")
+                  .click()
+               .end()
+               .findByCssSelector("#GROUPED_CHECKABLE_3")
+                  .click()
+               .end()
+               .findByCssSelector(TestCommon.topicSelector("ALF_CHECKABLE_MENU_ITEM__CHECKABLE_GROUP", "publish"))
+                  .then(null, function() {
+                     assert(false, "Test #15 - Mouse selection of grouped item didn't publish to group");
+                  })
+               .execute("return dijit.registry.byId('GROUPED_CHECKABLE_1').checked")
+                  .then(function(result) {
+                     assert.isFalse(result, "The first GROUPED menu item should have been UNCHECKED following mouse navigation");
+                  })
+               .execute("return dijit.registry.byId('GROUPED_CHECKABLE_2').checked")
+                  .then(function(result) {
+                     assert.isFalse(result, "The second GROUPED menu item should have been UNCHECKED following mouse navigation");
+                  })
+               .execute("return dijit.registry.byId('GROUPED_CHECKABLE_3').checked")
+                  .then(function(result) {
+                     assert.isTrue(result, "The third GROUPED menu item should have been CHECKED following mouse navigation");
+                  });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Checkable Menu Item Tests (Accessibility)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/AlfCheckableMenuItem", "Checkable Menu Item Tests (Accessibility)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Open the menu and check ungrouped role": function() {
+            return browser.findByCssSelector(selectors.popupMenu.label)
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(selectors.popupMenu.popup)
+            .end()
+
+            .findByCssSelector(selectors.checkableMenuItems.ungrouped1.item)
+               .getAttribute("role")
+               .then(function(role) {
+                  assert.equal(role, "menuitemcheckbox");
+               });
+         },
+
+         "Check grouped role": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.grouped1.item)
+               .getAttribute("role")
+               .then(function(role) {
+                  assert.equal(role, "menuitemradio");
+               });
+         },
+
+         "Check ungrouped unchecked item aria state": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.ungrouped1.item)
+               .getAttribute("aria-checked")
+               .then(function(state) {
+                  assert.equal(state, "false");
+               });
+         },
+
+         "Check ungrouped checked item aria state": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.ungrouped2.item)
+               .getAttribute("aria-checked")
+               .then(function(state) {
+                  assert.equal(state, "true");
+               });
+         },
+
+         "Check grouped unchecked item aria state": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.grouped1.item)
+               .getAttribute("aria-selected")
+               .then(function(state) {
+                  assert.equal(state, "true");
+               });
+         },
+
+         "Check grouped checked item aria state": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.grouped2.item)
+               .getAttribute("aria-selected")
+               .then(function(state) {
+                  assert.equal(state, "false");
+               });
+         },
+
+         "Toggle ungrouped unchecked item aria state": function() {
+            return browser.findByCssSelector(selectors.checkableMenuItems.ungrouped1.item)
+               .click()
+               .getAttribute("aria-checked")
+               .then(function(state) {
+                  assert.equal(state, "true");
+               });
+         },
+
+         "Toggle ungrouped checked item aria state": function() {
+            return browser.findByCssSelector(selectors.popupMenu.label)
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(selectors.popupMenu.popup)
+            .end()
+
+            .findByCssSelector(selectors.checkableMenuItems.ungrouped1.item)
+               .click()
+               .getAttribute("aria-checked")
+               .then(function(state) {
+                  assert.equal(state, "false");
+               });
+         },
+
+         "Toggle grouped unchecked item aria state": function() {
+            return browser.findByCssSelector(selectors.popupMenu.label)
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(selectors.popupMenu.popup)
+            .end()
+
+            .findByCssSelector(selectors.checkableMenuItems.grouped2.item)
+               .click()
+               .getAttribute("aria-selected")
+               .then(function(state) {
+                  assert.equal(state, "true");
+               })
+            .end()
+
+            .findByCssSelector(selectors.checkableMenuItems.grouped1.item)
+               .getAttribute("aria-selected")
+               .then(function(state) {
+                  assert.equal(state, "false");
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/test-selectors/alfresco/menus/AlfCheckableMenuItem.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/menus/AlfCheckableMenuItem.properties
@@ -1,0 +1,12 @@
+# Menu item that is checked
+checked.item=#{0}.alfresco-menus-AlfCheckableMenuItem--checked
+
+# Menu item (may or may not be checked)
+item=#{0}.alfresco-menus-AlfCheckableMenuItem
+
+# The icon for menu item
+item.icon=#{0} alfresco-menus-AlfCheckableMenuItem__icon
+
+# Menu item label
+item.label=#{0}_text
+

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfCheckableMenuItem.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfCheckableMenuItem.get.js
@@ -8,9 +8,9 @@ model.jsonModel = {
          config: {
             widgets: [
                {
+                  id: "CHECKABLE_MENU_ITEMS_DROPDOWN",
                   name: "alfresco/menus/AlfMenuBarPopup",
                   config: {
-                     id: "CHECKABLE_MENU_ITEMS_DROPDOWN",
                      label: "Checkable Menu Items",
                      widgets: [
                         {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-872 to improve the accessibility of the AlfCheckableMenuItem widget. The CSS styling has been updated to meet our current standards and the appropriate roles and aria states are set for the menu items as they are used.