### PR TITLE
AKU-916: Dialog scrolls page

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -62,7 +62,31 @@ define(["dojo/_base/declare",
         function(declare, Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, topics, _FocusMixin, lang, sniff, array,
                  domConstruct, domClass, domStyle, domGeom, html, aspect, on, when, $) {
    
-   return declare([Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin], {
+    /**
+    * This is a customization of the default dijit/Dialog implementation to support
+    * AKU-916, preventing dialogs from scrolling the page when opened.
+    */
+   var CustomDialog = declare([Dialog], {
+
+      /**
+       * Override the default dialog method to ensure that the dialog starts its position
+       * at the top of the page to avoid the page scrolling to focus on its content (see
+       * call to child.focus() below).
+       * 
+       * @instance
+       * @override
+       * @returns {Promise} Returns the superclass' promise
+       * @since 1.0.63
+       */
+      show: function alfresco_dialogs_AlfDialog__CustomDialog__show() {
+         domStyle.set(this.domNode, {
+            top: "0"
+         });
+         return this.inherited(arguments);
+      }
+   });
+   
+   return declare([CustomDialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin], {
       
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -62,31 +62,7 @@ define(["dojo/_base/declare",
         function(declare, Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, topics, _FocusMixin, lang, sniff, array,
                  domConstruct, domClass, domStyle, domGeom, html, aspect, on, when, $) {
    
-    /**
-    * This is a customization of the default dijit/Dialog implementation to support
-    * AKU-916, preventing dialogs from scrolling the page when opened.
-    */
-   var CustomDialog = declare([Dialog], {
-
-      /**
-       * Override the default dialog method to ensure that the dialog starts its position
-       * at the top of the page to avoid the page scrolling to focus on its content (see
-       * call to child.focus() below).
-       * 
-       * @instance
-       * @override
-       * @returns {Promise} Returns the superclass' promise
-       * @since 1.0.63
-       */
-      show: function alfresco_dialogs_AlfDialog__CustomDialog__show() {
-         domStyle.set(this.domNode, {
-            top: "0"
-         });
-         return this.inherited(arguments);
-      }
-   });
-   
-   return declare([CustomDialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin], {
+   return declare([Dialog, AlfCore, CoreWidgetProcessing, ResizeMixin, _FocusMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -586,6 +562,23 @@ define(["dojo/_base/declare",
          {
             this.inherited(arguments);
          }
+      },
+
+      /**
+       * Override the default dialog method to ensure that the dialog starts its position
+       * at the top of the page to avoid the page scrolling to focus on its content (see
+       * call to child.focus() below).
+       * 
+       * @instance
+       * @override
+       * @returns {Promise} Returns the superclass' promise
+       * @since 1.0.63
+       */
+      show: function alfresco_dialogs_AlfDialog__show() {
+         domStyle.set(this.domNode, {
+            top: (document.body.scrollTop || document.documentElement.scrollTop) + "px"
+         });
+         return this.inherited(arguments);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/DialogServiceTest.js
@@ -663,6 +663,26 @@ define(["module",
             .end()
 
          .findByCssSelector("#RESIZING_DIALOG.dialogHidden");
+      },
+
+      "Page does not scroll when dialogs opened": function() {
+         return this.remote.findById("CREATE_FORM_DIALOG")
+            .click()
+            .end()
+
+         .findByCssSelector("#FD2.dialogDisplayed")
+            .end()
+
+         .execute(function() {
+               var firstButton = document.querySelector(".alfresco-buttons-AlfButton"),
+                  clientRect = firstButton && firstButton.getBoundingClientRect(),
+                  buttonTop = clientRect && clientRect.top,
+                  buttonOffScreen = isNaN(buttonTop) || buttonTop < 0;
+               return buttonOffScreen;
+            })
+            .then(buttonOffScreen => {
+               assert.isFalse(buttonOffScreen);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,11 +27,10 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   runAllTests = false; // Comment/uncomment this line to toggle
+   // runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "src/test/resources/alfresco/CodeCoverageBalancer",
       "src/test/resources/alfresco/upload/UploadMonitorTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE


### PR DESCRIPTION
This PR addresses [AKU-916](https://issues.alfresco.com/jira/browse/AKU-916) where opening a dialog scrolls the page. Have changed AlfDialog and updated associated tests. Also reset defaults in Suites.js