### PR TITLE
AKU-869: Add NodePreviewService

### DIFF
--- a/aikau/ReleaseNotes.md
+++ b/aikau/ReleaseNotes.md
@@ -1,7 +1,15 @@
 Aikau 1.0.58 Release Notes
 ===
 
-Current deprecations:
+New deprecations:
+---
+* alfresco/renderers/Thumbnail.js
+  * onNodePromiseResolved                                        (configure usePreviewService to be true)
+  * onLoadNode                                                   (configure usePreviewService to be true)
+  * onNodeLoaded                                                 (configure usePreviewService to be true)
+  * onShowPreview                                                (configure usePreviewService to be true)
+
+Previous deprecations:
 ---
 * alfresco/buttons/AlfFormDialogButton.js                        (use alfresco/services/DialogService)
 * alfresco/core/Core "alfDeleteFrameworkAttributes"              (use alfresco/core/Core "alfCleanFrameworkAttributes")

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1076,8 +1076,9 @@ define([],function() {
        * @since 1.0.59
        *
        * @event
+       * @property {string} title The title for the lightbox
+       * @property {string} src The location of the image file to show in the lightbox
        */
-      
       SHOW_LIGHTBOX: "ALF_DISPLAY_LIGHTBOX",
 
       /**
@@ -1090,6 +1091,8 @@ define([],function() {
        * @since 1.0.59
        *
        * @event
+       * @property {object} [node] The Node to show the preview for
+       * @property {string} [nodeRef] The NodeRef of the Node to show the preview for
        */
       SHOW_NODE_PREVIEW: "ALF_SHOW_NODE_PREVIEW",
 

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1067,6 +1067,33 @@ define([],function() {
       SET_THUMBNAIL_SIZE: "ALF_SET_THUMBNAIL_SIZE",
 
       /**
+       * This topic is subscribed to by the [LightboxService]{@link module:alfresco/services/LightboxService}
+       * in order to handle requests to display lightboxes that show an image preview of a Node.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.59
+       *
+       * @event
+       */
+      
+      SHOW_LIGHTBOX: "ALF_DISPLAY_LIGHTBOX",
+
+      /**
+       * This topic is subscribed to by the [FilePreviewService]{@link module:alfresco/services/NodePreviewService}
+       * in order to handle requests to display previews of nodes.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.59
+       *
+       * @event
+       */
+      SHOW_NODE_PREVIEW: "ALF_SHOW_NODE_PREVIEW",
+
+      /**
        * This topic can be published to perform the actual creation of a site. Unlike 
        * [CREATE_SITE]{@link module:alfresco/core/topics#CREATE_SITE} this requires a payload that includes the
        * details for the new site (as it performs the actual creation on the Alfresco Repository rather than

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -25,7 +25,9 @@
  * <p>As well as providing basic actions for navigating a Document Library (e.g. clicking a folder
  * requests to display the content of that folder and clicking on a document links to the details
  * page that renders the document) it is also possible to configure custom actions along with the
- * ability to request a preview of the node be displayed.</p>
+ * ability to request a preview of the node be displayed. <b>PLEASE NOTE:</b> If previews are to
+ * be shown then the [NodePreviewService]{@link module:alfresco/services/NodePreviewService} should
+ * be included on the page.</p>
  * <p>A thumbnail can also be configured to perform selection/de-selection action when clicked through
  * the configuration of the [selectOnClick]{@link module:alfresco/renderers/Thumbnail#selectOnClick}
  * and [onlySelectOnClick]{@link module:alfresco/renderers/Thumbnail#onlySelectOnClick} attributes.</p>

--- a/aikau/src/main/resources/alfresco/services/NodePreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/NodePreviewService.js
@@ -1,0 +1,223 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module alfresco/services/NodePreviewService
+ * @extends module:alfresco/services/BaseService
+ * @mixes module:alfresco/core/CoreXhr
+ * @author Dave Draper
+ * @since 1.0.59
+ */
+define(["dojo/_base/declare",
+        "alfresco/services/BaseService",
+        "alfresco/core/CoreXhr",
+        "alfresco/core/topics",
+        "dojo/window",
+        "dojo/_base/lang",
+        "service/constants/Default"],
+        function(declare, BaseService, AlfXhr, topics, win, lang, AlfConstants) {
+   
+   return declare([BaseService, AlfXhr], {
+      
+      /**
+       * An array of the i18n files to use with this widget.
+       *
+       * @instance
+       * @type {object[]}
+       * @default [{i18nFile: "./i18n/NodePreviewService.properties"}]
+       */
+      i18nRequirements: [{i18nFile: "./i18n/NodePreviewService.properties"}],
+
+      /**
+       * Indicates whether or not XHR requests should be rooted directly to the Alfresco Repository
+       * and bypass the Share web-tier.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      rawData: true,
+      
+      /**
+       * Sets up the subscriptions for the TagService
+       * 
+       * @instance 
+       * @listens module:alfresco/core/topics#SHOW_NODE_PREVIEW
+       */
+      registerSubscriptions: function alfresco_services_NodePreviewService__registerSubscriptions() {
+         this.alfSubscribe(topics.SHOW_NODE_PREVIEW, lang.hitch(this, this.checkNodeMetadata));
+      },
+
+      /**
+       * 
+       * @instance
+       */
+      checkNodeMetadata: function alfresco_services_NodePreviewService__checkNodeMetadata(payload) {
+         var nodeRef = payload.nodeRef;
+         var node = payload.node;
+         var mimetype;
+         if (node)
+         {
+            mimetype = lang.getObject("node.mimetype", false, node);
+         }
+         if (nodeRef && mimetype)
+         {
+            this.showPreview(nodeRef, mimetype);
+         }
+         else
+         {
+            this.onLoadNode(nodeRef);
+         }
+      },
+
+      /**
+       * Makes a reqeust to load all the data for the node. This is required for preview actions when data
+       * is not available in the currentItem object.
+       *
+       * @instance
+       * @param {string} nodeRef The nodeRef to reqeuest the details for
+       *
+       * @fires module:alfresco/core/topics#GET_DOCUMENT
+       */
+      onLoadNode: function alfresco_services_NodePreviewService__onLoadNode(nodeRef) {
+         if (nodeRef)
+         {
+            var responseTopic = this.generateUuid();
+            var subscriptionHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onNodeLoaded), true);
+            this.alfPublish(topics.GET_DOCUMENT, {
+               subscriptionHandle: subscriptionHandle,
+               alfResponseTopic: responseTopic,
+               nodeRef: nodeRef,
+               rawData: this.rawData
+            }, true);
+         }
+         else
+         {
+            this.alfLog("warn", "No nodeRef supplied to use to retrieve all data.", this);
+         }
+      },
+
+      /**
+       * Handles the loading of the complete node data.
+       * 
+       * @instance
+       * @param {object} payload 
+       */
+      onNodeLoaded: function alfresco_services_NodePreviewService__onNodeLoaded(payload) {
+         this.alfUnsubscribe(payload.requestConfig.subscriptionHandle);
+         var item = lang.getObject("response.item", false, payload);
+         if (item) 
+         {
+            var nodeRef = lang.getObject("node.nodeRef", false, item);
+            var mimetype = lang.getObject("node.mimetype", false, item);
+            if (nodeRef && mimetype)
+            {
+               this.showPreview(nodeRef, mimetype);
+            }
+            else
+            {
+               this.alfLog("warn", "A request was made to show a preview for a Node that has no MIME type", nodeRef, mimetype, this);
+            }
+         }
+         else
+         {
+            this.alfLog("warn", "Node data was provided but the 'response.item' attribute was not found", payload, this);
+         }
+      },
+
+      /**
+       * Handles requests to show a preview of a node.
+       *
+       * @instance
+       * @param {string} nodeRef The nodeRef of the node to preview
+       * @param {string} mimetype The mimetype of the node
+       */
+      showPreview: function alfresco_services_NodePreviewService__showPreview(nodeRef, mimetype) {
+         // Since we're going to be publishing to services we need to publish globally...
+         this.publishGlobal = true;
+         if (mimetype && mimetype.indexOf("image/") === 0)
+         {
+            // get last modified for image preview if present in the metadata
+            var lastModified = lang.getObject(this.lastThumbnailModificationProperty, false, this.currentItem) || 1;
+            this.publishTopic = topics.SHOW_LIGHTBOX;
+            if (nodeRef)
+            {
+               this.publishPayload = {
+                  src: AlfConstants.PROXY_URI + "api/node/" + nodeRef.replace(":/", "") +
+                       "/content/thumbnails/imgpreview?c=force&lastModified=" + encodeURIComponent(lastModified),
+                  title: this.imgTitle
+               };
+            }
+            else
+            {
+               this.alfLog("warn", "Could not find a nodeRef to process", this.currentItem, this);
+            }
+         }
+         else
+         {
+            // Because the content of the previewer will load asynchronously it's important that 
+            // we set some dimensions for the dialog body, otherwise it will appear off-center
+            var vs = win.getBox();
+            this.publishTopic = topics.CREATE_DIALOG;
+            this.publishPayload = {
+               contentWidth: (vs.w*0.7) + "px",
+               contentHeight: (vs.h-250) + "px",
+               handleOverflow: false,
+               dialogTitle: this.imgTitle,
+               additionalCssClasses: "no-padding",
+               widgetsContent: [
+                  {
+                     name: "alfresco/documentlibrary/AlfDocument",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/preview/AlfDocumentPreview",
+                              config: {
+                                 heightMode: "DIALOG"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ],
+               widgetsButtons: [
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     config: {
+                        label: this.message("close.node.preview.dialog"),
+                        publishTopic: "NO_OP",
+                        additionalCssClasses: "call-to-action"
+                     }
+                  }
+               ],
+               publishOnShow: [
+                  {
+                     publishTopic: topics.GET_DOCUMENT,
+                     publishPayload: {
+                        rawData: true,
+                        nodeRef: nodeRef
+                     }
+                  }
+               ]
+            };
+         }
+         this.alfPublish(this.publishTopic, this.publishPayload, this.publishGlobal, this.publishToParent);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/NodePreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/NodePreviewService.js
@@ -26,14 +26,14 @@
  */
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
-        "alfresco/core/CoreXhr",
+        "alfresco/core/ObjectProcessingMixin",
         "alfresco/core/topics",
         "dojo/window",
         "dojo/_base/lang",
         "service/constants/Default"],
-        function(declare, BaseService, AlfXhr, topics, win, lang, AlfConstants) {
+        function(declare, BaseService, ObjectProcessingMixin, topics, win, lang, AlfConstants) {
    
-   return declare([BaseService, AlfXhr], {
+   return declare([BaseService, ObjectProcessingMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -43,6 +43,61 @@ define(["dojo/_base/declare",
        * @default [{i18nFile: "./i18n/NodePreviewService.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/NodePreviewService.properties"}],
+
+      /**
+       * The property to use for the image title. This will be displayed on lightboxes or dialogs used
+       * to show previews by default.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      imageTitleProperty: "displayName",
+
+      /**
+       * Defines any condition overrides for the previewer. This data is passed directly to the 
+       * [previewer configuration]{@link module:alfresco/preview/AlfDocumentPreview#pluginConditionsOverrides}.
+       *
+       * @instance
+       * @type {object[]}
+       * @default
+       */
+      pluginConditionsOverrides: null,
+
+      /**
+       * The proxy to use for the rest api call for the node's content or thumbnails. This is passed
+       * directly to the [previewer configuration]{@link module:alfresco/preview/AlfDocumentPreview#proxy}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      proxy: "alfresco",
+
+      /**
+       * This is an alternative payload that will be published when showing a preview. This is the payload
+       * that will be published on the [topic]{@link module:alfresco/services/NodePreviewService#publishTopic}
+       * published by [showPreview]{@link module:alfresco/services/NodePreviewService#showPreview}.
+       *
+       * @instance
+       * @type {object}
+       * @default
+       */
+      publishPayload: null,
+
+      /**
+       * The topic to publish when displaying a preview. By default this publishes a request that is expected to
+       * be handled by the [DialogService]{@link module:alfresco/services/DialogService}, however this could be
+       * configured to be an alternative topic to ensure that previews are displayed differently. If this configuration
+       * is changed from the default then it is likely that the 
+       * [publishPayload]{@link module:alfresco/services/NodePreviewService#publishPayload} will also need to be
+       * configured for the new topic.
+       * 
+       * @instance
+       * @type {string}
+       * @default [CREATE_DIALOG]{@link module:alfresco/topics#CREATE_DIALOG}
+       */
+      publishTopic: topics.CREATE_DIALOG,
 
       /**
        * Indicates whether or not XHR requests should be rooted directly to the Alfresco Repository
@@ -55,6 +110,27 @@ define(["dojo/_base/declare",
       rawData: true,
       
       /**
+       * Indicates whether or not the [LightboxService]{@link module:alfresco/services/LightboxService} (or
+       * equivalent service) should be used for displaying image previews (i.e. Nodes that have a MIME
+       * type that contains the text "image/").
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      useLightboxForImages: true,
+
+      /**
+       * Defines any plugin overrides for the previewer. This data is passed directly to the 
+       * [previewer configuration]{@link module:alfresco/preview/AlfDocumentPreview#widgetsForPluginsOverrides}.
+       *
+       * @instance
+       * @type {object[]}
+       * @default
+       */
+      widgetsForPluginsOverrides: null, 
+
+      /**
        * Sets up the subscriptions for the TagService
        * 
        * @instance 
@@ -65,8 +141,12 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * 
+       * Checks the node provided in the payload argument. If no "node.mimetype" attribute is provided then
+       * is will be necessary to load the full metadata for the Node (assuming that a "nodeRef" attribute
+       * has been provided.)
+       *
        * @instance
+       * @param {object} payload The payload for the show preview request.
        */
       checkNodeMetadata: function alfresco_services_NodePreviewService__checkNodeMetadata(payload) {
          var nodeRef = payload.nodeRef;
@@ -80,19 +160,22 @@ define(["dojo/_base/declare",
          {
             this.showPreview(nodeRef, mimetype);
          }
-         else
+         else if (nodeRef)
          {
             this.onLoadNode(nodeRef);
+         }
+         else
+         {
+            this.alfLog("warn", "A request was made to show the preview for a node, but no 'nodeRef' was provided", payload, this);
          }
       },
 
       /**
-       * Makes a reqeust to load all the data for the node. This is required for preview actions when data
-       * is not available in the currentItem object.
+       * Makes a request to load full metadata for the node. This is required for preview actions when MIME type
+       * data is not available in the currentItem object.
        *
        * @instance
        * @param {string} nodeRef The nodeRef to reqeuest the details for
-       *
        * @fires module:alfresco/core/topics#GET_DOCUMENT
        */
       onLoadNode: function alfresco_services_NodePreviewService__onLoadNode(nodeRef) {
@@ -114,7 +197,8 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Handles the loading of the complete node data.
+       * Handles the loading of the complete node metadat issued from 
+       * [onLoadNode]{@link module:alfresco/services/NodePreviewService#onLoadNode}.
        * 
        * @instance
        * @param {object} payload 
@@ -126,9 +210,15 @@ define(["dojo/_base/declare",
          {
             var nodeRef = lang.getObject("node.nodeRef", false, item);
             var mimetype = lang.getObject("node.mimetype", false, item);
+            var title = lang.getObject(this.imageTitleProperty, false, item);
             if (nodeRef && mimetype)
             {
-               this.showPreview(nodeRef, mimetype);
+               this.showPreview({
+                  item: item,
+                  nodeRef: nodeRef, 
+                  mimetype: mimetype,
+                  title: title
+               });
             }
             else
             {
@@ -142,44 +232,56 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Handles requests to show a preview of a node.
+       * Shows the preview of the Node.
        *
        * @instance
-       * @param {string} nodeRef The nodeRef of the node to preview
-       * @param {string} mimetype The mimetype of the node
+       * @param {object} previewData The data object for showing the preview
+       * @param {object} previewData.item The item to be previewed (used for custom payloads)
+       * @param {string} previewData.nodeRef The nodeRef of the node to preview
+       * @param {string} previewData.mimetype The mimetype of the node
+       * @param {string} previewData.title The mimetype of the node
+       * @fires module:alfresco/core/topics#SHOW_LIGHTBOX
+       * @fires module:alfresco/core/topics#CREATE_DIALOG
        */
-      showPreview: function alfresco_services_NodePreviewService__showPreview(nodeRef, mimetype) {
+      showPreview: function alfresco_services_NodePreviewService__showPreview(previewData) {
          // Since we're going to be publishing to services we need to publish globally...
-         this.publishGlobal = true;
-         if (mimetype && mimetype.indexOf("image/") === 0)
+         var publishPayload;
+         if (this.useLightboxForImages && previewData.mimetype && previewData.mimetype.indexOf("image/") === 0)
          {
             // get last modified for image preview if present in the metadata
             var lastModified = lang.getObject(this.lastThumbnailModificationProperty, false, this.currentItem) || 1;
-            this.publishTopic = topics.SHOW_LIGHTBOX;
-            if (nodeRef)
+            if (previewData.nodeRef)
             {
-               this.publishPayload = {
-                  src: AlfConstants.PROXY_URI + "api/node/" + nodeRef.replace(":/", "") +
+               publishPayload = {
+                  src: AlfConstants.PROXY_URI + "api/node/" + previewData.nodeRef.replace(":/", "") +
                        "/content/thumbnails/imgpreview?c=force&lastModified=" + encodeURIComponent(lastModified),
-                  title: this.imgTitle
+                  title: previewData.title
                };
+               this.alfServicePublish(topics.SHOW_LIGHTBOX, publishPayload);
             }
             else
             {
                this.alfLog("warn", "Could not find a nodeRef to process", this.currentItem, this);
             }
          }
+         else if (this.publishPayload)
+         {
+            // Use a custom payload for displaying the preview.
+            publishPayload = lang.clone(this.publishPayload);
+            this.currentItem = previewData.item;
+            this.processObject(["processCurrentItemTokens"], publishPayload);
+            this.alfServicePublish(this.publishTopic, publishPayload);
+         }
          else
          {
             // Because the content of the previewer will load asynchronously it's important that 
             // we set some dimensions for the dialog body, otherwise it will appear off-center
             var vs = win.getBox();
-            this.publishTopic = topics.CREATE_DIALOG;
-            this.publishPayload = {
+            publishPayload = {
                contentWidth: (vs.w*0.7) + "px",
                contentHeight: (vs.h-250) + "px",
                handleOverflow: false,
-               dialogTitle: this.imgTitle,
+               dialogTitle: previewData.title,
                additionalCssClasses: "no-padding",
                widgetsContent: [
                   {
@@ -189,7 +291,10 @@ define(["dojo/_base/declare",
                            {
                               name: "alfresco/preview/AlfDocumentPreview",
                               config: {
-                                 heightMode: "DIALOG"
+                                 heightMode: "DIALOG",
+                                 pluginConditionsOverrides: this.pluginConditionsOverrides,
+                                 proxy: this.proxy || "alfresco",
+                                 widgetsForPluginsOverrides: this.widgetsForPluginsOverrides
                               }
                            }
                         ]
@@ -211,13 +316,13 @@ define(["dojo/_base/declare",
                      publishTopic: topics.GET_DOCUMENT,
                      publishPayload: {
                         rawData: true,
-                        nodeRef: nodeRef
+                        nodeRef: previewData.nodeRef
                      }
                   }
                ]
             };
+            this.alfServicePublish(this.publishTopic, publishPayload);
          }
-         this.alfPublish(this.publishTopic, this.publishPayload, this.publishGlobal, this.publishToParent);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/NodePreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/NodePreviewService.js
@@ -18,6 +18,17 @@
  */
 
 /**
+ * This service can be included in pages to handle the displaying previews of Nodes. By default the
+ * [LightboxService]{@link module:alfresco/services/LightboxService} will be used to preview images
+ * and all other Nodes will be shown using the 
+ * [AlfDocumentPreview]{@link module:alfresco/preview/AlfDocumentPreview} via the
+ * [DialogService]{@link module:alfresco/services/DialogService}. It is possible to override the 
+ * services used through the configuration of this service to publish alternative 
+ * [payloads]{@link module:alfresco/preview/AlfDocumentPreview#publishPayload} on
+ * alternative [topics]{@link module:alfresco/preview/AlfDocumentPreview#publishTopic}. It is also 
+ * possible to pass additional configuration to the 
+ * [AlfDocumentPreview]{@link module:alfresco/preview/AlfDocumentPreview} widget.
+ * 
  * @module alfresco/services/NodePreviewService
  * @extends module:alfresco/services/BaseService
  * @mixes module:alfresco/core/CoreXhr
@@ -294,7 +305,7 @@ define(["dojo/_base/declare",
                               config: {
                                  heightMode: "DIALOG",
                                  pluginConditionsOverrides: this.pluginConditionsOverrides,
-                                 proxy: this.proxy || "alfresco",
+                                 proxy: this.proxy,
                                  widgetsForPluginsOverrides: this.widgetsForPluginsOverrides
                               }
                            }

--- a/aikau/src/main/resources/alfresco/services/NodePreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/NodePreviewService.js
@@ -281,6 +281,7 @@ define(["dojo/_base/declare",
                contentWidth: (vs.w*0.7) + "px",
                contentHeight: (vs.h-250) + "px",
                handleOverflow: false,
+               dialogId: "NODE_PREVIEW_SERVICE_DIALOG",
                dialogTitle: previewData.title,
                additionalCssClasses: "no-padding",
                widgetsContent: [

--- a/aikau/src/main/resources/alfresco/services/i18n/NodePreviewService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/NodePreviewService.properties
@@ -1,0 +1,1 @@
+close.node.preview.dialog=Close

--- a/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ThumbnailTest.js
@@ -26,6 +26,15 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"], 
         function (registerSuite, assert, TestCommon, keys) {
 
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+   var selectors = {
+      dialogs: {
+         preview: {
+            visible: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["NODE_PREVIEW_SERVICE_DIALOG"])
+         }
+      },
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -80,12 +89,7 @@ define(["intern!object",
             return browser.findByCssSelector("#TASKS1 .alfresco-renderers-Thumbnail .alfresco-renderers-Thumbnail__image")
                .click()
             .end()
-            .sleep(1000) // Give the lightbox a chance to populate
-            .findByCssSelector("#aikauLightbox")
-               .isDisplayed()
-               .then(function(displayed) {
-                  assert.isTrue(displayed, "The lightbox preview was not displayed");
-               });
+            .findDisplayedById("aikauLightbox");
          },
 
          "Escape closes lightbox preview": function() {
@@ -105,6 +109,50 @@ define(["intern!object",
                .then(function(elements) {
                   assert.lengthOf(elements, 1, "PDFjs preview not displayed");
                });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Thumbnail Tests (Using NodePreviewService)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/Thumbnail?usePreviewService=true", "Thumbnail Tests (Using NodePreviewService)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Lightbox preview": function() {
+            return browser.findByCssSelector("#TASKS1 .alfresco-renderers-Thumbnail .alfresco-renderers-Thumbnail__image")
+               .click()
+            .end()
+
+            .findDisplayedById("aikauLightbox")
+            .end()
+
+            .findDisplayedById("aikauCloseButton")
+               .click();
+         },
+
+         "PDFjs Preview": function() {
+            return browser.findByCssSelector("#HARDCODED .alfresco-renderers-Thumbnail .alfresco-renderers-Thumbnail__image")
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.dialogs.preview.visible)
+            .end()
+
+            .findDisplayedByCssSelector(".alfresco-preview-PdfJs");
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/NodePreviewServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NodePreviewServiceTest.js
@@ -25,6 +25,21 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, TestCommon) {
 
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+
+   var selectors = {
+      buttons: {
+         imagePreview: TestCommon.getTestSelector(buttonSelectors, "button.label", ["IMAGE_PREVIEW"]),
+         videoPreview: TestCommon.getTestSelector(buttonSelectors, "button.label", ["VIDEO_PREVIEW"])
+      },
+      dialogs: {
+         preview: {
+            visible: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["NODE_PREVIEW_SERVICE_DIALOG"])
+         }
+      },
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -41,6 +56,70 @@ define(["intern!object",
             browser.end();
          },
 
+         "Show image preview": function() {
+            return browser.findByCssSelector(selectors.buttons.imagePreview)
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST")
+            .getLastPublish("ALF_DISPLAY_LIGHTBOX")
+
+            .findDisplayedById("aikauLightbox")
+            .end()
+
+            .findDisplayedById("aikauCloseButton")
+               .click()
+            .end()
+
+            .clearLog();
+         },
+
+         "Show video preview": function() {
+            return browser.findByCssSelector(selectors.buttons.videoPreview)
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST")
+            .getLastPublish("ALF_CREATE_DIALOG_REQUEST")
+
+            .findByCssSelector(selectors.dialogs.preview.visible)
+            .end()
+
+            .findByCssSelector("video");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+
+         name: "NodePreviewService Tests (alternate display)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NodePreviewService?altDisplay=true", "NodePreviewService Tests (alternate display)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Show image preview": function() {
+            return browser.findByCssSelector(selectors.buttons.imagePreview)
+               .click()
+            .end()
+
+            .getLastPublish("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST")
+            .getLastPublish("ALF_DISPLAY_STICKY_PANEL")
+
+            .findDisplayedByCssSelector(".alfresco-layout-StickyPanel__panel .alfresco-preview-AlfDocumentPreview");
+         },
 
          "Post Coverage Results": function() {
             TestCommon.alfPostCoverageResults(this, browser);

--- a/aikau/src/test/resources/alfresco/services/NodePreviewServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NodePreviewServiceTest.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(registerSuite, assert, TestCommon) {
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+
+         name: "NodePreviewService Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/NodePreviewService", "NodePreviewService Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -283,6 +283,7 @@ define({
       "src/test/resources/alfresco/services/FullScreenDialogTest",
       "src/test/resources/alfresco/services/LoggingServiceTest",
       "src/test/resources/alfresco/services/NavigationServiceTest",
+      "src/test/resources/alfresco/services/NodePreviewServiceTest",
       "src/test/resources/alfresco/services/NotificationServiceTest",
       "src/test/resources/alfresco/services/SearchServiceTest",
       "src/test/resources/alfresco/services/ServiceFilteringTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Thumbnail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Thumbnail.get.js
@@ -1,3 +1,7 @@
+/* global page */
+/* jshint sub:true */
+var usePreviewService = (page.url.args["usePreviewService"] === "true");
+
 model.jsonModel = {
    services: [
       {
@@ -16,6 +20,12 @@ model.jsonModel = {
       "alfresco/services/NodePreviewService"
    ],
    widgets:[
+      {
+         name: "alfresco/html/Markdown",
+         config: {
+            markdown: "Use ?usePreviewService=true request parameter to use the NodePreviewService for previews"
+         }
+      },
       {
          id: "DOCLIB_RENDITIONS",
          name: "alfresco/layout/ClassicWindow",
@@ -190,7 +200,8 @@ model.jsonModel = {
                                                       name: "alfresco/renderers/Thumbnail",
                                                       config: {
                                                          assumeRendition: true,
-                                                         showDocumentPreview: true
+                                                         showDocumentPreview: true,
+                                                         usePreviewService: usePreviewService
                                                       }
                                                    }
                                                 ]
@@ -268,7 +279,8 @@ model.jsonModel = {
                         nodeRef: "workspace://SpacesStore/26ae500c-91a9-496f-aca6-14101f985c28",
                         displayName: "Test PDF"
                      },
-                     showDocumentPreview: true
+                     showDocumentPreview: true,
+                     usePreviewService: usePreviewService
                   }
                }
             ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Thumbnail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Thumbnail.get.js
@@ -12,7 +12,8 @@ model.jsonModel = {
       "alfresco/services/DocumentService",
       "alfresco/services/DialogService",
       "alfresco/services/CrudService",
-      "alfresco/services/LightboxService"
+      "alfresco/services/LightboxService",
+      "alfresco/services/NodePreviewService"
    ],
    widgets:[
       {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>NodePreviewService</shortname>
+  <description>Displays buttons that can be used to drive the NodePreviewService</description>
+  <family>aikau-unit-tests</family>
+  <url>/NodePreviewService</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.js
@@ -12,10 +12,16 @@ model.jsonModel = {
       },
       "alfresco/services/DialogService",
       "alfresco/services/LightboxService",
-      "alfresco/services/NodePreviewService",
-      "alfresco/services/DocumentService"
+      "alfresco/services/DocumentService",
+      "alfresco/services/NotificationService"
    ],
    widgets: [
+      {
+         name: "alfresco/html/Markdown",
+         config: {
+            markdown: "Use ?altDisplay=true request parameters to use StickyPanel rather than Dialog"
+         }
+      },
       {
          id: "IMAGE_PREVIEW",
          name: "alfresco/buttons/AlfButton",
@@ -46,3 +52,42 @@ model.jsonModel = {
       }
    ]
 };
+
+/* global page */
+/* jshint sub:true */
+if (page.url.args["altDisplay"] === "true")
+{
+   model.jsonModel.services.push({
+      name: "alfresco/services/NodePreviewService",
+      config: {
+         useLightboxForImages: false,
+         publishTopic: "ALF_DISPLAY_STICKY_PANEL",
+         publishPayload: {
+            title: "{displayName}",
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/AlfDocument",
+                  config: {
+                     rawData: true,
+                     xhrRequired: true,
+                     nodeRef: "{node.nodeRef}",
+                     widgets: [
+                        {
+                           name: "alfresco/preview/AlfDocumentPreview",
+                           config: {
+                              heightMode: 400
+                           }
+                        }
+                     ]
+                  }
+               }
+            ],
+            width: 500
+         }
+      }
+   });
+}
+else
+{
+   model.jsonModel.services.push("alfresco/services/NodePreviewService");
+}

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NodePreviewService.get.js
@@ -1,0 +1,48 @@
+// jshint undef:false
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DialogService",
+      "alfresco/services/LightboxService",
+      "alfresco/services/NodePreviewService",
+      "alfresco/services/DocumentService"
+   ],
+   widgets: [
+      {
+         id: "IMAGE_PREVIEW",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show Image Preview",
+            publishTopic: "ALF_SHOW_NODE_PREVIEW",
+            publishPayload: {
+               nodeRef: "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4"
+            }
+         }
+      },
+      {
+         id: "VIDEO_PREVIEW",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show Video Preview",
+            publishTopic: "ALF_SHOW_NODE_PREVIEW",
+            publishPayload: {
+               nodeRef: "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5"
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PreviewMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PreviewMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/PreviewMockXhr.js
@@ -74,6 +74,38 @@ define(["dojo/_base/declare",
                                      {"Content-Type":"application/json;charset=UTF-8",
                                      "Content-Length":2947517},
                                      audioNode]); 
+
+            // Raw data requests....
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/slingshot\/doclib2\/node\/workspace\/SpacesStore\/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4\?(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":7962},
+                                     imageNode]);
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/slingshot\/doclib2\/node\/workspace\/SpacesStore\/a4fc4392-27f6-49fd-8b6e-20b953c59ff5\?(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":5520127},
+                                     videoNode]); 
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/slingshot\/doclib2\/node\/workspace\/SpacesStore\/8a93f2cc-5276-45b6-929a-f5112e7a645d\?(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":5520127},
+                                     videoH264Node]); 
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/slingshot\/doclib2\/node\/workspace\/SpacesStore\/b5973042-9f07-472f-980d-940eb117524b\?(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":5520127},
+                                     videoOggNode]); 
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/slingshot\/doclib2\/node\/workspace\/SpacesStore\/50e8fa78-86ee-4209-9de0-b5c996b7ee52\?(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8",
+                                     "Content-Length":2947517},
+                                     audioNode]); 
          }
          catch(e)
          {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-869 to provide a new NodePreviewService that can be used to handle previewing of nodes. The existing preview capabilities from the alfresco/renderers/Thumbnail widget have been retained for backwards compatibility but deprecated with the intention to swap to using the NodePreviewService by default at some point in the future. Unit tests have been added to verify the new service and the new configuration mode for Thumbnails.