### PR TITLE
Prototype Angular 2 Bootstrap integration

### DIFF
--- a/aikau/pom.xml
+++ b/aikau/pom.xml
@@ -176,6 +176,13 @@
          </resource>
 
          <resource>
+            <!-- Extension WebScripts can't use a version with dots, so an Ant plugin renames the target folder later -->
+             <targetPath>./alfresco/site-webscripts/customizations/${project.version}</targetPath>
+            <filtering>true</filtering>
+            <directory>${basedir}/src/main/resources/extension-webscripts</directory>
+         </resource>
+
+         <resource>
             <!-- WebScripts go into their own package -->
             <targetPath>./alfresco/site-webscripts/org/alfresco/aikau/${project.version}/webscripts</targetPath>
             <filtering>true</filtering>
@@ -275,6 +282,20 @@
                         <copy todir="${project.build.testOutputDirectory}/testApp/WEB-INF/classes">
                            <fileset dir="${project.build.testOutputDirectory}" includes="**/*.class" />
                         </copy>
+                      </target>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>rename-extensions-folder</id>
+                  <phase>prepare-package</phase>
+                  <goals>
+                     <goal>run</goal>
+                  </goals>
+                  <configuration>
+                     <target>
+                        <echo>Renaming folder</echo>
+                        <move file="${project.build.outputDirectory}/alfresco/site-webscripts/customizations/${project.version}"
+                              tofile="${project.build.outputDirectory}/alfresco/site-webscripts/customizations/${webscript.version}"/>
                       </target>
                   </configuration>
                 </execution>

--- a/aikau/src/main/resources/alfresco/experimental/ng2/Bootstrap.js
+++ b/aikau/src/main/resources/alfresco/experimental/ng2/Bootstrap.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p><b>PLEASE NOTE: As this module resides within the "alfresco/experimental" package it is not subject to the
+ * same backwards compatibility rules as other widgets. It can change or even be removed between released</b></p>
+ * <p>The purpose of this widget is to provide a way to bootstrap Angular 2 widgets. In order to use this widget
+ * it is necessary to apply the "Angular 2 Support Extension" module to provide the SystemJS support required
+ * to dynamically transpile TypeScript.</p>
+ *
+ * @module alfresco/experimental/ng2/Bootstrap
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @author Dave Draper
+ * @since 1.0.66
+ */
+define(["dojo/_base/declare",
+        "dijit/_TemplatedMixin",
+        "dijit/_WidgetBase"], 
+        function(declare, _TemplatedMixin, _WidgetBase) {
+   
+   return declare([_WidgetBase, _TemplatedMixin], {
+
+      /**
+       * This should be configured with the DOM template that contains the custom elements that will
+       * be matched by the Angular 2 components loaded.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      templateString: "<div>No template provided</div",
+
+      /**
+       * This should be configured to be the component to be loaded to bootstrap Angular 2. This will be
+       * resolved against the standard AMD packages so care should be taken to ensure that this will
+       * resolve appropriately.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      main: null,
+
+      /**
+       * This bootstraps the Angular 2 components
+       *
+       * @instance
+       */
+      postCreate: function alfresco_experimental_ng2_Bootstrap__postCreate(){
+         /* global System, console */
+         // PLEASE NOTE: This code looks a bit mental, but it's necessary to stop the YUI compressor in Surf from 
+         //              having an issue with calling System.import
+         if (this.main && System && typeof System["import"] === "function")
+         {
+            System["import"](require.toUrl(this.main)).then(null, console.error.bind(console));
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/extension-module/angular2-support-extension.xml
+++ b/aikau/src/main/resources/extension-module/angular2-support-extension.xml
@@ -1,0 +1,17 @@
+<extension>
+   <id>Angular 2 Support Extension (version: ${project.version})</id>
+   <modules>
+      <module>
+         <id>Angular2 Support (version: ${project.version})</id>
+         <version>${project.version}</version>
+         <auto-deploy>false</auto-deploy>
+         <evaluator type="default.extensibility.evaluator"/>
+         <customizations>
+            <customization>
+               <targetPackageRoot>dojo</targetPackageRoot>
+               <sourcePackageRoot>customizations/${webscript.version}</sourcePackageRoot>
+            </customization>
+         </customizations>
+    </module>
+  </modules>
+</extension>

--- a/aikau/src/main/resources/extension-webscripts/dojo-bootstrap.get.html.ftl
+++ b/aikau/src/main/resources/extension-webscripts/dojo-bootstrap.get.html.ftl
@@ -1,0 +1,18 @@
+<@markup id="systemjs" target="setDojoConfig" action="before">
+   <!-- NOTE: Using CDN resources whilst this extension is in the prototype phase -->
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.0/es6-shim.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.26/system-polyfills.js"></script>
+   <script src="https://npmcdn.com/angular2@2.0.0-beta.16/es6/dev/src/testing/shims_for_IE.js"></script>
+    
+   <script src="https://code.angularjs.org/2.0.0-beta.16/angular2-polyfills.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.26/system.js"></script>
+   <script src="https://npmcdn.com/typescript@1.8.10/lib/typescript.js"></script>
+   <script src="https://code.angularjs.org/2.0.0-beta.16/Rx.js"></script>
+   <script src="https://code.angularjs.org/2.0.0-beta.16/angular2.dev.js"></script>
+   <script>
+      System.config({
+        transpiler: 'typescript', 
+        typescriptOptions: { emitDecoratorMetadata: true }
+      });
+   </script>
+</@markup>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/angular2/angular2.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/angular2/angular2.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Angular 2 Prototype</shortname>
+  <description>Example page for testing Angular 2 integration. This page will NOT work unless the support module is applied and the page is updated to reference some Angular 2 Components.</description>
+  <family>aikau-unit-tests</family>
+  <url>/Angular2</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/angular2/angular2.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/angular2/angular2.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/angular2/angular2.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/angular2/angular2.get.js
@@ -1,0 +1,26 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      // NOTE: Provided as an example only, the tutorial files are not in the source, they can be re-added
+      {
+         name: "alfresco/experimental/ng2/Bootstrap",
+         config: {
+            main: "alfresco/experimental/ng2/tutorial-example/main.ts",
+            templateString: "<my-app>Loading...</my-app>"
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR provides a prototype widget for allowing Angular 2 integration within an Aikau page model. A new support module is provided that can be deployed to request that the Angular 2 dependencies be loaded from CDN into the page. The widget can then be used to load a bootstrap Angular 2 Component and defined the initial DOM model to be parsed on bootstrapping. 

No unit tests are provided as this has been added to a new "alfresco/experimental" package with appropriate JSDoc commenting to indicate that it may be removed or changed between releases (unlike other widgets). A blog post will be published on release to demonstrate how this can be used in Share.