### PR TITLE
AKU-938: Control in control row in dialog with no value in form fix

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -1038,7 +1038,7 @@ define(["dojo/_base/declare",
             }
             else
             {
-               this.setValue(this.value);
+               this.setValue(this.value || {});
             }
             
             // Create an object that we're going to use to check off all the form controls as they report their

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1801,10 +1801,14 @@ define(["dojo/_base/declare",
          }
          else
          {
-            var v = lang.getObject(this.get("name"), false, values);
-            if (v !== undefined)
+            var name = this.get("name");
+            if (name)
             {
-               this.setValue(v);
+               var v = lang.getObject(this.get("name"), false, values);
+               if (typeof v !== "undefined")
+               {
+                  this.setValue(v);
+               }
             }
          }
       },

--- a/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
+++ b/aikau/src/test/resources/alfresco/forms/ControlRowTest.js
@@ -22,8 +22,25 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!assert"],
-        function(module, defineSuite, assert) {
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(module, defineSuite, assert, TestCommon) {
+
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+   var selectors = {
+      dialogs: {
+         withForm: {
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["DIALOG_WITH_FORM"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(dialogSelectors, "disabled.form.dialog.confirmation.button", ["DIALOG_WITH_FORM"]),
+            displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["DIALOG_WITH_FORM"]),
+            hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["DIALOG_WITH_FORM"]),
+         },
+      },
+      buttons: {
+         showDialogWithForm: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_FORM_IN_DIALOG"])
+      }
+   };
 
    defineSuite(module, {
       name: "ControlRow Tests",
@@ -32,16 +49,19 @@ define(["module",
       "Test child form controls publish values": function() {
          return this.remote.findByCssSelector("#DB1_label")
             .click()
-            .end()
-            .getLastPublish("FORM1__valueChangeOf_SELECT1")
+         .end()
+         
+         .getLastPublish("FORM1__valueChangeOf_SELECT1")
             .then(function(payload) {
                assert.equal(payload.value, "ONE", "The initial value of the select field wasn't published");
             })
-            .getLastPublish("FORM1__valueChangeOf_TEXTBOX1")
+         
+         .getLastPublish("FORM1__valueChangeOf_TEXTBOX1")
             .then(function(payload) {
                assert.equal(payload.value, "Initial Value", "The initial value of the text box field wasn't published");
             })
-            .getLastPublish("FORM1_TEST")
+         
+         .getLastPublish("FORM1_TEST")
             .then(function(payload) {
                assert.equal(payload.selected, "ONE", "The dynamic payload button didn't get the published update");
             });
@@ -53,6 +73,19 @@ define(["module",
             .then(function(visibleText) {
                assert.equal(visibleText, "");
             });
+      },
+
+
+      "Text box in control row in form with no value in dialog publishes value change": function() {
+         return this.remote.findByCssSelector(selectors.buttons.showDialogWithForm)
+            .clearLog()
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.withForm.displayed)
+         .end()
+
+         .getLastPublish("CONTROL_ROW_FORM__valueChangeOf_CONTROL_ROW_TEXT_BOX");
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -131,7 +131,7 @@ define(["module",
          .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "Update1_3", "Updated label not set correctly by pub/sub");
+               assert.equal(resultText, "Update1_4", "Updated label not set correctly by pub/sub");
             });
       },
 
@@ -234,7 +234,7 @@ define(["module",
          .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "Update1_4", "Updated label not set correctly by pub/sub");
+               assert.equal(resultText, "Update1_6", "Updated label not set correctly by pub/sub");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/ControlRow.get.js
@@ -10,7 +10,8 @@ model.jsonModel = {
                error: true
             }
          }
-      }
+      },
+      "alfresco/services/DialogService"
    ],
    widgets: [
       {
@@ -119,6 +120,62 @@ model.jsonModel = {
                   }
                }
             ]
+         }
+      },
+      {
+         name: "alfresco/html/Spacer",
+         config: {
+            height: "30px"
+         }
+      },
+      {
+         id: "CREATE_FORM_IN_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show Form",
+            publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "DIALOG_WITH_FORM",
+               dialogTitle: "Form With Control Row",
+               widgetsContent: [ 
+                  {
+                     id: "FORM_WITH_CONTROL_ROW",
+                     name: "alfresco/forms/Form",
+                     config: {
+                        pubSubScope: "CONTROL_ROW_FORM_",
+                        widgets: [
+                           {
+                              id: "CONTROL_ROW",
+                              name: "alfresco/forms/ControlRow",
+                              config: {
+                                 title: "Control Row 2",
+                                 widgets: [ 
+                                    {
+                                       id: "CONTROL_ROW_TEXT_BOX",
+                                       name: "alfresco/forms/controls/TextBox",
+                                       config: {
+                                          fieldId: "CONTROL_ROW_TEXT_BOX",
+                                          name: "Test",
+                                          label: "Test"
+                                       }
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     }
+                  } 
+               ],
+               widgetsButtons: [ 
+                  {
+                     name: "alfresco/buttons/AlfButton",
+                     config: {
+                        label: "Close dialog",
+                        publishTopic: "CUSTOM_TOPIC"
+                     }
+                  }
+               ]
+            }
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-938 / #999 to ensure that ControlRow widgets behave in the same way regardless of whether or not they are placed in a dialog and whether or not the form they are in are assigned a value. This was quite a tricky problem to solve and a number of different options were explored. In the end it was determined that the best approach was always to assign the form a value (even if empty). This resulted in some other changes being necessary to form controls and existing tests that were written in a sub-optimal way. Also, it was found that it was necessary to rework the PubQueue singleton to ensure that all publications were truly made in the intended order.

**DO NOT MERGE YET !!! - FULL REGRESSION TEST RUN IN PROGRESS**