### PR TITLE
AKU-991: Added node.nodeRef fallback to NodePreviewService

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NodePreviewService.js
+++ b/aikau/src/main/resources/alfresco/services/NodePreviewService.js
@@ -161,6 +161,13 @@ define(["dojo/_base/declare",
        */
       checkNodeMetadata: function alfresco_services_NodePreviewService__checkNodeMetadata(payload) {
          var nodeRef = payload.nodeRef;
+         if (!nodeRef && payload.node)
+         {
+            // Check the node in the payload for a nodeRef if not specifically requested in the 
+            // payload - this is useful when working against APIs that do not provide a separate
+            // nodeRef attribute on the item...
+            nodeRef = payload.node.nodeRef;
+         }
          var node = payload.node;
          var mimetype;
          if (node)


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-991 to provide a fallback option for locating a NodeRef of the Node to preview when it is not explicitly declared in the payload. I've not included a unit test change for this issue as it is a minor additive change and have verified the existing unit tests continue to work.