### PR TITLE
AKU-908: Convert inline edit actions labels to buttons

### DIFF
--- a/aikau/.gitignore
+++ b/aikau/.gitignore
@@ -18,3 +18,4 @@
 /resources/vagrant/.vagrant/
 /src/test/resources/testApp/js/aikau/testing/RequireEverything.js
 /src/test/vagrant/.vagrant/
+alfresco.log.*

--- a/aikau/src/main/resources/alfresco/forms/css/Form.css
+++ b/aikau/src/main/resources/alfresco/forms/css/Form.css
@@ -6,4 +6,13 @@
    .alfresco-forms-Form__warnings--hidden {
       display: none;
    }
+
+   &--single-line {
+      >div {
+         display: inline-block;
+      }
+      >form {
+         display: inline-block;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditSelect.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditSelect.js
@@ -43,6 +43,7 @@ define(["dojo/_base/declare",
        */
       getPrimaryFormWidget: function alfresco_renderers_InlineEditSelect__getPrimaryFormWidget() {
          return {
+            id: this.id + "_SELECT",
             name: "alfresco/forms/controls/Select",
             config: {
                name: this.postParam,

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -34,19 +34,6 @@
          display: none;
       }
    }
-   .action {
-      color: @general-font-color;
-      cursor: pointer;
-      display: inline-block;
-      font-family: @standard-font;
-      font-size: @normal-font-size;
-      height: 85%;
-      vertical-align: middle;
-      &.disabled {
-         color: @de-emphasized-font-color;
-         cursor: default;
-      }
-   }
    > .editor {
       display: inline-block;
       height: 40px;

--- a/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
@@ -3,8 +3,6 @@
    <span data-dojo-attach-point="renderedValueNode" data-dojo-attach-event="onkeypress:onKeyPress,ondijitclick:onClickRenderedValue" class="inlineEditValue ${renderedValueClass}" tabindex="0">${!renderedValue}</span>
    <span data-dojo-attach-point="editNode" class="editor hidden" data-dojo-attach-event="onkeypress:onValueEntryKeyPress,onclick:suppressFocusRequest">
       <span data-dojo-attach-point="formWidgetNode"></span>
-      <span class="action save" data-dojo-attach-point="saveLinkNode" data-dojo-attach-event="ondijitclick:onSave" tabindex="0">${saveLabel}</span>
-      <span class="action cancel" data-dojo-attach-event="ondijitclick:onCancel" tabindex="0">${cancelLabel}</span>
    </span>
    <img class="editIcon" src="${editIconImageSrc}" alt="${editAltText}" title="${editAltText}" data-dojo-attach-point="editIconNode" data-dojo-attach-event="ondijitclick:onEditClick"/>
 </span>

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -29,6 +29,53 @@ define(["intern!object",
 
    /* global window */
 
+   var inlineEditSelectors = TestCommon.getTestSelectors("alfresco/renderers/InlineEditProperty");
+
+   var selectors = {
+      inlineEditProperties: {
+         first: {
+            readValue: TestCommon.getTestSelector(inlineEditSelectors, "readonly.value", ["INLINE_EDIT_1_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditSelectors, "edit.form", ["INLINE_EDIT_1_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditSelectors, "edit.icon", ["INLINE_EDIT_1_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditSelectors, "edit.save", ["INLINE_EDIT_1_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditSelectors, "edit.cancel", ["INLINE_EDIT_1_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_1_ITEM_0"])
+         },
+         second: {
+            readValue: TestCommon.getTestSelector(inlineEditSelectors, "readonly.value", ["INLINE_EDIT_2_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditSelectors, "edit.form", ["INLINE_EDIT_2_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditSelectors, "edit.icon", ["INLINE_EDIT_2_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditSelectors, "edit.save", ["INLINE_EDIT_2_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditSelectors, "edit.cancel", ["INLINE_EDIT_2_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_2_ITEM_0"])
+         },
+         third: {
+            readValue: TestCommon.getTestSelector(inlineEditSelectors, "readonly.value", ["INLINE_EDIT_3_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditSelectors, "edit.form", ["INLINE_EDIT_3_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditSelectors, "edit.icon", ["INLINE_EDIT_3_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditSelectors, "edit.save", ["INLINE_EDIT_3_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditSelectors, "edit.cancel", ["INLINE_EDIT_3_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_3_ITEM_0"])
+         },
+         fourth: {
+            readValue: TestCommon.getTestSelector(inlineEditSelectors, "readonly.value", ["INLINE_EDIT_4_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditSelectors, "edit.form", ["INLINE_EDIT_4_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditSelectors, "edit.icon", ["INLINE_EDIT_4_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditSelectors, "edit.save", ["INLINE_EDIT_4_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditSelectors, "edit.cancel", ["INLINE_EDIT_4_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_4_ITEM_0"])
+         },
+         fifth: {
+            readValue: TestCommon.getTestSelector(inlineEditSelectors, "readonly.value", ["INLINE_EDIT_5_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditSelectors, "edit.form", ["INLINE_EDIT_5_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditSelectors, "edit.icon", ["INLINE_EDIT_5_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditSelectors, "edit.save", ["INLINE_EDIT_5_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditSelectors, "edit.cancel", ["INLINE_EDIT_5_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_5_ITEM_0"])
+         }
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -45,7 +92,7 @@ define(["intern!object",
          },
 
          "Property is rendered correctly": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "Test item (topic, no scope)", "Value not rendered correctly");
@@ -53,60 +100,57 @@ define(["intern!object",
          },
 
          "Edit widget not initially created": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 [data-dojo-attach-point=\"formWidgetNode\"]") // Make sure placeholder is present
-               .end()
-
-            .findAllByCssSelector("#INLINE_EDIT_ITEM_0 .alfresco-forms-Form")
+            return browser.findAllByCssSelector(selectors.inlineEditProperties.first.editForm)
                .then(function(elements) {
-                  assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
+                  assert.lengthOf(elements, 0);
                });
          },
 
          "Edit icon initially invisible": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                .isDisplayed()
                .then(function(result) {
-                  assert.isFalse(result, "Icon should not be displayed");
+                  assert.isFalse(result);
                });
          },
 
          "Icon appears on focus": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .then(function(element) {
                   element.type(""); // Focus on element
 
                   browser.end()
-                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+                     .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                      .isDisplayed()
                      .then(function(result) {
-                        assert.isTrue(result, "Edit icon was not revealed on focus");
+                        assert.isTrue(result);
                      });
                });
          },
 
          "Icon disappears on blur": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .then(function(element) {
                   element.type([keys.SHIFT, keys.TAB]); // Focus away from element
 
                   browser.end()
-                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+                     .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                      .isDisplayed()
                      .then(function(result) {
-                        assert.isFalse(result, "Edit icon was not hidden on blur");
+                        assert.isFalse(result);
                      });
                });
          },
 
          "Icon appears on mouseover": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .moveMouseTo()
             .end()
 
-            .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+            .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                .isDisplayed()
                .then(function(result) {
-                  assert.isTrue(result, "Edit icon was not revealed on mouse over");
+                  assert.isTrue(result);
                });
          },
 
@@ -115,24 +159,24 @@ define(["intern!object",
                .moveMouseTo(0, 0)
                .then(function() {
                   browser.end()
-                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+                     .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                      .isDisplayed()
                      .then(function(result) {
-                        assert.isFalse(result, "Edit icon was not hidden on mouse out");
+                        assert.isFalse(result);
                      });
                });
          },
 
          "Edit widgets are created on edit": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                .click()
             .end()
 
-            .findByCssSelector("#INLINE_EDIT_ITEM_0 .alfresco-forms-Form");
+            .findByCssSelector(selectors.inlineEditProperties.first.editForm);
          },
 
          "Read property is hidden when editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Read-only span was not hidden");
@@ -140,34 +184,22 @@ define(["intern!object",
          },
 
          "Save and cancel buttons are displayed when editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
-               .isDisplayed()
-               .then(function(result) {
-                  assert.isTrue(result, "Save button not visible when editing");
-               })
+            return browser.findDisplayedByCssSelector(selectors.inlineEditProperties.first.editSave)
             .end()
 
-            .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
-               .isDisplayed()
-               .then(function(result) {
-                  assert.isTrue(result, "Cancel button not visible when editing");
-               });
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.editCancel);
          },
 
          "Escape key cancels editing": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editInput)
                .pressKeys([keys.ESCAPE])
             .end()
 
-            .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-               .isDisplayed()
-               .then(function(result) {
-                  assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-               });
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue);
          },
 
          "Clicking on property fires topic": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .click()
             .end()
 
@@ -175,7 +207,7 @@ define(["intern!object",
          },
 
          "Clicking on property does not start editing": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editInput)
                .isDisplayed()
                .then(function(result) {
                   assert.isFalse(result, "Edit box revealed when clicking on property value");
@@ -183,40 +215,36 @@ define(["intern!object",
          },
 
          "Clicking on cancel button stops editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .moveMouseTo()
                .then(function() {
                   return browser.end()
-                     .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
+                     .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                      .click()
                   .end()
 
-                  .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+                  .findByCssSelector(selectors.inlineEditProperties.first.readValue)
                      .isDisplayed()
                      .then(function(result) {
                         assert.isFalse(result, "Edit mode not entered when clicking on icon");
                      })
                   .end()
 
-                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
+                  .findByCssSelector(selectors.inlineEditProperties.first.editCancel)
                      .click()
                   .end()
 
-                  .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-                     .isDisplayed()
-                     .then(function(result) {
-                        assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-                     });
+                  .findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue);
                });
          },
 
          "CTRL-E starts editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .pressKeys([keys.CONTROL, "e"])
                .pressKeys(keys.NULL)
             .end()
 
-            .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
+            .findByCssSelector(selectors.inlineEditProperties.first.editInput)
                .isDisplayed()
                .then(function(result) {
                   assert.isTrue(result, "Edit box not revealed on CTRL-E");
@@ -224,19 +252,12 @@ define(["intern!object",
          },
 
          "Changes published on save": function() {
-            return browser.findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
-               .isDisplayed()
-               .then(function(result) {
-                  assert.isTrue(result, "Edit box not visible");
-               })
-            .end()
-
-            .findByCssSelector("#INLINE_EDIT_ITEM_0 .dijitInputContainer input")
+            return browser.findDisplayedByCssSelector(selectors.inlineEditProperties.first.editInput)
                .clearValue()
                .type("New")
             .end()
 
-            .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
+            .findByCssSelector(selectors.inlineEditProperties.first.editSave)
                .click()
             .end()
 
@@ -249,28 +270,23 @@ define(["intern!object",
          },
 
          "Readonly view displayed when finished editing": function() {
-            return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-               .isDisplayed()
-               .then(function(result) {
-                  assert.isTrue(result, "Read-only span not revealed on save");
-               })
-
-            .getVisibleText()
+            return browser.findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .getVisibleText()
                .then(function(text) {
                   assert.equal(text, "New", "Read-only value not updated correctly");
                });
          },
 
          "Scoped property link update has response scoped": function() {
-            return browser.findByCssSelector("#LIST_TOPIC_SCOPED .editIcon")
+            return browser.findByCssSelector(selectors.inlineEditProperties.second.editIcon)
                .click()
             .end()
 
-            .findByCssSelector("#LIST_TOPIC_SCOPED .alfresco-forms-controls-TextBox:first-child .dijitInputContainer input")
+            .findByCssSelector(selectors.inlineEditProperties.second.editInput)
                .type("New2")
             .end()
 
-            .findByCssSelector("#LIST_TOPIC_SCOPED .save")
+            .findByCssSelector(selectors.inlineEditProperties.second.editSave)
                .clearLog()
                .click()
             .end()
@@ -282,7 +298,7 @@ define(["intern!object",
          },
 
          "Property links publish correct payloads": function() {
-            return browser.findByCssSelector("#LIST_TOPIC_NOSCOPE .alfresco-renderers-InlineEditProperty .alfresco-renderers-Property")
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
                .clearLog()
                .click()
             .end()
@@ -293,7 +309,7 @@ define(["intern!object",
                })
             .end()
 
-            .findByCssSelector("#LIST_TOPIC_SCOPED .alfresco-renderers-InlineEditProperty .alfresco-renderers-Property")
+            .findByCssSelector(selectors.inlineEditProperties.second.readValue)
                .clearLog()
                .click()
             .end()
@@ -304,7 +320,7 @@ define(["intern!object",
                })
             .end()
 
-            .findByCssSelector("#LIST_NOTOPIC_SCOPED .alfresco-renderers-InlineEditProperty .alfresco-renderers-Property")
+            .findByCssSelector(selectors.inlineEditProperties.third.readValue)
                .clearLog()
                .click()
             .end()
@@ -334,17 +350,17 @@ define(["intern!object",
 
          "Edit encoded value": function() {
             // Move the mouse over the hidden edit icon...
-            return browser.findByCssSelector("#LIST_XSS_ITEMS .editIcon")
+            return browser.findByCssSelector(selectors.inlineEditProperties.fifth.editIcon)
                .moveMouseTo()
             .end()
 
             // Wait for it to appear and clikc it...
-            .findDisplayedByCssSelector("#LIST_XSS_ITEMS .editIcon")
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.fifth.editIcon)
                .click()
             .end()
 
             // Check that the edit value isn't encoded...
-            .findDisplayedByCssSelector("#LIST_XSS_ITEMS .alfresco-forms-controls-TextBox .dijitInputContainer input")
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.fifth.editInput)
                .getProperty("value")
                .then(function(value) {
                   assert.equal(value, "<img src=\"1\" onerror=\"window.hackedProperty=true\">", "Incorrect edit field value");
@@ -352,11 +368,11 @@ define(["intern!object",
          },
 
          "Save value and check XSS is not injected": function() {
-            return browser.findByCssSelector("#LIST_XSS_ITEMS .action.save")
+            return browser.findByCssSelector(selectors.inlineEditProperties.fifth.editSave)
                .click()
             .end()
 
-            .findDisplayedByCssSelector("#LIST_XSS_ITEMS #INLINE_EDIT_ITEM_0 .inlineEditValue")
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.fifth.readValue)
                .getVisibleText()
                .then(function(visibleText) {
                   assert.equal(visibleText, "<img src=\"1\" onerror=\"window.hackedProperty=true\">");

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -27,362 +27,372 @@ define(["intern!object",
         "intern/dojo/node!leadfoot/keys"],
    function(registerSuite, assert, TestCommon, keys) {
 
-registerSuite(function(){
-   var browser;
+   var inlineEditPropertySelectors = TestCommon.getTestSelectors("alfresco/renderers/InlineEditProperty");
+   var inlineEditSelectSelectors = TestCommon.getTestSelectors("alfresco/renderers/InlineEditSelect");
 
-   return {
-      name: "InlineEditProperty",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/InlineEditProperty", "InlineEditProperty")
-            .end();
+   var selectors = {
+      inlineEditProperties: {
+         first: {
+            label: TestCommon.getTestSelector(inlineEditPropertySelectors, "label", ["INLINE_EDIT_ITEM_0"]),
+            readValue: TestCommon.getTestSelector(inlineEditPropertySelectors, "readonly.value", ["INLINE_EDIT_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.form", ["INLINE_EDIT_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.icon", ["INLINE_EDIT_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.save", ["INLINE_EDIT_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.cancel", ["INLINE_EDIT_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.input", ["INLINE_EDIT_ITEM_0"])
+         },
+         second: {
+            editIcon: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.icon", ["INLINE_EDIT_NO_VALUE_ITEM_0"])
+         },
+         third: {
+            editIcon: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.icon", ["INLINE_EDIT_ITEM_1"]),
+            readValue: TestCommon.getTestSelector(inlineEditPropertySelectors, "readonly.value", ["INLINE_EDIT_ITEM_1"])
+         },
+         fourth: {
+            editIcon: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.icon", ["INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0"]),
+            readValue: TestCommon.getTestSelector(inlineEditPropertySelectors, "readonly.value", ["INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.save", ["INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0"]),
+            editInput: TestCommon.getTestSelector(inlineEditPropertySelectors, "edit.input", ["INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0"])
+         }
+      },
+      inlineEditSelects: {
+         first: {
+            label: TestCommon.getTestSelector(inlineEditSelectSelectors, "label", ["INLINE_SELECT_ITEM_0"]),
+            readValue: TestCommon.getTestSelector(inlineEditSelectSelectors, "readonly.value", ["INLINE_SELECT_ITEM_0"]),
+            editForm: TestCommon.getTestSelector(inlineEditSelectSelectors, "edit.form", ["INLINE_SELECT_ITEM_0"]),
+            editIcon: TestCommon.getTestSelector(inlineEditSelectSelectors, "edit.icon", ["INLINE_SELECT_ITEM_0"]),
+            editSave: TestCommon.getTestSelector(inlineEditSelectSelectors, "edit.save", ["INLINE_SELECT_ITEM_0"]),
+            editCancel: TestCommon.getTestSelector(inlineEditSelectSelectors, "edit.cancel", ["INLINE_SELECT_ITEM_0"]),
+            editOpenMenuIcon: TestCommon.getTestSelector(inlineEditSelectSelectors, "edit.open.menu.icon", ["INLINE_SELECT_ITEM_0"]),
+            editOptions: {
+               second: TestCommon.getTestSelector(inlineEditSelectSelectors, "edit.nth.option.label", ["INLINE_SELECT_ITEM_0", "2"])
+            }
+         }
       },
 
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Label is displayed": function() {
-         return browser.findDisplayedByCssSelector("#INLINE_EDIT_ITEM_0 .label");
-      },
-
-      "Property is rendered correctly": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "Test", "Value not rendered correctly");
-            });
-      },
-
-      "Edit widget not initially created": function() {
-         return browser.findAllByCssSelector("#INLINE_EDIT_ITEM_0 > .editWidgetNode > *")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
-            });
-      },
-
-      "Edit icon initially invisible": function() {
-         return browser.findByCssSelector(".alfresco_logging_DebugLog__header")
-            .moveMouseTo()
-         .end()
-         .sleep(250) // Make sure the mouse isn't over the row!
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isFalse(result, "Icon should not be displayed");
-            });
-      },
-
-      "Render on new line configuration doesn't effect icon": function() {
-         var valueX;
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .inlineEditValue")
-            .getPosition()
-            .then(function(p) {
-               valueX = p.x;
-            })
-         .end()
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-            .getPosition()
-            .then(function(p) {
-               assert.notEqual(valueX, p.x, "The value and icon should NOT be starting at the same X co-ordinate");
-            })
-         .end();
-      },
-
-      "Icon appears on focus": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .then(function(element) {
-               element.type(""); // Focus on element
-
-               browser.end()
-                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-                  .isDisplayed()
-                  .then(function(result) {
-                     assert.isTrue(result, "Edit icon was not revealed on focus");
-                  });
-            });
-      },
-
-      "Icon disappears on blur": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .then(function(element) {
-               element.type([keys.SHIFT, keys.TAB]); // Focus away from element
-
-               browser.end()
-                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-                  .isDisplayed()
-                  .then(function(result) {
-                     assert.isFalse(result, "Edit icon was not hidden on blur");
-                  });
-            });
-      },
-
-      "Icon appears on mouseover": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .moveMouseTo()
-            .end()
-
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Edit icon was not revealed on mouse over");
-            });
-      },
-
-      "Icon hides on mouseout": function() {
-         return browser.findByCssSelector("body")
-            .moveMouseTo(0, 0)
-            .then(function() {
-               browser.end()
-                  .findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-                  .isDisplayed()
-                  .then(function(result) {
-                     assert.isFalse(result, "Edit icon was not hidden on mouse out");
-                  });
-            });
-      },
-
-      "Edit widgets are created on edit": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .editIcon")
-            .click()
-            .end()
-
-         .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
-            .then(null, function() {
-               assert(false, "Clicking edit icon did not create the validation text box");
-            });
-      },
-
-      "Read property is hidden when editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isFalse(result, "Read-only span was not hidden");
-            });
-      },
-
-      "Save and cancel buttons are displayed when editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Save button not visible when editing");
-            })
-            .end()
-
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Cancel button not visible when editing");
-            });
-      },
-
-      "Escape key cancels editing": function() {
-         return browser.findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
-            .pressKeys([keys.ESCAPE])
-            .end()
-
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-            });
-      },
-
-      "Clicking on read-only value starts editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .click()
-            .end()
-
-         .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Edit box not revealed when clicking on read-only value");
-            });
-      },
-
-      "Clicking on cancel button stops editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .action.cancel")
-            .click()
-            .end()
-
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Read-only value not revealed on cancelling edit");
-            });
-      },
-
-      "CTRL-E starts editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .pressKeys([keys.CONTROL, "e"])
-            .pressKeys(keys.NULL)
-            .end()
-
-         .findByCssSelector(".alfresco-forms-controls-TextBox:first-child")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Edit box not revealed on CTRL-E");
-            });
-      },
-
-      "Changes published on save": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 .dijitInputContainer input")
-            .clearValue()
-            .type("New")
-         .end()
-
-         .findByCssSelector("#INLINE_EDIT_ITEM_0 .action.save")
-            .click()
-         .end()
-
-         .getLastPublish("ALF_CRUD_UPDATE")
-            .then(function(payload) {
-               assert.propertyVal(payload, "name", "New", "New value didn't publish correctly");
-               assert.propertyVal(payload, "hiddenData", "hidden_update", "Hidden value didn't get included");
-            });
-      },
-
-      "Readonly view displayed when finished editing": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_0 > .alfresco-renderers-Property")
-            .isDisplayed()
-            .then(function(result) {
-               assert.isTrue(result, "Read-only span not revealed on save");
-            })
-
-         .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "New", "Read-only value not updated correctly");
-            });
-      },
-
-      "Inline-edit select restores values on failed save": function() {
-         return browser.findByCssSelector("#INLINE_SELECT_ITEM_0 > .alfresco-renderers-Property")
-            .then(function(element) {
-               return browser.moveMouseTo(element)
-                  .then(function() {
-                     return browser.end()
-                        .findByCssSelector("#INLINE_SELECT_ITEM_0 .editIcon")
-                        .click()
-                        .end()
-
-                     .findByCssSelector("#INLINE_SELECT_ITEM_0 .alfresco-forms-controls-BaseFormControl .dijitArrowButtonInner")
-                        .click()
-                        .end()
-
-                     .findByCssSelector(".dijitPopup table tr:nth-child(2) td.dijitMenuItemLabel")
-                        .click()
-                        .end()
-
-                     .findByCssSelector("#INLINE_SELECT_ITEM_0 .action.save")
-                        .click()
-                        .end()
-
-                     .findByCssSelector("#INLINE_SELECT_ITEM_0 > .alfresco-renderers-Property")
-                        .isDisplayed()
-                        .then(function(result) {
-                           assert.isTrue(result, "Read-only span not revealed on failed save");
-                        })
-
-                     .getVisibleText()
-                        .then(function(text) {
-                           assert.equal(text, "1", "Read-only value not restored correctly after failed save");
-                        });
-                  });
-            });
-      },
-
-      "Check rendered alt text when no value available": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_ITEM_0 .editIcon")
-            .getAttribute("alt")
-            .then(function(alt) {
-               assert.equal(alt, "Click to edit", "Alt text for missing value incorrect");
-            });
-      },
-
-      "Check edit disabled when user has no write permissions": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_1 .inlineEditValue")
-            .moveMouseTo()
-         .end()
-         .findByCssSelector("#INLINE_EDIT_ITEM_1 .editIcon")
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isFalse(displayed, "The edit icon should not be displayed for items without write permission");
-            });
-      },
-
-      "Check keyboard shortcut edit disabled when user has no write permissions": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_ITEM_1 .inlineEditValue")
-            .click()
-            .pressKeys([keys.CONTROL, "e"])
-            .pressKeys(keys.NULL)
-            .isDisplayed()
-            .then(function(displayed) {
-               assert.isTrue(displayed, "Keyboard shortcut should not have worked for item without write permission");
-            });
-      },
-
-      "Check warning message on item with no value": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "(No property set)", "Value not rendered correctly");
-            });
-      },
-
-      "Check fade class applied to warning value": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
-      },
-
-      "Edit and save item check rendered value has prefix/suffix": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .editIcon")
-            .click()
-         .end()
-         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .alfresco-forms-controls-TextBox .dijitInputContainer input")
-            .clearValue()
-            .type("Updated")
-         .end()
-         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .action.save")
-            .click()
-         .end()
-         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "(Updated)", "Value not rendered correctly");
-            });
-      },
-
-      "Check that faded style has been removed": function() {
-         return browser.findAllByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Faded style was not removed when a value was provided");
-            });
-      },
-
-      "Edit and save item to remove value to check warning returns": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .editIcon")
-            .click()
-         .end()
-         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .alfresco-forms-controls-TextBox .dijitInputContainer input")
-            .clearValue()
-         .end()
-         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 .action.save")
-            .click()
-         .end()
-         .findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property")
-            .getVisibleText()
-            .then(function(text) {
-               assert.equal(text, "(No property set)", "Value not rendered correctly");
-            });
-      },
-
-      "Check that faded style has been reapplied": function() {
-         return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
-      }
    };
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "InlineEditProperty",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/InlineEditProperty", "InlineEditProperty")
+               .end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Label is displayed": function() {
+            return browser.findDisplayedByCssSelector(selectors.inlineEditProperties.first.label);
+         },
+
+         "Property is rendered correctly": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Test", "Value not rendered correctly");
+               });
+         },
+
+         "Edit widget not initially created": function() {
+            return browser.findAllByCssSelector("#INLINE_EDIT_ITEM_0 > .editWidgetNode > *")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Edit widget node should be empty until needed");
+               });
+         },
+
+         "Edit icon initially invisible": function() {
+            return browser.findByCssSelector(".alfresco_logging_DebugLog__header")
+               .moveMouseTo()
+               .click() // Make sure the mouse isn't over the row!
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result, "Icon should not be displayed");
+               });
+         },
+
+         "Render on new line configuration doesn't effect icon": function() {
+            var valueX;
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .getPosition()
+               .then(function(p) {
+                  valueX = p.x;
+               })
+            .end()
+            .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
+               .getPosition()
+               .then(function(p) {
+                  assert.notEqual(valueX, p.x, "The value and icon should NOT be starting at the same X co-ordinate");
+               })
+            .end();
+         },
+
+         "Icon appears on focus": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .then(function(element) {
+                  element.type(""); // Focus on element
+
+                  browser.end()
+                     .findDisplayedByCssSelector(selectors.inlineEditProperties.first.editIcon);
+               });
+         },
+
+         "Icon disappears on blur": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .then(function(element) {
+                  element.type([keys.SHIFT, keys.TAB]); // Focus away from element
+
+                  browser.end()
+                     .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
+                     .isDisplayed()
+                     .then(function(result) {
+                        assert.isFalse(result, "Edit icon was not hidden on blur");
+                     });
+               });
+         },
+
+         "Icon appears on mouseover": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .moveMouseTo()
+            .end()
+
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.editIcon);
+         },
+
+         "Icon hides on mouseout": function() {
+            return browser.findByCssSelector("body")
+               .moveMouseTo(0, 0)
+               .then(function() {
+                  browser.end()
+                     .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
+                     .isDisplayed()
+                     .then(function(result) {
+                        assert.isFalse(result, "Edit icon was not hidden on mouse out");
+                     });
+               });
+         },
+
+         "Edit widgets are created on edit": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editIcon)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.first.editInput)
+               .then(null, function() {
+                  assert(false, "Clicking edit icon did not create the validation text box");
+               });
+         },
+
+         "Read property is hidden when editing": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .isDisplayed()
+               .then(function(result) {
+                  assert.isFalse(result, "Read-only span was not hidden");
+               });
+         },
+
+         "Save and cancel buttons are displayed when editing": function() {
+            return browser.findDisplayedByCssSelector(selectors.inlineEditProperties.first.editSave)
+               .end()
+
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.editCancel);
+         },
+
+         "Escape key cancels editing": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editInput)
+               .pressKeys([keys.ESCAPE])
+               .end()
+
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue);
+         },
+
+         "Clicking on read-only value starts editing": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.editInput);
+         },
+
+         "Clicking on cancel button stops editing": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editCancel)
+               .click()
+            .end()
+
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue);
+         },
+
+         "CTRL-E starts editing": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .pressKeys([keys.CONTROL, "e"])
+               .pressKeys(keys.NULL)
+            .end()
+
+            .findDisplayedByCssSelector(selectors.inlineEditProperties.first.editInput);
+         },
+
+         "Changes published on save": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.first.editInput)
+               .clearValue()
+               .type("New")
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.first.editSave)
+               .click()
+            .end()
+
+            .getLastPublish("ALF_CRUD_UPDATE")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "name", "New", "New value didn't publish correctly");
+                  assert.propertyVal(payload, "hiddenData", "hidden_update", "Hidden value didn't get included");
+               });
+         },
+
+         "Readonly view displayed when finished editing": function() {
+            return browser.findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "New", "Read-only value not updated correctly");
+               });
+         },
+
+         "Inline-edit select restores values on failed save": function() {
+            return browser.findByCssSelector(selectors.inlineEditSelects.first.readValue)
+               .then(function(element) {
+                  return browser.moveMouseTo(element)
+                     .then(function() {
+                        return browser.end()
+                           .findByCssSelector(selectors.inlineEditSelects.first.editIcon)
+                           .click()
+                        .end()
+
+                        .findByCssSelector(selectors.inlineEditSelects.first.editOpenMenuIcon)
+                           .click()
+                        .end()
+
+                        .findDisplayedByCssSelector(selectors.inlineEditSelects.first.editOptions.second)
+                           .click()
+                        .end()
+
+                        .findByCssSelector(selectors.inlineEditSelects.first.editSave)
+                           .click()
+                           .end()
+
+                        .findDisplayedByCssSelector(selectors.inlineEditSelects.first.readValue)
+                           .getVisibleText()
+                           .then(function(text) {
+                              assert.equal(text, "1", "Read-only value not restored correctly after failed save");
+                           });
+                     });
+               });
+         },
+
+         "Check rendered alt text when no value available": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.second.editIcon)
+               .getAttribute("alt")
+               .then(function(alt) {
+                  assert.equal(alt, "Click to edit", "Alt text for missing value incorrect");
+               });
+         },
+
+         "Check edit disabled when user has no write permissions": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.third.readValue)
+               .moveMouseTo()
+            .end()
+            .findByCssSelector(selectors.inlineEditProperties.third.editIcon)
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed, "The edit icon should not be displayed for items without write permission");
+               });
+         },
+
+         "Check keyboard shortcut edit disabled when user has no write permissions": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.third.readValue)
+               .click()
+               .pressKeys([keys.CONTROL, "e"])
+               .pressKeys(keys.NULL)
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isTrue(displayed, "Keyboard shortcut should not have worked for item without write permission");
+               });
+         },
+
+         "Check warning message on item with no value": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.fourth.readValue)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "(No property set)", "Value not rendered correctly");
+               });
+         },
+
+         "Check fade class applied to warning value": function() {
+            return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
+         },
+
+         "Edit and save item check rendered value has prefix/suffix": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.fourth.editIcon)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.fourth.editInput)
+               .clearValue()
+               .type("Updated")
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.fourth.editSave)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.fourth.readValue)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "(Updated)", "Value not rendered correctly");
+               });
+         },
+
+         "Check that faded style has been removed": function() {
+            return browser.findAllByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Faded style was not removed when a value was provided");
+               });
+         },
+
+         "Edit and save item to remove value to check warning returns": function() {
+            return browser.findByCssSelector(selectors.inlineEditProperties.fourth.editIcon)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.fourth.editInput)
+               .clearValue()
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.fourth.editSave)
+               .click()
+            .end()
+
+            .findByCssSelector(selectors.inlineEditProperties.fourth.readValue)
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "(No property set)", "Value not rendered correctly");
+               });
+         },
+
+         "Check that faded style has been reapplied": function() {
+            return browser.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -114,9 +114,8 @@ define(["intern!object",
             .end()
 
             // Click the cancel button
-            .findByCssSelector("#TAGS_4 span.action:nth-of-type(2)")
-               .click()
-            .end();
+            .findByCssSelector("#TAGS_4 .editor .alfresco-forms-Form .cancelButton .dijitButtonText")
+               .click();
          },
 
          "Post Coverage Results": function() {
@@ -229,18 +228,17 @@ define(["intern!object",
          },
 
          "Check that actions are not displayed": function() {
-            return browser.findByCssSelector("#TAGS_2 .action.save")
-               .isDisplayed()
-               .then(function(displayed) {
-                  assert.isFalse(displayed, "Save action should not be shown");
+            return browser.findAllByCssSelector("#TAGS_2 .editor .alfresco-forms-Form .confirmationButton .dijitButtonText")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
                })
             .end()
 
-            .findByCssSelector("#TAGS_2 .action.cancel")
-               .isDisplayed()
-               .then(function(displayed) {
-                  assert.isFalse(displayed, "Save action should not be shown");
-               });
+            .findAllByCssSelector("#TAGS_2  .editor .alfresco-forms-Form .cancelButton .dijitButtonText")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0);
+               })
+               .end();
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/test-selectors/alfresco/renderers/InlineEditProperty.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/renderers/InlineEditProperty.properties
@@ -1,0 +1,20 @@
+# An optional label to prefix the property
+label=#{0}.alfresco-renderers-InlineEditProperty > span.label
+
+# The read-only value (displayed when not editing)
+readonly.value=#{0}.alfresco-renderers-InlineEditProperty > span.inlineEditValue
+
+# The form (widget, not element) used in edit mode
+edit.form=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form
+
+# The image icon used to enter edit mode
+edit.icon=#{0}.alfresco-renderers-InlineEditProperty img.editIcon
+
+# The button used for saving the edited value
+edit.save=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form .confirmationButton .dijitButtonText
+
+# The button used for cancelling changes the edited value
+edit.cancel=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form .cancelButton .dijitButtonText
+
+# The input field used for editing the property value
+edit.input=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form .alfresco-forms-controls-TextBox .dijitInputContainer input

--- a/aikau/src/test/resources/test-selectors/alfresco/renderers/InlineEditSelect.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/renderers/InlineEditSelect.properties
@@ -1,0 +1,29 @@
+# An optional label to prefix the property
+label=#{0}.alfresco-renderers-InlineEditProperty > span.label
+
+# The read-only value (displayed when not editing)
+readonly.value=#{0}.alfresco-renderers-InlineEditProperty > span.inlineEditValue
+
+# The form (widget, not element) used in edit mode
+edit.form=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form
+
+# The image icon used to enter edit mode
+edit.icon=#{0}.alfresco-renderers-InlineEditProperty img.editIcon
+
+# The button used for saving the edited value
+edit.save=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form .confirmationButton .dijitButtonText
+
+# The button used for cancelling changes the edited value
+edit.cancel=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form .cancelButton .dijitButtonText
+
+# Options drop-down
+edit.option.menu=#{0}_SELECT_CONTROL_dropdown
+
+# Open drop-down arrow icon
+edit.open.menu.icon=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form  .dijitArrowButtonInner
+
+# all options
+edit.options=#{0}_SELECT_CONTROL_dropdown table tr
+
+# nth option label
+edit.nth.option.label=#{0}_SELECT_CONTROL_dropdown table tr:nth-child({1}) td.dijitMenuItemLabel

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
@@ -1,4 +1,5 @@
-var propertyLinkWidgets = [
+function getPropertyLinkWidgets(id) {
+   return [
       {
          name: "alfresco/lists/views/layouts/Row",
          config: {
@@ -8,7 +9,7 @@ var propertyLinkWidgets = [
                   config: {
                      widgets: [
                         {
-                           id: "INLINE_EDIT",
+                           id: id,
                            name: "alfresco/renderers/InlineEditPropertyLink",
                            config: {
                               permissionProperty: null,
@@ -38,8 +39,11 @@ var propertyLinkWidgets = [
             ]
          }
       }
-   ],
-   propertyLinkWidgetsNoTopic = [
+   ];
+}
+
+function getPropertyLinkWidgetsNoTopic(id) {
+   return [
       {
          name: "alfresco/lists/views/layouts/Row",
          config: {
@@ -49,7 +53,7 @@ var propertyLinkWidgets = [
                   config: {
                      widgets: [
                         {
-                           id: "INLINE_EDIT",
+                           id: id,
                            name: "alfresco/renderers/InlineEditPropertyLink",
                            config: {
                               permissionProperty: null,
@@ -78,6 +82,7 @@ var propertyLinkWidgets = [
          }
       }
    ];
+}
 
 model.jsonModel = {
    services: [
@@ -105,7 +110,7 @@ model.jsonModel = {
                   }
                ]
             },
-            widgets: propertyLinkWidgets
+            widgets: getPropertyLinkWidgets("INLINE_EDIT_1")
          }
       },
       {
@@ -120,7 +125,7 @@ model.jsonModel = {
                   }
                ]
             },
-            widgets: propertyLinkWidgets
+            widgets: getPropertyLinkWidgets("INLINE_EDIT_2")
          }
       },
       {
@@ -135,7 +140,7 @@ model.jsonModel = {
                   }
                ]
             },
-            widgets: propertyLinkWidgetsNoTopic
+            widgets: getPropertyLinkWidgetsNoTopic("INLINE_EDIT_3")
          }
       },
       {
@@ -149,7 +154,7 @@ model.jsonModel = {
                   }
                ]
             },
-            widgets: propertyLinkWidgets
+            widgets: getPropertyLinkWidgets("INLINE_EDIT_4")
          }
       },
       {
@@ -163,7 +168,7 @@ model.jsonModel = {
                   }
                ]
             },
-            widgets: propertyLinkWidgets
+            widgets: getPropertyLinkWidgets("INLINE_EDIT_5")
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-908 to swap the action labels in the InlineEditProperty (and descendant widgets) with the previously hidden form buttons. The unit tests have been updated and the InlineEditProperty and InlineEditSelect test selectors have been externalised.