### PR TITLE
1098: Use appropriate module name for variable

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentList.js
@@ -32,9 +32,9 @@ define(["dojo/_base/declare",
         "alfresco/util/hashUtils",
         "dojo/io-query",
         "dojo/dom-class"],
-        function(declare, AlfSortablePaginatedList, JsNode, topics, array, lang, hashUtils, ioQuery, domClass) {
+        function(declare, AlfFilteredList, JsNode, topics, array, lang, hashUtils, ioQuery, domClass) {
 
-   return declare([AlfSortablePaginatedList], {
+   return declare([AlfFilteredList], {
 
       /**
        * An array of the i18n files to use with this widget.


### PR DESCRIPTION
This PR addresses #1098 to set a more appropriate variable name in AlfDocumentList. The variable name used in the define callback/declare statement was not changed when the module was updated to extend AlfFilteredList instead of AlfSortablePaginatedList