### PR TITLE
Add missing message call to iconAltText case

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/menus/_AlfMenuItemMixin.js
@@ -164,7 +164,7 @@ define(["dojo/_base/declare",
          }
          if (!this.iconAltText && this.title)
          {
-            this.iconAltText = originalLabel;
+            this.iconAltText = this.message(originalLabel);
          }
          else if (this.iconAltText)
          {


### PR DESCRIPTION
This minor change ensures that iconAltText is properly set (looking up in i18n resources) in one specific case of the _AlfMenuItemMixin postMixInProperties.