### PR TITLE
AKU-907: Remove line in UploadMonitor

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1465,6 +1465,24 @@ define([],function() {
       UPLOAD_CANCELLATION: "ALF_UPLOAD_DIALOG_CANCEL_CLICK",
 
       /**
+       * This topic can be published to to request modification of a line-item in the
+       * [UploadMonitor widget]{@link module:alfresco/upload/UploadMonitor}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.65
+       *
+       * @event
+       * @property {String} uploadId The ID of the upload item to modify. This will be
+       *                             passed by every configured action when it publishes
+       *                             for a specific upload.
+       * @property {String} action The desired action, which must be "REMOVE". More actions
+       *                           will be added later.
+       */
+      UPLOAD_MODIFY_ITEM: "ALF_UPLOAD_MODIFY_ITEM",
+
+      /**
        * This topic is published to request an upload.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/renderers/_PublishPayloadMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_PublishPayloadMixin.js
@@ -209,7 +209,7 @@ define(["dojo/_base/declare",
        * @param {object} [receivedPayload] A payload that has been received that triggers the generation.
        * @returns {object} The generated payload.
        */
-      getGeneratedPayload: function alfresco_renderers__PublishPayloadMixin__generatePayload(regenerate, receivedPayload) {
+      getGeneratedPayload: function alfresco_renderers__PublishPayloadMixin__getGeneratedPayload(regenerate, receivedPayload) {
          if (this._generatedPayload === null || regenerate === true || receivedPayload !== null)
          {
             this._generatedPayload = this.generatePayload(this.publishPayload, this.currentItem, receivedPayload, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
@@ -266,7 +266,7 @@ define(["dojo/_base/declare",
          {
             if (this.currentItem !== null)
             {
-               lang.mixin(generatedPayload, currentItem);
+               generatedPayload = lang.mixin(generatedPayload || {}, currentItem);
             }
             else
             {

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -347,15 +347,15 @@ define(["alfresco/core/CoreXhr",
        * @since 1.0.56
        */
       onUploadCancelRequest: function alfresco_services__BaseUploadService__onUploadCancelRequest(payload) {
-         var fileId = payload && payload.fileId,
-            fileInfo = this.fileStore[fileId];
+         var uploadId = payload && payload.uploadId,
+            fileInfo = this.fileStore[uploadId];
          if (fileInfo) {
             try {
                if (fileInfo.progress === 0) {
                   fileInfo.request = { // Manually force status of 0 to notify of cancellation
                      status: 0
                   };
-                  this.failureListener(fileId); // Manually call the failure listener for this file
+                  this.failureListener(uploadId); // Manually call the failure listener for this file
                } else {
                   fileInfo.request.abort();
                }
@@ -716,9 +716,9 @@ define(["alfresco/core/CoreXhr",
          while ((nextFile = filesToUpload.shift())) {
 
             // Ensure a unique file ID
-            var fileId = "file" + Date.now();
+            var fileId = Date.now();
             while (this.fileStore.hasOwnProperty(fileId)) {
-               fileId = "file" + Date.now();
+               fileId = Date.now();
             }
 
             // Add the data to the upload property of XMLHttpRequest so that we can determine which file each

--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -413,6 +413,7 @@ define(["alfresco/core/FileSizeMixin",
             upload.nodes.progressBar.parentNode.removeChild(upload.nodes.progressBar);
             upload.nodes.progress.textContent = this.displayUploadPercentage ? "100%" : "";
             domConstruct.place(upload.nodes.row, this.successfulItemsNode, "first");
+            domClass.remove(upload.nodes.row, this.baseClass + "__item--finishing");
 
             // Parse the request to get the information about the resulting nodes that have been created
             // This information could be used to allow actions or links to be generated for the uploaded content

--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -1,5 +1,6 @@
 .alfresco-upload-UploadMonitor {
    box-sizing: border-box;
+   min-height: 20px;
    overflow: hidden;
    * {
       box-sizing: inherit;

--- a/aikau/src/test/resources/alfresco/services/FileUploadServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/FileUploadServiceTest.js
@@ -72,6 +72,13 @@ define(["module",
                assert.propertyVal(payload, "fileName", "File for v1 API.docx");
                assert.propertyVal(payload, "nodeRef", "workspace://SpacesStore/c2128109-6b01-450f-9a8c-ec2dc4934553");
             });
+      },
+
+      "'Undo' action removes upload line": function() {
+         return this.remote.findAllByCssSelector(".alfresco-upload-UploadMonitor__successful-items tr")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/FileUploadService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/FileUploadService.get.js
@@ -28,15 +28,10 @@ model.jsonModel = {
                               width: 16,
                               title: "Undo upload",
                               publishTopic: "UNDO_UPLOAD",
-                              publishPayloadType: "PROCESS",
                               publishPayload: {
                                  nodeRef: "{response.nodeRef}",
                                  fileName: "{fileObj.name}"
-                              },
-                              useCurrentItemAsPayload: false,
-                              publishPayloadModifiers: [
-                                 "processCurrentItemTokens"
-                              ]
+                              }
                            }
                         }
                      ]
@@ -45,7 +40,8 @@ model.jsonModel = {
             ]
          }
       },
-      "alfresco/services/NotificationService"
+      "alfresco/services/NotificationService",
+      "aikauTesting/mockservices/FileUploadMockService"
    ],
    widgets: [
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FileUploadMockService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FileUploadMockService.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/FileUploadMockService
+ * @extends module:alfresco/core/Core
+ * @author Martin Doyle
+ * @since 1.0.65
+ */
+define(["alfresco/core/Core",
+        "alfresco/core/topics", 
+        "dojo/_base/array", 
+        "dojo/_base/declare", 
+        "dojo/_base/lang"], 
+        function(AlfCore, topics, array, declare, lang) {
+
+   return declare([AlfCore], {
+
+      /**
+       * Constructor
+       *
+       * @instance
+       * @param {array} args The constructor arguments.
+       */
+      constructor: function alfresco_testing_mockservices_FileUploadMockService__constructor(args) {
+         declare.safeMixin(this, args);
+         this.alfSubscribe("UNDO_UPLOAD", lang.hitch(this, this._undoUpload));
+      },
+
+      /**
+       * Undo the upload
+       *
+       * @instance
+       * @param    {object} payload The publish payload
+       */
+      _undoUpload: function alfresco_testing_mockservices_FileUploadMockService___undoUpload(payload) {
+         var uploadId = payload.uploadId;
+         this.alfPublish(topics.UPLOAD_MODIFY_ITEM, {
+            uploadId: uploadId,
+            action: "REMOVE"
+         });
+      }
+   });
+});


### PR DESCRIPTION
This addresses issue [AKU-907](https://issues.alfresco.com/jira/browse/AKU-907) and permits removal of an item in the UploadMonitor widget. With each action, an `uploadId` will be included in the published payload, which can then be used with a publish to `alfresco/core/topics#UPLOAD_MODIFY_ITEM` to request removal of that row. Tests have been updated, and a couple of minor fixes put in.