### PR TITLE
AKU-909: Update actions renderer

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Actions.js
+++ b/aikau/src/main/resources/alfresco/renderers/Actions.js
@@ -94,15 +94,21 @@
 define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
         "dijit/_TemplatedMixin",
+        "dijit/_HasDropDown",
         "dojo/text!./templates/Actions.html",
         "alfresco/renderers/_ActionsMixin",
+        "alfresco/buttons/AlfButton",
+        "alfresco/menus/AlfMenuGroups",
+        "alfresco/menus/AlfMenuGroup",
         "dijit/Menu",
         "dojo/dom-class",
         "dojo/_base/event",
+        "dojo/_base/lang",
         "dojo/keys"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, _ActionsMixin, Menu, domClass, Event, keys) {
+        function(declare, _WidgetBase, _TemplatedMixin, _HasDropDown, template, _ActionsMixin, AlfButton, 
+                 AlfMenuGroups, AlfMenuGroup, Menu, domClass, Event, lang, keys) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _ActionsMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, _HasDropDown, _ActionsMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -152,18 +158,17 @@ define(["dojo/_base/declare",
       label: "alf.renderers.Actions.menuLabel",
 
       /**
-       * This will hold a reference to a diijt/Menu widget that is created to hold the menu. This
-       * should not be referenced by extending widgets as it may not always be available depending 
-       * upon how implementation of the menu changes as required. For example, this widget previously
-       * used an [AlfMenuBar]{@link module:alfresco/menus/AlfMenuBar} but it was necessary to change
-       * the implementation to resolve menu pop-up location issues (see AKU-706).
+       * This will hold a reference to the [button]{@link module:alfresco/buttons/AlfButton} that when
+       * clicked will display a drop-down menu containing the available actions. This should not be 
+       * referenced by extending widgets as it may not always be available depending upon how implementation 
+       * of widget changes.
        * 
        * @instance
        * @type {object}
        * @default
-       * @since 1.0.46
+       * @since 1.0.62
        */
-      _menu: null,
+      _button: null,
 
       /**
        * Ensures that the [menu]{@link module:alfresco/renderers/Actions#_menu} is destroyed.
@@ -225,14 +230,17 @@ define(["dojo/_base/declare",
             // No action
          }
 
-         this._menu = new Menu({
-            id: this.id + "_GROUP", // Used "_GROUP" as a suffix for backwards compatibility with tests
-            leftClickToOpen: true,
-            targetNodeIds: [this.labelNode]
+         this._button = this.createWidget({
+            name: "alfresco/buttons/AlfButton",
+            config: {
+               additionalCssClasses: "call-to-action",
+               label: this.message("alf.renderers.Actions.menuLabel"),
+               publishTopic: "NO_OP"
+            }
          });
-         
-         // Add all the actions...
-         this.addActions();
+         this._button.placeAt(this.domNode);
+         this._buttonNode = this._button.domNode;
+         this._aroundNode = this._button.domNode;
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
@@ -316,6 +316,64 @@ define(["dojo/_base/declare",
          {
             this.alfLog("log", "Skipping action as it's missing from whitelist: " + action);
          }
+      },
+
+      /**
+       * 
+       * @instance
+       * @since 1.0.62
+       */
+      createEmptyMenu: function alfresco_renderers__ActionsMixin__createEmptyMenu() {
+         this.dropDown = this.createWidget({
+            id: this.id + "_DROPDOWN",
+            name: "alfresco/menus/AlfMenuGroups",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/menus/AlfMenuGroup",
+                     assignToScope: this,
+                     assignTo: "_menu"
+                  }
+               ]
+            }
+         });
+      },
+
+      /**
+       * 
+       * @instance
+       * @param  {Function} callback The function to call to display the drop-down
+       * @since 1.0.62
+       */
+      createDropDownMenu: function alfresco_renderers__ActionsMixin__createDropDownMenu(callback) {
+         this.createEmptyMenu();
+         this.addActions();
+         callback();
+      },
+
+      /**
+       * 
+       * @instance
+       * @since 1.0.62
+       */
+      isLoaded: function alfresco_renderers__ActionsMixin__isLoaded() {
+         return (!!this.dropDown && this.dropDown.isLoaded);
+      },
+
+      /**
+       * 
+       * @instance
+       * @param  {Function} callback The function to call to display the drop-down
+       * @since 1.0.62
+       */
+      loadDropDown: function alfresco_renderers__ActionsMixin__loadDropDown(callback) {
+         var dropDown = this.dropDown;
+         if(!dropDown) { 
+            this.createDropDownMenu(callback);
+         }
+         else {
+            callback();
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/_XhrActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_XhrActionsMixin.js
@@ -48,69 +48,40 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/_XhrActionsMixin.properties"}],
 
       /**
-       * A boolean flag indicating whether or not the actions have been loaded yet.
-       *
-       * @instance
-       * @type {boolean}
-       * @default
-       */
-      _actionsLoaded: false,
-
-      /**
-       * The JSON model for controlling the widgets that are displayed whilst waiting for the
-       * XHR request to complete.
-       *
-       * @instance
-       * @type {array}
-       */
-      widgetsForLoading: [
-         {
-            name: "alfresco/header/AlfMenuItem",
-            config: {
-               iconClass: "alf-loading-icon",
-               label: "loading.label"
-            }
-         }
-      ],
-
-      /**
-       * Extends the [inherited function]{@link module:alfresco/renderers/_ActionsMixin#addActions} to create place
-       * holding [widgets]{@link module:alfresco/renderers/_XhrActionsMixin#widgetsForLoading} to display until the
-       * XHR request to retrieve the full Node details returns. This function is subsequently called when the user
-       * opens the pop-up menu to render all the actions.
+       * Overrides the [inherited function]{@link module:alfresco/renderers/_ActionsMixin#createDropDownMenu}
+       * to call [loadActions]{@link module:alfresco/renderers/_XhrActionsMixin#loadActions} to ensure that
+       * the actions are loaded before the drop-down menu is displayed.
        * 
        * @instance
+       * @param  {function} callback The function to call to display the drop-down
+       * @since 1.0.62
        */
-      addActions: function alfresco_renderers__XhrActionsMixin__postCreate() {
-         if (this._actionsLoaded)
-         {
-            this.inherited(arguments);
-         }
-         else
-         {
-            this.processWidgets(this.widgetsForLoading);
-
-            // Pass the loading JSON model to the actions menu group to be displayed...
-            aspect.after(this._menu, "_scheduleOpen", lang.hitch(this, this.loadActions));
-         }
+      createDropDownMenu: function alfresco_renderers__XhrActionsMixin__createDropDownMenu(callback) {
+         this.createEmptyMenu();
+         this.loadActions(callback);
       },
 
       /**
        * Called whenever the user opens up the actions pop-up menu. If an XHR request has not yet been made to 
-       * retrieve the full Node data for the current item then the [getXhrData]{@link module:alfresco/renderers/_XhrActionsMixin#getXhrData}
-       * function will be called, otherwise the previously rendered actions will be shown.
+       * retrieve the full Node data for the current item then the 
+       * [getXhrData]{@link module:alfresco/renderers/_XhrActionsMixin#getXhrData} function will be called, otherwise 
+       * the previously rendered actions will be shown.
        * 
        * @instance
+       * @param  {function} callback The function to call to display the drop-down
        */
-      loadActions: function alfresco_renderers__XhrActionsMixin__loadActions() {
+      loadActions: function alfresco_renderers__XhrActionsMixin__loadActions(callback) {
          if (this._actionsLoaded)
          {
             this.alfLog("log", "Actions already loaded");
+            callback();
          }
          else
          {
             this.alfLog("log", "Loading actions");
-            this.getXhrData();
+            this._button.set("label", this.message("loading.label"));
+            this._button.set("disabled", true);
+            this.getXhrData(callback);
          }
       },
 
@@ -118,16 +89,17 @@ define(["dojo/_base/declare",
        * Publishes a request to retrieve the full Node data for the current item.
        * 
        * @instance
+       * @param  {function} callback The function to call to display the drop-down
        * @fires module:alfresco/core/topics#GET_DOCUMENT
        */
-      getXhrData: function alfresco_renderers__XhrActionsMixin__getXhrData() {
+      getXhrData: function alfresco_renderers__XhrActionsMixin__getXhrData(callback) {
          var nodeRef = lang.getObject("nodeRef", false, this.currentItem);
          if (nodeRef)
          {
             // Generate a UUID for the response to the publication to ensure that only this widget
             // handles to the XHR data...
             var responseTopic = this.generateUuid();
-            this._xhrDataRequestHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onXhrData), true);
+            this._xhrDataRequestHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onXhrData, callback), true);
             this.alfPublish(topics.GET_DOCUMENT, {
                alfResponseTopic: responseTopic,
                nodeRef: nodeRef
@@ -144,16 +116,16 @@ define(["dojo/_base/declare",
        * [addXhrItems]{@link module:alfresco/renderers/_XhrActionsMixin#addXhrItems} to render the actions.
        * 
        * @instance
+       * @param  {function} callback The function to call to display the drop-down
        * @param {object} payload 
        */
-      onXhrData: function alfresco_renderers__XhrActionsMixin__onXhrData(payload) {
+      onXhrData: function alfresco_renderers__XhrActionsMixin__onXhrData(callback, payload) {
          this.alfUnsubscribeSaveHandles([this._xhrDataRequestHandle]);
          if (lang.exists("response.item", payload)) 
          {
-            this._actionsLoaded = true;
             this.currentItem = payload.response.item;
-            this.clearLoadingItem();
             this.addXhrItems();
+            callback();
          }
          else
          {
@@ -162,22 +134,14 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Removes the "Loading..." place holder menu item. Called from [onXhrData]{@link module:alfresco/renderers/_XhrActionsMixin#onXhrData}
-       * 
-       * @instance
-       */
-      clearLoadingItem: function alfresco_renderers__XhrActionsMixin__clearLoadingItem() {
-         array.forEach(this._menu.getChildren(), function(widget) {
-            this._menu.removeChild(widget);
-         }, this);
-      },
-
-      /**
-       * Adds the menu items for the asynchronously retrieved data. Called from [onXhrData]{@link module:alfresco/renderers/_XhrActionsMixin#onXhrData}
+       * Adds the menu items for the asynchronously retrieved data. Called from 
+       * [onXhrData]{@link module:alfresco/renderers/_XhrActionsMixin#onXhrData}.
        *
        * @instance
        */
       addXhrItems: function alfresco_renderers__XhrActionsMixin__addXhrItems() {
+         this._button.set("label", this.message("alf.renderers.Actions.menuLabel"));
+         this._button.set("disabled", false);
          this.addActions();
       }
    });

--- a/aikau/src/main/resources/alfresco/renderers/css/Actions.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Actions.css
@@ -1,10 +1,26 @@
-.alfresco-lists-views-layout-_MultiItemRendererMixin__item:hover .alfresco-renderers-Actions.hover-only > div,
-.alfresco-lists-views-layout-_MultiItemRendererMixin__item .alfresco-renderers-Actions.hover-only > div.dijitSelected {
-   visibility: visible;
-}
+.alfresco-lists-views-layout-_MultiItemRendererMixin__item {
+   &:hover {
+      .alfresco-renderers-Actions {
+         &.hover-only {
+            >.alfresco-buttons-AlfButton {
+               visibility: visible;
+            }
+         }
+      }
+   }
+   .alfresco-renderers-Actions {
+      &.hover-only {
+         &.dijitHasDropDownOpen {
+            >.alfresco-buttons-AlfButton {
+               visibility: visible;
+            }
+         }
 
-.alfresco-lists-views-layout-_MultiItemRendererMixin__item .alfresco-renderers-Actions.hover-only > div {
-   visibility: hidden;
+         > .alfresco-buttons-AlfButton {
+            visibility: hidden;
+         }
+      }
+   }
 }
 
 .alfresco-renderers-Actions {

--- a/aikau/src/main/resources/alfresco/renderers/templates/Actions.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/Actions.html
@@ -1,3 +1,1 @@
-<div class="alfresco-renderers-Actions">
-   <span id="${id}_MENU_text" class="alfresco-renderers-Actions__label" data-dojo-attach-event="onkeypress:onKeyPress" data-dojo-attach-point="labelNode" tabindex="0" role="button" aria-haspopup="true">${label}</span>
-</div>
+<div class="alfresco-renderers-Actions"></div>

--- a/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/ActionsTest.js
@@ -25,6 +25,38 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function (registerSuite, assert, TestCommon) {
 
+   var actionsSelectors = TestCommon.getTestSelectors("alfresco/renderers/Actions");
+   var selectors = {
+      restActions: {
+         first: {
+            label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["REST_ACTIONS", "0"]),
+            dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["REST_ACTIONS", "0"]),
+            action: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.actions", ["REST_ACTIONS", "0"])
+         }
+      },
+      customActions: {
+         first: {
+            label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["CUSTOM_ACTIONS", "0"]),
+            dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["CUSTOM_ACTIONS", "0"]),
+            action: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.actions", ["CUSTOM_ACTIONS", "0"])
+         }
+      },
+      mergedActions: {
+         first: {
+            label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["MERGED_ACTIONS", "0"]),
+            dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["MERGED_ACTIONS", "0"]),
+            action: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.actions", ["MERGED_ACTIONS", "0"])
+         }
+      },
+      footerActions: {
+         first: {
+            label: TestCommon.getTestSelector(actionsSelectors, "label", ["FOOTER_ACTIONS"]),
+            dropDown: TestCommon.getTestSelector(actionsSelectors, "dropdown", ["FOOTER_ACTIONS"]),
+            action1: TestCommon.getTestSelector(actionsSelectors, "dropdown.nth.action.label", ["FOOTER_ACTIONS", "1"])
+         }
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -41,43 +73,59 @@ define(["intern!object",
          },
 
          "Count REST API actions": function() {
-            return browser.findByCssSelector("#REST_ACTIONS_ITEM_0_MENU_text")
+            return browser.waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+            .end()
+
+            .findByCssSelector(selectors.restActions.first.label)
                .click()
             .end()
-            .findAllByCssSelector("#REST_ACTIONS_ITEM_0_GROUP tr")
+
+            .findDisplayedByCssSelector(selectors.restActions.first.dropDown)
+            .end()
+
+            .findAllByCssSelector(selectors.restActions.first.action)
                .then(function(elements) {
                   assert.lengthOf(elements, 10, "Unexpected number of REST API actions rendered");
                });
          },
 
          "Count custom actions": function() {
-
-            return browser.findByCssSelector("#CUSTOM_ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.customActions.first.label)
                .click()
             .end()
-            .findAllByCssSelector("#CUSTOM_ACTIONS_ITEM_0_GROUP tr")
+
+            .findDisplayedByCssSelector(selectors.customActions.first.dropDown)
+            .end()
+            
+            .findAllByCssSelector(selectors.customActions.first.action)
                .then(function(elements) {
                   assert.lengthOf(elements, 2, "Unexpected number of custom actions rendered");
                });
          },
 
          "Count filtered merged actions": function() {
-
-            return browser.findByCssSelector("#MERGED_ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.mergedActions.first.label)
                .click()
             .end()
-            .findAllByCssSelector("#MERGED_ACTIONS_ITEM_0_GROUP tr")
+
+            .findDisplayedByCssSelector(selectors.mergedActions.first.dropDown)
+            .end()
+            
+            .findAllByCssSelector(selectors.mergedActions.first.action)
                .then(function(elements) {
                   assert.lengthOf(elements, 5, "Unexpected number of filtered merged REST API and custom actions rendered");
                });
          },
 
          "Check that actions don't appear off the screen": function() {
-            return browser.findById("FOOTER_ACTIONS_MENU_text")
+            return browser.findByCssSelector(selectors.footerActions.first.label)
                .click()
             .end()
+
+            .findDisplayedByCssSelector(selectors.footerActions.first.dropDown)
+            .end()
             
-            .findDisplayedById("FOOTER_ACTIONS_F1_text")
+            .findDisplayedByCssSelector(selectors.footerActions.first.action1)
                // NOTE: These tests should ensure that the menu item is visible.
                .isDisplayed()
                .click();

--- a/aikau/src/test/resources/alfresco/renderers/XhrActionsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/XhrActionsTest.js
@@ -25,6 +25,24 @@ define(["intern!object",
         "alfresco/TestCommon"],
        function (registerSuite, assert, TestCommon) {
 
+   var actionsSelectors = TestCommon.getTestSelectors("alfresco/renderers/Actions");
+   var selectors = {
+      restActions: {
+         first: {
+            label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["XHR_ACTIONS", "0"]),
+            dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["XHR_ACTIONS", "0"]),
+            action: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.actions", ["XHR_ACTIONS", "0"])
+         }
+      },
+      mergedActions: {
+         first: {
+            label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["MERGED_XHR_ACTIONS", "0"]),
+            dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["MERGED_XHR_ACTIONS", "0"]),
+            action: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.actions", ["MERGED_XHR_ACTIONS", "0"])
+         }
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -43,50 +61,39 @@ define(["intern!object",
         "Check Actions menu was rendered": function () {
             // Test spec:
             // 1: Check dropdown element exists
-            return browser.findById("XHR_ACTIONS_ITEM_0_MENU_text");
+            return browser.findByCssSelector(selectors.restActions.first.label);
          },
 
          "Check that document request event was triggered": function() {
             // 2: Click on it. Check event triggered: ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST
-            return browser.findById("XHR_ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.restActions.first.label)
                .click()
             .end()
             .getLastPublish("ALF_RETRIEVE_SINGLE_DOCUMENT_REQUEST", "Retrieve single doc request not triggered");
          },
 
          "Check default behaviour to render 'legacy' document actions": function() {
-            return browser.findById("XHR_ACTIONS_ITEM_0_document-download")
+            return browser.findDisplayedByCssSelector(selectors.restActions.first.dropDown)
                .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-view-content")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-edit-properties")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-upload-new-version")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-edit-offline")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-copy-to")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-move-to")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-delete")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-assign-workflow")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-assign-workflow")
-               .end()
-               .findById("XHR_ACTIONS_ITEM_0_document-manage-granular-permissions");
+
+               .findAllByCssSelector(selectors.restActions.first.action)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 11);
+               });
          },
 
          "Check merged and filtered actions": function() {
-            return browser.findById("MERGED_XHR_ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.mergedActions.first.label)
                .click()
             .end()
-            .findById("MERGED_XHR_ACTIONS_ITEM_0_document-delete")
+
+            .findDisplayedByCssSelector(selectors.mergedActions.first.dropDown)
             .end()
-            .findById("MERGED_XHR_ACTIONS_ITEM_0_CUSTOM3")
-            .end()
-            .findById("MERGED_XHR_ACTIONS_ITEM_0_MANAGE_ASPECTS");
+
+            .findAllByCssSelector(selectors.mergedActions.first.action)
+               .then(function(elements) {
+                  assert.lengthOf(elements, 3);
+               });
          },
 
          "Post Coverage Results": function() {

--- a/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/DownloadAsZipTest.js
@@ -26,131 +26,154 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, TestCommon) {
 
-registerSuite(function(){
-   var browser;
-
-   return {
-      name: "Download as ZIP Action Tests",
-
-      setup: function() {
-         browser = this.remote;
-         return TestCommon.loadTestWebScript(this.remote, "/DownloadAsZip", "Download as ZIP Action Tests").end();
+   var actionsSelectors = TestCommon.getTestSelectors("alfresco/renderers/Actions");
+   var selectors = {
+      downloadDocument: {
+         label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["ACTIONS", "0"]),
+         dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["ACTIONS", "0"]),
+         action1: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.nth.action.label", ["ACTIONS", "0", "1"])
       },
-
-      beforeEach: function() {
-         browser.end();
-      },
-
-      "Test single item download": function() {
-         // This test simulates the payload that would be generated from legacy document library action 
-         // configuration to check that the appropriate publications occur...
-         return browser.setFindTimeout(5000).findById("SINGLE_DOWNLOAD_VIA_ACTION_SERVICE_label")
-               .click()
-            .end()
-            .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Archiving dialog not displayed");
-               })
-            .end()
-            .getLastPublish("ALF_SINGLE_DOCUMENT_ACTION_REQUEST", 5000, "Single document action request not made")
-            .getLastPublish("ALF_DOWNLOAD_AS_ZIP", 5000, "Single document action not passed to document service")
-            .getLastPublish("ALF_ARCHIVE_REQUEST", 5000, "A request was not made to initiate the archive generation")
-            .findAllByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Archiving dialog not hidden");
-               })
-            .end()
-            .getLastPublish("ALF_DOWNLOAD_FILE", 5000, "Generated archive not downloaded")
-            .clearLog();
-      },
-
-      "Test multiple item download": function() {
-         // This test simulates the payload that would be generated from a multiple item selection action 
-         // based on the legacy Share document library action configuration...
-         return browser.setFindTimeout(5000).findById("MULTIPLE_DOWNLOAD_VIA_ACTION_SERVICE_label")
-               .click()
-            .end()
-            .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Archiving dialog not displayed");
-               })
-            .end()
-            .getLastPublish("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", 5000, "Multiple document action request not made")
-            .getLastPublish("ALF_DOWNLOAD_AS_ZIP", 5000, "Multiple document action not passed to document service")
-               .then(function(payload) {
-                  assert.lengthOf(payload.documents, 2, "Incorrect number of nodes requested to be archived");
-               })
-            .getLastPublish("ALF_ARCHIVE_REQUEST", 5000, "A request was not made to initiate the archive generation")
-            .findAllByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
-               .then(function(elements) {
-                  assert.lengthOf(elements, 1, "Archiving dialog not hidden");
-               })
-            .end()
-            .getLastPublish("ALF_DOWNLOAD_FILE", 5000, "Generated archive not downloaded")
-            .clearLog();
-      },
-
-      "Test that action does NOT appear for document": function() {
-         return browser.findByCssSelector("#ACTIONS_ITEM_0_MENU_text")
-            .click()
-         .end()
-         .findAllByCssSelector("#ACTIONS_ITEM_0_DOWNLOAD_AS_ZIP")
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Download as zip action should not be present for document");
-            });
-      },
-
-      "Test that action does appear for folder": function() {
-         return browser.findByCssSelector("#ACTIONS_ITEM_1_MENU_text")
-            .click()
-         .end()
-         .findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD_AS_ZIP")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Download as zip action was not created for folder");
-            });
-      },
-
-      "Test non-legacy action version": function() {
-         return browser.findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD_AS_ZIP")
-            .click()
-         .end()
-         .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Archiving dialog not displayed");
-            })
-         .end()
-         .getLastPublish("ALF_ARCHIVE_REQUEST", 5000, "A request was not made to initiate the archive generation")
-         .findAllByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Archiving dialog not hidden");
-            })
-         .end()
-         .getLastPublish("ALF_DOWNLOAD_FILE", 5000, "Generated archive not downloaded")
-         .clearLog();
-      },
-
-      "Cancel will prevent the download occurring": function() {
-         return browser.findById("MULTIPLE_DOWNLOAD_VIA_ACTION_SERVICE")
-            .clearLog()
-            .click()
-            .end()
-
-         .findByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed .dijitButtonNode")
-            .click()
-            .end()
-
-         .findByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
-            .end()
-
-         .getAllPublishes("ALF_DOWNLOAD_FILE")
-            .then(function(publishes) {
-               assert.lengthOf(publishes, 0);
-            });
-      },
-
-      "Post Coverage Results": function() {
-         TestCommon.alfPostCoverageResults(this, browser);
+      downloadFolder: {
+         label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["ACTIONS", "1"]),
+         dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["ACTIONS", "1"])
       }
    };
