### PR TITLE
Issue988_ResolveWebScriptClash

### DIFF
--- a/aikau/src/main/resources/alfresco/html/Markdown.js
+++ b/aikau/src/main/resources/alfresco/html/Markdown.js
@@ -57,11 +57,12 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/Markdown.html",
         "alfresco/core/Core",
         "alfresco/core/CoreXhr",
+        "webscripts/defaults",
         "service/constants/Default",
         "dojo/_base/lang",
         "dojo/_base/array",
         "showdown"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreXhr, AlfConstants, lang, array, showdown) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreXhr, webScriptDefaults, AlfConstants, lang, array, showdown) {
    
    return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreXhr], {
 
@@ -164,7 +165,7 @@ define(["dojo/_base/declare",
                var html = this.converter.makeHtml(markdown);
 
                // Sanitize the output to ensure it is safe to render...
-               var url = AlfConstants.URL_SERVICECONTEXT + "sanitize/data";
+               var url = AlfConstants.URL_SERVICECONTEXT + webScriptDefaults.WEBSCRIPT_VERSION + "/sanitize/data";
                if (url) {
                   this.serviceXhr({
                      url: url,

--- a/aikau/src/main/resources/alfresco/services/CommentService.js
+++ b/aikau/src/main/resources/alfresco/services/CommentService.js
@@ -32,10 +32,11 @@
 define(["dojo/_base/declare",
         "alfresco/services/BaseService",
         "alfresco/core/CoreXhr",
+        "webscripts/defaults",
         "dojo/_base/lang",
         "dojo/_base/array",
         "service/constants/Default"],
-        function(declare, BaseService, CoreXhr, lang, array, AlfConstants) {
+        function(declare, BaseService, CoreXhr, webScriptDefaults, lang, array, AlfConstants) {
    
    return declare([BaseService, CoreXhr], {
       
@@ -81,7 +82,9 @@ define(["dojo/_base/declare",
          {
             startIndex = (payload.page - 1) * pageSize;
          }
-         var url = AlfConstants.URL_SERVICECONTEXT + "/sanitize/response?items=items&attribute=content&ws=/api/node/" + payload.nodeRef + "/comments%3Freverse=" + reverse + "%26startIndex=" + startIndex + "%26pageSize=" + pageSize;
+         var url = AlfConstants.URL_SERVICECONTEXT + webScriptDefaults.WEBSCRIPT_VERSION + 
+                   "/sanitize/response?items=items&attribute=content&ws=/api/node/" + payload.nodeRef + 
+                   "/comments%3Freverse=" + reverse + "%26startIndex=" + startIndex + "%26pageSize=" + pageSize;
          this.serviceXhr({
             url: url,
             alfTopic: payload.alfResponseTopic || null,

--- a/aikau/src/main/resources/webscripts/defaults.get.js.ftl
+++ b/aikau/src/main/resources/webscripts/defaults.get.js.ftl
@@ -26,6 +26,7 @@ define(["dojo/_base/lang"],
         function(lang) {
    
    return {
-      ACCEPT_LANGUAGE: "${data.headers.acceptLanguage!""}"
+      ACCEPT_LANGUAGE: "${data.headers.acceptLanguage!""}",
+      WEBSCRIPT_VERSION: "${webscript.version}"
    };
 });

--- a/aikau/src/main/resources/webscripts/sanitize-data.post.desc.xml
+++ b/aikau/src/main/resources/webscripts/sanitize-data.post.desc.xml
@@ -1,7 +1,7 @@
 <webscript>
   <shortname>Sanitize Data</shortname>
   <description>This WebScript to strip unsafe HTML from the posted data. This is provided for use of removing unsafe data from Markdown content.</description>
-  <url>/sanitize/data</url>
+  <url>/${webscript.version}/sanitize/data</url>
   <format default="json">argument</format>
   <authentication>user</authentication>
 </webscript>

--- a/aikau/src/main/resources/webscripts/sanitize-response.get.desc.xml
+++ b/aikau/src/main/resources/webscripts/sanitize-response.get.desc.xml
@@ -1,7 +1,7 @@
 <webscript>
   <shortname>Sanitize Content</shortname>
   <description>This WebScript can be used as a proxy to sanitize responses from Repository APIs to ensure the content can be rendered safely in a browser.</description>
-  <url>/sanitize/response</url>
+  <url>/${webscript.version}/sanitize/response</url>
   <format default="json">argument</format>
   <authentication>user</authentication>
 </webscript>


### PR DESCRIPTION
This addresses #988 to ensure that errors are not displayed when refreshing WebScripts with multiple Aikau JARs in an application. This solves the problem going forwards, but will not fix occurrences where one of the JARs is 1.0.62.