### PR TITLE
ALF-21614: Update and deprecations

### DIFF
--- a/aikau/ReleaseNotes.md
+++ b/aikau/ReleaseNotes.md
@@ -1,6 +1,10 @@
 Aikau 1.0.66 Release Notes
 ===
 
+New deprecations:
+---
+* alfresco/dialogs/AlfFormDialog                                 (use alfresco/services/DialogService)
+
 Previous deprecations:
 ---
 * alfresco/renderers/Thumbnail.js

--- a/aikau/src/main/resources/alfresco/dialogs/AlfFormDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfFormDialog.js
@@ -28,6 +28,7 @@
  * @module alfresco/dialogs/AlfFormDialog
  * @extends external:dijit/Dialog
  * @author Dave Draper
+ * @deprecated Since 1.0.67 - use the [DialogService]{@link module:alfresco/services/DialogService} instead.
  */
 define(["dojo/_base/declare",
         "alfresco/dialogs/AlfDialog",
@@ -175,7 +176,7 @@ define(["dojo/_base/declare",
             when(payload.dialogContent, lang.hitch(this, function(dialogContent) {
                if (dialogContent && dialogContent.length)
                {
-                  var data = payload.dialogContent[0].getValue();
+                  var data = dialogContent[0].getValue();
                   if (!this.formSubmissionPayload)
                   {
                      this.formSubmissionPayload = {};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/ALF-21614. It is no longer recommended to use the AlfFormDialog (and really should have been deprecated a long time ago). However, although Aikau no longer uses this module we will change as requested. No tests have been updated or added as this module will ultimately be removed.