+
+   registerSuite(function(){
+      var browser;
+
+      return {
+         name: "Download as ZIP Action Tests",
+
+         setup: function() {
+            browser = this.remote;
+            return TestCommon.loadTestWebScript(this.remote, "/DownloadAsZip", "Download as ZIP Action Tests").end();
+         },
+
+         beforeEach: function() {
+            browser.end();
+         },
+
+         "Test single item download": function() {
+            // This test simulates the payload that would be generated from legacy document library action 
+            // configuration to check that the appropriate publications occur...
+            return browser.setFindTimeout(5000).findById("SINGLE_DOWNLOAD_VIA_ACTION_SERVICE_label")
+                  .click()
+               .end()
+
+               .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Archiving dialog not displayed");
+                  })
+               .end()
+
+               .getLastPublish("ALF_SINGLE_DOCUMENT_ACTION_REQUEST", 5000, "Single document action request not made")
+               .getLastPublish("ALF_DOWNLOAD_AS_ZIP", 5000, "Single document action not passed to document service")
+               .getLastPublish("ALF_ARCHIVE_REQUEST", 5000, "A request was not made to initiate the archive generation")
+               
+               .findAllByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Archiving dialog not hidden");
+                  })
+               .end()
+
+               .getLastPublish("ALF_DOWNLOAD_FILE", 5000, "Generated archive not downloaded")
+               .clearLog();
+         },
+
+         "Test multiple item download": function() {
+            // This test simulates the payload that would be generated from a multiple item selection action 
+            // based on the legacy Share document library action configuration...
+            return browser.setFindTimeout(5000).findById("MULTIPLE_DOWNLOAD_VIA_ACTION_SERVICE_label")
+                  .click()
+               .end()
+
+               .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Archiving dialog not displayed");
+                  })
+               .end()
+
+               .getLastPublish("ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST", 5000, "Multiple document action request not made")
+               .getLastPublish("ALF_DOWNLOAD_AS_ZIP", 5000, "Multiple document action not passed to document service")
+                  .then(function(payload) {
+                     assert.lengthOf(payload.documents, 2, "Incorrect number of nodes requested to be archived");
+                  })
+               .getLastPublish("ALF_ARCHIVE_REQUEST", 5000, "A request was not made to initiate the archive generation")
+               
+               .findAllByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
+                  .then(function(elements) {
+                     assert.lengthOf(elements, 1, "Archiving dialog not hidden");
+                  })
+               .end()
+
+               .getLastPublish("ALF_DOWNLOAD_FILE", 5000, "Generated archive not downloaded")
+               .clearLog();
+         },
+
+         "Test that action does NOT appear for document": function() {
+            return browser.findByCssSelector(selectors.downloadDocument.label)
+               .click()
+            .end()
+
+            .findAllByCssSelector("#ACTIONS_ITEM_0_DOWNLOAD_AS_ZIP")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 0, "Download as zip action should not be present for document");
+               });
+         },
+
+         "Test that action does appear for folder": function() {
+            return browser.findByCssSelector(selectors.downloadFolder.label)
+               .click()
+            .end()
+            
+            .findDisplayedById("ACTIONS_ITEM_1_DOWNLOAD_AS_ZIP");
+         },
+
+         "Test non-legacy action version": function() {
+            return browser.findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD_AS_ZIP")
+               .click()
+            .end()
+
+            .findAllByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Archiving dialog not displayed");
+               })
+            .end()
+
+            .getLastPublish("ALF_ARCHIVE_REQUEST", 5000, "A request was not made to initiate the archive generation")
+            .findAllByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 1, "Archiving dialog not hidden");
+               })
+            .end()
+
+            .getLastPublish("ALF_DOWNLOAD_FILE", 5000, "Generated archive not downloaded")
+            .clearLog();
+         },
+
+         "Cancel will prevent the download occurring": function() {
+            return browser.findById("MULTIPLE_DOWNLOAD_VIA_ACTION_SERVICE")
+               .clearLog()
+               .click()
+               .end()
+
+            .findByCssSelector("#ARCHIVING_DIALOG.dialogDisplayed .dijitButtonNode")
+               .click()
+               .end()
+
+            .findByCssSelector("#ARCHIVING_DIALOG.dialogHidden")
+               .end()
+
+            .getAllPublishes("ALF_DOWNLOAD_FILE")
+               .then(function(publishes) {
+                  assert.lengthOf(publishes, 0);
+               });
+         },
+
+         "Post Coverage Results": function() {
+            TestCommon.alfPostCoverageResults(this, browser);
+         }
+      };
    });
 });

