### PR TITLE
AKU-973: Update AlfListView to use process id instead of WidgetsCreator

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -887,7 +887,7 @@ define(["dojo/_base/declare",
        * @param {number} index The index of the filter configuration
        * @returns {boolean} True if the filter criteria have been met and false otherwise.
        */
-      processFilterConfig: function alfresco_core_WidgetsProcessingFilterMixin__processFilterConfig(renderFilterConfig, /*jshint unused:false*/ index) {
+      processFilterConfig: function alfresco_core_CoreWidgetProcessing__processFilterConfig(renderFilterConfig, /*jshint unused:false*/ index) {
          var passesFilter = false;
          if (this.filterPropertyExists(renderFilterConfig))
          {
@@ -1013,7 +1013,7 @@ define(["dojo/_base/declare",
        * @param {string|boolean|number} target The target object to match (ideally this should be a string, boolean or a number
        * @returns {boolean} true If the supplied value matches the target value and false otherwise.
        */
-      processFilter: function alfresco_core_WidgetsProcessingFilterMixin__processFilter(renderFilterConfig, target, currValue) {
+      processFilter: function alfresco_core_CoreWidgetProcessing__processFilter(renderFilterConfig, target, currValue) {
          if (ObjectTypeUtils.isString(currValue))
          {
             currValue = lang.trim(currValue);
@@ -1047,7 +1047,7 @@ define(["dojo/_base/declare",
        * @param {{property: string, values: string[]|string}} renderFilterConfig The filter configuration to process.
        * @returns {boolean} true if the property exists and false if it doesn't.
        */
-      filterPropertyExists: function alfresco_core_WidgetsProcessingFilterMixin__filterPropertyExists(renderFilterConfig) {
+      filterPropertyExists: function alfresco_core_CoreWidgetProcessing__filterPropertyExists(renderFilterConfig) {
          var targetObject = this.currentItem;
          if (renderFilterConfig.target && lang.exists(renderFilterConfig.target))
          {
@@ -1071,7 +1071,7 @@ define(["dojo/_base/declare",
        * @returns {object} The property of [currentItem]{@link module:alfresco/core/WidgetsProcessingFilterMixin#currentItem} defined
        * by the "property" attribute of the filter configuration.
        */
-      getRenderFilterPropertyValue: function alfresco_core_WidgetsProcessingFilterMixin__getRenderFilterPropertyValue(renderFilterConfig) {
+      getRenderFilterPropertyValue: function alfresco_core_CoreWidgetProcessing__getRenderFilterPropertyValue(renderFilterConfig) {
          var targetObject = this.currentItem;
          if (renderFilterConfig.target && lang.exists(renderFilterConfig.target))
          {
@@ -1090,7 +1090,7 @@ define(["dojo/_base/declare",
        * @param {{property: string, values: string[]|string}} renderFilter The filter configuration to process.
        * @returns {string} The name of the filter
        */
-      getCustomRenderFilterProperty: function alfresco_core_WidgetsProcessingFilterMixin__getCustomRenderFilterProperty(currentItem) {
+      getCustomRenderFilterProperty: function alfresco_core_CoreWidgetProcessing__getCustomRenderFilterProperty(currentItem) {
          var result = null;
          if (currentItem instanceof Boolean || typeof currentItem === "boolean")
          {
@@ -1109,7 +1109,7 @@ define(["dojo/_base/declare",
        * @returns {string[]} An array (assumed to be of strings) that is either empty, the same array supplied as an argument or a single
        * string element supplied as an argument.
        */
-      getRenderFilterValues: function alfresco_core_WidgetsProcessingFilterMixin__getRenderFilterValues(renderFilter) {
+      getRenderFilterValues: function alfresco_core_CoreWidgetProcessing__getRenderFilterValues(renderFilter) {
          var result = null;
          if (ObjectTypeUtils.isArray(renderFilter.values))
          {

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -576,11 +576,8 @@ define(["dojo/_base/declare",
          // the default message with them...
          if (this.widgetsForNoDataDisplay)
          {
-            var wc = new WidgetsCreator({
-               widgets: this.widgetsForNoDataDisplay
-            });
             domConstruct.empty(this.messageNode);
-            wc.buildWidgets(this.messageNode);
+            this.processWidgets(this.widgetsForNoDataDisplay, this.messageNode, "WIDGETS_FOR_NO_DATA_DISPLAY");
          }
       },
 

--- a/aikau/src/test/resources/alfresco/lists/views/ViewNoDataWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/ViewNoDataWidgetsTest.js
@@ -21,8 +21,9 @@
  * @author Dave Draper
  */
 define(["module",
-        "alfresco/defineSuite"],
-        function(module, defineSuite) {
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
 
    defineSuite(module, {
       name: "View With No Data Widgets Tests",
@@ -30,6 +31,17 @@ define(["module",
 
       "No data widgets displayed": function() {
          return this.remote.findDisplayedById("NO_DATA_WARNING");
+      },
+
+      "Render filter in no data display (rule pass)": function() {
+         return this.remote.findDisplayedById("LOGO1");
+      },
+
+      "Render filter in no data display (rule fail)": function() {
+         return this.remote.findAllByCssSelector("#LOGO2")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            });
       },
 
       "Data failure widgets displayed": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ViewNoDataWidgets.get.js
@@ -30,6 +30,9 @@ model.jsonModel = {
                            id: "VIEW1",
                            name: "alfresco/lists/views/AlfListView",
                            config: {
+                              testCustomFilterData: {
+                                 show: true
+                              },
                               widgetsForNoDataDisplay: [
                                  {
                                     id: "NO_DATA_WARNING",
@@ -39,6 +42,35 @@ model.jsonModel = {
                                           {
                                              message: "No data to display!",
                                              level: 1
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "LOGO1",
+                                    name: "alfresco/logo/Logo",
+                                    config: {
+                                       renderFilter: [
+                                          {
+                                             target: "testCustomFilterData",
+                                             property: "show",
+                                             values: [true],
+                                             renderOnAbsentProperty: true
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "LOGO2",
+                                    name: "alfresco/logo/Logo",
+                                    config: {
+                                       logoClasses: "surf-logo-large",
+                                       renderFilter: [
+                                          {
+                                             target: "testCustomFilterData",
+                                             property: "show",
+                                             values: [false],
+                                             renderOnAbsentProperty: true
                                           }
                                        ]
                                     }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-973 to swap out the use of the WidgetsCreator in the AlfListView and just use processWidgets (with a custom `processWidgetsId`). I've updated the existing test page to add a couple of widgets that should and shouldn't be rendered (via renderFilter that relies on the correct scope) and added tests to verify.