### PR TITLE
AKU-411: Update to build to version lib files

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -170,7 +170,7 @@
 
          <resource>
             <!-- WebScript library files go straight into a package -->
-            <targetPath>./alfresco/site-webscripts/org/alfresco/aikau/webscript/libs</targetPath>
+            <targetPath>./alfresco/site-webscripts/org/alfresco/aikau/${project.version}/libs</targetPath>
             <filtering>false</filtering>
             <directory>${basedir}/src/main/resources/webscript-libs</directory>
          </resource>

--- a/aikau/src/main/resources/extension-module/aikau-extension.xml
+++ b/aikau/src/main/resources/extension-module/aikau-extension.xml
@@ -15,6 +15,7 @@
                      <bootstrap-file>/res/js/lib/dojo-${dependency.dojo.version}/dojo/dojo.js</bootstrap-file>
                      <page-widget>alfresco/core/Page</page-widget>
                      <base-url>/res/</base-url>
+                     <aikau-version>${project.version}</aikau-version>
                      <default-less-configuration>/js/aikau/${project.version}/alfresco/css/less/defaults.less</default-less-configuration><messages-object>Alfresco</messages-object>
                      <packages>
                         <package name="webscripts"    location="../service/${webscript.version}" />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLib.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLib.get.js
@@ -1,5 +1,4 @@
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/service-filtering.lib.js">
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib.js">
 
 var pageServices = [
    {
@@ -15,7 +14,7 @@ var pageServices = [
    "alfresco/services/LogoutService"];
 
 var docLibServices = getDocumentLibraryServices();
-var services = alfAddUniqueServices(pageServices, docLibServices);
+var services = pageServices.concat(docLibServices);
 
 var docLib = getDocLib({
    siteId: "site1", 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLib.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLib.get.properties
@@ -1,1 +1,1 @@
-surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.js
@@ -1,5 +1,4 @@
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/service-filtering.lib.js">
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib.js">
 
 /* global page */
 /* jshint sub:true */
@@ -23,7 +22,7 @@ var pageServices = [
    "alfresco/services/LogoutService"];
 
 var docLibServices = getDocumentLibraryServices();
-var services = alfAddUniqueServices(pageServices, docLibServices);
+var services = pageServices.concat(docLibServices);
 
 var docLib = getDocLib({
    siteId: null, 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibBigData.get.properties
@@ -1,1 +1,1 @@
-surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.js
@@ -1,5 +1,4 @@
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/service-filtering.lib.js">
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib.js">
 
 var pageServices = [
    {
@@ -15,7 +14,7 @@ var pageServices = [
    "alfresco/services/LogoutService"];
 
 var docLibServices = getDocumentLibraryServices();
-var services = alfAddUniqueServices(pageServices, docLibServices);
+var services = pageServices.concat(docLibServices);
 
 model.jsonModel = {
    services: services,

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibNoHash.get.properties
@@ -1,1 +1,1 @@
-surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibRawData.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibRawData.get.js
@@ -1,5 +1,4 @@
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/service-filtering.lib.js">
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib.js">
 
 var pageServices = [
    {
@@ -21,7 +20,7 @@ var pageServices = [
    "alfresco/services/LogoutService"];
 
 var docLibServices = getDocumentLibraryServices();
-var services = alfAddUniqueServices(pageServices, docLibServices);
+var services = pageServices.concat(docLibServices);
 
 var docLib = getDocLib({
    siteId: "site1", 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibRawData.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/DocLibRawData.get.properties
@@ -1,1 +1,1 @@
-surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
@@ -1,4 +1,4 @@
-<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/webscript/libs/doclib/doclib.lib.js">
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib.js">
 
 /* global page */
 /* jshint sub:true */

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.properties
@@ -1,1 +1,1 @@
-surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.properties
@@ -1,1 +1,1 @@
-surf.include.resources=org/alfresco/aikau/webscript/libs/doclib/doclib.lib
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib

--- a/aikau/src/test/resources/testApp/WEB-INF/surf.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/surf.xml
@@ -114,6 +114,8 @@
                <base-url>/res/</base-url>
 
                <default-less-configuration>/js/aikau/${project.version}/alfresco/css/less/defaults.less</default-less-configuration>
+
+               <aikau-version>${project.version}</aikau-version>
                
                <messages-object>Alfresco</messages-object>
                <packages>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-411 to make it possible to specify the version of Aikau that is in use by the application for WebScript library file imports (currently limited to a Document Library import). This can be used in both WebScript controller and properties files. The unit test pages have been updated to make use of this new capability. This will only work when used on 5.0.3 and above or on 5.1 and above (or the Surf 6.x).