### PR TITLE
AKU-953: SelectedItemStateMixin fix

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
@@ -178,7 +178,7 @@ define(["dojo/_base/declare",
          if (payload && payload.value)
          {
             var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
-            if (itemKey)
+            if (typeof itemKey !== "undefined")
             {
                delete this.currentlySelectedItems[itemKey];
                if (this.selectionTimeout)
@@ -203,7 +203,7 @@ define(["dojo/_base/declare",
          if (payload && payload.value)
          {
             var itemKey = lang.getObject(this.itemKeyProperty, false, payload.value);
-            if (itemKey)
+            if (typeof itemKey !== "undefined")
             {
                this.currentlySelectedItems[itemKey] = payload.value;
                if (this.selectionTimeout)

--- a/aikau/src/test/resources/alfresco/renderers/SelectorTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SelectorTest.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This test renders examples of FileTypes.
+ *
+ * The test is simple and much of its validity is in the use of slightly damaged or incomplete models to inspect edge cases.
+ *
+ * @author Richard Smith
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
+
+   defineSuite(module, {
+      name: "Selector Tests",
+      testPage: "/Selector",
+
+      "Selected items menu is initially disabled": function() {
+         return this.remote.findDisplayedByCssSelector("#SELECTED_ITEMS.dijitDisabled").clearLog();
+      },
+
+      "Checking first selector enables items menu": function() {
+         return this.remote.findByCssSelector("#SELECTOR_ITEM_0")
+            .click()
+         .end()
+
+         .getLastPublish("ALF_DOCLIST_FILE_SELECTION")
+            .then(function(payload) {
+               assert.property(payload, "selectedItems");
+            });
+      },
+
+      "Unchecking first selector disabled menu item": function() {
+         return this.remote.findAllByCssSelector("#SELECTED_ITEMS.dijitDisabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            })
+         .end()
+
+         .clearLog()
+
+         .findByCssSelector("#SELECTOR_ITEM_0")
+            .click()
+         .end()
+
+         .getLastPublish("ALF_DOCLIST_FILE_SELECTION")
+            .then(function(payload) {
+               assert.property(payload, "selectedItems");
+            })
+
+         .findDisplayedByCssSelector("#SELECTED_ITEMS.dijitDisabled");
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/renderers/SelectorTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SelectorTest.js
@@ -18,11 +18,8 @@
  */
 
 /**
- * This test renders examples of FileTypes.
- *
- * The test is simple and much of its validity is in the use of slightly damaged or incomplete models to inspect edge cases.
- *
- * @author Richard Smith
+ * @author Dave Draper
+ * @since 1.0.66
  */
 define(["module",
         "alfresco/defineSuite",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -252,7 +252,7 @@ define(function() {
       "alfresco/renderers/PublishPayloadMixinOnActionsTest",
       "alfresco/renderers/ReorderTest",
       "alfresco/renderers/SearchResultPropertyLinkTest",
-      "src/test/resources/alfresco/renderers/SelectorTest",
+      "alfresco/renderers/SelectorTest",
       "alfresco/renderers/SocialRenderersTest",
       "alfresco/renderers/TagsTest",
       "alfresco/renderers/ThumbnailTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -252,6 +252,7 @@ define(function() {
       "alfresco/renderers/PublishPayloadMixinOnActionsTest",
       "alfresco/renderers/ReorderTest",
       "alfresco/renderers/SearchResultPropertyLinkTest",
+      "src/test/resources/alfresco/renderers/SelectorTest",
       "alfresco/renderers/SocialRenderersTest",
       "alfresco/renderers/TagsTest",
       "alfresco/renderers/ThumbnailTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.desc.xml
@@ -1,0 +1,7 @@
+<webscript>
+  <shortname>Selector Renderer</shortname>
+  <description>Displays Selector renderers for testing.</description>
+  <description></description>
+  <family>aikau-unit-tests</family>
+  <url>/Selector</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.desc.xml
@@ -1,7 +1,6 @@
 <webscript>
   <shortname>Selector Renderer</shortname>
   <description>Displays Selector renderers for testing.</description>
-  <description></description>
   <family>aikau-unit-tests</family>
   <url>/Selector</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.js
@@ -1,0 +1,119 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         id: "MENU_BAR",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "SELECTED_ITEMS",
+                  name: "alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup",
+                  config: {
+                     debounceTime: 0, // Remove debounce time to aid testing
+                     passive: false,
+                     itemKeyProperty: "index",
+                     label: "Selected items...",
+                     widgets: [
+                        {
+                           name: "alfresco/menus/AlfMenuGroup",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "MENU_ITEM",
+                                    name: "alfresco/menus/AlfSelectedItemsMenuItem",
+                                    config: {
+                                       label: "Test",
+                                       clearSelectedItemsOnClick: true,
+                                       publishTopic: "TEST_ITEMS"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "LIST",
+         name: "alfresco/lists/AlfList",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     name: "One"
+                  },
+                  {
+                     name: "Two"
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  id: "VIEW",
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [
+                        {
+                           id: "ROW",
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "CELL1",
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       width: "20px",
+                                       widgets: [
+                                          {
+                                             id: "SELECTOR",
+                                             name: "alfresco/renderers/Selector",
+                                             config: {
+                                                itemKey: "index"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "CELL2",
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "PROPERTY",
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "name"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-953 to ensure that the SelectedItemStateMixin treats all values appropriately. A new unit test has been added to verify and prevent regressions.