### PR TITLE
AKU-956: Ensure paginator gets page size update

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -77,6 +77,9 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        */
       postCreate: function alfresco_core_Page__postCreate() {
+         // See AKU-956 - register a new page with with the PubQueue...
+         PubQueue.getSingleton().registerPage();
+
          /*jshint devel:true*/
          shims.apply();
          

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -161,8 +161,10 @@ define(["dojo/_base/declare",
       setPageSize: function alfresco_lists_AlfSortablePaginatedList__setPageSize(value) {
          if (value)
          {
-            this.onItemsPerPageChange({
-               value: value
+            this.alfPublish(this.docsPerpageSelectionTopic, {
+               label: this.message("list.paginator.perPage.label", {0: value}),
+               value: value,
+               selected: true
             });
          }
          this.currentPageSize = value || this.currentPageSize || 25;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-965 to ensure that pagination preferences work - specifically when there are multiple Surf Components on a Page that are each rendering an Aikau "page". This example impacted is the Sites Manager page in Share but this issue could potentially impact other pages - especially Aikau dashlets. 

The fix is for each Page widget to register itself with the PubQueue singleton. Publications are only released when all the Page widgets have completed rendering.