### PR TITLE
AKU-930: Update SiteService to ensure moderated site data is shown correctly

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -84,7 +84,7 @@ define(["alfresco/core/ProcessWidgets",
          {
             if (AlfConstants.DEBUG)
             {
-               require.on("error", this.onError);
+               require.on("error", lang.hitch(this, this.onError));
             }
 
             // If we're in debug mode, then we should add some DOM elements for the Developer View. This will

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -872,6 +872,13 @@ define(["dojo/_base/declare",
          var shortName = lang.getObject("shortName", false, response);
          if (response)
          {
+            // Set the moderated and visibility attributes appropriately...
+            response.moderated = response.visibility === "MODERATED";
+            if (response.moderated)
+            {
+               response.visibility = "PUBLIC";
+            }
+
             var dialogWidgets = lang.clone(this.widgetsForEditSiteDialog);
             this.processObject(["processInstanceTokens"], dialogWidgets);
             this.alfServicePublish(topics.CREATE_FORM_DIALOG, {

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -178,6 +178,31 @@ define(["module",
             });
       },
 
+      "Edit moderated site": function() {
+         return this.remote.findById("EDIT_MODERATED_SITE_label")
+            .click()
+            .end()
+
+         // The moderated checkbox should be checked
+         .findByCssSelector("#EDIT_SITE_DIALOG #EDIT_SITE_FIELD_MODERATED .dijitCheckBoxChecked")
+         .end()
+
+         // The public visibility radio button should be selected
+         .findByCssSelector("#EDIT_SITE_DIALOG #EDIT_SITE_FIELD_VISIBILITY_CONTROL .dijitRadioChecked input[value=PUBLIC]")
+         .end()
+
+         .clearLog()
+
+         .findById("EDIT_SITE_DIALOG_OK_label")
+            .click()
+            .end()
+
+         .findByCssSelector("#EDIT_SITE_DIALOG.dialogHidden")
+            .end()
+
+         .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible");
+      },
+
       "Request to join site navigates user to their dashboard afterwards": function() {
          return this.remote.findById("REQUEST_SITE_MEMBERSHIP_label")
             .click()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -42,6 +42,17 @@ model.jsonModel = {
       },
       {
          name: "alfresco/buttons/AlfButton",
+         id: "EDIT_MODERATED_SITE",
+         config: {
+            label: "Edit Moderated Site",
+            publishTopic: "ALF_EDIT_SITE",
+            publishPayload: {
+               site: "site2"
+            }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
          id: "BECOME_SITE_MANAGER",
          config: {
             label: "Become Site Manager",

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SiteMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SiteMockXhr.js
@@ -26,11 +26,12 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "alfresco/testing/MockXhr",
         "dojo/text!./responseTemplates/SiteTest/GetSite.json",
+        "dojo/text!./responseTemplates/SiteTest/GetModeratedSite.json",
         "dojo/text!./responseTemplates/SiteTest/PutSite.json",
         "dojo/text!./responseTemplates/SiteTest/DeleteSite.json",
         "dojo/text!./responseTemplates/SiteTest/PostBecomeSiteManager.json",
         "dojo/text!./responseTemplates/SiteTest/PostRequestSiteMembership.json"], 
-        function(declare, lang, MockXhr, getSite, putSite, deleteSite, postBecomeSiteManager, postRequestSiteMembership) {
+        function(declare, lang, MockXhr, getSite, getModeratedSite, putSite, deleteSite, postBecomeSiteManager, postRequestSiteMembership) {
    
    return declare([MockXhr], {
 
@@ -78,6 +79,16 @@ define(["dojo/_base/declare",
                   200,
                   {"Content-Type":"application/json;charset=UTF-8"},
                   getSite
+               ]
+            );
+
+            this.server.respondWith(
+               "GET",
+               "/aikau/proxy/alfresco/api/sites/site2",
+               [
+                  200,
+                  {"Content-Type":"application/json;charset=UTF-8"},
+                  getModeratedSite
                ]
             );
 

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SiteTest/GetModeratedSite.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/SiteTest/GetModeratedSite.json
@@ -1,0 +1,20 @@
+{  
+   "url":"\/alfresco\/s\/api\/sites\/site2",
+   "sitePreset":"site-dashboard",
+   "shortName":"site2",
+   "title":"Moderated Site",
+   "description":"",
+   "createdDate":"2014-05-16T15:27:43.301+01:00",
+   "lastModifiedDate":"2014-05-16T15:27:44.388+01:00",
+   "visibility":"MODERATED",
+   "userIsSiteManager":"false",
+   "siteManagers":[  
+      {  
+         "entry":{  
+            "userName":"userFacetedSearch1400250449557@freetht1.test",
+            "firstName":"userFacetedSearch1400250449557@freetht1.test",
+            "lastName":"LName"
+         }
+      }
+   ]
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-930 to ensure that moderated site data is reflected correctly when editing sites.