### PR TITLE
AKU-949: Safe local storage detection.

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -168,13 +168,22 @@ define(["dojo/_base/declare",
             var hashString = hashUtils.getHashString();
             if (hashString === "")
             {
-               if (this.useLocalStorageHashFallback === true && 
-                   ("localStorage" in window && window.localStorage !== null))
+               try 
                {
-                  // No hash has been provided, check local storage for last hash...
-                  var locallyStoredHash = localStorage.getItem(this.useLocalStorageHashFallbackKey);
-                  hashString = (locallyStoredHash !== null) ? locallyStoredHash : "";
-                  this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.updateLocallyStoredHash));
+                  if (this.useLocalStorageHashFallback === true && 
+                      ("localStorage" in window && window.localStorage !== null))
+                  {
+                     // No hash has been provided, check local storage for last hash...
+                     var locallyStoredHash = localStorage.getItem(this.useLocalStorageHashFallbackKey);
+                     hashString = (locallyStoredHash !== null) ? locallyStoredHash : "";
+                     this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.updateLocallyStoredHash));
+                  }
+               }
+               catch(e)
+               {
+                  // No action when error occurs. The only reason that we're wrapping the local storage
+                  // utilization in a try/catch block is to prevent failures when Firefox is used with
+                  // SSO with cookies disabled. See MNT-16167 for details.
                }
 
                if (hashString)


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-949 to perform safe access to local storage. This is required because exceptions can be thrown by Firefox in Share when SSO is enabled with cookies disabled. Although not best practice generally to code by exception this is the suggested approach by Mozilla, see https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API