### PR TITLE
AKU-958: Update Maven archetype to include bean for login controller

### DIFF
--- a/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/web-application-config.xml
+++ b/aikau-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/config/web-application-config.xml
@@ -97,6 +97,7 @@
        <property name="useExpiresHeader"><value>true</value></property>
        <property name="useCacheControlHeader"><value>true</value></property>
        <property name="userFactory" ref="webframework.factory.user.aikau"></property>
+       <property name="webFrameworkConfiguration" ref="webframework.config.element"></property>
        <property name="supportedMethods">
            <list>
                <value>HEAD</value>


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-958 / #1033 to ensure that the AikauLoginController created by the Maven Archetype is configured with all the necessary beans to support login. This has been broken since we updated the Archetype to use Surf 6