### PR TITLE
AKU-955: Upload box text misaligned when item name is too long

### DIFF
--- a/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
+++ b/aikau/src/main/resources/alfresco/upload/UploadMonitor.js
@@ -115,7 +115,7 @@ define(["alfresco/core/FileSizeMixin",
        * @default
        * @since 1.0.66
        */
-      useEllipsisForLongFilenames: false,
+      useEllipsisForLongFilenames: true,
 
       /**
        * <p>This collection of [PublishAction]{@link module:alfresco/renderers/PublishAction} widgets
@@ -386,10 +386,10 @@ define(["alfresco/core/FileSizeMixin",
        *
        * @instance
        * @param {object} file The upload file
-       * @param {boolean} [doNotTruncate=false] If true then will prevent truncating the display text
+       * @param {boolean} [doNotModify=false] If true then will prevent any post-modification of the display text
        * @returns {string} The name of the upload to be deisplayed
        */
-      getDisplayText: function alfesco_upload_UploadMonitor__getDisplayText(file, doNotTruncate) {
+      getDisplayText: function alfesco_upload_UploadMonitor__getDisplayText(file, doNotModify) {
 
          // Create upload name as "filename.ext, xxx kB"
          var filename = file.name,
@@ -398,9 +398,11 @@ define(["alfresco/core/FileSizeMixin",
             uploadName = filename + separator + filesize;
 
          // If filename is too long, adjust
-         if (this.useEllipsisForLongFilenames) {
+         if (doNotModify) {
+            // Leave it unchanged
+         } else if (this.useEllipsisForLongFilenames) {
             uploadName = uploadName.split("").reverse().join("");
-         } else if (!doNotTruncate && uploadName.length > this.maxUploadNameLength) {
+         } else if (uploadName.length > this.maxUploadNameLength) {
 
             // Calculate how long name can be
             var maxNameLength = this.maxUploadNameLength - filesize.length - separator.length;

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/FileUploadService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/upload/FileUploadService.get.js
@@ -18,7 +18,6 @@ model.jsonModel = {
                {
                   name: "alfresco/upload/UploadMonitor",
                   config: {
-                     useEllipsisForLongFilenames: true,
                      widgetsForSuccessfulActions: [
                         {
                            name: "alfresco/html/SVGImage",


### PR DESCRIPTION
This pull-request re-addresses issue [AKU-955](https://issues.alfresco.com/jira/browse/AKU-955) and changes the default behaviour to be the _new_ auto-truncation of long names. Also, a bug with a reversed title attribute has been fixed. Upload regression tests all passing.