### PR TITLE
AKU-842: Ensure infinite scrolling DocLib can be sorted by menu

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -286,6 +286,10 @@ define(["dojo/_base/declare",
             }
             if (this._readyToLoad === true)
             {
+               if (this.useInfiniteScroll)
+               {
+                  this.clearViews();
+               }
                if (this.useHash === true)
                {
                   var currHash = hashUtils.getHash();

--- a/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
@@ -27,6 +27,9 @@ define(["intern!object",
 
    var rowSelectors = TestCommon.getTestSelectors("alfresco/lists/views/layouts/Row");
    var headerCellSelectors = TestCommon.getTestSelectors("alfresco/lists/views/layouts/HeaderCell");
+   var menuBarSelectSelectors = TestCommon.getTestSelectors("alfresco/menus/AlfMenuBarSelect");
+   var checkableMenuItemSelectors = TestCommon.getTestSelectors("alfresco/menus/AlfCheckableMenuItem");
+   
 
    var selectors = {
       rows: {
@@ -42,6 +45,13 @@ define(["intern!object",
             descending: TestCommon.getTestSelector(headerCellSelectors, "descending.indicator", ["TABLE_VIEW_NAME_HEADING"]),
             label: TestCommon.getTestSelector(headerCellSelectors, "label", ["TABLE_VIEW_NAME_HEADING"])
          }
+      },
+      sortMenu: {
+         label: TestCommon.getTestSelector(menuBarSelectSelectors, "label", ["DOCLIB_SORT_FIELD_SELECT"]),
+         popup: TestCommon.getTestSelector(menuBarSelectSelectors, "popup", ["DOCLIB_SORT_FIELD_SELECT"])
+      },
+      sortItems: {
+         fourth: TestCommon.getTestSelector(checkableMenuItemSelectors, "nth.item.label", ["DOCLIB_SORT_FIELD_SELECT_GROUP","4"])
       }
    };
 
@@ -105,6 +115,52 @@ define(["intern!object",
             .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
             .findDisplayedByCssSelector(selectors.headerCells.all.indicators);
+         },
+
+         "Post Coverage Results (1)": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
+   });
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "AlfDocumentList Sorting Tests (sort via menu)",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/InfiniteScrollDocumentList?includeSortMenu=true", "AlfDocumentList Sorting Tests (sort via menu)").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Sort via menu": function() {
+            // Open the sort menu...
+            return browser.findByCssSelector(selectors.sortMenu.label)
+               .click()
+            .end()
+
+            .clearLog()
+
+            // Wait for it to open...
+            .findDisplayedByCssSelector(selectors.sortMenu.popup)
+            .end()
+
+            // Click the fourth sort item...
+            .findDisplayedByCssSelector(selectors.sortItems.fourth)
+               .click()
+            .end()
+
+            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+            .findAllByCssSelector(selectors.rows.all)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 4);
+               });
          },
 
          "Post Coverage Results (1)": function() {

--- a/aikau/src/test/resources/test-selectors/alfresco/menus/AlfCheckableMenuItem.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/menus/AlfCheckableMenuItem.properties
@@ -10,3 +10,9 @@ item.icon=#{0} alfresco-menus-AlfCheckableMenuItem__icon
 # Menu item label
 item.label=#{0}_text
 
+# The nth checkable menu item in a group (the first argument is the GROUP id)
+nth.item=#{0} .alfresco-menus-AlfCheckableMenuItem:nth-child({1})
+
+# The label of the nth checkable menu item in a group (the first argument is the GROUP id)
+nth.item.label=#{0} .alfresco-menus-AlfCheckableMenuItem:nth-child({1}) td.dijitMenuItemLabel
+

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
@@ -1,3 +1,5 @@
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+
 /* global page */
 /* jshint sub:true */
 var useHash = true;
@@ -9,6 +11,12 @@ var useInfiniteScroll = true;
 if (page.url.args["useInfiniteScroll"])
 {
    useInfiniteScroll = page.url.args["useInfiniteScroll"] === "true";
+}
+
+var includeSortMenu = false;
+if (page.url.args["includeSortMenu"])
+{
+   includeSortMenu = page.url.args["includeSortMenu"] === "true";
 }
 
 model.jsonModel = {
@@ -32,7 +40,7 @@ model.jsonModel = {
       {
          name: "alfresco/html/Label",
          config: {
-            label: "Use ?useHash=false&useInfiniteScroll=false request parameters to disable infinite scroll and hashing"
+            label: "Use ?useHash=false&useInfiniteScroll=false&includeSortMenu=true request parameters to disable infinite scroll and hashing"
          }
       },
       {
@@ -62,3 +70,30 @@ model.jsonModel = {
       }
    ]
 };
+
+if (includeSortMenu)
+{
+   model.jsonModel.widgets.splice(1, 0, {
+      name: "alfresco/menus/AlfMenuBar",
+      config: {
+         widgets: [
+            {
+               id: "DOCLIB_SORT_FIELD_SELECT",
+               name: "alfresco/menus/AlfMenuBarSelect",
+               config: {
+                  selectionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+                  widgets: [
+                     {
+                        id: "DOCLIB_SORT_FIELD_SELECT_GROUP",
+                        name: "alfresco/menus/AlfMenuGroup",
+                        config: {
+                           widgets: getDocLibSortOptions({})
+                        }
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   });
+}

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.properties
@@ -1,0 +1,1 @@
+surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-842 to ensure that infinite scrolling document lists can be sorted via menus without duplicating the list contents.