### PR TITLE
AKU-920, AKU-921: Expanded cell form control focus and cursor keys use

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -88,6 +88,7 @@
  * @mixes module:alfresco/forms/controls/FormControlValidationMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/forms/controls/utilities/RulesEngineMixin
+ * @mixes module:alfresco/lists/KeyboardNavigationSuppressionMixin
  * @extendSafe
  * @author Dave Draper
  * @author Richard Smith
@@ -301,6 +302,22 @@ define(["dojo/_base/declare",
        * @since 1.0.33
        */
       getPubSubOptionsImmediately: true,
+
+      /**
+       * This attribute should only be configured to be true when the control is being used within the
+       * a [list]{@link module:alfresco/lists/AlfList} - for example as part of the widget model for
+       * [a list appendix]{@link module:alfresco/lists/views/AlfListView#widgetsForAppendix} or as 
+       * part of the rendering of an item. Configuring this to true will ensure that using the cursor
+       * keys will not control the selected list item and that focus will not be stolen from the wrapped
+       * control - however, this should be used with caution as it may limit or alter the behaviour
+       * of some form controls. See AKU-920/AKU-921 for the background of why this has been added.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.63
+       */
+      usedInList: false,
 
       /**
        * The default visibility status is always true (this can be overridden by extending controls).
@@ -1261,12 +1278,21 @@ define(["dojo/_base/declare",
                this.deferredValuePublication.resolve();
             }
 
-            on(this.domNode, "click", lang.hitch(this, this.suppressFocusRequest));
+            if (this.usedInList)
+            {
+               on(this.domNode, "click", lang.hitch(this, this.suppressFocusRequest));
+            }
          }
          else
          {
             // No action yet. Don't unsubscribe.
          }
+      },
+
+      suppressFocusRequest: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressFocusRequest(evt) {
+         evt.stopPropagation();
+         evt.preventDefault();
+         this.focus();
       },
 
       /**
@@ -1338,7 +1364,10 @@ define(["dojo/_base/declare",
             this._pendingValidationFailureDisplay = false;
             this.showValidationFailure();
          }
-         this.suppressContainerKeyboardNavigation(false);
+         if (this.usedInList)
+         {
+            this.suppressContainerKeyboardNavigation(false);
+         }
          this.inherited(arguments);
       },
 
@@ -1354,7 +1383,10 @@ define(["dojo/_base/declare",
        * @since 1.0.63
        */
       _onFocus: function alfresco_forms_controls_BaseFormControl___onFocus() {
-         this.suppressContainerKeyboardNavigation(true);
+         if (this.usedInList)
+         {
+            this.suppressContainerKeyboardNavigation(true);
+         }
          this.inherited(arguments);
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1289,12 +1289,6 @@ define(["dojo/_base/declare",
          }
       },
 
-      suppressFocusRequest: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressFocusRequest(evt) {
-         evt.stopPropagation();
-         evt.preventDefault();
-         this.focus();
-      },
-
       /**
        * Adds the widget into the current DOM fragment and then sets up subscriptions on widget processing complete
        * publications as we want to wait the most recently requested widget processing to complete (which in all likelihood

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -99,6 +99,7 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/forms/controls/FormControlValidationMixin",
         "alfresco/forms/controls/utilities/RulesEngineMixin",
+        "alfresco/lists/KeyboardNavigationSuppressionMixin",
         "dojo/text!./templates/BaseFormControl.html",
         "alfresco/core/topics",
         "alfresco/core/ObjectTypeUtils",
@@ -112,11 +113,13 @@ define(["dojo/_base/declare",
         "dojo/query",
         "dojo/dom-construct",
         "dojo/Deferred",
+        "dojo/on",
         "jquery"],
-        function(declare, _Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, RulesEngineMixin, template, topics,
-                 ObjectTypeUtils, arrayUtils, lang, array, domStyle, domClass, Tooltip, domAttr, query, domConstruct, Deferred, $) {
+        function(declare, _Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, RulesEngineMixin, 
+                 KeyboardNavigationSuppressionMixin, template, topics, ObjectTypeUtils, arrayUtils, lang, array, domStyle, 
+                 domClass, Tooltip, domAttr, query, domConstruct, Deferred, on, $) {
 
-   return declare([_Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, RulesEngineMixin], {
+   return declare([_Widget, _Templated, _FocusMixin, AlfCore, FormControlValidationMixin, RulesEngineMixin, KeyboardNavigationSuppressionMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -1257,6 +1260,8 @@ define(["dojo/_base/declare",
             {
                this.deferredValuePublication.resolve();
             }
+
+            on(this.domNode, "click", lang.hitch(this, this.suppressFocusRequest));
          }
          else
          {
@@ -1333,6 +1338,23 @@ define(["dojo/_base/declare",
             this._pendingValidationFailureDisplay = false;
             this.showValidationFailure();
          }
+         this.suppressContainerKeyboardNavigation(false);
+         this.inherited(arguments);
+      },
+
+      /**
+       * This function is called whenever the form control gains focus. This results in the 
+       * [suppressContainerKeyboardNavigation]{@link module:alfresco/lists/KeyboardNavigationSuppressionMixin#suppressContainerKeyboardNavigation}
+       * function being called to ensure that when the form is placed inside a 
+       * [list]{@link module:alfresco/lists/AlfList} the [view]{@link module:alfresco/lists/views/AlfListView}
+       * does not use the key presses (typically the cursor keys) to navigate the user around items in the
+       * list.
+       *
+       * @instance
+       * @since 1.0.63
+       */
+      _onFocus: function alfresco_forms_controls_BaseFormControl___onFocus() {
+         this.suppressContainerKeyboardNavigation(true);
          this.inherited(arguments);
       },
 

--- a/aikau/src/main/resources/alfresco/lists/KeyboardNavigationSuppressionMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/KeyboardNavigationSuppressionMixin.js
@@ -18,7 +18,9 @@
  */
 
 /**
- *
+ * This mixin provides both the ability to request the suppression of keyboard events that are handled by 
+ * the dijit/_KeyNavContainer mixin and the ability to perform the actual suppression. As such this should
+ * always be mixed into a module after dijit/_KeyNavContainer as it overrides some of its functions.
  * 
  * @module alfresco/lists/KeyboardNavigationSuppressionMixin
  * @author Dave Draper
@@ -31,6 +33,19 @@ define(["dojo/_base/declare",
    
    return declare(null, {
       
+      /**
+       * The ability to suppress keyboard navigation (e.g. the ability to move around the rendered list of items using
+       * the keyboard) has been added to support widgets that allow inline editing (such as the
+       * [InlineEditProperty]{@link alfresco/renderers/InlineEditProperty} widget). In order to allow their keyboard
+       * events to bubble up to the browser, this widget needs to stop searching for keyboard navigation matches.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.63
+       */
+      suppressKeyNavigation: false,
+
       /**
        * Checks for the CTRL-e combination and when detected moves into edit mode.
        * 
@@ -85,9 +100,10 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {boolean} suppress Whether or not to suppress keyboard navigation
+       * @param {element} [node] The node to suppress navigation from.
        */
-      suppressContainerKeyboardNavigation: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressContainerKeyboardNavigation(suppress) {
-         on.emit(this.domNode, "onSuppressKeyNavigation", {
+      suppressContainerKeyboardNavigation: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressContainerKeyboardNavigation(suppress, node) {
+         on.emit(node || this.domNode, "onSuppressKeyNavigation", {
             bubbles: true,
             cancelable: true,
             suppress: suppress
@@ -107,6 +123,50 @@ define(["dojo/_base/declare",
        */
       suppressFocusRequest: function alfresco_lists_KeyboardNavigationSuppressionMixin__suppressFocusRequest(evt) {
          evt && event.stop(evt);
+      },
+
+      /**
+       * Updates the [suppressKeyNavigation]{@link module:alfresco/lists/KeyboardNavigationSuppressionMixin#suppressKeyNavigation}
+       * with the emitted event details
+       *
+       * @instance
+       * @param {object} evt The emitted event.
+       * @since 1.0.63
+       */
+      onSuppressKeyNavigation: function alfresco_lists_KeyboardNavigationSuppressionMixin__onSuppressKeyNavigation(evt) {
+         this.suppressKeyNavigation = evt.suppress === true;
+      },
+
+      /**
+       * Extends the function mixed in from the dijit/_KeyNavContainer module to perform no action when
+       * [suppressKeyNavigation]{@link module:alfresco/lists/KeyboardNavigationSuppressionMixin#suppressKeyNavigation}
+       * is set to true.
+       * 
+       * @instance
+       * @param {object} evt The keyboard event
+       * @since 1.0.63
+       */
+      _onContainerKeypress: function alfresco_lists_KeyboardNavigationSuppressionMixin___onContainerKeypress(/*jshint unused:false*/ evt) {
+         if (this.suppressKeyNavigation === false)
+         {
+            this.inherited(arguments);
+         }
+      },
+
+      /**
+       * Extends the function mixed in from the dijit/_KeyNavContainer module to perform no action when
+       * [suppressKeyNavigation]{@link module:alfresco/lists/KeyboardNavigationSuppressionMixin#suppressKeyNavigation}
+       * is set to true.
+       * 
+       * @instance
+       * @param {object} evt The keyboard event
+       * @since 1.0.63
+       */
+      _onContainerKeydown: function lfresco_lists_KeyboardNavigationSuppressionMixin___onContainerKeydown(/*jshint unused:false*/ evt) {
+         if (this.suppressKeyNavigation === false)
+         {
+            this.inherited(arguments);
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/lists/views/ListRenderer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/ListRenderer.js
@@ -42,6 +42,7 @@
  * @mixes external:dojo/_TemplatedMixin
  * @mixes external:dojo/_KeyNavContainer
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
+ * @mixes module:alfresco/lists/KeyboardNavigationSuppressionMixin
  * @mixes module:alfresco/core/Core
  * @author Dave Draper
  */
@@ -49,6 +50,7 @@ define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
         "dijit/_TemplatedMixin",
         "dijit/_KeyNavContainer",
+        "alfresco/lists/KeyboardNavigationSuppressionMixin",
         "dojo/text!./templates/ListRenderer.html",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
@@ -59,10 +61,10 @@ define(["dojo/_base/declare",
         "dojo/keys",
         "jquery",
         "jqueryui"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _KeyNavContainer, template, _MultiItemRendererMixin, 
-                 AlfCore, JsNode, lang, array, on, keys, $) {
+        function(declare, _WidgetBase, _TemplatedMixin, _KeyNavContainer, KeyboardNavigationSuppressionMixin, template, 
+                 _MultiItemRendererMixin, AlfCore, JsNode, lang, array, on, keys, $) {
    
-   return declare([_WidgetBase, _TemplatedMixin, _KeyNavContainer, _MultiItemRendererMixin, AlfCore], {
+   return declare([_WidgetBase, _TemplatedMixin, _KeyNavContainer, _MultiItemRendererMixin, KeyboardNavigationSuppressionMixin, AlfCore], {
       
       /**
        * The HTML template to use for the widget.
@@ -101,39 +103,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * The ability to suppress keyboard navigation (e.g. the ability to move around the rendered list of items using
-       * the keyboard) has been added to support widgets that allow inline editing (such as the
-       * [InlineEditProperty]{@link alfresco/renderers/InlineEditProperty} widget). In order to allow their keyboard
-       * events to bubble up to the browser, this widget needs to stop searching for keyboard navigation matches.
-       *
-       * @instance
-       * @type {boolean}
-       * @default
-       */
-      suppressKeyNavigation: false,
-
-      /**
-       * Updates the [suppressKeyNavigation]{@link module:alfresco/lists/views/ListRenderer#suppressKeyNavigation}
-       * with the emitted event details
-       *
-       * @instance
-       * @param {object} evt The emitted event.
-       */
-      onSuppressKeyNavigation: function alfresco_lists_views_ListRenderer__onSuppressKeyNavigation(evt) {
-         this.suppressKeyNavigation = evt.suppress === true;
-      },
-      
-      /**
-       * This sets up the default keyboard handling for a view. The standard controls are navigation to the
-       * next item by pressing the down key and navigation to the previous item by pressing the up key.
-       * 
-       * @instance
-       */
-      setupKeyboardNavigation: function alfresco_lists_views_ListRenderer__setupKeyboardNavigation() {
-         this.connectKeyNavHandlers([keys.UP_ARROW], [keys.DOWN_ARROW]);
-      },
-      
-      /**
        * Overrides the _KevNavContainer function to call the "blur" function of the widget that has lost
        * focus (assuming it has one).
        * 
@@ -147,36 +116,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Extends the function mixed in from the dijit/_KeyNavContainer module to perform no action when
-       * [suppressKeyNavigation]{@link module:alfresco/lists/views/ListRenderer#suppressKeyNavigation}
-       * is set to true.
-       * 
-       * @instance
-       * @param {object} evt The keyboard event
-       */
-      _onContainerKeydown: function alfresco_lists_views_ListRenderer___onContainerKeydown(/*jshint unused:false*/ evt) {
-         if (this.suppressKeyNavigation === false)
-         {
-            this.inherited(arguments);
-         }
-      },
-
-      /**
-       * Extends the function mixed in from the dijit/_KeyNavContainer module to perform no action when
-       * [suppressKeyNavigation]{@link module:alfresco/lists/views/ListRenderer#suppressKeyNavigation}
-       * is set to true.
-       * 
-       * @instance
-       * @param {object} evt The keyboard event
-       */
-      _onContainerKeypress: function alfresco_lists_views_ListRenderer___onContainerKeypress(/*jshint unused:false*/ evt) {
-         if (this.suppressKeyNavigation === false)
-         {
-            this.inherited(arguments);
-         }
-      },
-
-      /**
        * Handles requests to focus a specific child item that has been clicked on. This is a custom
        * event issued from a module mixing in the 
        * [_MultiItemRendererMixin]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin}.
@@ -186,6 +125,16 @@ define(["dojo/_base/declare",
        */
       onItemFocused: function alfresco_lists_views_ListRenderer__onItemFocused(evt) {
          this.focusChild(evt.item);
+      },
+
+      /**
+       * This sets up the default keyboard handling for a view. The standard controls are navigation to the
+       * next item by pressing the down key and navigation to the previous item by pressing the up key.
+       * 
+       * @instance
+       */
+      setupKeyboardNavigation: function alfresco_lists_views_ListRenderer__setupKeyboardNavigation() {
+         this.connectKeyNavHandlers([keys.UP_ARROW], [keys.DOWN_ARROW]);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Grid.js
@@ -26,6 +26,7 @@
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
+ * @mixes module:alfresco/lists/KeyboardNavigationSuppressionMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
@@ -35,6 +36,7 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "alfresco/core/ResizeMixin",
         "dijit/_KeyNavContainer",
+        "alfresco/lists/KeyboardNavigationSuppressionMixin",
         "dojo/text!./templates/Grid.html",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/core/Core",
@@ -52,11 +54,11 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dijit/registry",
         "dijit/focus"],
-        function(declare, _WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, template, _MultiItemRendererMixin,
+        function(declare, _WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, KeyboardNavigationSuppressionMixin, template, _MultiItemRendererMixin,
                  AlfCore, _LayoutMixin, WidgetsCreator, keys, on, lang, array, domAttr, domClass, domConstruct, domGeom, query, domStyle,
                  registry, focusUtil) {
 
-   return declare([_WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, _MultiItemRendererMixin, AlfCore, _LayoutMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, ResizeMixin, _KeyNavContainer, _MultiItemRendererMixin, KeyboardNavigationSuppressionMixin, AlfCore, _LayoutMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -240,6 +242,8 @@ define(["dojo/_base/declare",
          }
 
          this.setupKeyboardNavigation();
+         on(this.domNode, "onSuppressKeyNavigation", lang.hitch(this, this.onSuppressKeyNavigation));
+         on(this.domNode, "onItemFocused", lang.hitch(this, this.onItemFocused));
 
          // Update the grid as the window changes...
          this.alfSetupResizeSubscriptions(this.resizeCells, this);

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,17 +27,11 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   runAllTests = false; // Comment/uncomment this line to toggle
+   // runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "src/test/resources/alfresco/forms/controls/CheckBoxTest",
-      // "src/test/resources/alfresco/forms/controls/FormButtonDialogTest",
-      // "src/test/resources/alfresco/forms/controls/PushButtonsTest",
-      // "src/test/resources/alfresco/search/SearchSuggestionsTest",
-      // "src/test/resources/alfresco/core/PageTest",
-      // "src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest",
-      // "src/test/resources/alfresco/forms/controls/ContainerPickerTest"
+      "src/test/resources/alfresco/upload/UploadMonitorTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,11 +27,17 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   // runAllTests = false; // Comment/uncomment this line to toggle
+   runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "src/test/resources/alfresco/upload/UploadMonitorTest"
+      "src/test/resources/alfresco/forms/controls/CheckBoxTest",
+      // "src/test/resources/alfresco/forms/controls/FormButtonDialogTest",
+      // "src/test/resources/alfresco/forms/controls/PushButtonsTest",
+      // "src/test/resources/alfresco/search/SearchSuggestionsTest",
+      // "src/test/resources/alfresco/core/PageTest",
+      // "src/test/resources/alfresco/documentlibrary/views/MediaFilmStripViewTest",
+      // "src/test/resources/alfresco/forms/controls/ContainerPickerTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "src/test/resources/alfresco/preview/PdfJsPreviewFaultsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
@@ -81,11 +81,118 @@ model.jsonModel = {
                               publishPayloadItemMixin: true,
                               widgets: [
                                  {
+                                    id: "EXPAND_LINK",
+                                    name: "alfresco/renderers/PropertyLink",
+                                    config: {
+                                       label: "Alternative",
+                                       publishTopic: "EXPAND",
+                                       publishPayloadType: "PROCESS",
+                                       publishPayloadModifiers: ["processCurrentItemTokens"],
+                                       useCurrentItemAsPayload: false,
+                                       publishPayload: {
+                                          nodeRef: "{nodeRef}",
+                                          widgets: [
+                                             {
+                                                id: "EXPANDED_LIST",
+                                                name: "alfresco/lists/AlfList",
+                                                config: {
+                                                   currentData: {
+                                                      items: [
+                                                         {
+                                                            name: "{displayName}"
+                                                         }
+                                                      ]
+                                                   },
+                                                   pubSubScope: "EditCaveatGroupListView",
+                                                   waitForPageWidgets: false,
+                                                   widgets: [
+                                                      {
+                                                         id: "EXPANDED_LIST_VIEW",
+                                                         name: "alfresco/lists/views/AlfListView",
+                                                         config: {
+                                                            additionalCssClasses: "bordered",
+                                                            widgets: [
+                                                               {
+                                                                  name: "alfresco/lists/views/layouts/Row",
+                                                                  config: {
+                                                                     widgets: [
+                                                                        {
+                                                                           name: "alfresco/lists/views/layouts/Cell",
+                                                                           config: {
+                                                                              widgets: [
+                                                                                 {
+                                                                                    id: "EXPANDED_LIST_INLINE_EDIT",
+                                                                                    name: "alfresco/renderers/InlineEditProperty",
+                                                                                    config: {
+                                                                                       propertyToRender: "name",
+                                                                                       postParam: "fake",
+                                                                                       publishTopic: "ALT_INLINE_EDIT_SAVE",
+                                                                                       publishPayloadType: "PROCESS",
+                                                                                       publishPayloadModifiers: ["processCurrentItemTokens"],
+                                                                                       publishPayloadItemMixin: true,
+                                                                                       publishPayload: {
+                                                                                          data: "{name}"
+                                                                                       },
+                                                                                       publishGlobal: true
+                                                                                    }
+                                                                                 }
+                                                                              ]
+                                                                           }
+                                                                        }
+                                                                     ]
+                                                                  }
+                                                               }
+                                                            ],
+                                                            widgetsForAppendix: [
+                                                               {
+                                                                  name: "alfresco/lists/views/layouts/Row",
+                                                                  config: {
+                                                                     widgets: [
+                                                                        {
+                                                                           name: "alfresco/lists/views/layouts/Cell",
+                                                                           config: {
+                                                                              colspan: 2,
+                                                                              widgets: [
+                                                                                 {
+                                                                                    id: "APPENDIX_FORM",
+                                                                                    name: "alfresco/forms/Form",
+                                                                                    config: {
+                                                                                       okButtonPublishTopic: "SAVE",
+                                                                                       scopeFormControls: false,
+                                                                                       widgets: [
+                                                                                          {
+                                                                                             id: "APPENDIX_TEXTBOX",
+                                                                                             name: "alfresco/forms/controls/TextBox",
+                                                                                             config: {
+                                                                                                fieldId: "APPENDIX_TEXTBOX",
+                                                                                                name: "test",
+                                                                                                value: ""
+                                                                                             }
+                                                                                          }
+                                                                                       ]
+                                                                                    }
+                                                                                 }
+                                                                              ]
+                                                                           }
+                                                                        }
+                                                                     ]
+                                                                  }
+                                                               }
+                                                            ]
+                                                         }
+                                                      }
+                                                   ]
+                                                }
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 },
+                                 {
                                     id: "PROPERTY",
                                     name: "alfresco/renderers/Property",
                                     config: {
                                        propertyToRender: "node.properties.cm:name"
-                                       
                                     }
                                  }
                               ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
@@ -164,6 +164,7 @@ model.jsonModel = {
                                                                                              id: "APPENDIX_TEXTBOX",
                                                                                              name: "alfresco/forms/controls/TextBox",
                                                                                              config: {
+                                                                                                usedInList: true,
                                                                                                 fieldId: "APPENDIX_TEXTBOX",
                                                                                                 name: "test",
                                                                                                 value: ""


### PR DESCRIPTION
This PR jointly addresses both https://issues.alfresco.com/jira/browse/AKU-920 and https://issues.alfresco.com/jira/browse/AKU-921 to ensure when form controls are present in the expanded area of a list or grid that they can be given focus and the cursor keys can be used as expected without controlling the item focused in the enclosing list. 

**FULL REGRESSION SUITE RUNNING - REVIEW DON'T MERGE!**