### PR TITLE
AKU-989: Added CollapsibleSection for form layout

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/CollapsibleSection.js
+++ b/aikau/src/main/resources/alfresco/forms/CollapsibleSection.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This extends the [Twister]{@link module:alfresco/layout/Twister} and mixes in
+ * the [LayoutMixin]{@link module:alfresco/forms/LayoutMixin} to provide a collapsible section
+ * into which form controls can be placed. 
+ *
+ * @example <caption>Example form with a CollapsibleSection</caption>
+ * {
+ *   name: "alfresco/forms/Form",
+ *   config: {
+ *     okButtonPublishTopic: "SAVE_FORM",
+ *     widgets: [
+ *       {
+ *         name: "alfresco/forms/CollapsibleSection",
+ *         config: {
+ *           label: "Section"
+ *           widgets: [
+ *             {
+ *               name: "alfresco/forms/controls/TextBox",
+ *               config: {
+ *               fieldId: "TB1",
+ *               name: "tb1",
+ *               label: "Text box"
+ *               }
+ *             }
+ *           ]
+ *         }
+ *       }
+ *     ]
+ *   }
+ * }
+ * 
+ * @module alfresco/forms/CollapsibleSection
+ * @extends module:alfresco/layout/Twister,
+ * @mixes module:alfresco/forms/LayoutMixin
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/layout/Twister",
+        "alfresco/forms/LayoutMixin"], 
+        function(declare, Twister, LayoutMixin) {
+   
+   return declare([Twister, LayoutMixin], {
+      // NOTE: All the code for this widget is provided by the mixing of Twister and LayoutMixin
+   });
+});

--- a/aikau/src/test/resources/alfresco/forms/CollapsibleSectionTest.js
+++ b/aikau/src/test/resources/alfresco/forms/CollapsibleSectionTest.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(module, defineSuite, assert, TestCommon) {
+
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
+   var selectors = {
+      form: {
+         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["FORM1"])
+      },
+      textBoxes: {
+         tb1: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TB1"])
+         }
+      }
+   };
+
+   defineSuite(module, {
+      name: "CollapsibleSection Tests",
+      testPage: "/CollapsibleSection",
+
+      "Initial text box value is set": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.tb1.input)
+            .getProperty("value")
+            .then(function(resultText) {
+               assert.equal(resultText, "Some value");
+            });
+      },
+
+      "Updated text value is saved": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.tb1.input)
+            .clearValue()
+            .type("Updated Value")
+         .end()
+
+         .findByCssSelector(selectors.form.confirmationButton)
+            .click()
+         .end()
+
+         .getLastPublish("FORM1_SAVE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "textbox", "Updated Value");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -111,6 +111,7 @@ define(function() {
       "alfresco/footer/FooterTest",
 
       "alfresco/forms/AutoSaveFormsTest",
+      "alfresco/forms/CollapsibleSectionTest",
       "alfresco/forms/ControlRowTest",
       "alfresco/forms/CrudFormTest",
       "alfresco/forms/DynamicFormTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/CollapsibleSection.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/CollapsibleSection.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>CollapsibleSection (form layout)</shortname>
+  <description>Demonstrates the use of an alfresco/forms/CollapsibleSection in a form.</description>
+  <family>aikau-unit-tests</family>
+  <url>/CollapsibleSection</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/CollapsibleSection.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/CollapsibleSection.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/CollapsibleSection.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/CollapsibleSection.get.js
@@ -1,0 +1,53 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "FORM1",
+         name: "alfresco/forms/Form",
+         config: {
+            pubSubScope: "FORM1_",
+            okButtonPublishTopic: "SAVE",
+            value: {
+               select: "TWO",
+               textbox: "Some value"
+            },
+            widgets: [
+               {
+                  id: "CS1",
+                  name: "alfresco/forms/CollapsibleSection",
+                  config: {
+                     label: "Collapse Me",
+                     widgets: [
+                        {
+                           id: "TB1",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "TB1",
+                              name: "textbox",
+                              label: "Some Text",
+                              description: "Created to ensure that initial value is published"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-989 to provide a new CollapsibleSection layout widget for forms. This is simply a Twister mixed with the LayoutMixin - however, the name represents the fact that we're likely to change implementation in the future and this is a more abstract name. Unit tests have been added to verify it works as expected (e.g. form data is passed back and forth through the layout control).