### PR TITLE
Add pre-commit hook

### DIFF
--- a/bin/setup_hooks.sh
+++ b/bin/setup_hooks.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp hooks/* .git/hooks

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/bash
+source ~/.bash_profile
+node -e 'console.error("Hello world")'
+exit 1

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/bash
-source ~/.bash_profile
-node -e 'console.error("Hello world")'
-exit 1
+export PATH=/usr/local/bin:$PATH # This is messy, but it's the best guess at where grunt/node will be
+grunt --gruntfile aikau/Gruntfile.js jshint


### PR DESCRIPTION
This is an imperfect solution that should work on Linux and Mac, but does not work on Windows. It is also entirely optional, and will have no effect at all if the script is not run.

In order to use the hook, one should go to the root of the Aikau git working folder (not the `aikau` sub-directory), and run `bin/setup_hooks.sh`. This will then copy a __pre-commit__ hook to the `.git/hooks` directory. From then on, every single commit will have to pass a `grunt jshint` check prior to being allowed through.

This is not a negligible check, as it takes probably 5-10 seconds. If that's too much of a delay, do not use it (or remove the hook by running `rm .git/hooks/pre-commit`).