### PR TITLE
AKU-950: BrowserStack port change

### DIFF
--- a/aikau/src/test/resources/alfresco/CustomCommand.js
+++ b/aikau/src/test/resources/alfresco/CustomCommand.js
@@ -353,7 +353,7 @@ define(["intern/dojo/node!fs",
          getTextContent: function(selector) {
             return new this.constructor(this, function() {
                var browser = this.parent;
-               return browser.execute(cssSelector => {
+               return browser.execute(function (cssSelector) {
                   var elem = document.querySelector(cssSelector);
                   return elem && elem.textContent;
                }, [selector]);
@@ -682,7 +682,7 @@ define(["intern/dojo/node!fs",
                   .takeScreenshot()
                   .then(function(screenshot) {
                      fs.writeFile(screenshotPath, screenshot.toString("binary"), "binary", function(err) {
-                        browser.execute(id => {
+                        browser.execute(function(id) {
                            var infoBlock = document.getElementById(id);
                            if(infoBlock) {
                               infoBlock.parentNode.removeChild(infoBlock);

--- a/aikau/src/test/resources/intern_bamboo.js
+++ b/aikau/src/test/resources/intern_bamboo.js
@@ -28,6 +28,13 @@ define(["./config/Suites"], function(Suites) {
       // Dig Dug tunnel handler
       tunnel: "BrowserStackTunnel",
 
+      // Dig dug tunnel options
+      tunnelOptions: {
+         hostname: "hub.browserstack.com",
+         protocol: "https",
+         port: 443
+      },
+
       // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
       // used here
       loaderOptions: {

--- a/aikau/src/test/resources/intern_bs.js
+++ b/aikau/src/test/resources/intern_bs.js
@@ -16,9 +16,6 @@ define(["./config/Suites"], function(Suites) {
          browserName: "internet explorer",
          version: "11",
          platform: "WINDOWS"
-      }, {
-         browserName: "safari",
-         platform: "MAC"
       }],
       xenvData = [{
          browserName: "chrome",
@@ -41,6 +38,13 @@ define(["./config/Suites"], function(Suites) {
 
       // Dig Dug tunnel handler
       tunnel: "BrowserStackTunnel",
+
+      // Dig dug tunnel options
+      tunnelOptions: {
+         hostname: "hub.browserstack.com",
+         protocol: "https",
+         port: 443
+      },
 
       // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
       // used here


### PR DESCRIPTION
This addresses [AKU-950](https://issues.alfresco.com/jira/browse/AKU-950), where we need to change the port we use to access BrowserStack because it's being removed. Intern config updated and a couple of IE11-only errors fixed as well.