### PR TITLE
AKU-963: Support for onlyShowOnHover in PublishAction

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -36,8 +36,10 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/PublishAction.html",
         "alfresco/enums/urlTypes", 
         "alfresco/util/urlUtils",
-        "alfresco/core/Core"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, template, urlTypes, urlUtils, AlfCore) {
+        "alfresco/core/Core",
+        "dojo/dom-class"], 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, 
+                 template, urlTypes, urlUtils, AlfCore, domClass) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, AlfCore], {
       
@@ -88,7 +90,18 @@ define(["dojo/_base/declare",
        */
       imageSrc: null,
 
-     /**
+      /**
+       * Indicates that this should only be displayed when the item (note: NOT the renderer) is
+       * hovered over.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.70
+       */
+      onlyShowOnHover: false,
+
+      /**
        * This defines the topic that will be published on when the associated image is clicked. The payload will be
        * the "currentItem" attribute.
        *
@@ -147,6 +160,20 @@ define(["dojo/_base/declare",
          this.altText = this.message(this.altText, {
             0: altTextId
          });
+      },
+
+      /**
+       * Ensures that CSS classes are correctly applied.
+       * 
+       * @instance
+       * @since 1.0.70
+       */
+      postCreate: function alfresco_renderers_PublishAction__postCreate() {
+         this.inherited(arguments);
+         if (this.onlyShowOnHover === true) 
+         {
+            domClass.add(this.domNode, "alfresco-renderers-PublishAction--show-on-hover");
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/css/PublishAction.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/PublishAction.css
@@ -6,3 +6,15 @@
       vertical-align: text-bottom;
    }
 }
+
+.alfresco-lists-views-layout-_MultiItemRendererMixin__item {
+   &:hover {
+      .alfresco-renderers-PublishAction--show-on-hover {
+         visibility: visible;
+      }
+   }
+   .alfresco-renderers-PublishAction--show-on-hover {
+      visibility: hidden;
+      outline: none;
+    }
+}

--- a/aikau/src/test/resources/alfresco/renderers/PublishActionTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PublishActionTest.js
@@ -97,6 +97,26 @@ define(["module",
             .then(function(bodyClicked) {
                assert.isFalse(bodyClicked);
             });
+      },
+
+      "Hidden when not hovered over": function() {
+         return this.remote.findByCssSelector("#PUBLISH_ACTION_ITEM_0 .alfresco-renderers-PublishAction__image")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            });
+      },
+
+      "Displayed when hovered over": function() {
+         return this.remote.findByCssSelector("#PROP_CELL_ITEM_0 .inner .value")
+            .moveMouseTo()
+         .end()
+
+         .findByCssSelector("#PUBLISH_ACTION_ITEM_0 .alfresco-renderers-PublishAction__image")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/PublishAction.get.js
@@ -61,6 +61,63 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/lists/views/AlfListView",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     displayName: "Moomin"
+                  },
+                  {
+                     displayName: "Giants"
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  id: "ROW",
+                  name: "alfresco/lists/views/layouts/Row",
+                  config: {
+                     widgets: [
+                        {
+                           id: "PROP_CELL",
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "PROPERTY",
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "displayName",
+                                       onlyShowOnHover: false
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "ACTION_CELL",
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "PUBLISH_ACTION",
+                                    name: "alfresco/renderers/PublishAction",
+                                    config: {
+                                       onlyShowOnHover: true,
+                                       publishTopic: "PUBLISH_ACTION_FOR_HOVER"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-963 to provide onlyShowOnHover support for the PublishAction renderer. The unit tests have been updated. This replaces #1053 