### PR TITLE
AKU-929: Close notification by topic

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -379,6 +379,7 @@ define([],function() {
        *                                any widgets required must be either statically declared in the page model
        *                                or in a widgets property of a custom widget/service, or be specifically
        *                                required by a custom widget/service.
+       * @property {string} [closeTopic] If this topic is published to, then the notification will be closed
        * @property {string} [publishTopic] A topic to be published after the notification has closed
        * @property {object} [publishPayload] The payload to be published after the notification has closed
        * @property {boolean} [publishGlobal] Whether to publish the topic globally

--- a/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
+++ b/aikau/src/main/resources/alfresco/notifications/AlfNotification.js
@@ -68,6 +68,17 @@ define(["alfresco/core/Core",
       autoClose: true,
 
       /**
+       * If this property is specified, then it will be possible to close this notification by
+       * publishing to this topic.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       * @since 1.0.65
+       */
+      closeTopic: null,
+
+      /**
        * How many milliseconds to wait before destroying this widget after the notification has been hidden
        *
        * @instance
@@ -170,6 +181,12 @@ define(["alfresco/core/Core",
       postMixInProperties: function alfresco_notifications_AlfNotification__postMixInProperties() {
          if (!this.id || registry.byId(this.id)) {
             this.id = this.generateUuid();
+         }
+         if (this.closeTopic) {
+            var closeSubscription = this.alfSubscribe(this.closeTopic, lang.hitch(this, function() {
+               this.alfUnsubscribe(closeSubscription);
+               this._hide();
+            }));
          }
          this.inherited(arguments);
       },

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -104,7 +104,8 @@ define(["dojo/_base/declare",
                message: payload.message,
                widgets: payload.widgets,
                id: payload.notificationId,
-               inlineLink: payload.inlineLink
+               inlineLink: payload.inlineLink,
+               closeTopic: payload.closeTopic
             };
             if(typeof payload.autoClose !== "undefined") {
                config.autoClose = payload.autoClose;

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -34,7 +34,9 @@ define(["module",
       buttons: {
          nonClosingWithWidgets: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_WIDGETS_BUTTON"]),
          publishWithinNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["IN_NOTIFICATION_BUTTON"]),
-         inlineLinkNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_INLINE_LINK_BUTTON"])
+         inlineLinkNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_INLINE_LINK_BUTTON"]),
+         longNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["NOTIFICATION_BUTTON_LARGE"]),
+         closeNotification: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CLOSE_NOTIFICATION_BUTTON"])
       },
       notifications: {
          closeButton: TestCommon.getTestSelector(notificationSelectors, "button.close")
@@ -66,7 +68,7 @@ define(["module",
       },
 
       "Can close notification early": function() {
-         return this.remote.findByCssSelector("#NOTIFICATION_BUTTON_LARGE")
+         return this.remote.findByCssSelector(selectors.buttons.longNotification)
             .clearLog()
             .click()
             .end()
@@ -247,6 +249,22 @@ define(["module",
             .then(function(payload) {
                assert.propertyVal(payload, "sampleValue", "foo");
             });
+      },
+
+      "Can close notification by publishing on specified topic": function() {
+         return this.remote.findByCssSelector(selectors.buttons.longNotification)
+            .clearLog()
+            .click()
+            .end()
+
+         .findByCssSelector(".alfresco-notifications-AlfNotification")
+            .end()
+
+         .findByCssSelector(selectors.buttons.closeNotification)
+            .click()
+            .end()
+
+         .getLastPublish("ALF_NOTIFICATION_DESTROYED");
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.html.ftl
@@ -1,1 +1,7 @@
+<style>
+   .alfresco-buttons-AlfButton {
+      margin-top: 5px;
+   }
+</style>
+
 <@processJsonModel group="share"/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -18,7 +18,7 @@ model.jsonModel = {
       {
          name: "alfresco/html/Spacer",
          config: {
-            height: "20vh"
+            height: "50vh"
          }
       },
       {
@@ -76,8 +76,18 @@ model.jsonModel = {
             label: "Display notification (long)",
             publishTopic: "ALF_DISPLAY_NOTIFICATION",
             publishPayload: {
-               message: "This is a longer message. I shall Lorem Ipsum it. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum auctor feugiat tristique. Nulla sed egestas elit. Quisque malesuada eget felis eget auctor. Aenean mattis quam nisl, sit amet sollicitudin ex posuere eget."
+               message: "This is a longer message. I shall Lorem Ipsum it. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum auctor feugiat tristique. Nulla sed egestas elit. Quisque malesuada eget felis eget auctor. Aenean mattis quam nisl, sit amet sollicitudin ex posuere eget.",
+               closeTopic: "CLOSE_ME",
+               publishTopic: "ALF_NOTIFICATION_DESTROYED"
             }
+         }
+      },
+      {
+         name: "alfresco/buttons/AlfButton",
+         id: "CLOSE_NOTIFICATION_BUTTON",
+         config: {
+            label: "Close long notification",
+            publishTopic: "CLOSE_ME"
          }
       },
       {


### PR DESCRIPTION
This addresses [AKU-929](https://issues.alfresco.com/jira/browse/AKU-929), which is about being able to close a notification using a publication. A new test has been added.