### PR TITLE
AKU-923: Further menu encoding updates

### DIFF
--- a/aikau/src/main/resources/alfresco/header/AlfSitesMenu.js
+++ b/aikau/src/main/resources/alfresco/header/AlfSitesMenu.js
@@ -551,8 +551,6 @@ define(["dojo/_base/declare",
        */
       _addMenuItem: function alfresco_header_AlfSitesMenu___addMenuItem(group, widget, index) {
          this.alfLog("log", "Adding menu item", widget, index, group);
-
-         widget.config.label = this.encodeHTML(widget.config.label);
          var item = this.createWidget({
             name: "alfresco/header/AlfMenuItem",
             config: widget.config
@@ -781,7 +779,7 @@ define(["dojo/_base/declare",
          var newFavourite = this.createWidget({
             name: "alfresco/header/AlfMenuItem",
             config: {
-               label: this.encodeHTML(siteTitle),
+               label: siteTitle,
                iconClass: this.favouriteGroupIconClass,
                targetUrl: "site/" + siteShortName + this.siteLandingPage.replace(/^\/*/, "/"),
                siteShortName: siteShortName

--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -147,13 +147,16 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_menus__AlfMenuItemMixin__postMixInProperties() {
+         // We need to keep a copy of the unencoded label, in case it needs to be used for the 
+         // title (which must remain unencoded, to prevent double-encoding)...
+         var originalLabel = this.label;
          if (this.label)
          {
-            this.params.label = this.label = this.message(this.label);
+            this.params.label = this.label = this.encodeHTML(this.message(this.label));
          }
-         if (!this.title && this.label)
+         if (!this.title && originalLabel)
          {
-            this.title = this.label;
+            this.title = originalLabel;
          }
          else if (this.title)
          {
@@ -161,12 +164,13 @@ define(["dojo/_base/declare",
          }
          if (!this.iconAltText && this.title)
          {
-            this.iconAltText = this.label;
+            this.iconAltText = originalLabel;
          }
          else if (this.iconAltText)
          {
             this.iconAltText = this.message(this.iconAltText);
          }
+         this.params.title = this.title;
          this.inherited(arguments);
       },
 

--- a/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/_HtmlAnchorMixin.js
@@ -117,7 +117,11 @@ define(["dojo/_base/declare",
             className: "alfresco-navigation-_HtmlAnchorMixin",
             href: url
          };
-         if (this.label) {
+         if (this.title)
+         {
+            anchorAttrs.title = this.message(this.title);
+         }
+         else if (this.label) {
             anchorAttrs.title = this.message(this.label);
          }
          if (this.excludeFromTabOrder) {


### PR DESCRIPTION
This PR is a 2nd attempt at addressing https://issues.alfresco.com/jira/browse/AKU-923. The previous solution introduced vulnerabilities in other areas of Share. This solution ensures that the menu label is always encoded, but importantly ensures that the title attribute is not double encoded. 