### PR TITLE
AKU-956: Ensure empty comments cannot be saved

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/CommentsList.js
+++ b/aikau/src/main/resources/alfresco/renderers/CommentsList.js
@@ -43,6 +43,16 @@ define(["dojo/_base/declare",
    return declare([ProcessWidgets, ObjectProcessingMixin], {
 
       /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default [{cssFile:"./css/CommentsList.css"}]
+       * @since 1.0.67
+       */
+      cssRequirements: [{cssFile:"./css/CommentsList.css"}],
+
+      /**
        * An array of the i18n files to use with this widget.
        *
        * @instance
@@ -106,6 +116,7 @@ define(["dojo/_base/declare",
                         publishPayloadType: "PROCESS",
                         publishPayloadModifiers: ["processCurrentItemTokens","convertNodeRefToUrl"],
                         publishPayload: {
+                           dialogId: "ALF_COMMENTS_LIST_COMMENT_DIALOG",
                            dialogTitle: "comment.add",
                            dialogConfirmationButtonTitle: "comment.add.confirm",
                            dialogCancellationButtonTitle: "comment.add.cancel",
@@ -124,6 +135,9 @@ define(["dojo/_base/declare",
                                  name: "alfresco/forms/controls/TinyMCE",
                                  config: {
                                     name: "content",
+                                    requirementConfig: {
+                                       initialValue: true
+                                    },
                                     autoResize: "{addCommentsFullScreen}"
                                  }
                               }

--- a/aikau/src/main/resources/alfresco/renderers/css/CommentsList.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/CommentsList.css
@@ -1,0 +1,14 @@
+// This ensures the title row is NEVER displayed for comments dialog
+.alfresco-dialog-AlfDialog#ALF_COMMENTS_LIST_COMMENT_DIALOG {
+   .dialog-body {
+      .alfresco-forms-Form.root-dialog-form {
+         > form {
+            > .alfresco-forms-controls-BaseFormControl {
+               > .title-row {
+                  display: none;
+               }
+            }
+         }
+      }
+   }
+}

--- a/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
@@ -80,7 +80,7 @@ define(["module",
             });
       },
 
-      "Add comment": function() {
+      "Add comment (confirmation button initially disabled)": function() {
          return this.remote.findByCssSelector("#COMMENT_LIST .alf-menu-bar-label-node")
             .click()
             .end()
@@ -88,7 +88,11 @@ define(["module",
          .findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-editors-TinyMCE iframe") // Wait for control
             .end()
 
-         .findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-editors-TinyMCE iframe")
+         .findByCssSelector("#ALF_COMMENTS_LIST_COMMENT_DIALOG .confirmationButton.dijitButtonDisabled");
+      },
+
+      "Add comment": function() {
+         return this.remote.findAllByCssSelector(".alfresco-dialog-AlfDialog .alfresco-editors-TinyMCE iframe")
             .execute("tinymce.get(0).setContent('<p><strong>Hello tester!</strong></p>');")
             .execute("tinymce.get(0).save();")
             .end()
@@ -169,49 +173,52 @@ define(["module",
          return this.remote.findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .clearLog()
             .click()
-            .end()
+         .end()
 
-         .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
-            .clearLog()
-
-         .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
-            .click()
-            .end()
-
-         .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
-            .clearLog()
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
-            .end()
+         .end()
 
-         .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
-            .clearLog()
-
-         .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
-            .click()
-            .end()
-
-         .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
-            .clearLog()
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
-            .end()
+         .end()
+
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
-            .end()
+         .end()
 
-         .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
-            .clearLog()
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
-            .end()
+         .end()
 
-         .getLastPublish("COMMENTS1_ALF_DOCLIST_REQUEST_FINISHED")
-            .clearLog()
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
+
+         .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+            .click()
+         .end()
+
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
+
+         .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
+            .click()
+         .end()
+
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
          .findByCssSelector("#COMMENT_LIST .alfresco-lists-AlfList")
             .getVisibleText()


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-956 to ensure that it is not possible to save empty comments. A further update has been made to ensure that the title bar is never showed for the comments dialog (a recent regression in style). Unit tests have been updated and improved to try and solve the intermittent failures that sometimes occur on Firefox.