### PR TITLE
AKU-885: Ensure correct Accept-Language header on IE

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -178,7 +178,7 @@
          <resource>
             <!-- WebScripts go into their own package -->
             <targetPath>./alfresco/site-webscripts/org/alfresco/aikau</targetPath>
-            <filtering>false</filtering>
+            <filtering>true</filtering>
             <directory>${basedir}/src/main/resources/webscripts</directory>
          </resource>
 
@@ -216,6 +216,32 @@
       </testResources>
 
       <plugins>
+
+         <!-- See AKU-845 - This plugin has been brought in to create a property that is the project
+              version with all "." characters replaced with "-" characters. The reason that this is 
+              required is that we want to defined version specific WebScript URLs, but for some reason
+              (most likely in Surf) the RequestDispatcher fails to map URLs containing more than
+              one "." character - this means that the Aikau version cannot be used without modification -->
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>1.10</version>
+            <executions>
+               <execution>
+                  <id>regex-property</id>
+                  <goals>
+                     <goal>regex-property</goal>
+                  </goals>
+                  <configuration>
+                     <name>webscript.version</name>
+                     <value>${project.version}</value>
+                     <regex>\.</regex>
+                     <replacement>-</replacement>
+                     <failIfNoMatch>false</failIfNoMatch>
+                  </configuration>
+             </execution>
+           </executions>
+         </plugin>
 
          <plugin>
             <artifactId>maven-antrun-plugin</artifactId>

--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -431,12 +431,18 @@ define(["dojo/_base/declare",
          if (languages) 
          {
             languages = array.map(languages, function(nextLang) {
-               return nextLang.toLowerCase();
+               return nextLang;
             }).join(", ");
          } 
          else 
          {
             languages = webScriptDefaults.ACCEPT_LANGUAGE;
+         }
+
+         // Last resort... if for any reason the webscriptDefaults hasn't worked.
+         if (!languages)
+         {
+            languages = (navigator.language || navigator.userLanguage);
          }
 
          // Construct and return the headers

--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -27,6 +27,7 @@
  */
 define(["dojo/_base/declare",
         "service/constants/Default",
+        "webscripts/defaults",
         "dijit/registry",
         "dojo/topic",
         "dojo/_base/array",
@@ -37,7 +38,7 @@ define(["dojo/_base/declare",
         "dojo/json",
         "dojo/date/stamp",
         "dojo/cookie"],
-        function(declare, AlfConstants, registry, pubSub, array, lang, domConstruct, uuid, xhr, JSON, stamp, dojoCookie) {
+        function(declare, AlfConstants, webScriptDefaults, registry, pubSub, array, lang, domConstruct, uuid, xhr, JSON, stamp, dojoCookie) {
 
    return declare(null, {
 
@@ -427,12 +428,15 @@ define(["dojo/_base/declare",
 
          // Build up the Accept-Language header value
          var languages = navigator.languages;
-         if (languages) {
+         if (languages) 
+         {
             languages = array.map(languages, function(nextLang) {
                return nextLang.toLowerCase();
             }).join(", ");
-         } else {
-            languages = (navigator.language || navigator.userLanguage).toLowerCase();
+         } 
+         else 
+         {
+            languages = webScriptDefaults.ACCEPT_LANGUAGE;
          }
 
          // Construct and return the headers

--- a/aikau/src/main/resources/extension-module/aikau-extension.xml
+++ b/aikau/src/main/resources/extension-module/aikau-extension.xml
@@ -17,6 +17,7 @@
                      <base-url>/res/</base-url>
                      <default-less-configuration>/js/aikau/${project.version}/alfresco/css/less/defaults.less</default-less-configuration><messages-object>Alfresco</messages-object>
                      <packages>
+                        <package name="webscripts"    location="../service/${webscript.version}" />
                         <package name="service"       location="../service"/>
                         <package name="dojo"          location="js/lib/dojo-${dependency.dojo.version}/dojo"/>
                         <package name="dijit"         location="js/lib/dojo-${dependency.dojo.version}/dijit"/>

--- a/aikau/src/main/resources/webscripts/defaults.get.desc.xml
+++ b/aikau/src/main/resources/webscripts/defaults.get.desc.xml
@@ -1,0 +1,8 @@
+<webscript>
+  <shortname>Defaults</shortname>
+  <description>This WebScript is used to represent an AMD module that provides server-side constants</description>
+  <url>/${webscript.version}/defaults</url>
+  <family>WebScript-Generated-AMD-Modules</family>
+  <format default="js">extension</format>
+  <authentication>none</authentication>
+</webscript>

--- a/aikau/src/main/resources/webscripts/defaults.get.js
+++ b/aikau/src/main/resources/webscripts/defaults.get.js
@@ -1,0 +1,6 @@
+/* global model, Request */
+model.data = {
+   headers: {
+      acceptLanguage: Request.getRequest().getHeader("Accept-Language")
+   }
+};

--- a/aikau/src/main/resources/webscripts/defaults.get.js.ftl
+++ b/aikau/src/main/resources/webscripts/defaults.get.js.ftl
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2005-2013 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * @module webscripts/defaults
+ * @author Dave Draper
+ */
+define(["dojo/_base/lang"], 
+        function(lang) {
+   
+   return {
+      ACCEPT_LANGUAGE: "${data.headers.acceptLanguage!""}"
+   };
+});


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-885 (and #908) to ensure that the Accept-Language header is set for Internet Explorer. No unit tests have been added (because we don't yet have IE testing running automatically yet), but manual testing has been carried out against BrowserStack.