### PR TITLE
AKU-975: Update AlfSearchResult to ensure forward slash prefix on folder location link

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -448,11 +448,16 @@ define(["dojo/_base/declare",
          }
          else
          {
+            if (this.currentItem.path[0] !== "/")
+            {
+               this.currentItem.path = "/" + this.currentItem.path;
+            }
+
             // Create processed path as pathLink on this.currentItem
             var isRepo = !lang.exists("site.title", this.currentItem);
             this.currentItem.pathLink = isRepo ?
                encodeURIComponent("/" + this.currentItem.path.split("/").slice(2).join("/")) :
-               encodeURIComponent("/" + this.currentItem.path);
+               encodeURIComponent(this.currentItem.path);
 
             // jshint nonew:false
             new PropertyLink({

--- a/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
+++ b/aikau/src/test/resources/alfresco/search/AlfSearchResultTest.js
@@ -89,7 +89,7 @@ define(["module",
 
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.propertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2F%2Fone%2Ftwo%2Fthree%2Ffour", "In folder link goes to the correct path");
+               assert.propertyVal(payload, "url", "site/normalResult/documentlibrary?path=%2Fone%2Ftwo%2Fthree%2Ffour", "In folder link goes to the correct path");
             });
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-975 to ensure that site folder links displayed via the AlfSearchResult have a consistent "/" prefix. The unit test has been updated.