### PR TITLE
AKU-954: Ensure drag-and-drop upload behaviour is updated appropriately

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -129,13 +129,21 @@ define(["dojo/_base/declare",
        */
       copyViewData: function alfresco_lists_AlfList__copyViewData(/*jshint unused:false*/oldView, newView) {
          this.inherited(arguments);
-         if (this.currentFilter && this.currentFilter.path)
+
+         // See AKU-954: Ensure DND upload permissions are set correctly...
+         var userPermissions = lang.getObject("currentData.metadata.parent.permissions.user", false, this);
+         var isContainer = lang.getObject("currentData.metadata.parent.isContainer", false, this);
+         if (userPermissions &&
+             ((isContainer === true && userPermissions.CreateChildren === true) ||
+             (isContainer === false && userPermissions.Write === true)))
          {
             newView.addUploadDragAndDrop(newView.dragAndDropNode);
+            domClass.add(newView.domNode, "alfresco-documentlibrary-AlfDocumentList--upload-enabled");
          }
          else
          {
             newView.removeUploadDragAndDrop(newView.dragAndDropNode);
+            domClass.remove(newView.domNode, "alfresco-documentlibrary-AlfDocumentList--upload-enabled");
          }
       },
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/DocumentLibraryTest.js
@@ -172,6 +172,10 @@ define(["module",
          });
       },
 
+      "Upload is enabled for path view": function() {
+         return this.remote.findDisplayedByCssSelector(".alfresco-documentlibrary-AlfDocumentList--upload-enabled");
+      },
+
       "Switch to favourites filter": function() {
          return this.remote.then(() => {
                return switchToFilter(this.remote, "SCOPED_");
@@ -181,6 +185,13 @@ define(["module",
                var currHash = hashObjFromUrl(currentUrl);
                assert.propertyVal(currHash, "filter", "favourites", "Hash does not have correct filter parameter");
                assert.propertyVal(currHash, "description", "My%20Favorite%20Files%20and%20Folders", "Hash does not have correct description parameter");
+            });
+      },
+
+      "Upload is disabled for filter view": function() {
+         return this.remote.findAllByCssSelector(".alfresco-documentlibrary-AlfDocumentList--upload-enabled")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
             });
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-954 to ensure that drag-and-drop upload highlighting is updated correctly based on user permissions for the location being displayed. Unit tests have been updated. 

**FULL REGRESSION TEST RUNNING - REVIEW DON'T MERGE**