### PR TITLE
Avoid double pubSubScope-prefix in logged publications

### DIFF
--- a/aikau/src/main/resources/alfresco/services/LoggingService.js
+++ b/aikau/src/main/resources/alfresco/services/LoggingService.js
@@ -413,7 +413,7 @@ define(["dojo/_base/declare",
             switch (type)
             {
                case "PUBLICATION":
-                  event.topic = payload.alfPublishScope + payload.alfTopic;
+                  event.topic = payload.alfTopic;
                   event.payload = payload;
 
                   // If the widget that triggered the publish has been passed, pass that through, highlighting the id.


### PR DESCRIPTION
This minor change fixes a publication logging issue with pubSubScope / alfPublishScope being added as a redundant prefix to the already scoped alfTopic.