### PR TITLE
AKU-934: Render Date with missing user data

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Date.js
+++ b/aikau/src/main/resources/alfresco/renderers/Date.js
@@ -136,25 +136,19 @@ define(["dojo/_base/declare",
                this.modifiedByProperty = "jsNode.properties.modifier.displayName";
             }
             var modifiedBy = lang.getObject(this.modifiedByProperty, false, this.currentItem);
-
-            var dateI18N = "details.modified-by";
-
-            // TODO: This section is currently commented out as it deals explicitly with 
-            //       working copies. This isn't needed in any production page yet and should
-            //       only be commented out when needed. The unit test should also be updated at
-            //       that time.
-            // if (this.currentItem.workingCopy && this.currentItem.workingCopy.isWorkingCopy)
-            // {
-            //    dateI18N = "details.editing-started-by";
-            // }
-            // else if (dateProperty === properties.created.iso8601)
-            // {
-            //    dateI18N = "details.created-by";
-            // }
-            this.renderedValue = this.message(dateI18N, {
-               0: this.getRelativeTime(modifiedDate), 
-               1: this.encodeHTML(modifiedBy)
-            });
+            if (modifiedBy)
+            {
+               this.renderedValue = this.message("details.modified-by", {
+                  0: this.getRelativeTime(modifiedDate), 
+                  1: this.encodeHTML(modifiedBy)
+               });
+            }
+            else
+            {
+               this.renderedValue = this.message("details.modified-by.missing-user", {
+                  0: this.getRelativeTime(modifiedDate)
+               });
+            }
          }
          this.updateRenderedValueClass();
       }

--- a/aikau/src/main/resources/alfresco/renderers/i18n/Date.properties
+++ b/aikau/src/main/resources/alfresco/renderers/i18n/Date.properties
@@ -9,3 +9,4 @@ details.description.none=No Description
 details.tags.none=No Tags
 details.categories.none=No Categories
 details.user.deleted=''{0}'' (Deleted User)
+details.modified-by.missing-user=Modified {0}

--- a/aikau/src/test/resources/alfresco/renderers/DateTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateTest.js
@@ -58,6 +58,14 @@ define(["module",
             });
       },
 
+      "Check standard property with missing user data is rendered correctly": function() {
+         return this.remote.findByCssSelector("#STANDARD_PROPS_MISSING_USER .value")
+            .getVisibleText()
+            .then(function(resultText) {
+               assert(/(Modified over \d+ years ago)/g.test(resultText), "Standard property with missing user not rendered correctly: " + resultText);
+            });
+      },
+
       "Check simple date rendering": function() {
          return this.remote.findByCssSelector("#SIMPLE_MODE .value")
             .getVisibleText()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Date.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Date.get.js
@@ -45,6 +45,22 @@ model.jsonModel = {
          }
       },
       {
+         id: "STANDARD_PROPS_MISSING_USER",
+         name: "alfresco/renderers/Date",
+         config: {
+            currentItem: {
+               jsNode: {
+                  properties: {
+                     modified: {
+                        iso8601: "2000-04-11T12:42:02+00:00"
+                     }
+                  }
+               }
+            },
+            renderOnNewLine: true
+         }
+      },
+      {
          id: "SIMPLE_MODE",
          name: "alfresco/renderers/Date",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-934 to improve the output of the alfresco/renderers/Date widget when no user data is available. Unit tests have been updated.