### PR TITLE
AKU-757: Fix smart download for XHR metadata retrieval

### DIFF
--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -89,6 +89,18 @@ define(["dojo/_base/declare",
       downloadAPI: AlfConstants.PROXY_URI + "api/internal/downloads",
 
       /**
+       * This is a reference to an IFrame that gets created to handle download requests. An IFrame is required because
+       * it is possible that the full metadata for the node to download may need to be requested over an XHR request
+       * and the use of an IFrame prevents browser popup blocking occuring in this scenario. See AKU-757.
+       * 
+       * @instance
+       * @type {element}
+       * @default
+       * @since 1.0.61
+       */
+      downloadIFrame: null,
+
+      /**
        * Overrides the default setting for encoding URIs
        *
        * @instance
@@ -347,13 +359,18 @@ define(["dojo/_base/declare",
                contentURL = contentURL.substring(1);
             }
 
-            // NOTE: The key request parameter of "a=true" is important to ensure that a download rather than
-            //       a navigation occurs...
-            this.alfServicePublish(topics.NAVIGATE_TO_PAGE, {
-               url: AlfConstants.PROXY_URI + contentURL + "?a=true",
-               type: urlTypes.FULL_PATH,
-               target: "NEW"
-            });
+            if (this.downloadIFrame)
+            {
+               this.downloadIFrame.src = AlfConstants.PROXY_URI + contentURL + "?a=true";
+            }
+            else
+            {
+               this.downloadIFrame = domConstruct.create("iframe", {
+                  id: "ALF_DOCUMENT_SERVICE_DOWNLOAD_IFRAME",
+                  src: AlfConstants.PROXY_URI + contentURL + "?a=true",
+                  style: "display:none"
+               }, document.body);
+            }
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/services/DocumentServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DocumentServiceTest.js
@@ -45,11 +45,10 @@ define(["intern!object",
                .click()
             .end()
 
-            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
-               .then(function(payload) {
-                  assert.include(payload.url, 
-                                 "proxy/alfresco/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/2013-12-29%2009.58.43.jpg?a=true",
-                                 "Individual download request not detected");
+            .findByCssSelector("iframe#ALF_DOCUMENT_SERVICE_DOWNLOAD_IFRAME")
+               .getAttribute("src")
+               .then(function(src) {
+                  assert.include(src, "proxy/alfresco/slingshot/node/content/workspace/SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4/2013-12-29%2009.58.43.jpg?a=true");
                })
                .clearLog();
          },
@@ -68,11 +67,13 @@ define(["intern!object",
                .click()
             .end()
 
-            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
-               .then(function(payload) {
-                  assert.include(payload.url, 
-                                 "proxy/alfresco/slingshot/node/content/workspace/SpacesStore/26ae500c-91a9-496f-aca6-14101f985c28/PDF.pdf?a=true",
-                                 "Individual download request not detected");
+            .getLastPublish("ALF_DOWNLOAD_ON_NODE_RETRIEVAL_SUCCESS")
+            .clearLog()
+
+            .findByCssSelector("iframe#ALF_DOCUMENT_SERVICE_DOWNLOAD_IFRAME")
+               .getAttribute("src")
+               .then(function(src) {
+                  assert.include(src, "proxy/alfresco/slingshot/node/content/workspace/SpacesStore/26ae500c-91a9-496f-aca6-14101f985c28/PDF.pdf?a=true");
                })
                .clearLog();
          },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-757 to ensure that "smart" download works when it is necessary to retrieve the full metadata for a node before downloading. The change is to swap direct URL navigation to creating a re-usable IFrame for downloading to avoid browser popup blocking.