### PR TITLE
Fix broken tests

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
@@ -72,13 +72,14 @@ define(["dojo/_base/declare",
       processMiddleOrCtrlClick: function alfresco_navigation_LinkClickMixin__processMiddleOrCtrlClick(evt, publishTopic, publishPayload) {
          if (this.newTabOnMiddleOrCtrlClick && publishTopic === this.navigateToPageTopic) 
          {
-            if ((evt.which === 2 || 
-                (evt.which === 1 && evt.ctrlKey) ||
-                (evt.which === 1 && has("mac") && evt.metaKey)) && publishPayload.target !== this.newTarget)
+            var middleButton = evt.button === 2,
+               leftButton = evt.button === 1,
+               ctrlKey = has("mac") ? evt.metaKey : evt.ctrlKey;
+            if (middleButton || (leftButton && ctrlKey))
             {
                publishPayload.target = this.newTarget;
             }
-            else if (evt.which === 1 && publishPayload.target !== this.currentTarget)
+            else if (leftButton && publishPayload.target !== this.currentTarget)
             {
                publishPayload.target = this.defaultNavigationTarget || this.currentTarget;
             }

--- a/aikau/src/test/resources/alfresco/CustomCommand.js
+++ b/aikau/src/test/resources/alfresco/CustomCommand.js
@@ -744,8 +744,8 @@ define(["intern/dojo/node!fs",
                function tabAndCheck() {
                   return browser.pressKeys(reverse ? [keys.SHIFT, keys.TAB] : keys.TAB)
                      .pressKeys(keys.NULL)
-                     .execute(function(targetElemSelector, index) {
-                        var targetElem = document.querySelectorAll(targetElemSelector)[index];
+                     .execute(function(targetElemSelector, elemIndex) {
+                        var targetElem = document.querySelectorAll(targetElemSelector)[elemIndex];
                         return targetElem && targetElem === document.activeElement;
                      }, [selector, index])
                      .then(function(foundElem) {

--- a/aikau/src/test/resources/alfresco/CustomCommand.js
+++ b/aikau/src/test/resources/alfresco/CustomCommand.js
@@ -735,11 +735,6 @@ define(["intern/dojo/node!fs",
                   numTabs = 0,
                   dfd = new Promise.Deferred();
 
-               // Allow JUST providing a CSS selector
-               if (typeof arguments[0] === "string") {
-                  selector = arguments[0];
-               }
-
                // Sanitise arguments
                if (!selector) {
                   throw new Error("No valid selector provided in tabToElement()");

--- a/aikau/src/test/resources/alfresco/CustomCommand.js
+++ b/aikau/src/test/resources/alfresco/CustomCommand.js
@@ -341,7 +341,7 @@ define(["intern/dojo/node!fs",
          getTextContent: function(selector) {
             return new this.constructor(this, function() {
                var browser = this.parent;
-               return browser.execute(function (cssSelector) {
+               return browser.execute(function(cssSelector) {
                   var elem = document.querySelector(cssSelector);
                   return elem && elem.textContent;
                }, [selector]);
@@ -609,7 +609,7 @@ define(["intern/dojo/node!fs",
                // Get the environment info
                var rootSuite = this,
                   envType;
-               while(rootSuite.parent) {
+               while (rootSuite.parent) {
                   rootSuite = rootSuite.parent;
                }
                envType = rootSuite.environmentType;
@@ -693,7 +693,7 @@ define(["intern/dojo/node!fs",
                      fs.writeFile(screenshotPath, screenshot.toString("binary"), "binary", function(err) {
                         browser.execute(function(id) {
                            var infoBlock = document.getElementById(id);
-                           if(infoBlock) {
+                           if (infoBlock) {
                               infoBlock.parentNode.removeChild(infoBlock);
                            }
                         }, [infoId]);
@@ -714,11 +714,18 @@ define(["intern/dojo/node!fs",
           * Tab to the specified element on the page.
           *
           * @instance
-          * @param {string} selector The CSS selector of the element to tab to
-          * @param {int} [collectionIndex=0] If the selector matches a collection, this index will define the item within that collection if provided
-          * @param {int} [maxTabs=10] The maximum number of tabs to use (i.e. how many times to simulate pressing tab) - used to prevent forever looping round a page trying to find an element
+          * @param {Object} opts Options object
+          * @param {String} opts.selector The CSS selector of the element to tab to
+          * @param {String} [opts.index=0] If the selector matches a collection, this index will define the item within that collection if provided
+          * @param {int} [opts.maxTabs=10] The maximum number of tabs to use (i.e. how many times to simulate pressing tab) - used to prevent forever looping round a page trying to find an element
+          * @param {Boolean} [opts.reverse=false] If true, then shift+tab will be used instead (i.e. direction of tabbing is reversed)
           */
-         tabToElement: function(selector, collectionIndex, maxTabs) {
+         tabToElement: function({
+            selector = null,
+            index = 0,
+            maxTabs = 10,
+            reverse = false
+         }) {
 
             // Boilerplate stuff
             return new this.constructor(this, function() {
@@ -728,23 +735,27 @@ define(["intern/dojo/node!fs",
                   numTabs = 0,
                   dfd = new Promise.Deferred();
 
+               // Allow JUST providing a CSS selector
+               if (typeof arguments[0] === "string") {
+                  selector = arguments[0];
+               }
+
                // Sanitise arguments
-               collectionIndex = collectionIndex || 0;
-               maxTabs = maxTabs || 10;
                if (!selector) {
                   throw new Error("No valid selector provided in tabToElement()");
                }
 
                // Define tabAndCheck function
                function tabAndCheck() {
-                  return browser.pressKeys(keys.TAB)
+                  return browser.pressKeys(reverse ? [keys.SHIFT, keys.TAB] : keys.TAB)
+                     .pressKeys(keys.NULL)
                      .execute(function(targetElemSelector, index) {
                         var targetElem = document.querySelectorAll(targetElemSelector)[index];
                         return targetElem && targetElem === document.activeElement;
-                     }, [selector, collectionIndex])
+                     }, [selector, index])
                      .then(function(foundElem) {
                         if (typeof foundElem === "undefined") {
-                           throw new Error("Unable to find target element with selector \"" + selector + "\" and index " + collectionIndex);
+                           throw new Error("Unable to find target element with selector \"" + selector + "\" and index " + index);
                         } else if (!foundElem && numTabs++ < maxTabs) {
                            return tabAndCheck();
                         } else if (!foundElem) {

--- a/aikau/src/test/resources/alfresco/buttons/DropDownButtonTest.js
+++ b/aikau/src/test/resources/alfresco/buttons/DropDownButtonTest.js
@@ -62,7 +62,9 @@ define(["module",
 
       "Tab to and open right, drop-down": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement("#DDB2_DROP_DOWN_BUTTON")
+            .tabToElement({
+               selector: "#DDB2_DROP_DOWN_BUTTON"
+            })
             .pressKeys(keys.ENTER)
             .end()
 

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -80,9 +80,10 @@ define(["module",
          return this.remote.findByCssSelector("#FORM1 .confirmationButton > span")
             .click()
             .end()
-            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM1_POST", "data", "name", "bob"))
-            .then(null, function() {
-               assert(false, "Form didn't contain the value from the dropped item");
+
+         .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data[0].name", "bob");
             });
       },
 
@@ -97,9 +98,10 @@ define(["module",
          return this.remote.findByCssSelector("#FORM2 .confirmationButton > span")
             .click()
             .end()
-            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM2_POST", "data", "preset", "value1"))
-            .then(null, function() {
-               assert(false, "Preset form didn't contain the initialised value.");
+
+         .getLastPublish("FORM2_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data[0].preset", "value1");
             });
       },
 
@@ -114,9 +116,14 @@ define(["module",
       },
 
       "Test deleted preset value form value": function() {
-         return this.remote.findAllByCssSelector(TestCommon.pubDataRowsCssSelector("FORM2_POST", "data"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 0, "Preset dropped item was not deleted");
+         return this.remote.findByCssSelector("#FORM2 .confirmationButton > span")
+            .clearLog()
+            .click()
+            .end()
+
+         .getLastPublish("FORM2_POST")
+            .then(function(payload) {
+               assert.lengthOf(payload.data, 0);
             });
       }
    });
@@ -154,8 +161,10 @@ define(["module",
       testPage: "/basic-dnd",
 
       "Select item using keyboard": function() {
-         return this.remote.pressKeys(keys.TAB)
-            .sleep(pause)
+         return this.remote.tabToElement({
+               selector: "#DRAG_PALETTE .alfresco-dnd-DragAndDropItem",
+               index: 0
+            })
             .pressKeys(keys.ENTER)
             .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
             .then(function(elements) {
@@ -164,16 +173,10 @@ define(["module",
       },
 
       "Add item to target": function() {
-         // 3 more tabs should highlight the first drop target...
-         return this.remote.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-
-         // Hitting return should add the selected item...
-         .pressKeys(keys.ENTER)
+         return this.remote.tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget"
+            })
+            .pressKeys(keys.ENTER)
             .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "The item was not added");
@@ -181,40 +184,22 @@ define(["module",
       },
 
       "Submit the form to check the right item was added": function() {
-         // Six more tabs should highlight the confirmation button
-         return this.remote.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
+         return this.remote.tabToElement({
+               selector: "#FORM1 .dijitButtonNode [data-dojo-attach-point*=\"focusNode\"]"
+            })
             .pressKeys(keys.ENTER)
-            .findByCssSelector(TestCommon.pubDataNestedValueCssSelector("FORM1_POST", "data", "name", "bob"))
-            .then(null, function() {
-               assert(false, "Form didn't contain the value added by keyboard");
+            .getLastPublish("FORM1_POST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "data[0].name", "bob");
             });
       },
 
       "Select another item": function() {
-         // Shift tab 7 times should get back to the last item
-         return this.remote.pressKeys([keys.SHIFT])
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys([keys.SHIFT]) // Remember to release the shift key!
+         return this.remote.tabToElement({
+               selector: "#DRAG_PALETTE .alfresco-dnd-DragAndDropItem",
+               index: 2,
+               reverse: true
+            })
             .pressKeys(keys.ENTER)
             .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
             .then(function(elements) {
@@ -224,12 +209,10 @@ define(["module",
       },
 
       "Add the next item": function() {
-         // Just one more tab should get to the target again...
-         return this.remote.pressKeys(keys.TAB)
-            .sleep(pause)
-
-         // Hitting return should add the selected item...
-         .pressKeys(keys.ENTER)
+         return this.remote.tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget"
+            })
+            .pressKeys(keys.ENTER)
             .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
             .then(function(elements) {
                assert.lengthOf(elements, 2, "The second item was not added");
@@ -245,13 +228,10 @@ define(["module",
       },
 
       "Move item down a place": function() {
-         // 3 tabs should get to the move down action...
-         return this.remote.pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
+         return this.remote.tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget .action.down",
+               index: 0
+            })
             .pressKeys(keys.ENTER)
             .findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
             .getVisibleText()
@@ -261,11 +241,11 @@ define(["module",
       },
 
       "Move item back up a place": function() {
-         // We should still be focused on the same node, so a single shift-tab will get to the move up action...
-         return this.remote.pressKeys([keys.SHIFT])
-            .pressKeys(keys.TAB)
-            .pressKeys([keys.SHIFT]) // Release the SHIFT key!
-            .sleep(pause)
+         return this.remote.tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget .action.up",
+               index: 1,
+               reverse: true
+            })
             .pressKeys(keys.ENTER)
             .findByCssSelector("#FORM1 .previewPanel .alfresco-dnd-DroppedItemWrapper:nth-child(1) > .label")
             .getVisibleText()
@@ -274,20 +254,17 @@ define(["module",
             });
       },
 
-      // TODO: This test is passing on Chrome but failing on Firefox
-      // "Delete an item": function() {
-      //    // 2 tabs should get to the delete item action
-      //    return this.remote.pressKeys(keys.TAB)
-      //       .sleep(pause)
-      //       .pressKeys(keys.TAB)
-      //       .sleep(pause)
-      //       .pressKeys(keys.ENTER)
-
-      //       .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
-      //          .then(function(elements) {
-      //                assert.lengthOf(elements, 1, "The item was not deleted");
-      //          });
-      // }
+      "Delete an item": function() {
+         return this.remote.tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget .action.delete",
+               index: 0
+            })
+            .pressKeys(keys.ENTER)
+            .findAllByCssSelector("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget > div.previewPanel > .alfresco-dnd-DroppedItemWrapper")
+               .then(function(elements) {
+                     assert.lengthOf(elements, 1, "The item was not deleted");
+               });
+      }
    });
 
    defineSuite(module, {

--- a/aikau/src/test/resources/alfresco/dnd/DndTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/DndTest.js
@@ -27,8 +27,6 @@ define(["module",
         "intern/dojo/node!leadfoot/keys"],
         function(module, defineSuite, assert, TestCommon, keys) {
 
-   var pause = 150;
-
    defineSuite(module, {
       name: "Basic DND tests",
       testPage: "/basic-dnd",

--- a/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
@@ -28,7 +28,6 @@ define(["module",
         "intern/dojo/node!leadfoot/keys"],
         function(module, defineSuite, assert, require, TestCommon, keys) {
 
-   var pause = 150;
    defineSuite(module, {
       name: "Multi-source DND tests",
       testPage: "/multi-source-dnd",

--- a/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/MultiSourceTest.js
@@ -34,22 +34,19 @@ define(["module",
       testPage: "/multi-source-dnd",
 
       "Select item in source one, then select item in source two to deselect item in source one": function() {
-         // Select the item in the first source...
-         return this.remote.pressKeys(keys.TAB)
-            .sleep(pause)
+         return this.remote.tabToElement({
+               selector: "#DRAG_PALETTE1 .alfresco-dnd-DragAndDropItem"
+            })
             .pressKeys(keys.ENTER)
 
-         // Tab to the second source and select its item...
-         .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
-            .pressKeys(keys.TAB)
-            .sleep(pause)
+         .tabToElement({
+               selector: "#DRAG_PALETTE2 .alfresco-dnd-DragAndDropItem"
+            })
+            .clearLog()
             .pressKeys(keys.ENTER)
-            .sleep(pause)
 
-         // Check that just one item is selected...
+         .getLastPublish("ALF_DND_SOURCE_ITEM_SELECTED")
+
          .findAllByCssSelector(".alfresco-dnd-DragAndDropItem.selected")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "The wrong number of items were selected");
@@ -104,41 +101,28 @@ define(["module",
 
    var setupDroppedItems = function(browser) {
       // Select the item in the first source...
-      return browser.pressKeys(keys.TAB)
-         .sleep(pause)
+      return browser.tabToElement({
+            selector: "#DRAG_PALETTE1 .alfresco-dnd-DragAndDropItem"
+         })
          .pressKeys(keys.ENTER)
 
       // Tab to the drop target and add the selected item...
-      .pressKeys(keys.TAB)
-         .sleep(pause)
+      .tabToElement({
+            selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget"
+         })
          .pressKeys(keys.ENTER)
-         .sleep(pause)
 
       // Tab to the single use item and select...
-      .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
+      .tabToElement({
+            selector: "#DRAG_PALETTE2 .alfresco-dnd-DragAndDropItem"
+         })
          .pressKeys(keys.ENTER)
 
       // Tab back to the dropped target and add...
-      .pressKeys(keys.SHIFT)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.TAB)
-         .sleep(pause)
-         .pressKeys(keys.SHIFT) // Release shift key
+      .tabToElement({
+            selector: "#ROOT_DROPPED_ITEMS1 .dojoDndTarget .dojoDndTarget",
+            reverse: true
+         })
          .pressKeys(keys.ENTER)
 
       // Make sure everything is setup correctly

--- a/aikau/src/test/resources/alfresco/dnd/NestedConfigurationTest.js
+++ b/aikau/src/test/resources/alfresco/dnd/NestedConfigurationTest.js
@@ -36,15 +36,21 @@ define(["module",
       "Check outer widget doesn't inherit configuration": function() {
          // Select the available widget...
          return this.remote.findByCssSelector("body")
-            .tabToElement(".alfresco-dnd-DragAndDropItem")
+            .tabToElement({
+               selector: ".alfresco-dnd-DragAndDropItem"
+            })
             .pressKeys(keys.ENTER)
 
          // Tab to the target and add the widget...
-         .tabToElement("#ROOT_DROPPED_ITEMS1 .previewPanel")
+         .tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .previewPanel"
+            })
             .pressKeys(keys.ENTER)
 
          // Edit the item...
-         .tabToElement("#ROOT_DROPPED_ITEMS1 .previewPanel .action.edit")
+         .tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .previewPanel .action.edit"
+            })
             .pressKeys(keys.ENTER)
 
          .findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG.dialogDisplayed") // Wait for the dialog to render
@@ -67,15 +73,21 @@ define(["module",
             .end()
 
          // Re-select the draggable item...
-         .tabToElement(".alfresco-dnd-DragAndDropItem")
+         .tabToElement({
+               selector: ".alfresco-dnd-DragAndDropItem"
+            })
             .pressKeys(keys.ENTER)
 
          // Add it to the previously dropped item..
-         .tabToElement("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget .previewPanel .previewPanel")
+         .tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget .previewPanel .previewPanel"
+            })
             .pressKeys(keys.ENTER)
 
          // Edit the nested widget...
-         .tabToElement("#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget .previewPanel .previewPanel .action.edit")
+         .tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .alfresco-dnd-DragAndDropTarget .previewPanel .previewPanel .action.edit"
+            })
             .pressKeys(keys.ENTER)
 
          // Now check that there are 3 form controls (should have inherited one additional configuration field)
@@ -93,7 +105,9 @@ define(["module",
          .findByCssSelector("#ALF_DROPPED_ITEM_CONFIGURATION_DIALOG.dialogHidden") // Wait for the dialog to be hidden
             .end()
 
-         .tabToElement("#ROOT_DROPPED_ITEMS1 .previewPanel .action.edit")
+         .tabToElement({
+               selector: "#ROOT_DROPPED_ITEMS1 .previewPanel .action.edit"
+            })
             .sleep(pause)
             .pressKeys(keys.ENTER)
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/views/GalleryViewTest.js
@@ -143,7 +143,9 @@ define(["module",
 
       "Test selecting first item (Folder 1)": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement(".alfresco-lists-views-layouts-Grid tr:first-child td:first-child .alfresco-renderers-Thumbnail .alfresco-renderers-Selector")
+            .tabToElement({
+               selector: ".alfresco-lists-views-layouts-Grid tr:first-child td:first-child .alfresco-renderers-Thumbnail .alfresco-renderers-Selector"
+            })
             .pressKeys(keys.SPACE)
             .getLastPublish("HAS_ITEMS_ALF_DOCLIST_DOCUMENT_SELECTED")
             .then(function(payload) {

--- a/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/CheckBoxTest.js
@@ -111,7 +111,9 @@ define(["module",
       "Keyboard navigation and selection is supported": function() {
          return this.remote.findByCssSelector(selectors.buttons.updateCheckboxes)
             .click()
-            .tabToElement(selectors.checkBoxes.default.checkBox)
+            .tabToElement({
+               selector: selectors.checkBoxes.default.checkBox
+            })
             .pressKeys(keys.SPACE)
             .end()
 

--- a/aikau/src/test/resources/alfresco/html/ImageTest.js
+++ b/aikau/src/test/resources/alfresco/html/ImageTest.js
@@ -82,14 +82,18 @@ define(["module",
 
       "Image will publish topic when ENTER pressed": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement("#IMAGE_CLASS_STYLE_TOPIC")
+            .tabToElement({
+               selector: "#IMAGE_CLASS_STYLE_TOPIC"
+            })
             .pressKeys(keys.ENTER)
             .getLastPublish("LOGO_TOPIC_PUBLISHED");
       },
 
       "Image will act as link when ENTER pressed": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement("#IMAGE_CLASS_LINK a")
+            .tabToElement({
+               selector: "#IMAGE_CLASS_LINK a"
+            })
             .pressKeys(keys.ENTER)
             .end()
 

--- a/aikau/src/test/resources/alfresco/html/SVGImageTest.js
+++ b/aikau/src/test/resources/alfresco/html/SVGImageTest.js
@@ -44,7 +44,10 @@ define(["module",
       },
 
       "Image with actions can be tabbed to and actioned": function() {
-         return this.remote.findByCssSelector("body").end().tabToElement("#IMAGE1")
+         return this.remote.findByCssSelector("body").end()
+            .tabToElement({
+               selector: "#IMAGE1"
+            })
             .clearLog()
             .pressKeys(keys.ENTER)
             .end()

--- a/aikau/src/test/resources/alfresco/logo/LogoTest.js
+++ b/aikau/src/test/resources/alfresco/logo/LogoTest.js
@@ -103,14 +103,18 @@ define(["module",
 
       "Logo will publish topic when ENTER pressed": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement("#LOGO_WITH_TOPIC")
+            .tabToElement({
+               selector: "#LOGO_WITH_TOPIC"
+            })
             .pressKeys(keys.ENTER)
             .getLastPublish("LOGO_TOPIC_PUBLISHED");
       },
 
       "Logo will act as link when ENTER pressed": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement("#LOGO_WITH_URL a")
+            .tabToElement({
+               selector: "#LOGO_WITH_URL a"
+            })
             .pressKeys(keys.ENTER)
             .end()
 

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarSelectTest.js
@@ -106,7 +106,9 @@ define(["module",
 
       "Use the keyboard to test label set (using label)": function() {
          return this.remote.findByCssSelector("body")
-            .tabToElement(selectors.menuBarSelects.mbs1.menuItem)
+            .tabToElement({
+               selector: selectors.menuBarSelects.mbs1.menuItem
+            })
 
          .pressKeys(keys.ARROW_DOWN)
 

--- a/aikau/src/test/resources/alfresco/menus/MenuTests.js
+++ b/aikau/src/test/resources/alfresco/menus/MenuTests.js
@@ -98,18 +98,20 @@ define(["intern!object",
 
          "Open the drop-down menu and select the FIRST menut item using the space bar": function() {
             return browser.findByCssSelector("body")
-               .tabToElement(selectors.popupMenus.dropDown1.menuItem)
+               .tabToElement({
+                  selector: selectors.popupMenus.dropDown1.menuItem
+               })
                .pressKeys(keys.ARROW_DOWN)
 
-               .findDisplayedByCssSelector(selectors.popupMenus.dropDown1.popup)
+            .findDisplayedByCssSelector(selectors.popupMenus.dropDown1.popup)
                .end()
 
-               .pressKeys(keys.SPACE)
+            .pressKeys(keys.SPACE)
 
-               .getLastPublish("KEYBOARD_CLICK")
-                  .then(function(payload) {
-                     assert.propertyVal(payload, "item", "MENU_ITEM_1");
-                  });
+            .getLastPublish("KEYBOARD_CLICK")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "item", "MENU_ITEM_1");
+               });
          },
 
          "Open the drop-down menu and select the SECOND menu item using the return key": function() {

--- a/aikau/src/test/resources/alfresco/renderers/TagsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/TagsTest.js
@@ -125,7 +125,9 @@ define(["module",
          // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
          // An immediate request for existing tags should be made
          return this.remote.findByCssSelector("body")
-            .tabToElement("#TAGS_3 .inlineEditValue")
+            .tabToElement({
+               selector: "#TAGS_3 .inlineEditValue"
+            })
             .pressKeys([keys.CONTROL, "e"])
             .pressKeys(keys.NULL)
             .end()
@@ -177,7 +179,9 @@ define(["module",
          // Tab to the third Tags renderer and use the keyboard shortcut to edit it...
          // An immediate request for existing tags should be made
          return this.remote.findByCssSelector("body")
-            .tabToElement("#TAGS_2 .inlineEditValue")
+            .tabToElement({
+               selector: "#TAGS_2 .inlineEditValue"
+            })
             .pressKeys([keys.CONTROL, "e"])
             .pressKeys(keys.NULL)
             .end()

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -67,7 +67,7 @@ define(["module",
 
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "url", "site/eventResult/calendar?date=2015-04-01", "Did not navigate to correct page");
+               assert.propertyVal(payload, "url", "site/eventResult/calendar?date=2015-04-01", "Did not navigate to correct page");
             });
       },
 
@@ -78,7 +78,7 @@ define(["module",
 
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2Fone%2Ftwo%2Fthree%2Ffour%2Ftest1%20%26%20test2", "Special characters were not encoded");
+               assert.propertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2Fone%2Ftwo%2Fthree%2Ffour%2Ftest1%20%26%20test2", "Special characters were not encoded");
             });
       },
 
@@ -89,7 +89,7 @@ define(["module",
 
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2F%2Fone%2Ftwo%2Fthree%2Ffour", "In folder link goes to the correct path");
+               assert.propertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2F%2Fone%2Ftwo%2Fthree%2Ffour", "In folder link goes to the correct path");
             });
       },
 
@@ -128,7 +128,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "CURRENT", "Name link should use CURRENT target");
+               assert.propertyVal(payload, "target", "CURRENT", "Name link should use CURRENT target");
             })
             .clearLog();
       },
@@ -139,7 +139,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "CURRENT", "Site link should use CURRENT target");
+               assert.propertyVal(payload, "target", "CURRENT", "Site link should use CURRENT target");
             })
             .clearLog();
       },
@@ -150,7 +150,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "CURRENT", "Path link should use CURRENT target");
+               assert.propertyVal(payload, "target", "CURRENT", "Path link should use CURRENT target");
             })
             .clearLog();
       },
@@ -161,59 +161,59 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "CURRENT", "Date link should use CURRENT target");
+               assert.propertyVal(payload, "target", "CURRENT", "Date link should use CURRENT target");
             })
             .clearLog();
       },
 
       "Control click name goes to new target": function() {
          return this.remote.findByCssSelector("#SR_DISPLAY_NAME .value")
-            .pressKeys([keys.CONTROL])
+            .pressKeys(keys.CONTROL)
             .click()
             .pressKeys(keys.NULL)
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Control click name link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Control click name link should use NEW target");
             })
             .clearLog();
       },
 
       "Control click site goes to new target": function() {
          return this.remote.findByCssSelector("#SR_SITE .value")
-            .pressKeys([keys.CONTROL])
+            .pressKeys(keys.CONTROL)
             .click()
             .pressKeys(keys.NULL)
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Control click site link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Control click site link should use NEW target");
             })
             .clearLog();
       },
 
       "Control click path goes to new target": function() {
          return this.remote.findByCssSelector("#SR_PATH .value")
-            .pressKeys([keys.CONTROL])
+            .pressKeys(keys.CONTROL)
             .click()
             .pressKeys(keys.NULL)
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Control click path link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Control click path link should use NEW target");
             })
             .clearLog();
       },
 
       "Control click date goes to new target": function() {
          return this.remote.findByCssSelector("#SR_DATE .value")
-            .pressKeys([keys.CONTROL])
+            .pressKeys(keys.CONTROL)
             .click()
             .pressKeys(keys.NULL)
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Control click date link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Control click date link should use NEW target");
             })
             .clearLog();
       }
@@ -229,7 +229,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Name link should use NEW target");
             })
             .clearLog();
       },
@@ -240,7 +240,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Name link should use NEW target");
             })
             .clearLog();
       },
@@ -251,7 +251,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Name link should use NEW target");
             })
             .clearLog();
       },
@@ -262,7 +262,7 @@ define(["module",
             .end()
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.deepPropertyVal(payload, "target", "NEW", "Name link should use NEW target");
+               assert.propertyVal(payload, "target", "NEW", "Name link should use NEW target");
             })
             .clearLog();
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/basic.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dnd/basic.get.js
@@ -105,7 +105,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
Several small changes in this PR:

* Slight tidy-up of some button-clicking logic (while investigating another failing test) that seemed worthwhile including _(if you prefer, I'm happy to remove this?)_
* Fix some broken tests that were using `pressKeys(keys.TAB)` by replacing with `.tabToElement()` instead
* Update `CustomCommand.tabToElement()` to allow a `reverse` flag, and also update to use [_ES6 Destructuring Assignment_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#ES6_version) for the function parameters
* Update references to old signature of `tabToElement()` to instead use new signature
* Update references to `.deepPropertyVal()` to instead be `.propertyVal()` when deep property access isn't required