### PR TITLE
AKU-947: PushButton display long text as tooltip

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtonsControl.js
@@ -288,11 +288,15 @@ define(["alfresco/core/Core",
                labelNode = domConstruct.create("label", {
                   "for": optionId, // Quoted because reserved word
                   className: this.rootClass + "__label"
-               }, this.domNode);
+               }, this.domNode),
+               labelContentNode = domConstruct.create("div", {
+                  className: this.rootClass + "__label__content"
+               }, labelNode);
 
             // Add the label content (just text initially)
-            var labelContent = document.createTextNode(option.label || option.name || option.value);
-            labelNode.appendChild(labelContent);
+            var labelText = (option.label || option.name || option.value);
+            labelContentNode.textContent = labelText;
+            labelNode.setAttribute("title", labelText);
 
             // Setup change-listener
             var changeListener = on(inputNode, "change", lang.hitch(this, this._onInputChanged));
@@ -303,6 +307,7 @@ define(["alfresco/core/Core",
                id: optionId,
                inputNode: inputNode,
                labelNode: labelNode,
+               labelContentNode: labelContentNode,
                changeListener: changeListener,
                option: option
             });
@@ -386,7 +391,7 @@ define(["alfresco/core/Core",
             if (!this.width) {
                var maxLabelWidth = 0;
                array.forEach(this.opts, function(opt) {
-                  maxLabelWidth = Math.max(maxLabelWidth, opt.labelNode.scrollWidth);
+                  maxLabelWidth = Math.max(maxLabelWidth, opt.labelContentNode.scrollWidth);
                });
                var minLineLength = (maxLabelWidth + this.minPadding) * buttonsPerLine / (availButtonPercent / 100);
                domStyle.set(this.domNode, "width", Math.ceil(minLineLength) + "px");

--- a/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/PushButtonsControl.css
@@ -30,9 +30,15 @@
       color: @primary-font-color;
       cursor: pointer;
       display: inline-block;
+      float: left;
       font-size: @small-font-size;
       text-align: center;
       transition: background .2s ease-out, color .2s ease-out;
+      &__content {
+         margin: 0 8px;
+         overflow: hidden;
+         text-overflow: ellipsis;
+      }
    }
 }
 

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -32,7 +32,7 @@ define(["module",
       testPage: "/PushButtons",
 
       "Initial value is set correctly": function() {
-         return this.remote.findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+         return this.remote.findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
             .end()
@@ -60,7 +60,7 @@ define(["module",
             .click()
             .end()
 
-         .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+         .findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
             .end()
@@ -92,7 +92,7 @@ define(["module",
             .pressKeys(keys.SPACE)
             .end()
 
-         .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+         .findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
             .end()
@@ -110,7 +110,7 @@ define(["module",
             .click()
             .end()
 
-         .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+         .findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
             .end()
@@ -122,7 +122,7 @@ define(["module",
       },
 
       "Multi-mode control can act as deselectable radio buttons": function() {
-         return this.remote.findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+         return this.remote.findByCssSelector("#RIGHT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
             .end()
@@ -140,7 +140,7 @@ define(["module",
             .click()
             .end()
 
-         .findByCssSelector("#TEST_FORM .confirmationButton .dijitButtonNode")
+         .findByCssSelector("#RIGHT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
             .end()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -54,132 +54,206 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/forms/Form",
+         name: "alfresco/layout/HorizontalWidgets",
          config: {
-            id: "TEST_FORM",
-            okButtonPublishTopic: "POST_FORM",
-            setValueTopic: "SET_FORM_VALUE",
-            pubSubScope: "SCOPED_",
-            value: {
-               canbuild: true,
-               properfootball: ["rugby_football", "union_football"],
-               bestlanguage: "javascript"
-            },
             widgets: [
                {
-                  name: "alfresco/forms/controls/PushButtons",
-                  id: "CAN_BUILD",
+                  name: "alfresco/layout/VerticalWidgets",
                   config: {
-                     name: "canbuild",
-                     label: "Can we build it?",
-                     description: "Config options: noWrap=true, percentGap=5",
-                     noWrap: true,
-                     percentGap: 5,
-                     optionsConfig: {
-                        fixed: [
-                           {
-                              label: "Yes we can",
-                              value: true
-                           },
-                           {
-                              label: "No we can't",
-                              value: false
+                     widgets: [
+                        {
+                           name: "alfresco/forms/Form",
+                           config: {
+                              id: "LEFT_FORM",
+                              okButtonPublishTopic: "POST_FORM",
+                              setValueTopic: "SET_FORM_VALUE",
+                              pubSubScope: "SCOPED_",
+                              value: {
+                                 canbuild: true,
+                                 properfootball: ["rugby_football", "union_football"],
+                                 bestlanguage: "javascript"
+                              },
+                              widgets: [
+                                 {
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    id: "CAN_BUILD",
+                                    config: {
+                                       name: "canbuild",
+                                       label: "Can we build it?",
+                                       description: "Config options: noWrap=true, percentGap=5",
+                                       noWrap: true,
+                                       percentGap: 5,
+                                       optionsConfig: {
+                                          fixed: [
+                                             {
+                                                label: "Yes we can",
+                                                value: true
+                                             },
+                                             {
+                                                label: "No we can't",
+                                                value: false
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    id: "PROPER_FOOTBALL",
+                                    config: {
+                                       additionalCssClasses: "grey-gradient",
+                                       name: "properfootball",
+                                       label: "Only proper form of football?",
+                                       description: "Config options: width=400, multiMode=true, maxChoices=2",
+                                       width: 400,
+                                       maxChoices: 2,
+                                       multiMode: true,
+                                       optionsConfig: {
+                                          publishTopic: "GET_FOOTBALL_OPTIONS",
+                                          publishGlobal: true
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    id: "BEST_LANGUAGE",
+                                    config: {
+                                       additionalCssClasses: "grey-gradient",
+                                       name: "bestlanguage",
+                                       label: "What's the best language?",
+                                       description: "Config options: width=300, maxLineLength=3",
+                                       width: 300,
+                                       maxLineLength: 3,
+                                       optionsConfig: {
+                                          fixed: [
+                                             {
+                                                label: "PHP",
+                                                value: "php"
+                                             },
+                                             {
+                                                label: "JavaScript",
+                                                value: "javascript"
+                                             },
+                                             {
+                                                label: "VisualBasic",
+                                                value: "vb"
+                                             },
+                                             {
+                                                label: "Java",
+                                                value: "java"
+                                             },
+                                             {
+                                                label: "C",
+                                                value: "c"
+                                             },
+                                             {
+                                                label: "Ruby",
+                                                value: "ruby"
+                                             },
+                                             {
+                                                label: "Scala",
+                                                value: "scala"
+                                             },
+                                             {
+                                                label: "Go",
+                                                value: "go"
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/html/Spacer",
+                                    config: {
+                                       height: "20px"
+                                    }
+                                 }
+                              ]
                            }
-                        ]
-                     }
+                        }
+                     ]
                   }
                },
                {
-                  name: "alfresco/forms/controls/PushButtons",
-                  id: "PROPER_FOOTBALL",
+                  name: "alfresco/layout/VerticalWidgets",
                   config: {
-                     additionalCssClasses: "grey-gradient",
-                     name: "properfootball",
-                     label: "Only proper form of football?",
-                     description: "Config options: width=400, multiMode=true, maxChoices=2",
-                     width: 400,
-                     maxChoices: 2,
-                     multiMode: true,
-                     optionsConfig: {
-                        publishTopic: "GET_FOOTBALL_OPTIONS",
-                        publishGlobal: true
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/PushButtons",
-                  id: "BEST_LANGUAGE",
-                  config: {
-                     additionalCssClasses: "grey-gradient",
-                     name: "bestlanguage",
-                     label: "What's the best language?",
-                     description: "Config options: width=300, maxLineLength=3",
-                     width: 300,
-                     maxLineLength: 3,
-                     optionsConfig: {
-                        fixed: [
-                           {
-                              label: "PHP",
-                              value: "php"
-                           },
-                           {
-                              label: "JavaScript",
-                              value: "javascript"
-                           },
-                           {
-                              label: "VisualBasic",
-                              value: "vb"
-                           },
-                           {
-                              label: "Java",
-                              value: "java"
-                           },
-                           {
-                              label: "C",
-                              value: "c"
-                           },
-                           {
-                              label: "Ruby",
-                              value: "ruby"
-                           },
-                           {
-                              label: "Scala",
-                              value: "scala"
-                           },
-                           {
-                              label: "Go",
-                              value: "go"
+                     widgets: [
+                        {
+                           name: "alfresco/forms/Form",
+                           config: {
+                              id: "RIGHT_FORM",
+                              okButtonPublishTopic: "POST_FORM",
+                              setValueTopic: "SET_FORM_VALUE",
+                              pubSubScope: "SCOPED_",
+                              value: {
+                                 canbuild: true,
+                                 properfootball: ["rugby_football", "union_football"],
+                                 bestlanguage: "javascript"
+                              },
+                              widgets: [
+                                 {
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    id: "ONE_DESELECTABLE_CHOICE",
+                                    config: {
+                                       additionalCssClasses: "grey-gradient",
+                                       name: "onedeselectable",
+                                       label: "Deselectable single-choice buttons",
+                                       description: "Config options: multiMode=true, maxChoices=1",
+                                       maxChoices: 1,
+                                       multiMode: true,
+                                       optionsConfig: {
+                                          fixed: [
+                                             {
+                                                label: "One",
+                                                value: "one"
+                                             },
+                                             {
+                                                label: "Two",
+                                                value: "two"
+                                             },
+                                             {
+                                                label: "Three",
+                                                value: "three"
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    id: "LONG_BUTTONS",
+                                    config: {
+                                       additionalCssClasses: "grey-gradient",
+                                       name: "onedeselectable",
+                                       label: "Long button labels",
+                                       description: "Config options: multiMode=true, noWrap=true, width=300",
+                                       multiMode: true,
+                                       noWrap: true,
+                                       width: 300,
+                                       optionsConfig: {
+                                          fixed: [
+                                             {
+                                                label: "This is a really long label",
+                                                value: "A"
+                                             },
+                                             {
+                                                label: "Here's yet another really, really long label, but this time a bit longer",
+                                                value: "B"
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/html/Spacer",
+                                    config: {
+                                       height: "20px"
+                                    }
+                                 }
+                              ]
                            }
-                        ]
-                     }
-                  }
-               },
-               {
-                  name: "alfresco/forms/controls/PushButtons",
-                  id: "ONE_DESELECTABLE_CHOICE",
-                  config: {
-                     additionalCssClasses: "grey-gradient",
-                     name: "onedeselectable",
-                     label: "Deselectable single-choice buttons",
-                     description: "Config options: multiMode=true, maxChoices=1",
-                     maxChoices: 1,
-                     multiMode: true,
-                     optionsConfig: {
-                        fixed: [
-                           {
-                              label: "One",
-                              value: "one"
-                           },
-                           {
-                              label: "Two",
-                              value: "two"
-                           },
-                           {
-                              label: "Three",
-                              value: "three"
-                           }
-                        ]
-                     }
+                        }
+                     ]
                   }
                }
             ]


### PR DESCRIPTION
This addresses issue [AKU-947](https://issues.alfresco.com/jira/browse/AKU-947) and adds a title attribute to each push button and ensures that hidden text has an accompanying ellipsis. There is no specific test, however the visual layout has been confirmed in Chrome and FF.