### PR TITLE
AKU-972: FilteringSelect value

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/ServiceStore.js
@@ -117,7 +117,8 @@ define(["dojo/_base/declare",
             payload.alfResponseTopic = responseTopic;
             var resultsProperty = this.publishPayload.resultsProperty || "response";
             this._getOptionsHandle = [];
-            this._getOptionsHandle.push(this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, "onGetOptions", response, resultsProperty, id)));
+            this._getOptionsHandle.push(this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onGetOptions, response, resultsProperty, id)));
+            this._getOptionsHandle.push(this.alfSubscribe(responseTopic, lang.hitch(this, this.onGetOptions, response, resultsProperty, id)));
             this.alfPublish(this.publishTopic, payload, this.publishGlobal);
          }
          else if (this.fixed)

--- a/aikau/src/test/resources/alfresco/forms/controls/FilteringSelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/FilteringSelectTest.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This tests the FilteringSelect control.
+ * 
+ * @author Martin Doyle
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert",
+        "require"],
+        function(module, defineSuite, assert, require) {
+
+   defineSuite(module, {
+      name: "FilteringSelect Tests",
+      testPage: "/FilteringSelect",
+
+      "Test it works": function() {
+         assert.fail(null, null, "It doesn't work");
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/forms/controls/FilteringSelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/FilteringSelectTest.js
@@ -24,16 +24,27 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!assert",
-        "require"],
-        function(module, defineSuite, assert, require) {
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
 
    defineSuite(module, {
       name: "FilteringSelect Tests",
       testPage: "/FilteringSelect",
 
-      "Test it works": function() {
-         assert.fail(null, null, "It doesn't work");
+      "Value assigned to control is selected": function() {
+         this.remote.findByCssSelector("#FILTERING_SELECT_1_CONTROL")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "abeecher");
+            });
+      },
+
+      "Value assigned to form is selected": function() {
+         this.remote.findByCssSelector("#FILTERING_SELECT_2_CONTROL")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "abeecher");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -134,6 +134,7 @@ define(function() {
       "alfresco/forms/controls/DisablingSubmitFormTest",
       "alfresco/forms/controls/DocumentPickerTest",
       "alfresco/forms/controls/DocumentPickerSingleItemTest",
+      "alfresco/forms/controls/FilteringSelectTest",
       "alfresco/forms/controls/FormButtonDialogTest",
       "alfresco/forms/controls/MultipleEntryFormControlTest",
       "alfresco/forms/controls/MultiSelectInputTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>FilteringSelect form control</shortname>
+  <description>Shows an example of the alfresco/forms/controls/FilteringSelect form control</description>
+  <family>aikau-unit-tests</family>
+  <url>/FilteringSelect</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel />

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
@@ -1,0 +1,104 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/OptionsService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/forms/Form",
+         config: {
+            okButtonPublishTopic: "SAVE_FORM",
+            okButtonLabel: "Save",
+            value: {
+               person2: "abeecher"
+            },
+            widgets: [
+               {
+                  id: "FILTERING_SELECT_1",
+                  name: "alfresco/forms/controls/FilteringSelect",
+                  config: {
+                     fieldId: "FILTERING_SELECT_1",
+                     name: "person1",
+                     label: "Select a person (FilteringSelect config value)",
+                     value: "abeecher",
+                     optionsConfig: {
+                        queryAttribute: "label",
+                        labelAttribute: "label",
+                        valueAttribute: "value",
+                        publishTopic: "ALF_GET_FORM_CONTROL_OPTIONS",
+                        publishPayload: {
+                           resultsProperty: "options",
+                           url: url.context + "/proxy/alfresco/api/people",
+                           itemsAttribute: "people",
+                           labelAttribute: "userName",
+                           valueAttribute: "userName"
+                        }
+                     }
+                  }
+               },
+               {
+                  id: "FILTERING_SELECT_2",
+                  name: "alfresco/forms/controls/FilteringSelect",
+                  config: {
+                     fieldId: "FILTERING_SELECT_2",
+                     name: "person2",
+                     label: "Select a person (FilteringSelect form value)",
+                     optionsConfig: {
+                        queryAttribute: "label",
+                        labelAttribute: "label",
+                        valueAttribute: "value",
+                        publishTopic: "ALF_GET_FORM_CONTROL_OPTIONS",
+                        publishPayload: {
+                           resultsProperty: "options",
+                           url: url.context + "/proxy/alfresco/api/people",
+                           itemsAttribute: "people",
+                           labelAttribute: "userName",
+                           valueAttribute: "userName"
+                        }
+                     }
+                  }
+               },
+               {
+                  id: "COMBO_1",
+                  name: "alfresco/forms/controls/ComboBox",
+                  config: {
+                     fieldId: "COMBO_1",
+                     name: "person3",
+                     label: "Select a person (ComboBox config value)",
+                     value: "abeecher",
+                     optionsConfig: {
+                        queryAttribute: "label",
+                        labelAttribute: "label",
+                        valueAttribute: "value",
+                        publishTopic: "ALF_GET_FORM_CONTROL_OPTIONS",
+                        publishPayload: {
+                           resultsProperty: "options",
+                           url: url.context + "/proxy/alfresco/api/people",
+                           itemsAttribute: "people",
+                           labelAttribute: "userName",
+                           valueAttribute: "userName"
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/UserMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
@@ -1,3 +1,4 @@
+/* global url */
 model.jsonModel = {
    services: [
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UserMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/UserMockXhr.js
@@ -19,7 +19,7 @@
 
 /**
  *
- * @module aikauTesting/UserMockXhr
+ * @module aikauTesting/mockservices/UserMockXhr
  * @author Dave Draper
  */
 define(["dojo/_base/declare",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-972 / #1057 to ensure that FilteringSelect widgets will preselect the assigned option from the available list of options based on the assigned value. The issue was a missing subscription from the ServiceStore. Unit tests have been added to prevent regressions.