### PR TITLE
AKU-912: Remove sort field from SearchBox link

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -852,12 +852,12 @@ define(["dojo/_base/declare",
          if (this.searchResultsPage)
          {
             // Generate custom search page link...
-            url = this.searchResultsPage + "#searchTerm=" + this.generateSearchTerm(terms) + "&scope=" + scope + "&sortField=Relevance";
+            url = this.searchResultsPage + "#searchTerm=" + this.generateSearchTerm(terms) + "&scope=" + scope;
          }
          else if (this.linkToFacetedSearch === true)
          {
             // Generate faceted search page link...
-            url = "dp/ws/faceted-search#searchTerm=" + this.generateSearchTerm(terms) + "&scope=" + scope + "&sortField=Relevance";
+            url = "dp/ws/faceted-search#searchTerm=" + this.generateSearchTerm(terms) + "&scope=" + scope;
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
+++ b/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
@@ -164,7 +164,7 @@ define(["intern!object",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload) {
-                  assert.propertyVal(payload, "url", "dp/ws/faceted-search#searchTerm=pdf&scope=repo&sortField=Relevance", "Did not find expected navigation publication request (check the search scope!)");
+                  assert.propertyVal(payload, "url", "dp/ws/faceted-search#searchTerm=pdf&scope=repo", "Did not find expected navigation publication request (check the search scope!)");
                });
          },
 
@@ -231,7 +231,7 @@ define(["intern!object",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                .then(function(payload) {
-                  assert.propertyVal(payload, "url", "site/site1/dp/ws/faceted-search#searchTerm=site&scope=site1&sortField=Relevance");
+                  assert.propertyVal(payload, "url", "site/site1/dp/ws/faceted-search#searchTerm=site&scope=site1");
                });
          },
 
@@ -370,7 +370,7 @@ define(["intern!object",
                .end()
                .getLastPublish("ALF_NAVIGATE_TO_PAGE")
                   .then(function(payload) {
-                     assert.propertyVal(payload, "url", "dp/ws/faceted-search#searchTerm=(data%25test)%20secret%20squirrels&scope=repo&sortField=Relevance");
+                     assert.propertyVal(payload, "url", "dp/ws/faceted-search#searchTerm=(data%25test)%20secret%20squirrels&scope=repo");
                   });
          },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-912 to remove the hard-coded sort field from the links generated by the SearchBox. This change ensures that initial search (in Share) is derived from the drop-down sort selection menu. This doesn't impact other cases (e.g. where no sort menu is present) because the default is still to initial sort on "Relevance"