### PR TITLE
AKU-879: Improve DND upload overlay positioning

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -581,6 +581,7 @@ define(["dojo/_base/declare",
        * @since 1.0.42
        */
       setDndHighlightDimensions: function alfresco_documentlibrary__AlfDndDocumentUploadMixin__setDndHighlightDimensions() {
+         // jshint maxstatements:false
          var computedStyle = domStyle.getComputedStyle(this.dragAndDropNode);
          var dndNodeDimensions = domGeom.getMarginBox(this.dragAndDropNode, computedStyle);
          var dndNodePosition = domGeom.position(this.dragAndDropNode);
@@ -632,24 +633,39 @@ define(["dojo/_base/declare",
             {
                // Top of drop target is below the top of scroll area
                top = dndNodeBoundingRect.top;
+
+               if (dndNodeBoundingRect.bottom >= scrollAreaBoundingRect.bottom)
+               {
+                  // ...the bottom of the drop target is BELOW that of the scroll area... this means
+                  // that we just need to place the overlay over the ENTIRE scroll area...
+                  height = scrollAreaBoundingRect.bottom - dndNodeBoundingRect.top;
+               }
+               else
+               {
+                  // ...the bottom of the drop target is ABOVE that of the scroll area, this means
+                  // that we shouldn't overlay all the way to the bottom of the scroll area...
+                  height = dndNodeBoundingRect.bottom - dndNodeBoundingRect.top;
+               }
             }
             else
             {
                // Top of drop target is above the top of the scroll area (this implies that it has been scrolled)...
                top = scrollAreaBoundingRect.top;
+
+               if (dndNodeBoundingRect.bottom >= scrollAreaBoundingRect.bottom)
+               {
+                  // ...the bottom of the drop target is BELOW that of the scroll area... this means
+                  // that we just need to place the overlay over the ENTIRE scroll area...
+                  height = scrollAreaBoundingRect.bottom - scrollAreaBoundingRect.top;
+               }
+               else
+               {
+                  // ...the bottom of the drop target is ABOVE that of the scroll area, this means
+                  // that we shouldn't overlay all the way to the bottom of the scroll area...
+                  height = dndNodeBoundingRect.bottom - scrollAreaBoundingRect.top;
+               }
             }
-            if (dndNodeBoundingRect.bottom >= scrollAreaBoundingRect.bottom)
-            {
-               // ...the bottom of the drop target is BELOW that of the scroll area... this means
-               // that we just need to place the overlay over the ENTIRE scroll area...
-               height = scrollAreaBoundingRect.bottom - scrollAreaBoundingRect.top;
-            }
-            else
-            {
-               // ...the bottom of the drop target is ABOVE that of the scroll area, this means
-               // that we shouldn't overlay all the way to the bottom of the scroll area...
-               height = dndNodeBoundingRect.bottom - scrollAreaBoundingRect.top;
-            }
+            
          }
 
          domStyle.set(this.dragAndDropOverlayNode, {
@@ -666,7 +682,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @returns {element} The DOM element that is the scroll parent with scroll bars displayed
-       * @since 1.0.53
+       * @since 1.0.60
        */
       findScrollParent: function alfresco_documentlibrary__AlfDndDocumentUploadMixin__findScrollParent(domNode) {
          var scrollParent = $(domNode).scrollParent();

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -594,10 +594,10 @@ define(["dojo/_base/declare",
             var howFarScrolled = $(window).scrollTop();
             var heightOfDndNode = dndNodeDimensions.h;
             var whereDoesDndNodeStart = $(this.dragAndDropNode).offset().top;
-            if (howFarScrolled > whereDoesDndNodeStart)
+            if (howFarScrolled >= whereDoesDndNodeStart)
             {
                // We've scrolled beyond the start of the node. Therefore we need to start below the of the node
-               if (howFarScrolled > whereDoesDndNodeStart + heightOfDndNode)
+               if (howFarScrolled >= whereDoesDndNodeStart + heightOfDndNode)
                {
                   // but we've scrolled past the end of the node so there will be nothing to display
                   top = 0;
@@ -617,8 +617,28 @@ define(["dojo/_base/declare",
                   }
                   else
                   {
-                     height = clientHeight;
+                     height = clientHeight - top;
                   }
+               }
+            }
+            else
+            {
+               // We haven't scrolled beyond the start of the node (in fact we might not have scrolled at all)...
+               // Initially set the top to be how far we've scrolled, but correct if it is before the start of the node
+               top = howFarScrolled;
+               if (top < whereDoesDndNodeStart)
+               {
+                  top = whereDoesDndNodeStart;
+               }
+
+               // Work out the height based on the available space...
+               if (heightOfDndNode - top > clientHeight)
+               {
+                  height = clientHeight;
+               }
+               else
+               {
+                  height = heightOfDndNode - howFarScrolled;
                }
             }
          }
@@ -633,7 +653,6 @@ define(["dojo/_base/declare",
             {
                // Top of drop target is below the top of scroll area
                top = dndNodeBoundingRect.top;
-
                if (dndNodeBoundingRect.bottom >= scrollAreaBoundingRect.bottom)
                {
                   // ...the bottom of the drop target is BELOW that of the scroll area... this means

--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDndDocumentUploadMixin.js
@@ -617,7 +617,7 @@ define(["dojo/_base/declare",
                   }
                   else
                   {
-                     height = clientHeight - top;
+                     height = clientHeight;
                   }
                }
             }
@@ -634,11 +634,18 @@ define(["dojo/_base/declare",
                // Work out the height based on the available space...
                if (heightOfDndNode - top > clientHeight)
                {
-                  height = clientHeight;
+                  if (howFarScrolled === 0)
+                  {
+                     height = clientHeight - whereDoesDndNodeStart;
+                  }
+                  else
+                  {
+                     height = clientHeight;
+                  }
                }
                else
                {
-                  height = heightOfDndNode - howFarScrolled;
+                  height = clientHeight - howFarScrolled;
                }
             }
          }

--- a/aikau/src/main/resources/alfresco/documentlibrary/css/_AlfDndDocumentUploadMixin.css
+++ b/aikau/src/main/resources/alfresco/documentlibrary/css/_AlfDndDocumentUploadMixin.css
@@ -6,6 +6,7 @@
 }
 
 .alfresco-documentlibrary-_AlfDndDocumentUploadMixin__overlay {
+   box-sizing: border-box;
    display: none;
    opacity: @upload-highlight-overlay-opacity;
    position: absolute;

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -435,7 +435,7 @@ function getDocumentLibraryServices() {
       },
       {
          id: "UPLOAD_SERVICE",
-         name:  "alfresco/services/UploadService"
+         name:  "alfresco/services/FileUploadService"
       },
       {
          id: "CREATE_TEMPLATED_CONTENT_SERVICE",

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -435,7 +435,7 @@ function getDocumentLibraryServices() {
       },
       {
          id: "UPLOAD_SERVICE",
-         name:  "alfresco/services/FileUploadService"
+         name:  "alfresco/services/UploadService"
       },
       {
          id: "CREATE_TEMPLATED_CONTENT_SERVICE",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Document Library Example (lots of data)</shortname>
+  <description>This provides an example of building the standard Document Library using the doclib.lib.js library file.</description>
+  <family>aikau-unit-tests</family>
+  <url>/DocLibBigData</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.js
@@ -1,0 +1,66 @@
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/service-filtering.lib.js">
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+
+var pageServices = [
+   {
+      name: "alfresco/services/LoggingService",
+      config: {
+         loggingPreferences: {
+            enabled: true,
+            all: true
+         }
+      }
+   },
+   "alfresco/services/NavigationService",
+   "alfresco/services/LogoutService"];
+
+var docLibServices = getDocumentLibraryServices();
+var services = alfAddUniqueServices(pageServices, docLibServices);
+
+var docLib = getDocLib({
+   siteId: null, 
+   containerId: null, 
+   rootNode: "alfresco://company/home", 
+   rootLabel: "Documents",
+   getUserPreferences: false
+});
+docLib.config.pubSubScope = "SCOPED_";
+
+model.jsonModel = {
+   services: services,
+   widgets: [
+      // docLib,
+      {
+         name: "alfresco/layout/FixedHeaderFooter",
+         config: {
+            widgetsForHeader: [
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Bob"
+                  }
+               }
+            ],
+            widgets: [docLib],
+            widgetsForFooter: [
+               {
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Bob"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/testing/NodesMockXhr",
+         config: {
+            totalItems: 40,
+            folderRatio: [100]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.js
@@ -1,6 +1,14 @@
 <import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/service-filtering.lib.js">
 <import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
 
+/* global page */
+/* jshint sub:true */
+var full = true;
+if (page.url.args["full"])
+{
+   full = page.url.args["full"] === "true";
+}
+
 var pageServices = [
    {
       name: "alfresco/services/LoggingService",
@@ -26,32 +34,36 @@ var docLib = getDocLib({
 });
 docLib.config.pubSubScope = "SCOPED_";
 
+if (!full)
+{
+   docLib = {
+      name: "alfresco/layout/FixedHeaderFooter",
+      config: {
+         widgetsForHeader: [
+            {
+               name: "alfresco/html/Spacer",
+               config: {
+                  height: "50px"
+               }
+            }
+         ],
+         widgets: [docLib],
+         widgetsForFooter: [
+            {
+               name: "alfresco/html/Spacer",
+               config: {
+                  height: "50px"
+               }
+            }
+         ]
+      }
+   };
+}
+
 model.jsonModel = {
    services: services,
    widgets: [
-      // docLib,
-      {
-         name: "alfresco/layout/FixedHeaderFooter",
-         config: {
-            widgetsForHeader: [
-               {
-                  name: "alfresco/buttons/AlfButton",
-                  config: {
-                     label: "Bob"
-                  }
-               }
-            ],
-            widgets: [docLib],
-            widgetsForFooter: [
-               {
-                  name: "alfresco/buttons/AlfButton",
-                  config: {
-                     label: "Bob"
-                  }
-               }
-            ]
-         }
-      },
+      docLib,
       {
          name: "alfresco/testing/NodesMockXhr",
          config: {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.properties
@@ -1,0 +1,1 @@
+surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-879 to improve the way in which drag and drop upload overlays are handled. The position and dimensions of the overlay are now controlled so that the overlay is constrained to within the view port.

It's not possible automate unit tests for this, however a new unit test page has been provided to manually verify all the various scroll states with both full window scrolling and nested element scrolling.