### PR TITLE
Eager-resolve preferences loaded when provided via config

### DIFF
--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -86,13 +86,21 @@ define(["dojo/_base/declare",
 
          // Load the user preferences...
          this._preferencesLoaded = new Deferred();
-         var url = AlfConstants.PROXY_URI + "api/people/" + encodeURIComponent(AlfConstants.USERNAME) + "/preferences";
-         this.serviceXhr({url : url,
+         // early-resolve when localPreferences have been provided via config
+         if (this.localPreferences !== undefined && this.localPreferences !== null)
+         {
+             this._preferencesLoaded.resolve(this.localPreferences);
+         }
+         else
+         {
+             var url = AlfConstants.PROXY_URI + "api/people/" + encodeURIComponent(AlfConstants.USERNAME) + "/preferences";
+             this.serviceXhr({url : url,
                           successCallback: function(response) {
                               this._preferencesLoaded.resolve(response);
                           },
                           callbackScope: this,
                           method: "GET"});
+         }
       },
       
       /**


### PR DESCRIPTION
This minor change ensures that localPreferences - if set via configuration like share-header.lib.js does - will be used as the current preferences and early-resolve the promise. This ensures that e.g. the LoggingService can retrieve the logging preferences of the user without waiting for an asynch getPreference call or a log menu publishing changes (which may not be included in the page), which means that LoggingService will correctly log messages from the beginning instead of potentially missing some initial page load log requests.