### PR TITLE
AKU-959: Selector disablement support

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Selector.js
+++ b/aikau/src/main/resources/alfresco/renderers/Selector.js
@@ -35,8 +35,12 @@ define(["dojo/_base/declare",
         "dijit/_TemplatedMixin",
         "dijit/_OnDijitClickMixin",
         "alfresco/lists/ItemSelectionMixin",
-        "dojo/text!./templates/Selector.html"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin, template) {
+        "dojo/text!./templates/Selector.html",
+        "dojo/_base/array",
+        "dojo/_base/lang",
+        "dojo/dom-class"], 
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin, template, 
+                 array, lang, domClass) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin], {
       
@@ -57,6 +61,31 @@ define(["dojo/_base/declare",
       templateString: template,
       
       /**
+       * The dot-notation property to use in the 
+       * [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} to use to 
+       * indicate when the selector is disabled.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.70
+       */
+      disableProperty: null,
+
+      /**
+       * An array of values to match against the 
+       * [disableProperty]{@link module:alfresco/renderers/Selector#disableProperty} of the 
+       * [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem}. If any of the values
+       * are matched then the selector will be disabled.
+       *
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.70
+       */
+      disabledOnValues: null,
+
+      /**
        * Set up the attributes to be used when rendering the template.
        * 
        * @instance
@@ -68,6 +97,42 @@ define(["dojo/_base/declare",
          // events...
          // this.alfSubscribe(this.documentSelectionTopic, lang.hitch(this, this.onFileSelection), this.publishGlobal, this.publishToParent);
          this.createItemSelectionSubscriptions();
+      },
+
+      /**
+       * Checks the [disableProperty]{@link module:alfresco/renderers/Selector#disableProperty} of the 
+       * [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} against the 
+       * [array of values]{@link module:alfresco/renderers/Selector#disableProperty} that will cause the
+       * selector to be disabled.
+       * 
+       * @instance
+       * @since 1.0.70
+       */
+      postCreate: function alfresco_renderers_Selector__postCreate() {
+         this.inherited(arguments);
+         if(this.isDisabled())
+         {
+            this.selectOnClick = false;
+            domClass.add(this.domNode, "alfresco-lists-ItemSelectionMixin--disabled");
+         }
+      },
+
+      /**
+       * Checks the disabled state of the current item.
+       * 
+       * @instance
+       * @since 1.0.70
+       */
+      isDisabled: function alfresco_renderers_Selector__isDisabled() {
+         var disabled = false;
+         if (this.disableProperty && this.disabledOnValues)
+         {
+            var disablePropertyValue = lang.getObject(this.disableProperty, false, this.currentItem);
+            disabled = array.some(this.disabledOnValues, function(target) {
+               return disablePropertyValue === target;
+            });
+         }
+         return disabled;
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/css/Selector.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Selector.css
@@ -9,4 +9,8 @@
    &.alfresco-lists-ItemSelectionMixin--selected {
       background-image: url(./images/AllSelected.png);
    }
+
+   &.alfresco-lists-ItemSelectionMixin--disabled {
+      opacity: 0.3;
+   }
 }

--- a/aikau/src/test/resources/alfresco/renderers/SelectorTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SelectorTest.js
@@ -64,6 +64,21 @@ define(["module",
             })
 
          .findDisplayedByCssSelector("#SELECTED_ITEMS.dijitDisabled");
+      },
+
+      "Second selector is disabled": function() {
+         return this.remote.findByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--disabled");
+      },
+
+      "Second selector cannot be selected": function() {
+         return this.remote.findByCssSelector("#SELECTOR_ITEM_1")
+            .click()
+         .end()
+
+         .findAllByCssSelector("#SELECTOR_ITEM_1.alfresco-lists-ItemSelectionMixin--selected")
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Selector.get.js
@@ -54,10 +54,12 @@ model.jsonModel = {
             currentData: {
                items: [
                   {
-                     name: "One"
+                     name: "One",
+                     disabled: false
                   },
                   {
-                     name: "Two"
+                     name: "Two",
+                     disabled: true
                   }
                ]
             },
@@ -82,7 +84,9 @@ model.jsonModel = {
                                              id: "SELECTOR",
                                              name: "alfresco/renderers/Selector",
                                              config: {
-                                                itemKey: "index"
+                                                itemKey: "index",
+                                                disableProperty: "disabled",
+                                                disabledOnValues: ["disabled", true, "bobbins"]
                                              }
                                           }
                                        ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-959 to make it possible for a Selector to appear to be disabled. Unit tests have been added to verify the behaviour.