### PR TITLE
AKU-927: Comments delete scope

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/CommentsList.js
+++ b/aikau/src/main/resources/alfresco/renderers/CommentsList.js
@@ -282,7 +282,8 @@ define(["dojo/_base/declare",
                                                       confirmationPrompt: "comment.delete.prompt",
                                                       successMessage: "comment.delete.success",
                                                       requiresConfirmation: true,
-                                                      pubSubScope: "{pubSubScope}"
+                                                      pubSubScope: "{pubSubScope}",
+                                                      responseScope: "{pubSubScope}"
                                                    },
                                                    publishGlobal: true,
                                                    publishPayloadModifiers: ["processCurrentItemTokens"],


### PR DESCRIPTION
This addresses [AKU-927](https://issues.alfresco.com/jira/browse/AKU-927) by manually adding the correct `responseScope` to the `publishPayload` inside the `CommentsList` widget.