### PR TITLE
AKU-922: Service failure handling and lightbox updates

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -235,16 +235,12 @@ define(["alfresco/core/ProcessWidgets",
                catch (e) 
                {
                   _this.alfLog("error", "The following error occurred creating a service", e);
-                  this._showPage();
-                  if (callback)
-                  {
-                     callback.call((callbackScope || _this), service, index);
-                  }
+                  _this._showPage();
                }
             }
             else
             {
-               this._showPage();
+               _this._showPage();
                _this.alfLog("error", "The following service could not be found, so is not included on the page '" +  dep + "'. Please correct the use of this service in your page definition");
             }
             if (callback)

--- a/aikau/src/main/resources/alfresco/services/LightboxService.js
+++ b/aikau/src/main/resources/alfresco/services/LightboxService.js
@@ -45,7 +45,7 @@ define(["dojo/_base/declare",
        * @instance
        * @type {String[]}
        */
-      nonAmdDependencies: ["/js/lib/3rd-party/lightbox.js"],
+      nonAmdDependencies: ["/js/lib/3rd-party/lightbox/0.1/lightbox.js"],
       
       /**
        * If a service needs to act upon its post-mixed-in state before registering subscriptions then

--- a/aikau/src/main/resources/lib/3rd-party/lightbox/0.1/lightbox.js
+++ b/aikau/src/main/resources/lib/3rd-party/lightbox/0.1/lightbox.js
@@ -1,4 +1,12 @@
 /*
+
+   IMPORTANT: If you edit this file, please change the name of the parent folder to indicate an
+              increment in version in order to ensure that (where multiple instances of Aikau the
+              Aikau JAR exist in the web application application) that the LightBoxService will
+              load the correct version of this file. See AKU-922 for details.
+ */
+
+/*
    Lightbox JS: Fullsize Image Overlays 
    by Lokesh Dhakar - http://www.huddletogether.com
 

--- a/aikau/src/test/resources/alfresco/core/PageTest.js
+++ b/aikau/src/test/resources/alfresco/core/PageTest.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This test assesses the CoreRwd mixin as applied to AlfMenuBarPopup
+ *
+ * @author Richard Smith
+ * @author Dave Draper
+ */
+define(["module",
+        "alfresco/defineSuite"],
+        function(module, defineSuite) {
+
+   defineSuite(module, {
+      name: "Page Behaviour Tests",
+      testPage: "/Page#searchTerm=test",
+
+      // See AKU-922 for the background on this test
+      "Search request is published": function() {
+         return this.remote.getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST_SUCCESS");
+            
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/core/PageTest.js
+++ b/aikau/src/test/resources/alfresco/core/PageTest.js
@@ -18,10 +18,10 @@
  */
 
 /**
- * This test assesses the CoreRwd mixin as applied to AlfMenuBarPopup
+ * This tests the basic page loading behaviour with regards to service and widget creation.
  *
- * @author Richard Smith
  * @author Dave Draper
+ * @since 1.0.63
  */
 define(["module",
         "alfresco/defineSuite"],

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -61,6 +61,7 @@ define(function() {
       "src/test/resources/alfresco/core/CoreXhrTest",
       "src/test/resources/alfresco/core/NotificationUtilsTest",
       "src/test/resources/alfresco/core/ObjectProcessingMixinTest",
+      "src/test/resources/alfresco/core/PageTest",
       "src/test/resources/alfresco/core/PublishPayloadMixinTest",
       "src/test/resources/alfresco/core/RenderFilterTest",
       "src/test/resources/alfresco/core/ResponseScopeTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Page.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Page.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Page behaviour</shortname>
+  <description>Tests general page setup and rendering behaviours</description>
+  <family>aikau-unit-tests</family>
+  <url>/Page</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Page.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Page.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Page.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Page.get.js
@@ -1,0 +1,38 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/CrudService",
+      "aikauTesting/services/ThrowsInitException",
+      "alfresco/services/SearchService"
+   ],
+   widgets: [
+      {
+         id: "SEARCH_LIST",
+         name: "alfresco/search/AlfSearchList",
+         config: {
+            useHash: true,
+            widgets: [
+               {
+                  name: "alfresco/lists/views/HtmlListView"
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PaginatedSearchListMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/services/ThrowsInitException.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/services/ThrowsInitException.js
@@ -1,0 +1,41 @@
+/*globals Alfresco*/
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/services/ThrowsInitException
+ * @extends module:alfresco/services/BaseService
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/services/BaseService"],
+        function(declare, BaseService) {
+   
+   return declare([BaseService], {
+      
+      /**
+       * Intentionally causes an exception for testing purposes
+       * 
+       * @instance
+       */
+      initService: function aikauTesting_services_ThrowsInitException__initService() {
+         this.willSurelyDoIt();
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/services/ThrowsInitException.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/services/ThrowsInitException.js
@@ -1,4 +1,3 @@
-/*globals Alfresco*/
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *
@@ -35,7 +34,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       initService: function aikauTesting_services_ThrowsInitException__initService() {
-         this.willSurelyDoIt();
+         throw new Error("This is an error");
       }
    });
 });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-922 to ensure that the root Page module only decrements the registered services counters once when a service throws an exception on initialization. Updates have also been made to ensure that the LightBoxService will now always load the version of ligthbox.js from the same Aikau JAR. A unit tests has been added to prevent regressions in page behaviour. 