### PR TITLE
AKU-943: Support selecting items in loading SelectedListItems

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/SelectedListItems.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/SelectedListItems.js
@@ -37,10 +37,11 @@ define(["dojo/_base/declare",
         "alfresco/core/CoreWidgetProcessing",
         "dojo/_base/array",
         "dojo/_base/lang",
+        "dojo/aspect",
         "dojo/dom-class",
         "alfresco/core/topics",
         "alfresco/lists/AlfList"], 
-        function(declare, BaseFormControl, CoreWidgetProcessing, array, lang, domClass, topics) {
+        function(declare, BaseFormControl, CoreWidgetProcessing, array, lang, aspect, domClass, topics) {
    
    return declare([BaseFormControl, CoreWidgetProcessing], {
       
@@ -125,6 +126,13 @@ define(["dojo/_base/declare",
                if (this._listRendered)
                {
                   this.selectItemsInList();
+               }
+               else
+               {
+                  var aspectHandle = aspect.after(this.wrappedWidget.onDataLoadSuccess, lang.hitch(this, function() {
+                     aspectHandle.remove();
+                     this.selectItemsInList();
+                  }), true);
                }
             }
          }

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectedListItemsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectedListItemsTest.js
@@ -27,14 +27,21 @@ define(["module",
         "alfresco/TestCommon"],
         function(module, defineSuite, assert, TestCommon) {
 
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
    var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
    var selectorSelectors = TestCommon.getTestSelectors("alfresco/renderers/Selector");
 
    var selectors = {
+      buttons: {
+         selectItems: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BUTTON"])
+      },
       form: {
          confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["FORM"])
       },
       selectors: {
+         first: {
+            checked: TestCommon.getTestSelector(selectorSelectors, "nth.selector.checked", ["SELECTOR", "0"])
+         },
          fourth: {
             element: TestCommon.getTestSelector(selectorSelectors, "nth.selector", ["SELECTOR", "3"]),
             checked: TestCommon.getTestSelector(selectorSelectors, "nth.selector.checked", ["SELECTOR", "3"])
@@ -42,6 +49,9 @@ define(["module",
          fifth: {
             element: TestCommon.getTestSelector(selectorSelectors, "nth.selector", ["SELECTOR", "4"]),
             checked: TestCommon.getTestSelector(selectorSelectors, "nth.selector.checked", ["SELECTOR", "4"])
+         },
+         eigth: {
+            checked: TestCommon.getTestSelector(selectorSelectors, "nth.selector.checked", ["SELECTOR", "7"])
          }
       }
    };
@@ -84,6 +94,24 @@ define(["module",
                assert.deepPropertyVal(payload, "selectedItems[0].nodeRef", "workspace://SpacesStore/d040aa05-ad54-495f-bf4e-3266b96391e9");
                assert.deepPropertyVal(payload, "selectedItems[1].nodeRef", "workspace://SpacesStore/ee0461e1-daa0-4efc-a142-3f709452fa0b");
             });
+      },
+
+      "Select items via form setValueTopic": function() {
+         return this.remote.findByCssSelector(selectors.buttons.selectItems)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.selectors.eigth.checked);
       }
+   });
+
+   defineSuite(module, {
+      name: "SelectedListItems Tests (Publish selected items on page load)",
+      testPage: "/SelectedListItems?publishOnPageLoad=true",
+
+      "Values can be selected before list has rendered": function() {
+         return this.remote.findDisplayedByCssSelector(selectors.selectors.first.checked);
+      }
+
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/SelectedListItems.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/SelectedListItems.get.js
@@ -1,3 +1,11 @@
+/* global page */
+/* jshint sub:true */
+var publishOnPageLoad = false;
+if (page.url.args["publishOnPageLoad"])
+{
+   publishOnPageLoad = page.url.args["publishOnPageLoad"] === "true";
+}
+
 model.jsonModel = {
    services: [
       {
@@ -13,11 +21,32 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         id: "BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            pubSubScope: "FORM",
+            label: "Select items",
+            publishTopic: "SELECT_ITEMS",
+            publishPayload: {
+               selectedItems: [
+                  {
+                     nodeRef: "workspace://SpacesStore/d040aa05-ad54-495f-bf4e-3266b96391e9"
+                  },
+                  {
+                     nodeRef: "workspace://SpacesStore/a8d2eb8b-dba3-438b-b24b-69a25be698ba"
+                  }
+               ]
+            }
+         }
+      },
+      {
          id: "FORM",
          name: "alfresco/forms/Form",
          config: {
             pubSubScope: "FORM",
             okButtonPublishTopic: "SAVE",
+            setValueTopic: "SELECT_ITEMS",
+            setValueTopicGlobalScope: false,
             value: {
                selectedItems: [
                   {
@@ -107,3 +136,21 @@ model.jsonModel = {
       }
    ]
 };
+
+if (publishOnPageLoad) {
+   model.jsonModel.publishOnReady = [
+      {
+         publishTopic: "FORMSELECT_ITEMS",
+         publishPayload: {
+            selectedItems: [
+               {
+                  nodeRef: "workspace://SpacesStore/d040aa05-ad54-495f-bf4e-3266b96391e9"
+               },
+               {
+                  nodeRef: "workspace://SpacesStore/0ca6baf8-599b-4b72-9e22-6e761fac54cb"
+               }
+            ]
+         }
+      }
+   ];
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-943 to ensure that the SelectListItems widget can have items selected even if the list is still being loaded. The unit tests have been updated to verify this as well as the ability to set via the setValueTopic configuration in a form