### PR TITLE
#1049 - only set rulePassValue / ruleFailValue if actual value is defined

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -541,13 +541,20 @@ define(["dojo/_base/declare",
        * @param {boolean} hasPassedRule Indicated whether or not evaluation of the rules were successful
        */
       autoSetValue: function alfresco_forms_controls_BaseFormControl__autoSetValue(passValue, failValue, hasPassedRule) {
+         // passValue/failValue may not be set to any value in autoSetConfig to achieve positive-/negative-only rule behaviour
          if (hasPassedRule === true)
          {
-            this.setValue(passValue);
+            if (passValue !== undefined)
+            {
+                this.setValue(passValue);
+            }
          }
          else
          {
-            this.setValue(failValue);
+            if (failValue !== undefined)
+            {
+                this.setValue(failValue);
+            }
          }
       },
 


### PR DESCRIPTION
After checking @aviriel s issue #1049 I realized this is fixed by one small change to autoSetValue that we had already implemented as one of our 160+ fixes/changes.
This change avoids setting the value of a widget to undefined and thus allows rulePassValue or ruleFailValue to not be defined, so a developer can define rules that only change the value on positive or negative rule match, leaving the previous value intact otherwise. In the case of @aviriel the previous value may be a value of a different autoSetConfig rule set, since each element of the autoSetConfig is individually evaluated and her example triggers all the rules.