### PR TITLE
AKU-966: PublishAction icon path hardcoded

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -34,8 +34,10 @@ define(["dojo/_base/declare",
         "alfresco/renderers/_JsNodeMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "dojo/text!./templates/PublishAction.html",
+        "alfresco/enums/urlTypes", 
+        "alfresco/util/urlUtils",
         "alfresco/core/Core"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, template, AlfCore) {
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, template, urlTypes, urlUtils, AlfCore) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, AlfCore], {
       
@@ -73,7 +75,17 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      iconClass: "add-icon-16",
+      iconClass: null,
+
+      /**
+       * This property is auto-populated and will be injected into the template.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       * @since 1.0.68
+       */
+      imageSrc: null,
 
      /**
        * This defines the topic that will be published on when the associated image is clicked. The payload will be
@@ -84,6 +96,31 @@ define(["dojo/_base/declare",
        * @default
        */
       publishTopic: "ALF_ITEM_SELECTED",
+
+      /**
+       * The URL of the image to use (this is used in conjunction with the
+       * [srcType]{@link module:alfresco/renderers/PublishAction#srcType}
+       * property). If a src is provided, then the
+       * [classes]{@link module:alfresco/renderers/PublishAction#classes}
+       * property will not be used.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.68
+       */
+      src: "alfresco/renderers/css/images/add-icon-16.png",
+
+      /**
+       * The type of URL to use (see [urlTypes]{@link module:alfresco/enums/urlTypes}
+       * for possible values).
+       *
+       * @instance
+       * @type {string}
+       * @default {@link module:alfresco/enums/urlTypes#REQUIRE_PATH}
+       * @since 1.0.68
+       */
+      srcType: urlTypes.REQUIRE_PATH,
 
       /**
        * Set up the attributes to be used when rendering the template.
@@ -102,12 +139,9 @@ define(["dojo/_base/declare",
 
          if (this.iconClass)
          {
-            this.imageSrc = require.toUrl("alfresco/renderers/css/images/" + this.iconClass + ".png");
+            this.src = "alfresco/renderers/css/images/" + this.iconClass + ".png";
          }
-         else
-         {
-            this.imageSrc = require.toUrl("alfresco/renderers/css/images/add-icon-16.png");
-         }
+         this.imageSrc = urlUtils.convertUrl(this.src, this.srcType);
 
          // Localize the alt text...
          var altTextId = this.currentItem ? this.currentItem[this.propertyToRender] : "";

--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -67,9 +67,10 @@ define(["dojo/_base/declare",
       altText: "",
 
       /**
-       * This should be set to the icon to use. Currently this is just mapped to an actual image that is located
-       * in the css/images folder however it should ultimately map to a CSS selector that defines a section of 
-       * an image sprite.
+       * This property has been superseded by the [src]{@link module:alfresco/renderers/PublishAction#src} and
+       * [srcType]{@link module:alfresco/renderers/PublishAction#srcType} properties, however it continues to
+       * work as it did previously, which is that the name of an icon (e.g. "add-icon-16") can be specified
+       * which is resolved according to the pattern `alfresco/renderers/css/images/${this.iconClass}.png`.
        *
        * @instance
        * @type {string}
@@ -100,9 +101,7 @@ define(["dojo/_base/declare",
       /**
        * The URL of the image to use (this is used in conjunction with the
        * [srcType]{@link module:alfresco/renderers/PublishAction#srcType}
-       * property). If a src is provided, then the
-       * [classes]{@link module:alfresco/renderers/PublishAction#classes}
-       * property will not be used.
+       * property).
        *
        * @instance
        * @type {string}

--- a/aikau/src/test/resources/alfresco/renderers/PublishActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishActionTest.js
@@ -38,16 +38,56 @@ define(["module",
          });
       },
 
-      "Clicking on action publishes correctly": function() {
-         return this.remote.findById("EDIT_ME")
+      "Actions have correct images": function() {
+         return this.remote.findByCssSelector("#DEFAULT .alfresco-renderers-PublishAction__image")
+            .getAttribute("src")
+            .then(function(src) {
+               assert.include(src, "alfresco/renderers/css/images/add-icon-16.png", "Default icon incorrect");
+            })
+            .end()
+
+         .findByCssSelector("#CUSTOM_WITH_PAYLOAD .alfresco-renderers-PublishAction__image")
+            .getAttribute("src")
+            .then(function(src) {
+               assert.include(src, "alfresco/renderers/css/images/edit-16.png", "Custom icon incorrect");
+            })
+            .end()
+
+         .findByCssSelector("#CUSTOM_IMAGE .alfresco-renderers-PublishAction__image")
+            .getAttribute("src")
+            .then(function(src) {
+               assert.include(src, "/aikau/images/app-logo-48.png", "Custom image URL incorrect");
+            });
+      },
+
+      "Default action publishes correct topic": function() {
+         return this.remote.findById("DEFAULT")
             .clearLog()
             .click()
             .end()
 
-         .getLastPublish("EDIT_ME")
+         .getLastPublish("PUBLISH_ACTION_DEFAULT");
+      },
+
+      "Clicking on action with custom icon publishes payload correctly": function() {
+         return this.remote.findById("CUSTOM_WITH_PAYLOAD")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("PUBLISH_ACTION_CUSTOM_WITH_PAYLOAD")
             .then(function(payload) {
                assert.propertyVal(payload, "editMode", true);
             });
+      },
+
+      "Action with custom image publishes correct topic": function() {
+         return this.remote.findById("CUSTOM_IMAGE")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("PUBLISH_ACTION_CUSTOM_IMAGE");
       },
 
       "Action clicks do not bubble upwards": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.js
@@ -13,14 +13,51 @@ model.jsonModel = {
    ],
    widgets:[
       {
+         name: "alfresco/html/Heading",
+         config: {
+            label: "Default image",
+            level: 3
+         }
+      },
+      {
          name: "alfresco/renderers/PublishAction",
-         id: "EDIT_ME",
+         id: "DEFAULT",
+         config: {
+            publishTopic: "PUBLISH_ACTION_DEFAULT"
+         }
+      },
+      {
+         name: "alfresco/html/Heading",
+         config: {
+            label: "Custom icon with payload",
+            level: 3
+         }
+      },
+      {
+         name: "alfresco/renderers/PublishAction",
+         id: "CUSTOM_WITH_PAYLOAD",
          config: {
             iconClass: "edit-16",
-            publishTopic: "EDIT_ME",
+            publishTopic: "PUBLISH_ACTION_CUSTOM_WITH_PAYLOAD",
             publishPayload: {
                editMode: true
             }
+         }
+      },
+      {
+         name: "alfresco/html/Heading",
+         config: {
+            label: "Custom image URL",
+            level: 3
+         }
+      },
+      {
+         name: "alfresco/renderers/PublishAction",
+         id: "CUSTOM_IMAGE",
+         config: {
+            src: "images/app-logo-48.png",
+            srcType: "CONTEXT_RELATIVE",
+            publishTopic: "PUBLISH_ACTION_CUSTOM_IMAGE"
          }
       },
       {


### PR DESCRIPTION
This PR addresses issue [AKU-966](https://issues.alfresco.com/jira/browse/AKU-966), which is about freeing up the customisation of the icon used in the `alfresco/renderers/PublishAction` widget. Tests have been updated, and a full suite run successfully.