### PR TITLE
AKU-895: AlfBreadcrumbTrail doesn't reflect hash on load

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -740,7 +740,7 @@ define([],function() {
        * @default
        * @since 1.0.35
        *
-       * @event module:alfresco/core/topics~NAVIGATE_TO_PAGE
+       * @event
        * @property {string} url The URL to navigate to
        * @property {string} [type=PAGE_RELATIVE] The [type of navigation]{@link module:alfresco/enums/urlTypes}
        * @property {string} [target=CURRENT] Whether to use the "CURRENT" tab, open in a "NEW" tab, or use a "NAMED" tab

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -21,7 +21,7 @@
  * <p>This widget can be used to render breadcrumb trails. It can be used either to render a fixed set of breadcrumbs (e.g.
  * where you might want to render some information about a fixed location of a page) or it can be used to render path
  * based data. When rendering path based data it is possible to get the path from the
- * [browser URL hash]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#useHash} of from explicitly configured
+ * [browser URL hash]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#useHash} or from explicitly configured
  * [path publishing topics]{@link module:alfresco/documentlibrary/AlfBreadcrumbTrail#pathChangeTopic}. When rendering
  * a path based breadcrumb trail it is expected that the last item in the trail  represents the
  * current location and clicking it can either navigate the user to another page (in which case you should set the
@@ -52,12 +52,13 @@ define(["dojo/_base/declare",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/documentlibrary/AlfBreadcrumb",
+        "alfresco/util/hashUtils",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class"], 
         function(declare, _WidgetBase, _TemplatedMixin, template,  AlfCore, CoreWidgetProcessing, _AlfDocumentListTopicMixin, 
-                 _PublishPayloadMixin, AlfBreadcrumb, lang, array, domConstruct, domClass) {
+                 _PublishPayloadMixin, AlfBreadcrumb, hashUtils, lang, array, domConstruct, domClass) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, _PublishPayloadMixin, _AlfDocumentListTopicMixin], {
       
@@ -268,20 +269,21 @@ define(["dojo/_base/declare",
                this.alfSubscribe(this.metadataChangeTopic, lang.hitch(this, this.onCurrentNodeChange));
             }
 
+            if (this.currentPath)
+            {
+               this.renderPathBreadcrumbTrail();
+            }
             if (this.useHash === true)
             {
                // Subscribe using the widgets own scope (don't assume global) because the topic published
                // will in practice be published at a share scope (i.e. when used in the context of a 
                // scoped Document Library the hash change publication will be scoped, not global)...
-               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onPathChanged));
+               this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.onHashChanged));
+               this.onHashChanged(hashUtils.getHash());
             }
             else if (this.pathChangeTopic)
             {
                this.alfSubscribe(this.pathChangeTopic, lang.hitch(this, this.onPathChanged));
-            }
-            if (this.currentPath)
-            {
-               this.renderPathBreadcrumbTrail();
             }
          }
       },
@@ -321,6 +323,21 @@ define(["dojo/_base/declare",
             this.alfLog("error", "A request was made to update the current NodeRef, but no 'node' property was provided in the payload: ", payload);
          }
       },
+
+      /**
+       * Handle hash-change events
+       *
+       * @instance
+       * @param {object} newHash The new hash value
+       * @since 1.0.60
+       */
+      onHashChanged: function alfresco_documentlibrary_AlfBreadcrumbTrail__onHashChanged(newHash) {
+         if (newHash.path) {
+            this.onPathChanged(newHash);
+         } else if (newHash.filter && newHash.description) {
+            this.onFilterSelection(newHash);
+         }
+      },
       
       /**
        * This handles publications on the [hashChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#hashChangeTopic}
@@ -338,6 +355,12 @@ define(["dojo/_base/declare",
             this._filterDisplayed = false;
             this.currentPath = payload.path;
             this.renderPathBreadcrumbTrail();
+            if(this.useHash === true) {
+               hashUtils.updateHash({
+                  description: null
+               }, true)
+            }
+
          }
       },
      
@@ -489,6 +512,13 @@ define(["dojo/_base/declare",
             this.renderBreadcrumb({
                label: payload.description
             });
+            if(this.useHash === true) {
+               if(!hashUtils.getHash().description) {
+                  hashUtils.updateHash({
+                     description: payload.description
+                  }, true);
+               }
+            }
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/util/urlUtils.js
+++ b/aikau/src/main/resources/alfresco/util/urlUtils.js
@@ -119,7 +119,7 @@ define(["alfresco/enums/urlTypes",
          convertUrl: function alfresco_util_urlUtils__convertUrl(url, urlType) {
             var convertedUrl = url,
                falsyUrlTypeFallback = "FALSY_URL_TYPE_SUPPLIED";
-            if (url) {
+            if (url || urlType === urlTypes.HASH) {
                switch (urlType || falsyUrlTypeFallback) {
 
                   case urlTypes.SHARE_PAGE_RELATIVE:
@@ -157,7 +157,7 @@ define(["alfresco/enums/urlTypes",
                   case urlTypes.HASH:
                      // A hash path
                      // Ensure there is no leading hash
-                     convertedUrl = url.replace(/^#+/, "");
+                     convertedUrl = (url || "").replace(/^#+/, "");
                      break;
 
                   default:

--- a/aikau/src/test/resources/alfresco/forms/controls/SitePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SitePickerTest.js
@@ -50,8 +50,11 @@ define(["intern!object",
                .end()
 
             .findByCssSelector(".dijitMenuItem[aria-label^=\"Recent Sites\"]")
+               .clearLog()
                .click()
                .end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
             .findByCssSelector(".alfresco-lists-AlfList tr:nth-child(2) .alfresco-renderers-PublishAction")
                .click()
@@ -86,8 +89,11 @@ define(["intern!object",
                .end()
 
             .findByCssSelector(".dijitMenuItem[aria-label^=\"Favorite Sites\"]")
+               .clearLog()
                .click()
                .end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
             .findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) .alfresco-renderers-PublishAction")
                .click()

--- a/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
+++ b/aikau/src/test/resources/alfresco/upload/UploadMonitorTest.js
@@ -55,7 +55,7 @@ define(["intern!object",
 
                .execute(getTextContent, [".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title"])
                   .then(function(text) {
-                     assert.equal(text, "The file ''This file is empty.txt'' couldn't be be uploaded for the following reason. 0kb files can't be uploaded");
+                     assert.equal(text, "The file ''This file is empty.txt'' couldn't be uploaded for the following reason. 0kb files can't be uploaded");
                   })
                .end()
 
@@ -182,7 +182,7 @@ define(["intern!object",
 
             .execute(getTextContent, [".alfresco-upload-UploadMonitor__item__status__unsuccessful_icon svg title"])
                .then(function(text) {
-                  assert.equal(text, "The file ''Tiny dataset.csv'' couldn't be be uploaded for the following reason. The upload was cancelled");
+                  assert.equal(text, "The file ''Tiny dataset.csv'' couldn't be uploaded for the following reason. The upload was cancelled");
                })
             .end()
 


### PR DESCRIPTION
This addresses issue [AKU-895](https://issues.alfresco.com/jira/browse/AKU-895) by ensuring that, when loaded, `AlfBreadcrumbTrail` will read the hash and apply it. It also adds hash support for filters as opposed to just paths. Tests have been added and a full test suite run successfully. Additionally, a minor bug in `urlUtils` has been fixed.