--- a/aikau/src/test/resources/alfresco/services/actions/DownloadTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/DownloadTest.js
@@ -26,6 +26,19 @@ define(["intern!object",
         "alfresco/TestCommon"],
         function(registerSuite, assert, TestCommon) {
 
+   var actionsSelectors = TestCommon.getTestSelectors("alfresco/renderers/Actions");
+   var selectors = {
+      downloadDocument: {
+         label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["ACTIONS", "0"]),
+         dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["ACTIONS", "0"]),
+         action1: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.nth.action.label", ["ACTIONS", "0", "1"])
+      },
+      downloadFolder: {
+         label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["ACTIONS", "1"]),
+         dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["ACTIONS", "1"])
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -42,14 +55,15 @@ define(["intern!object",
          },
 
          "Test that action does appear for document": function() {
-            return browser.findById("ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.downloadDocument.label)
                .click()
             .end()
-            .findById("ACTIONS_ITEM_0_DOWNLOAD");
+
+            .findDisplayedById("ACTIONS_ITEM_0_DOWNLOAD");
          },
 
          "Test that action does NOT appear for folder": function() {
-            return browser.findById("ACTIONS_ITEM_1_MENU_text")
+            return browser.findByCssSelector(selectors.downloadFolder.label)
                .click()
             .end()
             .findAllByCssSelector("#ACTIONS_ITEM_1_DOWNLOAD")
@@ -59,11 +73,11 @@ define(["intern!object",
          },
 
          "Test download action": function() {
-            return browser.findById("ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.downloadDocument.label)
                .click()
             .end()
             
-            .findById("ACTIONS_ITEM_0_DOWNLOAD_text")
+            .findDisplayedByCssSelector(selectors.downloadDocument.action1)
                .click()
             .end()
 

--- a/aikau/src/test/resources/alfresco/services/actions/WorkflowTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/WorkflowTest.js
@@ -27,6 +27,15 @@ define(["intern!object",
         "alfresco/TestCommon"],
            function(registerSuite, assert, require, TestCommon) {
 
+   var actionsSelectors = TestCommon.getTestSelectors("alfresco/renderers/Actions");
+   var selectors = {
+      startWorkflow: {
+         label: TestCommon.getTestSelector(actionsSelectors, "nth.label", ["ACTIONS", "0"]),
+         dropDown: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown", ["ACTIONS", "0"]),
+         action1: TestCommon.getTestSelector(actionsSelectors, "nth.dropdown.nth.action.label", ["ACTIONS", "0", "1"])
+      }
+   };
+
    registerSuite(function(){
       var browser;
 
@@ -191,12 +200,14 @@ define(["intern!object",
          },
 
          "Test non-legacy action version": function() {
-            return browser.findByCssSelector("#ACTIONS_ITEM_0_MENU_text")
+            return browser.findByCssSelector(selectors.startWorkflow.label)
                .click()
             .end()
-            .findAllByCssSelector("#ACTIONS_ITEM_0_START-WORKFLOW_text")
+
+            .findDisplayedByCssSelector(selectors.startWorkflow.action1)
                .click()
             .end()
+            
             .getLastPublish("ALF_POST_TO_PAGE", "Start workflow navigation post not found")
                .then(function(payload) {
                   assert.deepPropertyVal(payload, "parameters.selectedItems", "workspace://SpacesStore/node4", "Incorrect nodeRef");

--- a/aikau/src/test/resources/test-selectors/alfresco/renderers/Actions.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/renderers/Actions.properties
@@ -1,0 +1,23 @@
+# The actions renderer label
+label=#{0} .alfresco-buttons-AlfButton .dijitButtonText
+
+# The actions menu group within the drop-down
+dropdown=#{0}_DROPDOWN
+
+# All actions within an action renderer drop-down
+dropdown.actions=#{0}_DROPDOWN tr.alfresco-menus-AlfMenuItem
+
+# The nth action in a specific action renderer
+dropdown.nth.action.label=#{0}_DROPDOWN tr.alfresco-menus-AlfMenuItem:nth-child({1}) td.dijitMenuItemLabel
+
+# The nth actions renderer label
+nth.label=#{0}_ITEM_{1} .alfresco-buttons-AlfButton .dijitButtonText
+
+# The actions menu group within the drop-down
+nth.dropdown=#{0}_ITEM_{1}_DROPDOWN
+
+# All actions within the nth action renderer drop-down
+nth.dropdown.actions=#{0}_ITEM_{1}_DROPDOWN tr.alfresco-menus-AlfMenuItem
+
+# The nth action in the nth action renderer
+nth.dropdown.nth.action.label=#{0}_ITEM_{1}_DROPDOWN tr.alfresco-menus-AlfMenuItem:nth-child({2}) td.dijitMenuItemLabel


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-909 by re-implementing the alfresco/renderer/Actions and alfresco/renderer/XhrActions widgets to prevent the issue occurring (and by doing so simultaneously addressing https://issues.alfresco.com/jira/browse/AKU-772 and https://issues.alfresco.com/jira/browse/AKU-850). Unit tests have been updated and test selectors externalised.