### PR TITLE
AKU-777: IE11/Edge MultiSelectInput choice removal

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/ChoiceMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/ChoiceMixin.js
@@ -28,8 +28,9 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/dom-construct",
         "dojo/dom-class",
+        "dojo/has",
         "dojo/on"], 
-        function(declare, lang, array, domConstruct, domClass, on) {
+        function(declare, lang, array, domConstruct, domClass, has, on) {
 
    return declare([], {
 
@@ -204,6 +205,24 @@ define(["dojo/_base/declare",
          var choiceObject = {},
             selectListener = on(choiceNode, "click", lang.hitch(this, this._onChoiceClick, choiceObject)),
             closeListener = on(closeButton, "mousedown", lang.hitch(this, this._onChoiceCloseMouseDown, choiceObject));
+
+         // See AKU-777 for the details of this issue...
+         // On IE11 and Edge Dojo will capture additional events that result in focus being given to
+         // a surrounding input field. However to resolve this issue we need to capture the event,
+         // stop it from propogating and issue a new event in it's place. The original event needs to 
+         // be stopped because it is not possible to change the 'target' attribute of an event once
+         // created (it is read-only).
+         // NOTE: The first line (assigning event) is copied directly from dijit/focus to ensure the same
+         //       event is captured
+         var event = has("pointer-events") ? "pointerdown" : has("MSPointer") ? "MSPointerDown" : has("touch-events") ? "mousedown, touchstart" : "mousedown";
+         pointerListener = on(choiceNode, event, lang.hitch(this, function(evt) {
+            evt.stopPropagation();
+            var clicker = new MouseEvent("pointerdown", {
+              "target": this.domNode
+            });
+            this.domNode.dispatchEvent(clicker);
+         }));
+
          this.own(selectListener, closeListener);
          lang.mixin(choiceObject, {
             domNode: choiceNode,
@@ -211,6 +230,7 @@ define(["dojo/_base/declare",
             closeButton: closeButton,
             selectListener: selectListener,
             closeListener: closeListener,
+            pointerListener: pointerListener,
             item: storeItem,
             value: value
          });
@@ -329,6 +349,7 @@ define(["dojo/_base/declare",
          domConstruct.destroy(choiceToRemove.domNode);
          choiceToRemove.selectListener.remove();
          choiceToRemove.closeListener.remove();
+         choiceToRemove.pointerListener.remove();
       },
 
       /**


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-777 to address an IE11 / Edge specific issue where deleting a previously selected choice results in the MultiSelectInput drop-down menu being displayed. This is a result of how dijit/focus handles pointer/touch events for those browsers. The fix here is to capture the event before dijit/focus can process it and change the target element (in fact it is necessary to stop the original event and replace it with a new one because the target attribute is read only). This results in the main widget being focused rather than the input field and means that the drop-down menu is not displayed.