### PR TITLE
AKU-951: Ensure that validation message is displayed when a form control has no label

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1249,7 +1249,6 @@ define(["dojo/_base/declare",
             }
             else
             {
-               // domStyle.set(this._titleRowNode, {display: "none"});
                domClass.add(this.domNode, "alfresco-forms-controls-BaseFormControl--no-label");
             }
 

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1073,6 +1073,10 @@ define(["dojo/_base/declare",
          {
             this.validationInProgressImgSrc = require.toUrl("alfresco/forms/controls/css/images/" + this.validationInProgressImg);
          }
+
+         // Make sure that the label is set, in case it's explicitly set as null and overrides the default...
+         this.label = this.label || "";
+
          this.validationInProgressAltText = this.message(this.validationInProgressAltText, {
             0: this.message(this.label)
          });
@@ -1245,7 +1249,8 @@ define(["dojo/_base/declare",
             }
             else
             {
-               domStyle.set(this._titleRowNode, {display: "none"});
+               // domStyle.set(this._titleRowNode, {display: "none"});
+               domClass.add(this.domNode, "alfresco-forms-controls-BaseFormControl--no-label");
             }
 
             // Set the description...

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -18,8 +18,14 @@
       margin: 0 4px;
       width: 16px;
    }
+   &--no-label {
+      > .title-row {
+         display: none;
+      }
+   }
    &--invalid {
       > .title-row {
+         display: block;
          > .alfresco-forms-controls-BaseFormControl__validation-error {
             display: inline-block;
          }

--- a/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
@@ -31,6 +31,7 @@ define(["module",
    var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
    var formControlSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/BaseFormControl");
    var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
 
    var selectors = {
       form: {
@@ -58,11 +59,24 @@ define(["module",
          matchSource: {
             input: TestCommon.getTestSelector(textBoxSelectors, "input", ["MATCH_SOURCE"]),
             validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["MATCH_SOURCE"])
-         }
+         },
+         dialogTextBox: {
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["DIALOG_FORM_TEXTBOX"])
+         },
+         
       },
       buttons: {
          blockResponse: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BLOCK_RESPONSE"]),
-         unblockResponse: TestCommon.getTestSelector(buttonSelectors, "button.label", ["UNBLOCK_RESPONSE"])
+         unblockResponse: TestCommon.getTestSelector(buttonSelectors, "button.label", ["UNBLOCK_RESPONSE"]),
+         showValidationDialog: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SHOW_VALIDATION_IN_DIALOG"]),
+      },
+      dialogs: {
+         checkMessage: {
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["VALIDATION_DIALOG"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(dialogSelectors, "disabled.form.dialog.confirmation.button", ["VALIDATION_DIALOG"]),
+            displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["VALIDATION_DIALOG"]),
+            hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["VALIDATION_DIALOG"]),
+         }
       }
    };
 
@@ -309,6 +323,17 @@ define(["module",
             .then(function(elements) {
                assert.lengthOf(elements, 0, "The forms confirmation button should be disabled");
             });
+      },
+
+      "Validation message visible with no label in form dialog": function() {
+         return this.remote.findByCssSelector(selectors.buttons.showValidationDialog)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.checkMessage.displayed)
+         .end()
+
+         .findDisplayedByCssSelector(selectors.textBoxes.dialogTextBox.validationMessage);
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -11,6 +11,7 @@ model.jsonModel = {
             }
          }
       },
+      "alfresco/services/DialogService",
       "aikauTesting/mockservices/FormControlValidationTestService",
       "alfresco/services/ErrorReporter"
    ],
@@ -24,7 +25,8 @@ model.jsonModel = {
                   id: "TEST_CONTROL",
                   name: "alfresco/forms/controls/DojoValidationTextBox",
                   config: {
-                     label: "Three Letters Or More",
+                     label: null, // PLEASE NOTE: Label left intentionally blank for testing purposes (AKU-951)
+                     description: "Three Letters Or More",
                      name: "name",
                      value: "",
                      validationConfig: [
@@ -140,7 +142,40 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "SHOW_VALIDATION_IN_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show validation in dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "VALIDATION_DIALOG",
+               dialogTitle: "Validation in Form Dialog",
+               formSubmissionTopic: "POST_DIALOG_FORM",
+               formSubmissionGlobal: true,
+               widgets: [
+                  {
+                     id: "DIALOG_FORM_TEXTBOX",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        label: null, // PLEASE NOTE: Label left intentionally blank for testing purposes (AKU-951)
+                        description: "Three Letters Or More",
+                        name: "name",
+                        value: "",
+                        validationConfig: [
+                           {
+                              validation: "minLength",
+                              length: 3,
+                              errorMessage: "Too short"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-951 to ensure that form controls will always display error messages even if they have no label. The unit tests have been updated to ensure this and an additional test has been added to ensure that error messages are shown in form dialogs (because currently the form dialogs have different layout)