### PR TITLE
AKU-968: PublishOrLinkMixin: Add support for preventing click bubbling

### DIFF
--- a/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
@@ -60,16 +60,14 @@ define(["alfresco/enums/urlTypes",
       cssRequirements: [{cssFile:"./css/_PublishOrLinkMixin.css"}],
 
       /**
-       * By default, clicks on the image will bubble up. To prevent click bubbling, simply set this to false. If
-       * a [publishTopic](module:alfresco/renderers/_PublishPayloadMixin#publishTopic) has been provided, then
-       * this will default to false automatically, however it can be overridden by explicitly setting this to true.
+       * By default, clicks on the image will bubble up. To prevent click bubbling, simply set this to false.
        *
        * @instance
        * @type {boolean}
-       * @default true
+       * @default
        * @since 1.0.69
        */
-      clickBubbling: null,
+      clickBubbling: true,
 
       /**
        * When set to true, the widget/anchors will be removed from the page tab-order by setting the tabindex to -1.
@@ -125,19 +123,6 @@ define(["alfresco/enums/urlTypes",
       wrapAllChildren: true,
 
       /**
-       * This is run immediately after properties are mixed in, and before the widget is started.
-       *
-       * @instance
-       * @since 1.0.69
-       */
-      postMixInProperties: function() {
-         this.inherited(arguments);
-         if (this.clickBubbling === null) {
-            this.clickBubbling = !this.publishTopic;
-         }
-      },
-
-      /**
        * Run after widget created
        *
        * @instance
@@ -151,13 +136,17 @@ define(["alfresco/enums/urlTypes",
          } else if (this.publishTopic) {
             this.domNode.setAttribute("tabIndex", this.excludeFromTabOrder ? -1 : 0);
             domClass.add(this.domNode, "alfresco-core-PublishOrLinkMixin--clickable");
+            this.own(on(this.domNode, "click", lang.hitch(this, this.doPublish)));
+            this.own(on(this.domNode, "keydown", lang.hitch(this, function(evt) {
+               if (evt.keyCode === keys.ENTER) {
+                  this.doPublish();
+               }
+            })));
+         } else if (!this.clickBubbling) {
+            this.own(on(this.domNode, "click", function(evt) {
+               evt.stopPropagation();
+            }));
          }
-         this.own(on(this.domNode, "click", lang.hitch(this, this.onClick)));
-         this.own(on(this.domNode, "keydown", lang.hitch(this, function(evt) {
-            if (evt.keyCode === keys.ENTER) {
-               this.doPublish();
-            }
-         })));
       },
 
       /**
@@ -166,21 +155,10 @@ define(["alfresco/enums/urlTypes",
        * @instance
        */
       doPublish: function alfresco_core__PublishOrLinkMixin__doPublish() {
-         this.publishTopic && this.alfPublish(this.publishTopic, this.publishPayload, this.publishGlobal, this.publishToParent);
-      },
-
-      /**
-       * Publish to the specified topic.
-       *
-       * @instance
-       * @param {Object} evt Dojo-normalised event object
-       * @since 1.0.69
-       */
-      onClick: function alfresco_core__PublishOrLinkMixin__onClick(evt) {
          if (!this.clickBubbling) {
             evt.stopPropagation();
          }
-         this.doPublish();
+         this.alfPublish(this.publishTopic, this.publishPayload, this.publishGlobal, this.publishToParent);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/core/_PublishOrLinkMixin.js
@@ -153,8 +153,9 @@ define(["alfresco/enums/urlTypes",
        * Publish to the specified topic.
        *
        * @instance
+       * @param {Object} evt The click-event that triggered the publish.
        */
-      doPublish: function alfresco_core__PublishOrLinkMixin__doPublish() {
+      doPublish: function alfresco_core__PublishOrLinkMixin__doPublish(evt) {
          if (!this.clickBubbling) {
             evt.stopPropagation();
          }

--- a/aikau/src/test/resources/alfresco/html/ImageTest.js
+++ b/aikau/src/test/resources/alfresco/html/ImageTest.js
@@ -77,6 +77,50 @@ define(["module",
    });
 
    defineSuite(module, {
+      name: "Image click bubbling tests",
+      testPage: "/Image",
+
+      "Click on image with bubbling disabled does not bubble": function() {
+         return this.remote.findById("IMAGE_WITH_DIMENSIONS")
+            .click()
+            .execute(function() {
+               return window.bodyClicked;
+            })
+            .then(function(bodyClicked) {
+               assert.isFalse(bodyClicked);
+            });
+      },
+
+      "Click on image with topic does not bubble": function() {
+         return this.remote.execute(function() {
+               window.bodyClicked = false;
+            })
+            .findById("IMAGE_CLASS_STYLE_TOPIC")
+            .click()
+            .execute(function() {
+               return window.bodyClicked;
+            })
+            .then(function(bodyClicked) {
+               assert.isFalse(bodyClicked);
+            });
+      },
+
+      "Click on image without bubbling disabled does bubble": function() {
+         return this.remote.execute(function() {
+               window.bodyClicked = false;
+            })
+            .findById("IMAGE_CLASS_AND_DIMENSIONS")
+            .click()
+            .execute(function() {
+               return window.bodyClicked;
+            })
+            .then(function(bodyClicked) {
+               assert.isTrue(bodyClicked);
+            });
+      }
+   });
+
+   defineSuite(module, {
       name: "Image Keyboard Tests",
       testPage: "/Image",
 

--- a/aikau/src/test/resources/alfresco/html/ImageTest.js
+++ b/aikau/src/test/resources/alfresco/html/ImageTest.js
@@ -84,20 +84,7 @@ define(["module",
          return this.remote.findById("IMAGE_WITH_DIMENSIONS")
             .click()
             .execute(function() {
-               return window.bodyClicked;
-            })
-            .then(function(bodyClicked) {
-               assert.isFalse(bodyClicked);
-            });
-      },
-
-      "Click on image with topic does not bubble": function() {
-         return this.remote.execute(function() {
-               window.bodyClicked = false;
-            })
-            .findById("IMAGE_CLASS_STYLE_TOPIC")
-            .click()
-            .execute(function() {
+               /*jshint browser:true*/
                return window.bodyClicked;
             })
             .then(function(bodyClicked) {
@@ -107,11 +94,13 @@ define(["module",
 
       "Click on image without bubbling disabled does bubble": function() {
          return this.remote.execute(function() {
+               /*jshint browser:true*/
                window.bodyClicked = false;
             })
             .findById("IMAGE_CLASS_AND_DIMENSIONS")
             .click()
             .execute(function() {
+               /*jshint browser:true*/
                return window.bodyClicked;
             })
             .then(function(bodyClicked) {

--- a/aikau/src/test/resources/reporters/ConcurrentReporter.js
+++ b/aikau/src/test/resources/reporters/ConcurrentReporter.js
@@ -129,7 +129,7 @@ define(["intern/dojo/node!fs",
       var CONFIG = {
          BreakOnError: false,
          ClearScreenBeforeResults: true,
-         LongRunningTestMs: 2000,
+         LongRunningTestMs: 3000,
          NumLongestRunningTests: 10,
          OutputReporterInfo: true,
          Title: "UNIT TESTS",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/html/Image.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/html/Image.get.html.ftl
@@ -1,1 +1,9 @@
+<script>
+   window.bodyClicked = false;
+   document.body.addEventListener("click", function() {
+      console.error("Body click was triggered!");
+      window.bodyClicked = true;
+   });
+</script>
+
 <@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/html/Image.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/html/Image.get.js
@@ -22,6 +22,7 @@ model.jsonModel = {
          name: "alfresco/html/Image",
          id: "IMAGE_WITH_DIMENSIONS",
          config: {
+            clickBubbling: false,
             height: 75,
             src: "images/app-logo-48.png",
             srcType: "CONTEXT_RELATIVE",


### PR DESCRIPTION
This addresses [AKU-968](https://issues.alfresco.com/jira/browse/AKU-968) by allowing `clickBubbling` to be set to `false`. Tests have been added and a full regression suite run successfully.