### PR TITLE
AKU-937, AKU-933: Added support for view modifiers as used in DocumentListPicker

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -318,6 +318,21 @@ define(["dojo/_base/declare",
       viewMap: null,
 
       /**
+       * This can be configured to an array of modifying functions (typically provided by the
+       * [ObjectProcessingMixin]{@link module:alfresco/core/ObjectProcessingMixin} but can be provided
+       * by extending or mixed in modules) to process the [widget models]{@link module:alfresco/lists/AlfList#widgets}
+       * used to render views. A common example might be to use the 
+       * [processInstanceTokens]{@link module:alfresco/core/ObjectProcessingMixin#processInstanceTokens} to pass on
+       * instance values of the list onto the views that are rendered.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.65
+       */
+      viewModifiers: null,
+
+      /**
        * The preference property to use for saving the current view. Initially defaulted to
        * the document library view preference but can be overridden if desired.
        *
@@ -1265,6 +1280,10 @@ define(["dojo/_base/declare",
                // (otherwise it will be set in the original model and re-used)...
                var index = this.viewDefinitionMap[this._currentlySelectedView];
                var clonedWidgets = [JSON.parse(JSON.stringify(this.widgets[index]))];
+               if (this.viewModifiers)
+               {
+                  this.processObject(this.viewModifiers, clonedWidgets);
+               }
                this.processWidgets(clonedWidgets, null, "NEW_VIEW_INSTANCE");
             }
          }

--- a/aikau/src/main/resources/alfresco/pickers/DocumentListPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/DocumentListPicker.js
@@ -133,8 +133,11 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_pickers_DocumentListPicker__postCreate() {
-         this.processObject(["processInstanceTokens"], this.widgets);
-         this.processWidgets(this.widgets, this.itemsNode);
+         // NOTE: Need to set viewModifiers for all subsequent calls to renderView...
+         this.viewModifiers =  ["processInstanceTokens"];
+         var clonedWidgets = lang.clone(this.widgets);
+         this.processObject(this.viewModifiers, clonedWidgets);
+         this.processWidgets(clonedWidgets, this.itemsNode);
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/lists/views/AlfListViewTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/AlfListViewTest.js
@@ -47,6 +47,15 @@ define(["module",
             .then(function(elements) {
                assert.lengthOf(elements, 4, "Did not render four list items successfully");
             });
+      },
+
+      // See AKU-933
+      "List modifiers work": function() {
+         return this.remote.findByCssSelector("#PROPERTY_ITEM_0 span.value")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Tinky Winky");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/AlfListView.get.js
@@ -12,6 +12,8 @@ var createList = function(id, label, loadTopic) {
          }, {
             name: "alfresco/lists/AlfList",
             config: {
+               propertyToken: "name",
+               viewModifiers: ["processInstanceTokens"],
                loadDataPublishTopic: loadTopic,
                widgets: [{
                   name: "alfresco/lists/views/AlfListView",
@@ -23,9 +25,10 @@ var createList = function(id, label, loadTopic) {
                               name: "alfresco/lists/views/layouts/Cell",
                               config: {
                                  widgets: [{
-                                    name: "alfresco/renderers/Property",
+                                    id: "PROPERTY",
+                                    name: "alfresco/renderers/PropertyLink",
                                     config: {
-                                       propertyToRender: "name"
+                                       propertyToRender: "{propertyToken}"
                                     }
                                  }]
                               }


### PR DESCRIPTION
This PR addresses both https://issues.alfresco.com/jira/browse/AKU-933 and https://issues.alfresco.com/jira/browse/AKU-937 to ensure that it is possible to process view models on each rendering of a view. This approach is then used on the DocumentListPicker to ensure that proper cloning of the view model is done before rendering. A unit test has been added to prevent future regressions.