### PR TITLE
AKU-914: Add widgets to notifications

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -342,6 +342,11 @@ define([],function() {
        *
        * @event
        * @property {string} message The message to be displayed
+       * @property {string} [autoClose=true] Whether the notification should automatically close itself
+       * @property {object[]} [widgets] Widgets to be inserted into the notification below the message. Note that
+       *                                any widgets required must be either statically declared in the page model
+       *                                or in a widgets property of a custom widget/service, or be specifically
+       *                                required by a custom widget/service.
        * @property {string} [publishTopic] A topic to be published after the notification has closed
        * @property {object} [publishPayload] The payload to be published after the notification has closed
        * @property {boolean} [publishGlobal] Whether to publish the topic globally

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -343,6 +343,9 @@ define([],function() {
        * @event
        * @property {string} message The message to be displayed
        * @property {string} [autoClose=true] Whether the notification should automatically close itself
+       * @property {number} [wordsPerSecond=5] How many words it is assumed one can read per second (decrease this
+       *                                       number to increase the duration of the notification being displayed
+       *                                       on-screen - assuming autoClose hasn't been disabled)
        * @property {object[]} [widgets] Widgets to be inserted into the notification below the message. Note that
        *                                any widgets required must be either statically declared in the page model
        *                                or in a widgets property of a custom widget/service, or be specifically

--- a/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
+++ b/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
@@ -207,7 +207,7 @@ define(["alfresco/core/Core",
             array.forEach(widgets, function(widget) {
                var conf = widget.config;
                if (conf) {
-                  for (propName in conf) {
+                  for (var propName in conf) {
                      if (conf.hasOwnProperty(propName) && propName.indexOf("widgets") === 0) {
                         countWidgets(conf[propName]);
                      }

--- a/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
+++ b/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
@@ -24,139 +24,239 @@
  * @author Martin Doyle
  */
 define(["alfresco/core/Core",
+        "alfresco/core/CoreWidgetProcessing", 
+        "dojo/_base/array",
         "dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/Deferred",
         "dojo/dom-class",
         "dijit/_TemplatedMixin",
         "dijit/_WidgetBase",
+        "dijit/registry",
         "dojo/text!./templates/AlfNotification.html"],
-        function(AlfCore, declare, lang, Deferred, domClass, _TemplatedMixin, _WidgetBase, template) {
+        function(AlfCore, CoreWidgetProcessing, array, declare, lang, Deferred, domClass, _TemplatedMixin, _WidgetBase, registry, template) {
 
-      return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
+   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
 
-         /**
-          * An array of the CSS files to use with this widget.
-          *
-          * @instance cssRequirements {Array}
-          * @type {object[]}
-          * @default [{cssFile:"./css/AlfNotification.css"}]
-          */
-         cssRequirements: [{
-            cssFile: "./css/AlfNotification.css"
-         }],
+      /**
+       * An array of the CSS files to use with this widget.
+       *
+       * @instance cssRequirements {Array}
+       * @type {object[]}
+       * @default [{cssFile:"./css/AlfNotification.css"}]
+       */
+      cssRequirements: [{
+         cssFile: "./css/AlfNotification.css"
+      }],
 
-         /**
-          * The HTML template to use for the widget.
-          *
-          * @instance
-          * @type {String}
-          */
-         templateString: template,
+      /**
+       * The HTML template to use for the widget.
+       *
+       * @instance
+       * @type {String}
+       */
+      templateString: template,
 
-         /**
-          * How many milliseconds to wait before destroying this widget after the notification has been hidden
-          *
-          * @instance
-          * @type  {number}
-          * @default
-          */
-         destroyAfterHideMs: 1000,
+      /**
+       * Whether to remain open and not automatically close.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.63
+       */
+      autoClose: true,
 
-         /**
-          * Variable to hold the Deferred object that will resolve once this notification is destroyed
-          *
-          * @type {object}
-          */
-         destroyDeferred: null,
+      /**
+       * How many milliseconds to wait before destroying this widget after the notification has been hidden
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      destroyAfterHideMs: 1000,
 
-         /**
-          * Estimate how many seconds it might take a user to focus on a notification
-          *
-          * @instance
-          * @type  {number}
-          * @default
-          */
-         notificationFocusSecs: 1,
+      /**
+       * Variable to hold the Deferred object that will resolve once this notification is destroyed
+       *
+       * @type {object}
+       */
+      destroyDeferred: null,
 
-         /**
-          * How many words per second a person will read, used to determine how long to display the message.
-          * First attempt to gauge how long to show message ... may need refining!
-          *
-          * @instance
-          * @type  {number}
-          * @default
-          */
-         wordsPerSecond: 5,
+      /**
+       * The notification ID (helps with customisation)
+       *
+       * @instance
+       * @type {String}
+       * @default
+       * @since 1.0.63
+       */
+      id: null,
 
-         /**
-          * Called when widget is destroyed
-          *
-          * @instance
-          */
-         destroy: function alfresco_notifications_AlfNotification__destroy() {
-            this.destroyDeferred.resolve();
-            this.inherited(arguments);
-         },
+      /**
+       * Estimate how many seconds it might take a user to focus on a notification
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      notificationFocusSecs: 1,
 
-         /**
-          * Display the notification.
-          *
-          * @instance
-          * @returns  {object} A promise that will resolve once the notification is destroyed.
-          */
-         display: function alfresco_notifications_AlfNotification__display() {
-            this.destroyDeferred = new Deferred();
-            setTimeout(lang.hitch(this, this._show), 0); // Add to page before showing, else transition fails
-            return this.destroyDeferred.promise;
-         },
+      /**
+       * How many seconds to add on for each included widget
+       *
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.63
+       */
+      widgetSecs: 1,
 
-         /**
-          * Called after widget created, but not sub-widgets
-          *
-          * @instance
-          */
-         postCreate: function alfresco_notifications_AlfNotification__postCreate() {
-            this.inherited(arguments);
-            document.body.appendChild(this.domNode);
-         },
+      /**
+       * An array of widgets to be inserted into the notification, underneath the message.
+       *
+       * @instance
+       * @type {Object[]}
+       * @default
+       * @since 1.0.63
+       */
+      widgets: null,
 
-         /**
-          * Hide the notification (and destroy it)
-          *
-          * @instance
-          * @private
-          */
-         _hide: function alfresco_notifications_AlfNotification___hide() {
-            if(this.domNode && this.domNode.parentNode === document.body) {
-               domClass.remove(this.domNode, "alfresco-notifications-AlfNotification--visible");
-               setTimeout(lang.hitch(this, this.destroy), this.destroyAfterHideMs);
+      /**
+       * How many words per second a person will read, used to determine how long to display the message.
+       * First attempt to gauge how long to show message ... may need refining!
+       *
+       * @instance
+       * @type {number}
+       * @default
+       */
+      wordsPerSecond: 5,
+
+      /**
+       * This is run after the properties have been mixed in, but before the
+       * widget is created.
+       *
+       * @instance
+       * @override
+       * @since 1.0.63
+       */
+      postMixInProperties: function alfresco_notifications_AlfNotification__postMixInProperties() {
+         if (!this.id || registry.byId(this.id)) {
+            this.id = this.generateUuid();
+         }
+         this.inherited(arguments);
+      },
+
+      /**
+       * Called after widget created, but not sub-widgets
+       *
+       * @instance
+       * @override
+       */
+      postCreate: function alfresco_notifications_AlfNotification__postCreate() {
+         this.inherited(arguments);
+         if (this.autoClose) {
+            domClass.add(this.domNode, "alfresco-notifications-AlfNotification--auto-close");
+         }
+         if (this.widgets && this.widgets.length) {
+            domClass.add(this.domNode, "alfresco-notifications-AlfNotification--has-widgets");
+            this.processWidgets(lang.clone(this.widgets), this.widgetsNode);
+         }
+         document.body.appendChild(this.domNode);
+      },
+
+      /**
+       * Called when widget is destroyed
+       *
+       * @instance
+       */
+      destroy: function alfresco_notifications_AlfNotification__destroy() {
+         this.destroyDeferred.resolve();
+         this.inherited(arguments);
+      },
+
+      /**
+       * Display the notification.
+       *
+       * @instance
+       * @returns  {object} A promise that will resolve once the notification is destroyed.
+       */
+      display: function alfresco_notifications_AlfNotification__display() {
+         this.destroyDeferred = new Deferred();
+         setTimeout(lang.hitch(this, this._show), 0); // Add to page before showing, else transition fails
+         return this.destroyDeferred.promise;
+      },
+
+      /**
+       * Count the number of widgets provided in the config
+       *
+       * @instance
+       * @private
+       * @returns {number} The number of widgets
+       * @since 1.0.63
+       */
+      _countWidgets: function alfresco_notifications_AlfNotification___countWidgets() {
+         var numWidgets = 0;
+         (function countWidgets(widgets) {
+            if (!widgets || !widgets.length) {
+               return;
             }
-         },
+            if (widgets.constructor === Array) {
+               numWidgets += widgets.length;
+            }
+            array.forEach(widgets, function(widget) {
+               var conf = widget.config;
+               if (conf) {
+                  for (propName in conf) {
+                     if (conf.hasOwnProperty(propName) && propName.indexOf("widgets") === 0) {
+                        countWidgets(conf[propName]);
+                     }
+                  }
+               }
+            });
+         })(this.widgets);
+         return numWidgets;
+      },
 
-         /**
-          * Handle clicks on the close button
-          *
-          * @instance
-          * @param {Object} evt Dojo-normalised event object
-          */
-         _onCloseClick: function alfresco_notifications_AlfNotification___onCloseClick(/*jshint unused:false*/ evt) {
-            this._hide();
-         },
+      /**
+       * Hide the notification (and destroy it)
+       *
+       * @instance
+       * @private
+       */
+      _hide: function alfresco_notifications_AlfNotification___hide() {
+         if (this.domNode && this.domNode.parentNode === document.body) {
+            domClass.remove(this.domNode, "alfresco-notifications-AlfNotification--visible");
+            setTimeout(lang.hitch(this, this.destroy), this.destroyAfterHideMs);
+         }
+      },
 
-         /**
-          * Show the notification
-          *
-          * @instance
-          * @private
-          */
-         _show: function alfresco_notifications_AlfNotification___show() {
-            domClass.add(this.domNode, "alfresco-notifications-AlfNotification--visible");
-            var messageText = this.messageNode.textContent || this.message.innerText || "",
-               messageWords = messageText.split(/\W+/),
-               autoHideSecs = Math.ceil(messageWords.length / this.wordsPerSecond) + this.notificationFocusSecs;
+      /**
+       * Handle clicks on the close button
+       *
+       * @instance
+       * @private
+       * @param {Object} evt Dojo-normalised event object
+       */
+      _onCloseClick: function alfresco_notifications_AlfNotification___onCloseClick( /*jshint unused:false*/ evt) {
+         this._hide();
+      },
+
+      /**
+       * Show the notification
+       *
+       * @instance
+       * @private
+       */
+      _show: function alfresco_notifications_AlfNotification___show() {
+         domClass.add(this.domNode, "alfresco-notifications-AlfNotification--visible");
+         var messageText = this.messageNode.textContent || this.message.innerText || "",
+            messageWords = messageText.split(/\W+/),
+            numWidgets = this._countWidgets(),
+            autoHideSecs = Math.ceil(messageWords.length / this.wordsPerSecond) + Math.ceil(numWidgets * this.widgetSecs) + this.notificationFocusSecs;
+         if (this.autoClose) {
             setTimeout(lang.hitch(this, this._hide), autoHideSecs * 1000);
          }
-      });
-   }
-);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -20,16 +20,13 @@
       width: @notification-width;
    }
    &__close {
-      color: @notification-foreground-dimmed;
+      color: @notification-foreground;
       cursor: pointer;
       font-size: 25px;
       position: absolute;
       right: 10px;
       top: 0;
       transition: all .1s ease-out;
-      &:hover {
-         color: @notification-foreground;
-      }
    }
    &__message {
       color: @notification-foreground;
@@ -37,11 +34,32 @@
       font-size: @normal-font-size;
       line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
    }
+   &__widgets {
+      display: none;
+      margin-top: 20px;
+   }
    &--visible {
       .alfresco-notifications-AlfNotification {
          &__container {
             opacity: 1;
             top: 20vh;
+         }
+      }
+   }
+   &--auto-close {
+      .alfresco-notifications-AlfNotification {
+         &__close {
+            color: @notification-foreground-dimmed;
+            &:hover {
+               color: @notification-foreground;
+            }
+         }
+      }
+   }
+   &--has-widgets {
+      .alfresco-notifications-AlfNotification {
+         &__widgets {
+            display: block;
          }
       }
    }

--- a/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/AlfNotification.css
@@ -46,6 +46,29 @@
          }
       }
    }
+   &--has-inline-button {
+      .alfresco-notifications-AlfNotification {
+         &__container {
+            padding: 20px;
+            line-height: ceil(@normal-font-size/@standard-line-height) * @standard-line-height;
+         }
+         &__close {
+            position: static;
+            right: 0;
+            float: right;
+         }
+         &__widgets {
+            display: block;
+            float: right;
+            margin: 0;
+            margin-right: @normal-font-size;
+            .alfresco-navigation-Link {
+               color: @notification-foreground;
+               text-decoration: underline;
+            }
+         }
+      }
+   }
    &--auto-close {
       .alfresco-notifications-AlfNotification {
          &__close {

--- a/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
+++ b/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
@@ -1,5 +1,5 @@
 <div class="alfresco-notifications-AlfNotification" id="${id}">
-   <div class="alfresco-notifications-AlfNotification__container">
+   <div class="alfresco-notifications-AlfNotification__container" data-dojo-attach-point="containerNode">
       <div class="alfresco-notifications-AlfNotification__close" data-dojo-attach-event="click:_onCloseClick">&times;</div>
       <span class="alfresco-notifications-AlfNotification__message" data-dojo-attach-point="messageNode" aria-live="assertive" role="status">${message}</span>
       <div class="alfresco-notifications-AlfNotification__widgets" data-dojo-attach-point="widgetsNode"></div>

--- a/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
+++ b/aikau/src/main/resources/alfresco/notifications/templates/AlfNotification.html
@@ -1,6 +1,7 @@
-<div class="alfresco-notifications-AlfNotification">
+<div class="alfresco-notifications-AlfNotification" id="${id}">
    <div class="alfresco-notifications-AlfNotification__container">
       <div class="alfresco-notifications-AlfNotification__close" data-dojo-attach-event="click:_onCloseClick">&times;</div>
       <span class="alfresco-notifications-AlfNotification__message" data-dojo-attach-point="messageNode" aria-live="assertive" role="status">${message}</span>
+      <div class="alfresco-notifications-AlfNotification__widgets" data-dojo-attach-point="widgetsNode"></div>
    </div>
 </div>

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -98,9 +98,19 @@ define(["dojo/_base/declare",
       onDisplayNotification: function alfresco_services_NotificationService__onDisplayNotification(payload) {
          var message = lang.getObject("message", false, payload);
          if (message) {
-            var newNotification = new AlfNotification({
-               message: payload.message
-            });
+
+            // Define and use config to create a new notification
+            var config = {
+               message: payload.message,
+               widgets: payload.widgets,
+               id: payload.notificationId
+            }
+            if(typeof payload.autoClose !== "undefined") {
+               config.autoClose = payload.autoClose;
+            }
+            var newNotification = new AlfNotification(config);
+
+            // Show the notification
             newNotification.startup();
             newNotification.display().then(lang.hitch(this, function() {
                this.alfPublish(this.closeNotificationTopic, {}, true);

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -103,10 +103,14 @@ define(["dojo/_base/declare",
             var config = {
                message: payload.message,
                widgets: payload.widgets,
-               id: payload.notificationId
+               id: payload.notificationId,
+               inlineLink: payload.inlineLink
             };
             if(typeof payload.autoClose !== "undefined") {
                config.autoClose = payload.autoClose;
+            }
+            if(typeof payload.wordsPerSecond !== "undefined") {
+               config.wordsPerSecond = payload.wordsPerSecond;
             }
             var newNotification = new AlfNotification(config);
 

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -104,7 +104,7 @@ define(["dojo/_base/declare",
                message: payload.message,
                widgets: payload.widgets,
                id: payload.notificationId
-            }
+            };
             if(typeof payload.autoClose !== "undefined") {
                config.autoClose = payload.autoClose;
             }

--- a/aikau/src/test/resources/alfresco/renderers/DateLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateLinkTest.js
@@ -1,3 +1,4 @@
+/*jshint browser:true*/
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *

--- a/aikau/src/test/resources/alfresco/renderers/DateTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateTest.js
@@ -1,3 +1,4 @@
+/*jshint browser:true*/
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *

--- a/aikau/src/test/resources/alfresco/renderers/PropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PropertyLinkTest.js
@@ -1,3 +1,4 @@
+/*jshint browser:true*/
 /**
  * Copyright (C) 2005-2016 Alfresco Software Limited.
  *

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -33,7 +33,8 @@ define(["module",
    var selectors = {
       buttons: {
          nonClosingWithWidgets: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_WIDGETS_BUTTON"]),
-         publishWithinNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["IN_NOTIFICATION_BUTTON"])
+         publishWithinNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["IN_NOTIFICATION_BUTTON"]),
+         inlineLinkNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_INLINE_LINK_BUTTON"])
       },
       notifications: {
          closeButton: TestCommon.getTestSelector(notificationSelectors, "button.close")
@@ -210,7 +211,7 @@ define(["module",
          .getLastPublish("ALF_NOTIFICATION_CLOSED");
       },
 
-      "Can prevent notification from automatically closing": function() {
+      "Notification can contain widgets and have auto-close disabled": function() {
          return this.remote.findByCssSelector(selectors.buttons.nonClosingWithWidgets)
             .clearLog()
             .click()
@@ -225,7 +226,27 @@ define(["module",
             .click()
             .end()
 
+         .getLastPublish("ALF_NOTIFICATION_DESTROYED")
+
          .getLastPublish("PUBLISH_FROM_NOTIFICATION");
+      },
+
+      "Notification can have inline-link": function() {
+         return this.remote.findByCssSelector(selectors.buttons.inlineLinkNotification)
+            .clearLog()
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-notifications-AlfNotification .alfresco-navigation-Link")
+            .click()
+            .end()
+
+         .getLastPublish("ALF_NOTIFICATION_DESTROYED", 5000)
+
+         .getLastPublish("PUBLISH_BY_NOTIFICATION_LINK")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sampleValue", "foo");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -23,9 +23,22 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!expect",
-        "intern/chai!assert"],
-        function(module, defineSuite, expect, assert) {
+        "intern/chai!assert",
+        "alfresco/TestCommon"], 
+        function(module, defineSuite, assert, TestCommon) {
+
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton"),
+      notificationSelectors = TestCommon.getTestSelectors("alfresco/notifications/AlfNotification");
+
+   var selectors = {
+      buttons: {
+         nonClosingWithWidgets: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_WIDGETS_BUTTON"]),
+         publishWithinNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["IN_NOTIFICATION_BUTTON"])
+      },
+      notifications: {
+         closeButton: TestCommon.getTestSelector(notificationSelectors, "button.close")
+      }
+   };
 
    defineSuite(module, {
       name: "NotificationService",
@@ -195,6 +208,24 @@ define(["module",
             .end()
 
          .getLastPublish("ALF_NOTIFICATION_CLOSED");
+      },
+
+      "Can prevent notification from automatically closing": function() {
+         return this.remote.findByCssSelector(selectors.buttons.nonClosingWithWidgets)
+            .clearLog()
+            .click()
+            .sleep(5000) // That actions can continue after this point proves notification still open
+            .end()
+
+         .findByCssSelector(selectors.buttons.publishWithinNotification)
+            .click()
+            .end()
+
+         .findByCssSelector(selectors.notifications.closeButton)
+            .click()
+            .end()
+
+         .getLastPublish("PUBLISH_FROM_NOTIFICATION");
       }
    });
 });

--- a/aikau/src/test/resources/test-selectors/alfresco/notifications/AlfNotification.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/notifications/AlfNotification.properties
@@ -1,0 +1,4 @@
+# NOTE: Relies on there currently only ever being one notification visible at a time
+
+# Close button
+button.close=.alfresco-notifications-AlfNotification__close

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -145,6 +145,27 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/buttons/AlfButton",
+         id: "NOTIFICATION_WIDGETS_BUTTON",
+         config: {
+            label: "Display non-closing notification with widgets",
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "This is a message",
+               autoClose: false,
+               notificationId: "NON_CLOSING_NOTIFICATION",
+               widgets: [{
+                  name: "alfresco/buttons/AlfButton",
+                  id: "IN_NOTIFICATION_BUTTON",
+                  config: {
+                     label: "Push me!",
+                     publishTopic: "PUBLISH_FROM_NOTIFICATION"
+                  }
+               }]
+            }
+         }
+      },
+      {
          name: "alfresco/html/Spacer",
          config: {
             height: "500px"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -152,6 +152,7 @@ model.jsonModel = {
             publishTopic: "ALF_DISPLAY_NOTIFICATION",
             publishPayload: {
                message: "This is a message",
+               publishTopic: "ALF_NOTIFICATION_DESTROYED",
                autoClose: false,
                notificationId: "NON_CLOSING_NOTIFICATION",
                widgets: [{
@@ -162,6 +163,26 @@ model.jsonModel = {
                      publishTopic: "PUBLISH_FROM_NOTIFICATION"
                   }
                }]
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "NOTIFICATION_INLINE_LINK_BUTTON",
+         config: {
+            label: "Display notification with inline link",
+            publishTopic: "ALF_DISPLAY_NOTIFICATION",
+            publishPayload: {
+               message: "This is a message",
+               publishTopic: "ALF_NOTIFICATION_DESTROYED",
+               wordsPerSecond: 3,
+               inlineLink: {
+                  label: "Perform action",
+                  publishTopic: "PUBLISH_BY_NOTIFICATION_LINK",
+                  publishPayload: {
+                     sampleValue: "foo"
+                  }
+               }
             }
          }
       },


### PR DESCRIPTION
This addresses [AKU-914](https://issues.alfresco.com/jira/browse/AKU-914) by adding the ability to configure widgets in notifications. A unit-test has been added and a full regression suite run successfully.