### PR TITLE
AKU-978: Classify action unavailable for documents

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -319,14 +319,18 @@ define(["alfresco/core/ProcessWidgets",
        * @instance
        * @param {Array} services An array of all the services that have been processed
        */
-      allServicesProcessed: function alfresco_core_Core__allServicesProcessed(services) {
+      allServicesProcessed: function alfresco_core_Page__allServicesProcessed(services) {
          /*jshint unused:false*/
          this.alfLog("log", "All services processed");
-         if (this.widgets)
+         if (this.widgets && this.widgets.length)
          {
             // Make sure to process widgets if there are no services...
             // Otherwise they will be processed once all the services are instantiated...
             this.processWidgets(this.widgets, this.containerNode);
+         }
+         else
+         {
+            PubQueue.getSingleton().release();
          }
       },
 


### PR DESCRIPTION
This pull-request fixes [AKU-978](https://issues.alfresco.com/jira/browse/AKU-978), which was exhibiting as an action being unavailable. This was caused by an unhandled edge-case of no widgets being present in the component.