### PR TITLE
AKU-924: Infinite scroll DocLib browser support browser back

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -296,6 +296,10 @@ define(["dojo/_base/declare",
             this._updateCoreHashVars(payload);
             if (this._readyToLoad)
             {
+               if (this.useInfiniteScroll)
+               {
+                  this.clearViews();
+               }
                this.loadData();
                dataLoaded = true;
             }

--- a/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
@@ -136,6 +136,18 @@ define(["module",
             .then(function(elements) {
                assert.lengthOf(elements, 4);
             });
+      },
+
+      // See AKU-924
+      "Use back button": function() {
+         return this.remote.goBack()
+
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+         .findAllByCssSelector(selectors.rows.all)
+            .then(function(elements) {
+               assert.lengthOf(elements, 4);
+            });
       }
    });
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-924 to ensure that the back button doesn't duplicate results when using an infinitely scrolling AlfDocumentList.