### PR TITLE
AKU-948: Possibility to deselect push button in non-multi-mode

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -187,6 +187,17 @@ define(["dojo/_base/declare",
       fieldId: "",
 
       /**
+       * When set to true, and this is a multi-value control, then the initial value will - if nothing
+       * is specifically set - be set to the first value available.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.65
+       */
+      firstValueIsDefault: true,
+
+      /**
        * The label identifying the data to provide. The value supplied will be checked against the available
        * scoped NLS resources to attempt to translate message keys into localized values.
        *
@@ -951,7 +962,7 @@ define(["dojo/_base/declare",
             this.setValue(value);
             this.value = value;
          }
-         else if (options && options.length > 0)
+         else if (options && options.length > 0 && this.firstValueIsDefault)
          {
             this.setValue(options[0].value);
             this.value = options[0].value;

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
@@ -34,13 +34,24 @@
 define(["alfresco/core/CoreWidgetProcessing",
         "alfresco/forms/controls/BaseFormControl",
         "dojo/_base/declare",
-        "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-class",
         "alfresco/forms/controls/PushButtonsControl"],
-       function(CoreWidgetProcessing, BaseFormControl, declare, array, lang, domClass) {
+       function(CoreWidgetProcessing, BaseFormControl, declare, lang, domClass) {
 
    return declare([BaseFormControl, CoreWidgetProcessing], {
+
+      /**
+       * When set to true, and this is a multi-value control, then the initial value will - if nothing
+       * is specifically set - be set to the first value available.
+       *
+       * @instance
+       * @override
+       * @type {boolean}
+       * @default
+       * @since 1.0.65
+       */
+      firstValueIsDefault: false,
 
       /**
        * Run after widget created.
@@ -84,6 +95,9 @@ define(["alfresco/core/CoreWidgetProcessing",
          }
          if (!isNaN(this.minPadding)) {
             widgetConfig.minPadding = this.minPadding;
+         }
+         if (!isNaN(this.maxChoices)) {
+            widgetConfig.maxChoices = this.maxChoices;
          }
 
          // Pass back the config

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -119,6 +119,36 @@ define(["module",
             .then(function(payload) {
                assert.propertyVal(payload, "bestlanguage", "javascript");
             });
+      },
+
+      "Multi-mode control can act as deselectable radio buttons": function() {
+         return this.remote.findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("SCOPED_POST_FORM", true)
+            .then(function(payload) {
+               assert.sameMembers(payload.onedeselectable, [], "Initial state of radio-checkbox invalid");
+            })
+
+         .findByCssSelector("#ONE_DESELECTABLE_CHOICE_CONTROL label:nth-of-type(1)")
+            .click()
+            .end()
+
+         .findByCssSelector("#ONE_DESELECTABLE_CHOICE_CONTROL label:nth-of-type(2)")
+            .click()
+            .end()
+
+         .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("SCOPED_POST_FORM", true)
+            .then(function(payload) {
+               assert.sameMembers(payload.onedeselectable, ["two"], "Modified state of radio-checkbox invalid");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -96,8 +96,9 @@ model.jsonModel = {
                      additionalCssClasses: "grey-gradient",
                      name: "properfootball",
                      label: "Only proper form of football?",
-                     description: "Config options: width=400, multiMode=true",
+                     description: "Config options: width=400, multiMode=true, maxChoices=2",
                      width: 400,
+                     maxChoices: 2,
                      multiMode: true,
                      optionsConfig: {
                         publishTopic: "GET_FOOTBALL_OPTIONS",
@@ -143,11 +144,39 @@ model.jsonModel = {
                            },
                            {
                               label: "Scala",
-                              value: "scale"
+                              value: "scala"
                            },
                            {
                               label: "Go",
                               value: "go"
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/PushButtons",
+                  id: "ONE_DESELECTABLE_CHOICE",
+                  config: {
+                     additionalCssClasses: "grey-gradient",
+                     name: "onedeselectable",
+                     label: "Deselectable single-choice buttons",
+                     description: "Config options: multiMode=true, maxChoices=1",
+                     maxChoices: 1,
+                     multiMode: true,
+                     optionsConfig: {
+                        fixed: [
+                           {
+                              label: "One",
+                              value: "one"
+                           },
+                           {
+                              label: "Two",
+                              value: "two"
+                           },
+                           {
+                              label: "Three",
+                              value: "three"
                            }
                         ]
                      }


### PR DESCRIPTION
This addresses issue [AKU-948](https://issues.alfresco.com/jira/browse/AKU-948) and adds a new `maxChoices` property to the `alfresco/forms/controls/PushButtons` widget, which should be set to `1` with `multiMode` set to true, in order to fulfil the desired use-case. A test has been added.