### PR TITLE
AKU-955: Upload box - text misaligned when item name is to long  

### DIFF
--- a/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
+++ b/aikau/src/main/resources/alfresco/upload/css/UploadMonitor.css
@@ -29,6 +29,11 @@
             padding-right: @upload-monitor-item-padding-right;
          }
       }
+      &__name {
+         &__content {
+            margin-right: 20px;
+         }
+      }
       &__progress {
          width: @upload-monitor-progress-column-width;
       }
@@ -131,6 +136,22 @@
             &__status__unsuccessful_icon {
                display: inline-block;
                margin-left: 10px;
+            }
+         }
+      }
+   }
+   &--use-ellipsis {
+      .alfresco-upload-UploadMonitor {
+         &__item {
+            &__name {
+               &__content {
+                  direction: rtl;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  unicode-bidi: bidi-override;
+                  white-space: nowrap;
+                  text-align: left;
+               }
             }
          }
       }

--- a/aikau/src/test/resources/alfresco/CustomCommand.js
+++ b/aikau/src/test/resources/alfresco/CustomCommand.js
@@ -554,6 +554,27 @@ define(["intern/dojo/node!fs",
          },
 
          /**
+          * Reload the page (but using a get of the current page, rather than reload, to avoid coverage info loss)
+          *
+          * @instance
+          * @since 1.0.66
+          */
+         reload: function() {
+
+            // Boilerplate
+            return new this.constructor(this, function() {
+               var browser = this.parent;
+
+               return browser.getCurrentUrl()
+                  .then(function(currentUrl) {
+                     return browser.get(currentUrl);
+                  })
+                  .findByCssSelector("body")
+                  .end()
+            });
+         },
+
+         /**
           * <p>Take a screenshot, and save to the src/test/screenshots directory. Can take up to
           * three arguments, in any order, where the argument type dictates how it's treated.</p>
           *

--- a/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
@@ -96,13 +96,8 @@ define(["module",
       },
 
       "Reload the page and check initial sorting displayed": function() {
-         return this.remote.getCurrentUrl()
-            .then(currentUrl => {
-               return this.remote.get(currentUrl);
-            })
-            .findByCssSelector("body")
-            .end()
-
+         return this.remote.reload()
+         
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
          .findDisplayedByCssSelector(selectors.headerCells.all.indicators);

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/FileUploadService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/FileUploadService.get.js
@@ -18,6 +18,7 @@ model.jsonModel = {
                {
                   name: "alfresco/upload/UploadMonitor",
                   config: {
+                     useEllipsisForLongFilenames: true,
                      widgetsForSuccessfulActions: [
                         {
                            name: "alfresco/html/SVGImage",
@@ -56,6 +57,26 @@ model.jsonModel = {
                   {
                      size: 1337,
                      name: "File for v1 API.docx"
+                  }
+               ],
+               targetData: {
+                  destination: "some://fake/node"
+               }
+            }
+         }
+      },
+      {
+         id: "LONG_FILENAME_UPLOAD",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Long Filename Upload",
+            publishTopic: "ALF_UPLOAD_REQUEST",
+            publishPayload: {
+               alfResponseTopic: "UPLOAD_COMPLETE_OR_CANCELLED",
+               files: [
+                  {
+                     size: 987654351,
+                     name: "This is a really long filename that should definitely cause display problems on any sensible display resolution.xls"
                   }
                ],
                targetData: {


### PR DESCRIPTION
This addresses issue [AKU-955](https://issues.alfresco.com/jira/browse/AKU-955) by adding a new property of `useEllipsisForLongFilenames` to `alfresco/upload/UploadMonitor`, which will ignore the `maxUploadNameLength` property and instead truncate any overly-long filenames. Also adds a helper `reload()` function to the custom Command object in Aikau.