### PR TITLE
Added 'renditions' to Form POST for v1 upload API support

### DIFF
--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -683,7 +683,9 @@ define(["alfresco/core/CoreXhr",
                formData.append("fileData", uploadData.filedata);
                formData.append("fileName", uploadData.filename);
                formData.append("autoRename", !uploadData.overwrite);
-               formData.append("renditions", uploadData.thumbnails);
+               if (thumbnails) {
+                  formData.append("renditions", uploadData.thumbnails);
+               }
                if (uploadData.uploaddirectory) {
                   formData.append("relativePath", uploadData.uploaddirectory);
                }

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -683,6 +683,7 @@ define(["alfresco/core/CoreXhr",
                formData.append("fileData", uploadData.filedata);
                formData.append("fileName", uploadData.filename);
                formData.append("autoRename", !uploadData.overwrite);
+               formData.append("renditions", uploadData.thumbnails);
                if (uploadData.uploaddirectory) {
                   formData.append("relativePath", uploadData.uploaddirectory);
                }

--- a/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
+++ b/aikau/src/main/resources/alfresco/services/_BaseUploadService.js
@@ -683,7 +683,7 @@ define(["alfresco/core/CoreXhr",
                formData.append("fileData", uploadData.filedata);
                formData.append("fileName", uploadData.filename);
                formData.append("autoRename", !uploadData.overwrite);
-               if (thumbnails) {
+               if (uploadData.thumbnails) {
                   formData.append("renditions", uploadData.thumbnails);
                }
                if (uploadData.uploaddirectory) {


### PR DESCRIPTION
Identical parameter format to v0 API, but param in v1 is called 'renditions' instead of 'thumbnails'.