### PR TITLE
AKU-888: Added MaskingTextBox, updated SiteService, tests and Sandpit

### DIFF
--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.desc.xml
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>alfresco/forms/controls/MaskingTextBox</shortname>
+  <description>A specialized TextBox that can have it's value automatically set and modified by changing another field.</description>
+  <family>ExamplePage</family>
+  <url>/MaskingTextBox</url>
+</webscript>

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.desc.xml
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.desc.xml
@@ -1,6 +1,6 @@
 <webscript>
-  <shortname>alfresco/forms/controls/MaskingTextBox</shortname>
-  <description>A specialized TextBox that can have it's value automatically set and modified by changing another field.</description>
-  <family>ExamplePage</family>
-  <url>/MaskingTextBox</url>
+   <shortname>alfresco/forms/controls/MaskingTextBox</shortname>
+   <description>A specialized TextBox that can have its value automatically set and modified by changing another field.</description>
+   <family>ExamplePage</family>
+   <url>/MaskingTextBox</url>
 </webscript>

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.html.ftl
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
@@ -1,0 +1,51 @@
+<import resource="classpath:alfresco/site-webscripts/imports/sandpit.lib.js">
+
+buildPageModel({
+   title: "page.title",
+   description: "page.description",
+   jsdoc: "https://dev.alfresco.com/resource/docs/aikau-jsdoc/MaskingTextBox.html",
+   mockXhrWidgets: [
+      {
+         name: "alfresco/testing/NodesMockXhr"
+      }
+   ],
+   examples: [
+      {
+         title: "example1.title",
+         description: "example1.description",
+         model: [
+            {
+               name: "alfresco/forms/Form",
+               config: {
+                  pubSubScope: "FORM",
+                  okButtonPublishTopic: "SAVE",
+                  widgets: [
+                     {
+                        name: "alfresco/forms/controls/TextBox",
+                        config: {
+                           fieldId: "TEXTBOX",
+                           label: "Seed value",
+                           description: "The value of this form control is used to set that of the MaskedTextBox",
+                           name: "text"
+                        }
+                     },
+                     {
+                        name: "alfresco/forms/controls/MaskingTextBox",
+                        config: {
+                           fieldId: "MASKEDTEXTBOX",
+                           targetId: "TEXTBOX",
+                           label: "Resulting value",
+                           description: "This value will be automatically set from the value of the other TextBox",
+                           name: "maskedText",
+                           mask: "[^0-9a-zA-Z\-\s]",
+                           trim: true,
+                           toLowerCase: true
+                        }
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   ]
+});

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
@@ -45,7 +45,7 @@ buildPageModel({
                               {
                                  regex: "\\s+",
                                  replacement: "-",
-                                 "g"
+                                 flags: "g"
                               }
                            ],
                            trim: true,

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
@@ -44,7 +44,8 @@ buildPageModel({
                               },
                               {
                                  regex: "\\s+",
-                                 replacement: "-"
+                                 replacement: "-",
+                                 "g"
                               }
                            ],
                            trim: true,

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.js
@@ -37,7 +37,16 @@ buildPageModel({
                            label: "Resulting value",
                            description: "This value will be automatically set from the value of the other TextBox",
                            name: "maskedText",
-                           mask: "[^0-9a-zA-Z\-\s]",
+                           replacements: [
+                              {
+                                 regex: "[^a-z0-9\\-\\s]",
+                                 flags: "gi"
+                              },
+                              {
+                                 regex: "\\s+",
+                                 replacement: "-"
+                              }
+                           ],
                            trim: true,
                            toLowerCase: true
                         }

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.properties
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.properties
@@ -2,5 +2,5 @@ page.title=MaskingTextBox
 page.description=This page demonstrates the alfresco/forms/controls/MaskingTextBox widget. This form control is a specialized TextBox that can have it's value automatically set and modified by changing another field. This widget was originally created for automatically generated site shortName values from a desired site title.
 
 example1.title=Basic Example
-example1.description=This example shows a form containing a regular TextBox and a MaskingTextBox where the value entered into the TextBox is used to seed the value of the MaskingTextBox. Note that you can change the 'mask' configuration as well as controlling whether or not the value is converted to lower-case and trimmed.
+example1.description=This example shows a form containing a regular TextBox and a MaskingTextBox where the value entered into the TextBox is used to seed the value of the MaskingTextBox. Note that you can change the 'replacements' configuration as well as controlling whether or not the value is converted to lower-case and trimmed.
 

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.properties
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/forms/controls/MaskingTextBoxExample.get.properties
@@ -1,0 +1,6 @@
+page.title=MaskingTextBox
+page.description=This page demonstrates the alfresco/forms/controls/MaskingTextBox widget. This form control is a specialized TextBox that can have it's value automatically set and modified by changing another field. This widget was originally created for automatically generated site shortName values from a desired site title.
+
+example1.title=Basic Example
+example1.description=This example shows a form containing a regular TextBox and a MaskingTextBox where the value entered into the TextBox is used to seed the value of the MaskingTextBox. Note that you can change the 'mask' configuration as well as controlling whether or not the value is converted to lower-case and trimmed.
+

--- a/aikau/src/main/resources/alfresco/forms/controls/MaskingTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MaskingTextBox.js
@@ -1,0 +1,192 @@
+   /**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a specialization of the [TextBox]{@link module:alfresco/forms/controls/TextBox}
+ * that can be configured to automatically set its value to that of another form control
+ * where the value is "masked" by a Regular Expression. This widget was written explicitly
+ * to address a requirement in the [SiteService]{@link module:alfresco/services/SiteService}
+ * where it was necessary for a "shortName" field to automatically be updated with the value
+ * of the "title" field but with certain characters and white space removed.
+ *
+ * @example <caption>This example shows how the MaskingTextBox can be used with another TextBox</caption>
+ * {
+ *   name: "alfresco/forms/Form",
+ *   config: {
+ *     pubSubScope: "FORM",
+ *     okButtonPublishTopic: "SAVE",
+ *     widgets: [
+ *        {
+ *           name: "alfresco/forms/controls/TextBox",
+ *           config: {
+ *              fieldId: "TEXTBOX",
+ *              label: "Seed value",
+ *              description: "The value of this form control is used to set that of the MaskedTextBox",
+ *              name: "text"
+ *           }
+ *        },
+ *        {
+ *           name: "alfresco/forms/controls/MaskingTextBox",
+ *           config: {
+ *              fieldId: "MASKEDTEXTBOX",
+ *              targetId: "TEXTBOX",
+ *              label: "Resulting value",
+ *              description: "This value will be automatically set from the value of the other TextBox",
+ *              name: "maskedText",
+ *              mask: "[^0-9a-zA-Z\-\s]",
+ *              trim: true,
+ *              toLowerCase: true
+ *           }
+ *        }
+ *     ]
+ *   }
+ * } 
+ * 
+ * @module alfresco/forms/controls/MaskingTextBox
+ * @extends module:alfresco/forms/controls/TextBox
+ * @author Dave Draper
+ * @since 1.0.60
+ */
+define(["dojo/_base/declare",
+        "alfresco/forms/controls/TextBox",
+        "dojo/_base/lang"], 
+        function(declare, TextBox, lang) {
+   
+   return declare([TextBox], {
+      
+      /**
+       * A Regular Expression of the characters to remove from the target value.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      mask: null,
+
+      /**
+       * Indicates whether or not the masked value should be converted to lower case.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      toLowerCase: true,
+
+      /**
+       * Indicates whether or not the masked value should have whitespace removed from the beginning and end
+       * of the value.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      trim: true,
+
+      /**
+       * This is the [fieldId]{@link module:alfresco/forms/controls/BaseFormControl#fieldId} of another control
+       * in the form that this form control should use to seed its value from.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      targetId: null,
+
+      /**
+       * A Regular Expression compiled from [mask]{@link module:alfresco/forms/controls/MaskingTextBox#mask}}
+       * 
+       * @instance
+       * @type {RegExp}
+       * @default
+       */
+      _maskRe: null,
+
+      /**
+       * This will be assigned a handle for the value change subscription created by
+       * [postCreate]{@link module:alfresco/forms/controls/MaskingTextBox#postCreate}. The subscription 
+       * will be removed as soon as the user has manually changed the value.
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       */
+      _maskUpdateSubscription: null,
+
+      /**
+       * This extends the [inherited function]{@link module:alfresco/forms/controls/utilities/TextBoxValueChangeMixin#handleKeyUp}
+       * to remove the [_maskUpdateSubscription]{@link module:alfresco/forms/controls/MaskingTextBox#_maskUpdateSubscription}
+       * when the user manually edits the field.
+       *
+       * @instance
+       * @param  {object} evt The keyup event
+       */
+      handleKeyUp: function alfresco_forms_controls_TextBox__handleKeyUp(/*jshint unused:false*/ evt) {
+         this.inherited(arguments);
+         if (this._maskUpdateSubscription)
+         {
+            this.alfUnsubscribe(this._maskUpdateSubscription);
+            this._maskUpdateSubscription = null;
+         }
+      },
+
+      /**
+       * This extends the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#postCreate}
+       * to create a subscription for the changing value of the form control with the 
+       * [fieldId]{@link module:alfresco/forms/controls/BaseFormControl#fieldId} of the configured
+       * [targetId]{@link module:alfresco/forms/controls/MaskingTextBox#targetId}.
+       * 
+       * @return {[type]} [description]
+       */
+      postCreate: function alfresco_forms_controls_MaskingTextBox__postCreate() {
+         this.inherited(arguments);
+         if (this.mask)
+         {
+            this._maskRe = new RegExp(this.mask, "g");
+         }
+         this._maskUpdateSubscription = this.alfSubscribe("_valueChangeOf_" + this.targetId, lang.hitch(this, this.setMaskedValue));
+      },
+
+      /**
+       *
+       * @instance
+       * @param {object} payload The payload containing the details of the updated value
+       */
+      setMaskedValue: function alfresco_forms_controls_MaskingTextBox__setMaskedValue(payload) {
+         if (payload && 
+             typeof payload.value !== "undefined" && 
+             typeof payload.value.toString === "function")
+         {
+            var maskedValue = payload.value.toString();
+            if (this._maskRe)
+            {
+               maskedValue = maskedValue.replace(this._maskRe, "");
+            }
+            if (this.toLowerCase)
+            {
+               maskedValue = maskedValue.toLowerCase();
+            }
+            if (this.trim)
+            {
+               maskedValue = lang.trim(maskedValue);
+            }
+            this.setValue(maskedValue);
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/forms/controls/MaskingTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MaskingTextBox.js
@@ -87,7 +87,7 @@ define(["dojo/_base/declare",
        * 
        * @typedef {Replacement}
        * @property {string} regex A Regular Expression to match characters in the text that should be replaced
-       * @property {string} [flags="g"] Flags to apply to the Regular Expression (defaults to "g" for global replacement)
+       * @property {string} [flags=""] Flags to apply to the Regular Expression (defaults to "g" for global replacement)
        * @property {string} [replacement=""] The text to replace the matched characters with
        */
       
@@ -174,7 +174,7 @@ define(["dojo/_base/declare",
                {
                   try
                   {
-                     var re = new RegExp(replacement.regex, replacement.flags || "g");
+                     var re = new RegExp(replacement.regex, replacement.flags || "");
                      replacement._re = re;
                   }
                   catch(e)

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1179,9 +1179,11 @@ define(["dojo/_base/declare",
          },
          {
             id: "CREATE_SITE_FIELD_SHORTNAME",
-            name: "alfresco/forms/controls/TextBox",
+            name: "alfresco/forms/controls/MaskingTextBox",
             config: {
                fieldId: "SHORTNAME",
+               mask: "[^0-9a-zA-Z\-\s]",
+               targetId: "TITLE",
                label: "create-site.dialog.urlname.label",
                description: "create-site.dialog.urlname.description",
                name: "shortName",

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1190,7 +1190,8 @@ define(["dojo/_base/declare",
                   },
                   {
                      regex: "\\s+",
-                     replacement: "-"
+                     replacement: "-",
+                     flags: "g"
                   }
                ],
                label: "create-site.dialog.urlname.label",

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1182,8 +1182,17 @@ define(["dojo/_base/declare",
             name: "alfresco/forms/controls/MaskingTextBox",
             config: {
                fieldId: "SHORTNAME",
-               mask: "[^0-9a-zA-Z\-\s]",
                targetId: "TITLE",
+               replacements: [
+                  {
+                     regex: "[^a-z0-9\\-\\s]",
+                     flags: "gi"
+                  },
+                  {
+                     regex: "\\s+",
+                     replacement: "-"
+                  }
+               ],
                label: "create-site.dialog.urlname.label",
                description: "create-site.dialog.urlname.description",
                name: "shortName",

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1185,7 +1185,7 @@ define(["dojo/_base/declare",
                targetId: "TITLE",
                replacements: [
                   {
-                     regex: "[^a-z0-9\\-\\s]",
+                     regex: "[^a-z0-9-\\s]",
                      flags: "gi"
                   },
                   {

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -27,6 +27,29 @@ define(["alfresco/TestCommon",
         "intern/chai!assert"], 
         function(TestCommon, registerSuite, assert) {
 
+   var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+
+   var selectors = {
+      buttons: {
+         createSite: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_SITE"])
+      },
+      dialogs: {
+         createSite: {
+            visible: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["CREATE_SITE_DIALOG"])
+         }
+      },
+      textBoxes: {
+         createSiteTitle: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["CREATE_SITE_FIELD_TITLE"])
+         },
+         createSiteShortName: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["CREATE_SITE_FIELD_SHORTNAME"])
+         }
+      }
+   };
+
    registerSuite(function() {
       var browser;
 
@@ -42,21 +65,47 @@ define(["alfresco/TestCommon",
             browser.end();
          },
 
-         "Create site (duplicate shortName)": function() {
+         "Create site (shortName set from title)": function() {
             return browser.setFindTimeout(5000)
 
-            .findById("CREATE_SITE_label")
+            .findByCssSelector(selectors.buttons.createSite)
                .click()
             .end()
 
-            .findDisplayedById("CREATE_SITE_DIALOG")
+            .findByCssSelector(selectors.dialogs.createSite.visible)
             .end()
 
-            .findByCssSelector("#CREATE_SITE_DIALOG #CREATE_SITE_FIELD_TITLE .dijitInputContainer input")
+            .findByCssSelector(selectors.textBoxes.createSiteTitle.input)
+               .type(" has*odd & chars")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.createSiteShortName.input)
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value,"hasoddchars");
+               });
+         },
+
+         "Create Site (edit shortName stops auto updating)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.createSiteShortName.input)
+               .clearValue()
                .type("fail")
             .end()
 
-            .findByCssSelector("#CREATE_SITE_DIALOG #CREATE_SITE_FIELD_SHORTNAME .dijitInputContainer input")
+            .findByCssSelector(selectors.textBoxes.createSiteTitle.input)
+               .type("no copying now")
+            .end()
+
+            .findByCssSelector(selectors.textBoxes.createSiteShortName.input)
+               .getProperty("value")
+               .then(function(value) {
+                  assert.equal(value,"fail");
+               });
+         },
+
+         "Create site (duplicate shortName)": function() {
+            return browser.findByCssSelector(selectors.textBoxes.createSiteTitle.input)
+               .clearValue()
                .type("fail")
             .end()
 

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -82,7 +82,7 @@ define(["alfresco/TestCommon",
             .findByCssSelector(selectors.textBoxes.createSiteShortName.input)
                .getProperty("value")
                .then(function(value) {
-                  assert.equal(value,"hasoddchars");
+                  assert.equal(value,"hasodd-chars");
                });
          },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-888 to add a new form control (alfresco/forms/controls/MaskingTextBox) that is used by the SiteService for the purpose of generating a valid site shortName from the entered title. The unit tests have been updated to verify the behaviour and a new Sandpit page has been provided.