### PR TITLE
AKU-903: PublishAction click bubbling

### DIFF
--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -525,6 +525,7 @@ define(["alfresco/core/ObjectTypeUtils",
           *
           * @instance
           * @param {Event} evt Dojo-normalised event object
+          * @since 1.0.61
           */
          _onWidgetClick: function alfresco_logging_DebugLog___onWidgetClick(evt) {
             evt.stopPropagation();

--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -521,6 +521,16 @@ define(["alfresco/core/ObjectTypeUtils",
          },
 
          /**
+          * This top-level click handler is to prevent click events on the log bubbling back up to the document.
+          *
+          * @instance
+          * @param {Event} evt Dojo-normalised event object
+          */
+         _onWidgetClick: function alfresco_logging_DebugLog___onWidgetClick(evt) {
+            evt.stopPropagation();
+         },
+
+         /**
           * Split the terms in a filter string to create an array of filter values. Terms are
           * comma-separated. To include a comma in a search term, double it up (use ,,) and
           * it will be converted into a single comma after the terms have been split.

--- a/aikau/src/main/resources/alfresco/logging/templates/DebugLog.html
+++ b/aikau/src/main/resources/alfresco/logging/templates/DebugLog.html
@@ -1,4 +1,4 @@
-<div class="${rootClass}">
+<div class="${rootClass}" data-dojo-attach-event="click:_onWidgetClick">
 
    <!-- Title -->
    <h3 class="${rootClass}__header">Subscription Log</h3>

--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -123,9 +123,10 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} evt The click event object
        */
-      onClick: function alfresco_renderers_PublishAction__onClick(/*jshint unused:false*/ evt) {
+      onClick: function alfresco_renderers_PublishAction__onClick(evt) {
          this.publishPayload = this.getGeneratedPayload();
          this.alfPublish(this.publishTopic, this.publishPayload, !!this.publishGlobal, !!this.publishToParent);
+         evt.stopPropagation();
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/testing/MockXhr.js
+++ b/aikau/src/main/resources/alfresco/testing/MockXhr.js
@@ -280,6 +280,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {Event} evt Dojo-normalised event object
+       * @since 1.0.61
        */
       _onWidgetClick: function alfresco_logging_DebugLog___onWidgetClick(evt) {
          evt.stopPropagation();

--- a/aikau/src/main/resources/alfresco/testing/MockXhr.js
+++ b/aikau/src/main/resources/alfresco/testing/MockXhr.js
@@ -276,6 +276,16 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * This top-level click handler is to prevent click events on the log bubbling back up to the document.
+       *
+       * @instance
+       * @param {Event} evt Dojo-normalised event object
+       */
+      _onWidgetClick: function alfresco_logging_DebugLog___onWidgetClick(evt) {
+         evt.stopPropagation();
+      },
+
+      /**
        * Toggle the body visibility for the log
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/testing/templates/MockXhr.html
+++ b/aikau/src/main/resources/alfresco/testing/templates/MockXhr.html
@@ -1,4 +1,4 @@
-<div class="alfresco-testing-MockXhr" data-dojo-attach-point="containerNode">
+<div class="alfresco-testing-MockXhr" data-dojo-attach-point="containerNode" data-dojo-attach-event="click:_onWidgetClick">
    <table class="log">
       <caption>
          MockXhr Log

--- a/aikau/src/test/resources/alfresco/renderers/PublishActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishActionTest.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Martin Doyle
+ */
+define(["intern!object",
+      "intern/chai!assert",
+      "alfresco/TestCommon"], 
+      function(registerSuite, assert, TestCommon) {
+
+   registerSuite(function() {
+      var browser;
+
+      return {
+         name: "PublishAction Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/PublishAction", "PublishAction Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Validate initial page state": function() {
+            return browser.execute(function() {
+               return window.bodyClicked;
+            }).then(function(bodyClicked) {
+               assert.isFalse(bodyClicked);
+            });
+         },
+
+         "Clicking on action publishes correctly": function() {
+            return browser.findById("EDIT_ME")
+               .clearLog()
+               .click()
+            .end()
+
+            .getLastPublish("EDIT_ME")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "editMode", true);
+               });
+         },
+
+         "Action clicks do not bubble upwards": function() {
+            return browser.execute(function() {
+                  return window.bodyClicked;
+               })
+               .then(function(bodyClicked) {
+                  assert.isFalse(bodyClicked);
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -250,6 +250,7 @@ define({
       "src/test/resources/alfresco/renderers/ProgressTest",
       "src/test/resources/alfresco/renderers/PropertyLinkTest",
       "src/test/resources/alfresco/renderers/PropertyTest",
+      "src/test/resources/alfresco/renderers/PublishActionTest",
       "src/test/resources/alfresco/renderers/PublishingDropDownMenuTest",
       "src/test/resources/alfresco/renderers/PublishPayloadMixinOnActionsTest",
       "src/test/resources/alfresco/renderers/ReorderTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>PublishAction Test</shortname>
+  <description>This page exercises the PublishAction renderer</description>
+  <family>aikau-unit-tests</family>
+  <url>/PublishAction</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.html.ftl
@@ -1,0 +1,9 @@
+<script>
+   window.bodyClicked = false;
+   document.body.addEventListener("click", function() {
+      console.error("Body click was triggered!");
+      window.bodyClicked = true;
+   });
+</script>
+
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.js
@@ -1,0 +1,30 @@
+/*jshint maxlen:1000*/
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         name: "alfresco/renderers/PublishAction",
+         id: "EDIT_ME",
+         config: {
+            iconClass: "edit-16",
+            publishTopic: "EDIT_ME",
+            publishPayload: {
+               editMode: true
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This addresses issue [AKU-903](https://issues.alfresco.com/jira/browse/AKU-903) by preventing the click action from bubbling up. A test page has been created for the PublishAction widget.