### PR TITLE
AKU-923: Ensure site titles are encoded

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -207,6 +207,10 @@ define(["dojo/_base/declare",
             args.content = args.textContent;
             delete args.textContent;
          }
+         if (args.content)
+         {
+            args.content = this.encodeHTML(args.content);
+         }
          declare.safeMixin(args);
       },
 
@@ -367,7 +371,7 @@ define(["dojo/_base/declare",
          {
             // Add basic text content into the container node. An example of this would be for
             // setting basic text content in an confirmation dialog...
-            html.set(this.bodyNode, this.encodeHTML(this.content));
+            html.set(this.bodyNode, this.content);
          }
 
          this.alfSetupResizeSubscriptions(this.onWindowResize, this);

--- a/aikau/src/main/resources/alfresco/header/AlfSitesMenu.js
+++ b/aikau/src/main/resources/alfresco/header/AlfSitesMenu.js
@@ -551,6 +551,8 @@ define(["dojo/_base/declare",
        */
       _addMenuItem: function alfresco_header_AlfSitesMenu___addMenuItem(group, widget, index) {
          this.alfLog("log", "Adding menu item", widget, index, group);
+
+         widget.config.label = this.encodeHTML(widget.config.label);
          var item = this.createWidget({
             name: "alfresco/header/AlfMenuItem",
             config: widget.config
@@ -779,7 +781,7 @@ define(["dojo/_base/declare",
          var newFavourite = this.createWidget({
             name: "alfresco/header/AlfMenuItem",
             config: {
-               label: siteTitle,
+               label: this.encodeHTML(siteTitle),
                iconClass: this.favouriteGroupIconClass,
                targetUrl: "site/" + siteShortName + this.siteLandingPage.replace(/^\/*/, "/"),
                siteShortName: siteShortName

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -465,7 +465,7 @@ define(["dojo/_base/declare",
          // TODO: Update this and other function with scroll setting...
          var dialogConfig = {
             id: payload.dialogId ? payload.dialogId : this.generateUuid(),
-            title: this.message(payload.dialogTitle || ""),
+            title: this.encodeHTML(this.message(payload.dialogTitle || "")),
             content: payload.textContent,
             duration: payload.duration || 0,
             fullScreenMode: payload.fullScreenMode || false,

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -65,18 +65,50 @@ define(["module",
       "Test that dialog with no ID can be created": function() {
          return this.remote.findByCssSelector("#CREATE_FORM_DIALOG_NO_ID")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector(".alfresco-dialog-AlfDialog")
-            .then(null, function() {
-               assert(false, "The Dialog did not appear");
-            });
+         .findDisplayedByCssSelector(".alfresco-dialog-AlfDialog");
       },
 
       "Test publication on dialog show": function() {
          return this.remote.findByCssSelector(".alfresco-dialog-AlfDialog")
             .end()
             .getLastPublish("DISPLAYED_FD1", "Could not find topic published when displayed dialog");
+      },
+
+      "Title not double encoded": function() {
+         return this.remote.findByCssSelector("#FD1 .dijitDialogTitle")
+            .getVisibleText()
+            .then(function(text) {
+               // NOTE: Only include is used because text is truncated via ellipsis
+               assert.include(text, "<img ='><svg onload=\"window");
+            });
+      },
+
+      "Text content not double encoded": function() {
+         return this.remote.findByCssSelector("#FD1 .dialog-body")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "<img ='><svg onload=\"window.bodyHacked=true\"'>");
+            });
+      },
+
+      "Title XSS attack failed": function() {
+         return this.remote.execute(function() {
+               return window.titleHacked;
+            })
+            .then(function(hacked) {
+               assert.isFalse(!!hacked);
+            });
+      },
+
+      "Body XSS attack failed": function() {
+         return this.remote.execute(function() {
+               return window.bodyHacked;
+            })
+            .then(function(hacked) {
+               assert.isFalse(!!hacked);
+            });
       },
 
       "Test recreating dialog with no ID": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -22,9 +22,9 @@ model.jsonModel = {
             publishTopic: "ALF_CREATE_DIALOG_REQUEST",
             publishPayload: {
                dialogId: "FD1",
-               dialogTitle: "Form Dialog 1",
+               dialogTitle: "<img ='><svg onload=\"window.titleHacked=true\"'>",
                additionalCssClasses: "custom-classes",
-               textContent: "Hello World",
+               textContent: "<img ='><svg onload=\"window.bodyHacked=true\"'>",
                publishOnShow: [
                   {
                      publishTopic: "DISPLAYED_FD1",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-923 to ensure that dialog body content is not vulnerable to XSS attack. In particular this addresses issues with site title related dialogs. This fix will be back-ported for specific hot-fix releases.