### PR TITLE
AKU-952: TinyMCE editor updates

### DIFF
--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -348,13 +348,22 @@ define(["dojo/_base/declare",
                }
             };
          }
-         config.plugins = [
-            "advlist autolink link image lists charmap print preview hr anchor pagebreak",
-            "searchreplace code fullscreen insertdatetime nonbreaking",
-            "table contextmenu paste textcolor visualblocks autoresize"
-         ];
+         if (!config.plugins)
+         {
+            config.plugins = [
+               "advlist autolink link image lists charmap print preview hr anchor pagebreak",
+               "searchreplace code fullscreen insertdatetime nonbreaking",
+               "table contextmenu paste textcolor visualblocks autoresize"
+            ];
+         }
+         if (config.additionalPlugins)
+         {
+            config.plugins = config.plugins.concat(config.additionalPlugins);
+         }
+         
          config.init_instance_callback = lang.hitch(this, this.editorInitialized);
 
+         this.updateEditorConfig(config);
          this.editor = new tinymce.Editor(this.editorNode, config, tinymce.EditorManager);
 
          // Allow back the "embed" tag as TinyMCE now removes it - this is allowed by our this.editors
@@ -365,6 +374,20 @@ define(["dojo/_base/declare",
          this.editor.render();
          this.editor.save();
          return this;
+      },
+
+      /**
+       * This is an extension point function that provides the opportunity for extending widgets to 
+       * make updates to the default configuration. This allows non-configurable options to be added
+       * to the configuration such as specific callback overrides for configuration plugins.
+       * 
+       * @instance
+       * @param {object} config The configuration object to be updated
+       * @since 1.0.66
+       * @overridable
+       */
+      updateEditorConfig: function alfresco_editors_TinyMCE__createEditor(/* jshint unused:false*/ config) {
+         // No action by default
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
@@ -68,7 +68,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       createFormControl: function alfresco_forms_controls_TinyMCE__createFormControl(config) {
-         if (!this.widgetsForEditor && !this.widgetsForEditor[0])
+         if (!this.widgetsForEditor || !this.widgetsForEditor[0])
          {
             this.alfLog("warn", "There is no 'widgetsForEditor' model defined, using default", this);
             this.widgetsForEditor = [

--- a/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
@@ -24,12 +24,13 @@
  * @extends module:alfresco/forms/controls/BaseFormControl
  * @author Dave Draper
  */
-define(["alfresco/forms/controls/BaseFormControl",
-        "dojo/_base/declare",
-        "alfresco/editors/TinyMCE"], 
-        function(BaseFormControl, declare, TinyMCE) {
+define(["dojo/_base/declare",
+        "alfresco/forms/controls/BaseFormControl",
+        "alfresco/core/CoreWidgetProcessing",
+        "dojo/_base/lang"], 
+        function(declare, BaseFormControl, CoreWidgetProcessing, lang) {
    
-   return declare([BaseFormControl], {
+   return declare([BaseFormControl, CoreWidgetProcessing], {
       
       /**
        * This indicates whether or not the [TinyMCE editor]{@link module:alfresco/editors/TinyMCE}
@@ -56,17 +57,34 @@ define(["alfresco/forms/controls/BaseFormControl",
             immediateInit: false,
             contentChangeScope: this,
             contentChangeHandler: this.onEditorValueChange,
-            autoResize: this.autoResize
+            autoResize: this.autoResize,
+            editorConfig: this.editorConfig
          };
       },
       
       /**
-       * Creates a new instance of the [TinyMCE editor]{@link module:alfresco/editors/TinyMCE}.
+       * Builds the configured [editor model]{@link module:alfresco/forms/controls/TinyMCE#widgetsForEditor}.
        * 
        * @instance
        */
       createFormControl: function alfresco_forms_controls_TinyMCE__createFormControl(config) {
-         var editor = new TinyMCE(config);
+         if (!this.widgetsForEditor && !this.widgetsForEditor[0])
+         {
+            this.alfLog("warn", "There is no 'widgetsForEditor' model defined, using default", this);
+            this.widgetsForEditor = [
+               {
+                  name: "alfresco/editors/TinyMCE"
+               }
+            ];
+         }
+      
+         // Clone the default model and mixin in the configured configuration into the declared model...
+         var editorWidgets = lang.clone(this.widgetsForEditor);
+         var declaredConfig = lang.getObject("0.config", true, editorWidgets);
+         lang.mixin(declaredConfig, config);
+         
+         // Create the widget
+         var editor = this.createWidget(editorWidgets[0]);
          return editor;
       },
 
@@ -118,6 +136,22 @@ define(["alfresco/forms/controls/BaseFormControl",
          {
             this.wrappedWidget.setDisabled(this._disabled);
          }
-      }
+      },
+
+      /**
+       * This is the default model for creating the editor to be displayed. It provides a way in which
+       * the default editor can be extended and used within the standard form control. The main reason 
+       * for wanting to use a customized version of the [default TinyMCE editor]{@link module:alfresco/editors/TinyMCE} is
+       * to provide custom callbacks for plugins. 
+       * 
+       * @instance
+       * @type {object[]}
+       * @since 1.0.66
+       */
+      widgetsForEditor: [
+         {
+            name: "alfresco/editors/TinyMCE"
+         }
+      ]
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/TinyMCETest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/TinyMCETest.js
@@ -47,6 +47,15 @@ define(["module",
             }).clearLog();
       },
 
+      // See AKU-952
+      "Custom editor can be used": function() {
+         return this.remote.findByCssSelector(".custom-tiny-mce-editor");
+      },
+
+      "Custom toolbar and plugins can be configured": function() {
+         return this.remote.findByCssSelector("#TINY_MCE_2 .mce-i-spellchecker");
+      },
+
       // See AKU-711...
       "Focus is set in dialog form": function() {
          return this.remote.findById("CREATE_FORM_DIALOG_label")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/editors/TinyMCE.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/editors/TinyMCE.get.js
@@ -28,6 +28,29 @@ model.jsonModel = {
                      label: "Content",
                      name: "RichText"
                   }
+               },
+               {
+                  id: "TINY_MCE_2",
+                  name: "alfresco/forms/controls/TinyMCE",
+                  config: {
+                     label: "Custom Editor",
+                     name: "RichText2",
+                     editorConfig: {
+                        toolbar: "spellchecker",
+                        browser_spellcheck: true,
+                        additionalPlugins: [
+                           "spellchecker"
+                        ]
+                     },
+                     widgetsForEditor: [
+                        {
+                           name: "aikauTesting/widgets/CustomTinyMceEditor",
+                           config: {
+                              additionalCssClasses: "custom-tiny-mce-editor"
+                           }
+                        }
+                     ]
+                  }
                }
             ]
          }
@@ -57,9 +80,6 @@ model.jsonModel = {
       },
       {
          name: "alfresco/logging/DebugLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/CustomTinyMceEditor.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/CustomTinyMceEditor.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @module aikauTesting/widgets/CustomTinyMceEditor
+ * @extends module:alfresco/editors/TinyMCE
+ * @author Dave Draper
+ * @since 1.0.66
+ */
+define(["dojo/_base/declare",
+        "alfresco/editors/TinyMCE"], 
+        function(declare, TinyMCE) {
+   
+   return declare([TinyMCE], {
+
+      
+   });
+});


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-952 to ensure that the TinyMCE form control is much more configurable. It now properly passes on configuration to the underlying editor widget and also supports the ability to swap in alternative editors. The unit tests have been updated.