### PR TITLE
AKU-946: Prevent list loading message catching pointer events

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/css/AlfList.css
+++ b/aikau/src/main/resources/alfresco/lists/css/AlfList.css
@@ -24,6 +24,7 @@
          line-height: @list-loading-message-line-height;
          padding: @list-loading-message-padding;
          top: -100%;
+         pointer-events: none;
          transition: @list-loading-message-transition;
       }
    }

--- a/aikau/src/test/resources/alfresco/forms/controls/SimplePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SimplePickerTest.js
@@ -23,10 +23,8 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon"],
-        function(module, defineSuite, assert, require, TestCommon) {
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
 
    defineSuite(module, {
       name: "Simple Picker Tests",
@@ -62,11 +60,13 @@ define(["module",
 
       "Test that PICKER2 posted value contains pre-selected item": function() {
          return this.remote.findByCssSelector("#FORM .confirmationButton > span")
+            .clearLog()
             .click()
-            .end()
-            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM_POST", "picker2", "name", "One"))
-            .then(null, function() {
-               assert(false, "Pre-selected item was not reflected in initial form value post");
+         .end()
+
+         .getLastPublish("FORM_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "picker2.0.name", "One");
             });
       },
 
@@ -83,11 +83,13 @@ define(["module",
 
       "Test that the picked item is reflected in the posted form value": function() {
          return this.remote.findByCssSelector("#FORM .confirmationButton > span")
+            .clearLog()
             .click()
-            .end()
-            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM_POST", "picker1", "name", "Three"))
-            .then(null, function() {
-               assert(false, "Picked item from PICKER1 is not reflected in form value post");
+         .end()
+
+         .getLastPublish("FORM_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "picker1.0.name", "Three");
             });
       },
 
@@ -119,12 +121,14 @@ define(["module",
 
       "Test form value post after removing previously picked item": function() {
          return this.remote.findByCssSelector("#FORM .confirmationButton > span")
+            .clearLog()
             .click()
-            .end()
-            .findAllByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM_POST", "picker1", "name", "Three"))
-            .then(function(elements) {
-               // NOTE: We should still find the previous post in the SubscriptionLog which is why we're checking for one...
-               assert.lengthOf(elements, 1, "Removed item from PICKER1 is not reflected in form value post");
+         .end()
+
+         .getLastPublish("FORM_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "picker2.0.name", "One");
+               assert.notDeepProperty(payload, "picker1.1.name");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/SimplePicker.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/SimplePicker.get.desc.xml
@@ -1,5 +1,6 @@
 <webscript>
   <shortname>Simple Picker Test</shortname>
+  <description>This page demonstrates a couple of configurations ofr the 'alfresco/forms/controls/SimplePicker' for unit testing purposes.</description>
   <family>aikau-unit-tests</family>
   <url>/SimplePicker</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/SimplePicker.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/SimplePicker.get.js
@@ -73,10 +73,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-953 / #1012  to ensure that the SimplePicker works with a single item remaining in the list of items to pick. The solution is to ensure that the list loading message does not intercept point events as this was preventing adding the last item.