### PR TITLE
AKU-956: Updated for handling TinyMCE change events

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/TinyMCE.js
@@ -106,7 +106,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       setupChangeEvents: function alfresco_forms_controls_TinyMCE__setupChangeEvents() {
-         // No action.
+         this.wrappedWidget.editor.on("keyup", lang.hitch(this, this.onEditorValueChange));
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/EditableComment.js
+++ b/aikau/src/main/resources/alfresco/renderers/EditableComment.js
@@ -75,13 +75,34 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
-       * Indicates whether or not the widget is in read mode or not. Default is true.
-       *
+       * This will be instantiated as a map of the controls used by the widget. It has been added in order
+       * to be passed as a reference for the "assignToScope" attribute of the 
+       * [TinyMCE form control]{@link module:alfresco/forms/controls/TinyMCE} that is referenced
+       * in the [widgetsForForm]{@link module:alfresco/renderers/EditableComment#widgetsForForm} model. This
+       * attribute should not be configured or set.
+       * 
        * @instance
-       * @type {boolean}
+       * @type {object}
+       * @default
+       * @since 1.0.68
+       */
+      controls: null,
+
+      /**
+       * @instance
+       * @type {string}
        * @default
        */
-      readMode: true,
+      okButtonLabel: "comment.save",
+
+      /**
+       * The parameter to post that contains the content.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      postParam: "content",
 
       /**
        * This should be set to the name of the property to render (e.g. "cm:name"). The property is expected
@@ -93,93 +114,6 @@ define(["dojo/_base/declare",
        */
       propertyToRender: null,
       
-      /**
-       * The topic that will be subscribed to that will toggle between edit and read modes.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      subscriptionTopic: "ALF_EDIT_COMMENT",
-
-      /**
-       * Set up the attributes to be used when rendering the template.
-       * 
-       * @instance
-       */
-      postMixInProperties: function alfresco_renderers_EditableComment__postMixInProperties() {
-         // Initialise the mode...
-         if (this.readMode === true)
-         {
-            this._mode = "read";
-         }
-         else
-         {
-            this._mode = "edit";
-         }
-
-         // Get the comment value...
-         this.renderedValue = lang.getObject(this.propertyToRender, false, this.currentItem);
-         if (this.renderedValue === null || typeof this.renderedValue === "undefined")
-         {
-            this.renderedValue = "";
-         }
-      },
-      
-      /**
-       * 
-       * @instance
-       */
-      postCreate: function alfresco_renderers_EditableComment__postCreate() {
-         this._formCreated = false;
-
-         // Clone the configured payload to avoid collisions with other instances...
-         this.publishPayload = lang.clone(this.publishPayload);
-
-         // Setup subscriptions as necessary... (TODO: Overridable function?)
-         this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.onEditRequest));
-         this.alfSubscribe("ALF_CANCEL_EDIT_COMMENT", lang.hitch(this, this.onCancelEdit));
-         this.alfSubscribe("ALF_EDIT_COMMENT_SAVE", lang.hitch(this, this.onEditSave));
-
-         // Safely add the rendered value to the document
-         var safeDocFrag = this._makeSafe(this.renderedValue);
-         this.readNode.appendChild(safeDocFrag);
-      },
-
-      /**
-       * This function switches the widget into edit mode. It will create the required editor as necessary
-       * the first time the function is called.
-       *
-       * @instance
-       * @param {object} payload
-       */
-      onEditRequest: function alfresco_renderers_EditableComment__onEditRequest(/*jshint unused:false*/ payload) {
-         if (this._formCreated === false)
-         {
-            var widgetsConfig = lang.clone(this.widgetsForForm);
-            this.processObject(["processInstanceTokens","processCurrentItemTokens","convertNodeRefToUrl"], widgetsConfig);
-            this.processWidgets(widgetsConfig, this.formNode);
-            this._formCreated = true;
-         }
-
-         // Toggle the CSS classes to reveal the edit form...
-         domClass.remove(this.domNode, "read");
-         domClass.add(this.domNode, "edit");
-         this._mode = "edit";
-      },
-
-      /**
-       * Handles requests to cancel editing
-       *
-       * @instance
-       * @param {object} payload The payload published on the cancellation topic
-       */
-      onCancelEdit: function alfresco_renderers_EditableComment__onCancelEdit(/*jshint unused:false*/ payload) {
-         domClass.remove(this.domNode, "edit");
-         domClass.add(this.domNode, "read");
-         this._mode = "read";
-      },
-
       /**
        * The topic to publish whenever the internal form is posted. By default this is expected to 
        * work with the [CrudService]{@link module:alfresco/services/CrudService} and uses its update
@@ -231,6 +165,107 @@ define(["dojo/_base/declare",
       publishGlobal: true,
 
       /**
+       * Indicates whether or not the widget is in read mode or not. Default is true.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      readMode: true,
+
+      /**
+       * The topic that will be subscribed to that will toggle between edit and read modes.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      subscriptionTopic: "ALF_EDIT_COMMENT",
+
+      /**
+       * Set up the attributes to be used when rendering the template.
+       * 
+       * @instance
+       */
+      postMixInProperties: function alfresco_renderers_EditableComment__postMixInProperties() {
+         // Initialise the mode...
+         if (this.readMode === true)
+         {
+            this._mode = "read";
+         }
+         else
+         {
+            this._mode = "edit";
+         }
+
+         // Get the comment value...
+         this.renderedValue = lang.getObject(this.propertyToRender, false, this.currentItem);
+         if (this.renderedValue === null || typeof this.renderedValue === "undefined")
+         {
+            this.renderedValue = "";
+         }
+      },
+      
+      /**
+       * 
+       * @instance
+       */
+      postCreate: function alfresco_renderers_EditableComment__postCreate() {
+         this._formCreated = false;
+
+         // Clone the configured payload to avoid collisions with other instances...
+         this.publishPayload = lang.clone(this.publishPayload);
+
+         // Setup subscriptions as necessary... (TODO: Overridable function?)
+         this.alfSubscribe(this.subscriptionTopic, lang.hitch(this, this.onEditRequest));
+         this.alfSubscribe("ALF_CANCEL_EDIT_COMMENT", lang.hitch(this, this.onCancelEdit));
+         this.alfSubscribe("ALF_EDIT_COMMENT_SAVE", lang.hitch(this, this.onEditSave));
+
+         // Safely add the rendered value to the document
+         var safeDocFrag = this._makeSafe(this.renderedValue);
+         this.readNode.appendChild(safeDocFrag);
+
+         this.controls = {};
+      },
+
+      /**
+       * This function switches the widget into edit mode. It will create the required editor as necessary
+       * the first time the function is called.
+       *
+       * @instance
+       * @param {object} payload
+       */
+      onEditRequest: function alfresco_renderers_EditableComment__onEditRequest(/*jshint unused:false*/ payload) {
+         if (this._formCreated === false)
+         {
+            var widgetsConfig = lang.clone(this.widgetsForForm);
+            this.processObject(["processInstanceTokens","processCurrentItemTokens","convertNodeRefToUrl"], widgetsConfig);
+            this.processWidgets(widgetsConfig, this.formNode);
+            this._formCreated = true;
+         }
+
+         // Toggle the CSS classes to reveal the edit form...
+         domClass.remove(this.domNode, "read");
+         domClass.add(this.domNode, "edit");
+         this._mode = "edit";
+      },
+
+      /**
+       * Handles requests to cancel editing
+       *
+       * @instance
+       * @param {object} payload The payload published on the cancellation topic
+       */
+      onCancelEdit: function alfresco_renderers_EditableComment__onCancelEdit(/*jshint unused:false*/ payload) {
+         domClass.remove(this.domNode, "edit");
+         domClass.add(this.domNode, "read");
+         this._mode = "read";
+
+         // On cancel, make sure to reset the value in the TinyMCE editor...
+         this._form._editControl.setValue(this.renderedValue);
+      },
+
+      /**
        * Handles requests to save the updated comment.
        *
        * @instance
@@ -252,22 +287,6 @@ define(["dojo/_base/declare",
          generatedPayload.responseScope = this.parentPubSubScope;
          this.alfPublish(this.publishTopic, generatedPayload, this.publishGlobal);
       },
-
-      /**
-       * The parameter to post that contains the content.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      postParam: "content",
-
-      /**
-       * @instance
-       * @type {string}
-       * @default
-       */
-      okButtonLabel: "comment.save",
 
       /**
        * Convert the supplied, potentially-unsafe HTML into a safe document fragment
@@ -295,6 +314,7 @@ define(["dojo/_base/declare",
       widgetsForForm: [
          {
             name: "alfresco/forms/Form",
+            assignTo: "_form",
             config: {
                okButtonPublishTopic: "ALF_EDIT_COMMENT_SAVE",
                okButtonLabel: "{okButtonLabel}",
@@ -305,9 +325,13 @@ define(["dojo/_base/declare",
                widgets: [
                   {
                      name: "alfresco/forms/controls/TinyMCE",
+                     assignTo: "_editControl",
                      config: {
                         name: "{postParam}",
-                        value: "{renderedValue}"
+                        value: "{renderedValue}",
+                        requirementConfig: {
+                           initialValue: true
+                        }
                      }
                   }
                ]

--- a/aikau/src/main/resources/alfresco/renderers/css/EditableComment.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/EditableComment.css
@@ -1,5 +1,11 @@
 .alfresco-renderers-EditableComment {
-
+   form {
+      > .alfresco-forms-controls-BaseFormControl {
+         > .title-row {
+            display: none;
+         }
+      }
+   }
 }
 
 .alfresco-renderers-EditableComment.read > .edit {

--- a/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/CommentsListTest.js
@@ -119,6 +119,11 @@ define(["module",
             });
       },
 
+      "Remove comment content to check save is disabled": function() {
+         return this.remote.execute("tinymce.get(1).setContent('');")
+            .findByCssSelector(".alfresco-renderers-EditableComment .alfresco-forms-Form .confirmationButton");
+      },
+
       "Save edit": function() {
          return this.remote.findAllByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-editors-TinyMCE iframe") // Wait for control
             .end()
@@ -175,50 +180,64 @@ define(["module",
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findDisplayedByCssSelector(".alfresco-lists-AlfList .alfresco-lists-views-layouts-Row:first-child .alfresco-renderers-PublishAction:nth-child(3) > img")
             .click()
          .end()
 
-         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
-         .end()
+         .getLastPublish("COMMENTS1_ALF_DOCLIST_SORT")
+         .clearLog()
+
+         .sleep(2000)
 
          .findByCssSelector("#COMMENT_LIST .alfresco-lists-AlfList")
             .getVisibleText()


### PR DESCRIPTION
This PR addresses both https://issues.alfresco.com/jira/browse/AKU-956 and https://issues.alfresco.com/jira/browse/AKU-961 (which is a duplicate) to ensure that the TinyMCE editor issues change events on key up to ensure that form buttons can be enabled/disabled on content change rather than a shift in focus. Additionally the edit as well as create comment requires data. Also, when cancelling editing a comment the original value is reset. Unit tests have been updated, unfortunately I've had to reintroduce sleep calls for reliability of testers.