### PR TITLE
AKU-926: OptionsService issue

### DIFF
--- a/aikau/src/main/resources/alfresco/services/OptionsService.js
+++ b/aikau/src/main/resources/alfresco/services/OptionsService.js
@@ -61,7 +61,7 @@ define(["dojo/_base/declare",
        */
       onOptionsRequest: function alfresco_services_OptionsService__onOptionsRequest(payload) {
          if (payload.url &&
-             payload.itemsAttribute &&
+             (payload.itemsAttribute || payload.itemsAttribute === "") &&
              payload.labelAttribute &&
              payload.valueAttribute &&
              (payload.responseTopic || payload.alfResponseTopic))

--- a/aikau/src/test/resources/alfresco/services/OptionsServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/OptionsServiceTest.js
@@ -101,6 +101,12 @@ define(["module",
             result: TestCommon.getTestSelector(msiSelectors, "result", ["MULTI_SELECT_INPUT_4"]),
             secondResult: TestCommon.getTestSelector(msiSelectors, "nth.result", ["MULTI_SELECT_INPUT_4", "2"]),
             searchbox: TestCommon.getTestSelector(msiSelectors, "searchbox", ["MULTI_SELECT_INPUT_4"]),
+         },
+         emptyItemsAttribute: {
+            loaded: TestCommon.getTestSelector(msiSelectors, "options.loaded.state", ["MULTI_SELECT_INPUT_5"]),
+            result: TestCommon.getTestSelector(msiSelectors, "result", ["MULTI_SELECT_INPUT_5"]),
+            secondResult: TestCommon.getTestSelector(msiSelectors, "nth.result", ["MULTI_SELECT_INPUT_5", "2"]),
+            searchbox: TestCommon.getTestSelector(msiSelectors, "searchbox", ["MULTI_SELECT_INPUT_5"]),
          }
       }
    };
@@ -329,6 +335,20 @@ define(["module",
                assert.equal(text, "Mike Jackson");
             })
             .click();
+      },
+
+      "itemsAttribute can be empty string": function() {
+         return this.remote.findByCssSelector(selectors.multiSelects.emptyItemsAttribute.searchbox)
+            .click()
+            .end()
+
+         .findByCssSelector(selectors.multiSelects.emptyItemsAttribute.loaded)
+            .end()
+
+         .findAllByCssSelector(selectors.multiSelects.emptyItemsAttribute.result)
+            .then(function(options) {
+               assert.lengthOf(options, 6);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/OptionsService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/OptionsService.get.js
@@ -208,7 +208,7 @@ model.jsonModel = {
                            name: "alfresco/forms/controls/MultiSelectInput",
                            config: {
                               fieldId: "MULTI_SELECT_INPUT_3",
-                              label: "Select People",
+                              label: "Select People #1",
                               description: "The people options are provided by the OptionsService, but can be filtered via the ServiceStore. More than one user can be selected",
                               name: "people1",
                               width: "400px",
@@ -232,7 +232,7 @@ model.jsonModel = {
                            name: "alfresco/forms/controls/MultiSelectInput",
                            config: {
                               fieldId: "MULTI_SELECT_INPUT_4",
-                              label: "Select People",
+                              label: "Select People #2",
                               description: "The people options are provided by the UserService, but can be filtered via the ServiceStore. Users are displayed with a sensible name.",
                               name: "people2",
                               width: "400px",
@@ -243,6 +243,30 @@ model.jsonModel = {
                                  publishTopic: "ALF_GET_USERS",
                                  publishPayload: {
                                     resultsProperty: "items"
+                                 }
+                              }
+                           }
+                        },
+                        {
+                           id: "MULTI_SELECT_INPUT_5",
+                           name: "alfresco/forms/controls/MultiSelectInput",
+                           config: {
+                              fieldId: "MULTI_SELECT_INPUT_5",
+                              label: "Select People #3",
+                              description: "This is essentially the same as 'Select People #1' but the payload contains an empty string as the itemsAttribute",
+                              name: "people1",
+                              width: "400px",
+                              optionsConfig: {
+                                 queryAttribute: "label",
+                                 labelAttribute: "label",
+                                 valueAttribute: "value",
+                                 publishTopic: "ALF_GET_FORM_CONTROL_OPTIONS",
+                                 publishPayload: {
+                                    resultsProperty: "options",
+                                    url: url.context + "/proxy/alfresco/api/people/raw",
+                                    itemsAttribute: "",
+                                    labelAttribute: "userName",
+                                    valueAttribute: "userName"
                                  }
                               }
                            }

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UserMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UserMockXhr.js
@@ -37,8 +37,16 @@ define(["dojo/_base/declare",
       setupServer: function alfresco_testing_UserMockXhr__setupServer() {
          try
          {
+            var parsedUsers = JSON.parse(users),
+               people = parsedUsers.people,
+               peopleJson = JSON.stringify(people);
             this.server.respondWith("GET",
-                                    /\/aikau\/proxy\/alfresco\/api\/people(.*)/,
+                                    /\/aikau\/proxy\/alfresco\/api\/people\/raw.*/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     peopleJson]);
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/api\/people[^/]*$/,
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      users]);


### PR DESCRIPTION
This addresses [AKU-926](https://issues.alfresco.com/jira/browse/AKU-926) by ensuring that empty strings can be passed as the itemsAttribute value. A new test has been added, and existing optionsService tests have been tested successfully in all test-environments on BrowserStack.

__NOTE: Running full regression suite still, to double-check for regressions - don't merge yet__
