### PR TITLE
AKU-979: Icons stuck to mouse pointer

### DIFF
--- a/aikau/src/main/resources/alfresco/node/DraggableNodeMixin.js
+++ b/aikau/src/main/resources/alfresco/node/DraggableNodeMixin.js
@@ -58,7 +58,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.39
        */
-      isDraggable: true,
+      isDraggable: false,
 
       /**
        * This will be assigned a reference to the "dojo/dnd/Moveable" instance created by the 


### PR DESCRIPTION
This addresses [AKU-979](https://issues.alfresco.com/jira/browse/AKU-979), which is a bug in a feature that was ported to Aikau but never fully implemented, specifically drag and drop within document library. To fix this, we will change the default for Thumbnails to not be draggable.