### PR TITLE
AKU-890: Uploads do not work correctly in Safari

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -336,11 +336,13 @@
 @upload-monitor-progress-column-width: 50px;
 @upload-monitor-status-column-width: 150px;
 @upload-monitor-status-color-inprogress: #ccc;
+@upload-monitor-status-color-finishing: #ccc;
 @upload-monitor-status-color-successful: #090;
 @upload-monitor-status-color-unsuccessful: #c00;
 @upload-monitor-progress-bar-height: 2px;
 @upload-monitor-progress-bar-background: #6bf;
 @upload-monitor-progress-bar-box-shadow: 0 0 2px 1px #dff;
+@upload-monitor-progress-bar-finishing-background: #0b0;
 
 // Filters
 @filter-hover-color: @list-hover-color;

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -770,6 +770,7 @@ define(["alfresco/core/CoreXhr",
             // successfully, if this occurs then we'll attach a function to the onreadystatechange extension
             // point and things to catch up before we check everything was ok.
             if (fileInfo.request.readyState !== 4) {
+               this.uploadDisplayWidget.updateUploadProgress(fileId, 100);
                fileInfo.request.onreadystatechange = lang.hitch(this, function() {
                   if (fileInfo.request.readyState === 4) {
                      this.processUploadCompletion(fileId, evt);
@@ -841,8 +842,8 @@ define(["alfresco/core/CoreXhr",
       uploadProgressListener: function alfresco_services__BaseUploadService__uploadProgressListener(fileId, evt) {
          var fileInfo = this.fileStore[fileId];
          if (fileInfo && evt.lengthComputable) {
-            var progress = Math.round(evt.loaded / evt.total * 100);
-            this.uploadDisplayWidget.updateUploadProgress(fileId, progress, evt);
+            var progress = Math.min(Math.round(evt.loaded / evt.total * 100), 100);
+            this.uploadDisplayWidget.updateUploadProgress(fileId, progress);
             fileInfo.progress = progress;
             this.updateAggregateProgress();
          } else {

--- a/aikau/src/main/resources/alfresco/upload/AlfUploadDisplay.js
+++ b/aikau/src/main/resources/alfresco/upload/AlfUploadDisplay.js
@@ -233,9 +233,8 @@ define(["dojo/_base/declare",
        * @override
        * @param {string} fileId The unique id of the file
        * @param {number} percentageComplete The current upload progress as a percentage
-       * @param {object} progressEvt The progress event
        */
-      updateUploadProgress: function alfresco_upload_AlfUploadDisplay__updateUploadProgress(fileId, percentageComplete, /*jshint unused:false*/ progressEvt) {
+      updateUploadProgress: function alfresco_upload_AlfUploadDisplay__updateUploadProgress(fileId, percentageComplete) {
          // Set progress position
          // var left = (-400 + ((percentage/100) * 400));
          var inProgressFile = this.inProgressFiles[fileId];

--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -293,6 +293,10 @@ define(["alfresco/core/FileSizeMixin",
             textContent: this.message("upload.status.inprogress")
          }, itemStatus);
          domConstruct.create("span", {
+            className: this.baseClass + "__item__status__finishing",
+            textContent: this.message("upload.status.finishing")
+         }, itemStatus);
+         domConstruct.create("span", {
             className: this.baseClass + "__item__status__successful",
             textContent: this.message("upload.status.successful")
          }, itemStatus);
@@ -512,17 +516,19 @@ define(["alfresco/core/FileSizeMixin",
        * @override
        * @param {string} fileId The unique id of the file
        * @param {number} percentageComplete The current upload progress as a percentage
-       * @param {object} progressEvt The progress event
        */
-      updateUploadProgress: function alfesco_upload_UploadMonitor__updateUploadProgress(fileId, percentageComplete, /*jshint unused:false*/ progressEvt) {
+      updateUploadProgress: function alfesco_upload_UploadMonitor__updateUploadProgress(fileId, percentageComplete) {
          if (!this.displayUploadPercentage) {
             return;
          }
          var upload = this._uploads[fileId];
          if (upload) {
             if (!upload.completed) {
-               upload.nodes.progress.textContent = percentageComplete + "%";
                domStyle.set(upload.nodes.progressBar, "width", percentageComplete + "%");
+               upload.nodes.progress.textContent = percentageComplete + "%";
+               if (percentageComplete === 100) {
+                  domClass.add(upload.nodes.row, this.baseClass + "__item--finishing");
+               }
             }
          } else {
             this.alfLog("warn", "Attempt to update upload that is not being tracked (id=" + fileId + ")");

--- a/aikau/src/main/resources/alfresco/upload/UploadsDisplayInterface.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadsDisplayInterface.js
@@ -107,9 +107,8 @@ define(["dojo/_base/declare"], function(declare) {
        * @instance
        * @param {string} fileId The unique id of the file
        * @param {number} percentageComplete The current upload progress as a percentage
-       * @param {object} progressEvt The progress event
        */
-      updateUploadProgress: function alfresco_upload__UploadsDisplayMixin__updateUploadProgress(fileId, percentageComplete, progressEvt) {
+      updateUploadProgress: function alfresco_upload__UploadsDisplayMixin__updateUploadProgress(fileId, percentageComplete) {
          this.alfLog("error", "Method not overridden in implementing class");
       }
    });

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -33,11 +33,14 @@
       }
       &__status {
          width: @upload-monitor-status-column-width;
-         &__inprogress, &__successful, &__unsuccessful, &__unsuccessful_icon {
+         &__inprogress, &__finishing, &__successful, &__unsuccessful, &__unsuccessful_icon {
             display: none;
          }
          &__inprogress {
             color: @upload-monitor-status-color-inprogress;
+         }
+         &__finishing {
+            color: @upload-monitor-status-color-finishing;
          }
          &__successful {
             color: @upload-monitor-status-color-successful;
@@ -63,8 +66,8 @@
          background: @upload-monitor-progress-bar-background;
          box-shadow: @upload-monitor-progress-bar-box-shadow;
          height: @upload-monitor-progress-bar-height;
-         width: 0;
          transition: width .3s ease;
+         width: 0;
       }
    }
    &__inprogress-items {
@@ -75,6 +78,25 @@
             }
             &__action__inprogress {
                display: inline-block;
+            }
+            &--finishing {
+               .alfresco-upload-UploadMonitor {
+                  &__item__status {
+                     &__inprogress {
+                        display: none;
+                     }
+                     &__finishing {
+                        display: inline-block;
+                     }
+                  }
+               }
+               + tr {
+                  .alfresco-upload-UploadMonitor {
+                     &__item__progress-bar {
+                        background: @upload-monitor-progress-bar-finishing-background;
+                     }
+                  }
+               }
             }
          }
       }

--- a/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
+++ b/aikau/src/main/resources/alfresco/upload/i18n/UploadMonitor.properties
@@ -3,6 +3,7 @@ upload.status.successful=Successful
 upload.status.unsuccessful=Unsuccessful
 upload.failure.unknown-reason=Failed for unknown reason
 upload.cancelled=The upload was cancelled
+upload.status.finishing=Finishing...
 
 upload.failure.icon.title=The file ''{0}'' couldn't be uploaded for the following reason. {1}
 upload.failure.icon.description=A picture of a warning triangle.


### PR DESCRIPTION
This addresses issue [AKU-890](https://issues.alfresco.com/jira/browse/AKU-890) whereby uploads appear to hang in Safari. It appears that the cause is waiting for the readystatechange to update, so it only appears to be broken. The "fix" is to send a 100% progress update to the display widget when the "load" event is fired, and in UploadMonitor to display this as "finishing" rather than "in progress", to give indication that the upload has probably succeeded. No new tests added (the timing of it would be very complex), however all existing Upload regression tests work perfectly in all browsers on BrowserStack (IE11, Chrome, FF, Safari).