### PR TITLE
AKU-869: Update process function order to prevent errors

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NodePreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/NodePreviewService.js
@@ -286,7 +286,7 @@ define(["dojo/_base/declare",
             // Use a custom payload for displaying the preview.
             publishPayload = lang.clone(this.publishPayload);
             this.currentItem = previewData.item;
-            this.processObject(["setCurrentItem","processCurrentItemTokens"], publishPayload);
+            this.processObject(["processCurrentItemTokens","setCurrentItem"], publishPayload);
             this.alfServicePublish(this.publishTopic, publishPayload);
          }
          else


### PR DESCRIPTION
This PR is a minor tweak to #923 in relating to https://issues.alfresco.com/jira/browse/AKU-869 to prevent errors when processing currentItem tokens **after** setting the currentItem for custom previewing via the NodePreviewService