### PR TITLE
Rollback Intern to resolve test failures

### DIFF
--- a/aikau/package.json
+++ b/aikau/package.json
@@ -15,7 +15,7 @@
     "grunt-prompt": "1.3.3",
     "grunt-shell-spawn": "0.3.10",
     "grunt-wait-server": "0.2.1",
-    "intern": "3.2.0",
+    "intern": "3.1.1",
     "istanbul": "0.4.3",
     "jsdoc": "3.4.0",
     "jshint-stylish": "2.2.0",

--- a/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
+++ b/aikau/src/main/resources/alfresco/navigation/LinkClickMixin.js
@@ -72,8 +72,8 @@ define(["dojo/_base/declare",
       processMiddleOrCtrlClick: function alfresco_navigation_LinkClickMixin__processMiddleOrCtrlClick(evt, publishTopic, publishPayload) {
          if (this.newTabOnMiddleOrCtrlClick && publishTopic === this.navigateToPageTopic) 
          {
-            var middleButton = evt.button === 2,
-               leftButton = evt.button === 1,
+            var middleButton = evt.button === 1,
+               leftButton = evt.button === 0,
                ctrlKey = has("mac") ? evt.metaKey : evt.ctrlKey;
             if (middleButton || (leftButton && ctrlKey))
             {


### PR DESCRIPTION
This PR rollbacks the recent update to Intern (from 3.20 back to 3.1.1) as it was causing certain tests to fail. The LinkClickMixin has also been updated to reference the correct buttons.