### PR TITLE
AKU-992: Breadcrumb trail publication updates

### DIFF
--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.desc.xml
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Breadcrumb Trails</shortname>
+  <description>Examples of how you can configure the AlfBreadcrumbTrail widget.</description>
+  <family>ExamplePage</family>
+  <url>/AlfBreadcrumbTrail</url>
+</webscript>

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.html.ftl
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.js
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.js
@@ -1,0 +1,125 @@
+<import resource="classpath:alfresco/site-webscripts/imports/sandpit.lib.js">
+
+buildPageModel({
+   title: "page.title",
+   description: "page.description",
+   jsdoc: "https://dev.alfresco.com/resource/docs/aikau-jsdoc/Markdown.html",
+   examples: [
+      {
+         title: "example1.title",
+         description: "example1.description",
+         model: [
+            {
+               name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+               config: {
+                  breadcrumbs: [
+                     {
+                        label: "Small"
+                     },
+                     {
+                        label: "Crumb"
+                     },
+                     {
+                        label: "Of"
+                     },
+                     {
+                        label: "Comfort"
+                     }
+                  ]
+               }
+            }
+         ]
+      },
+      {
+         title: "example2.title",
+         description: "example2.description",
+         model: [
+            {
+               name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+               config: {
+                  currentPath: "/the/road/less/travelled",
+                  showRootLabel: true
+               }
+            }
+         ]
+      },
+      {
+         title: "example3.title",
+         description: "example3.description",
+         model: [
+            {
+               name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+               config: {
+                  currentPath: "/there's/a/lady/who/knows",
+                  showRootLabel: true,
+                  rootLabel: "HOME",
+                  pathChangeTopic: "UPDATE_PATH"
+               }
+            },
+            {
+               name: "alfresco/buttons/AlfButton",
+               config: {
+                  label: "Update Path",
+                  publishTopic: "UPDATE_PATH",
+                  publishPayload: {
+                     path: "all/that/glitters/is/gold"
+                  }
+               }
+            }
+         ]
+      },
+      {
+         title: "example4.title",
+         description: "example4.description",
+         model: [
+            {
+               name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+               config: {
+                  currentPath: "/another/path/to/render",
+                  useHash: true
+               }
+            }
+         ]
+      },
+      {
+         title: "example5.title",
+         description: "example5.description",
+         model: [
+            {
+               name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+               config: {
+                  currentPath: "/another/path/to/render",
+                  publishTopic: "NAVIGATE",
+                  publishPayloadType: "PROCESS",
+                  publishPayloadModifiers: ["processInstanceTokens"],
+                  publishPayload: {
+                     url: "documentlibrary#filter=path|{path}",
+                     type: "PAGE_RELATIVE",
+                     target: "CURRENT"
+                  }
+               }
+            }
+         ]
+      },
+      {
+         title: "example6.title",
+         description: "example6.description",
+         model: [
+            {
+               name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+               config: {
+                  currentPath: "/another/path/to/render",
+                  lastBreadcrumbPublishTopic: "NAVIGATE",
+                  lastBreadcrumbPublishPayload: {
+                     url: "documentlibrary#filter=path|{path}",
+                     type: "PAGE_RELATIVE",
+                     target: "CURRENT"
+                  },
+                  lastBreadcrumbPublishPayloadType: "PROCESS",
+                  lastBreadcrumbPublishPayloadModifiers: ["processInstanceTokens"],
+               }
+            }
+         ]
+      }
+   ]
+});

--- a/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.properties
+++ b/aikau-sandpit-application/src/main/webapp/WEB-INF/classes/alfresco/site-webscripts/pages/documentlibrary/AlfBreadcrumbTrailExample.get.properties
@@ -1,0 +1,20 @@
+page.title=Breadcrumb Trails
+page.description=The 'alfresco/documentlibrary/AlfBreadcrumbTrail' provides a versatile way in which paths can be rendered. It was originally written for use in the Aikau version of the Document Library but be adapted for other purposes.
+
+example1.title=Individual Configuration
+example1.description=In this example the individual configuration for each breadcrumb is provided. The only required attribute is the 'label' - but additional attributes can be provided such as 'publishTopic' and 'publishPayload'. This is the most flexible way in which to create a breadcrumb trail but does require the most configuration within the page model.
+
+example2.title=Simple Path
+example2.description=This example shows how a path can be rendered from a simple string. It also shows how a root breadcrumb can be rendered using the 'showRootLabel' - try switching this to false and re-rendering.
+
+example3.title=Subscription Topic
+example3.description=It is possible to configure the 'pathChangeTopic' in order to re-render the breadcrumb trail as the path changes. This typically occurs in a Document Library that is configured to NOT use the browser hash (see next example). Click the button to re-render the breadcrumb trail. Also note that we're setting a custom root breadcrumb label by configuring 'rootLabel'.
+
+example4.title=Using the Browser Hash
+example4.description=In this example we are configured the breadcrumb trail to be set using the browser hash. Try manually editing the URL to include '#path=/new/path' (you may need to reload the page with the new URL depending on your browser) to see that the configured 'currentPath' is overridden by the 'path' hash parameter.
+
+example5.title=Publication Configuration
+example5.description=In this example we are configuring publications for all the breadcrumbs. The key thing to note here is that the 'path' for the breadcrumb is assigned to each individual breadcrumb - so you should ideally make use of the 'processInstanceTokens' with a {path} token to ensure that the payload published for each breadcrumb is different.
+
+example6.title=Last Breadcrumb Publication Configuration
+example6.description=It is also possible to publish payload configuration for ONLY the last breadcrumb. The reason that this capability exists is that in the Document Library there is a requirement for the last breadcrumb to be used to navigate to a details page for the folder (as opposed to just navigating around the document library). This configuration option can be used with the general publication configuration in the previous example - the last breadcrumb configuration will take precedence of the general configuration.

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumb.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumb.js
@@ -36,12 +36,14 @@ define(["dojo/_base/declare",
         "dijit/_OnDijitClickMixin",
         "dijit/_CssStateMixin",
         "alfresco/node/NodeDropTargetMixin",
+        "alfresco/renderers/_PublishPayloadMixin",
         "dojo/text!./templates/AlfBreadcrumb.html",
         "alfresco/core/Core",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _CssStateMixin, NodeDropTargetMixin, template, AlfCore, _AlfDocumentListTopicMixin) {
+        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _CssStateMixin, NodeDropTargetMixin,
+                 _PublishPayloadMixin, template, AlfCore, _AlfDocumentListTopicMixin) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _CssStateMixin, NodeDropTargetMixin, AlfCore, _AlfDocumentListTopicMixin], {
+   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _CssStateMixin, NodeDropTargetMixin, _PublishPayloadMixin, AlfCore, _AlfDocumentListTopicMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -116,7 +118,8 @@ define(["dojo/_base/declare",
       onClick: function alfresco_documentlibrary_AlfBreadcrumb(/* jshint unused:false */ evt) {
          if (this.publishTopic)
          {
-            this.alfPublish(this.publishTopic, this.publishPayload, (this.publishGlobal === true));
+            var publishPayload = this.generatePayload(this.publishPayload, this.currentItem, null, this.publishPayloadType, this.publishPayloadItemMixin, this.publishPayloadModifiers);
+            this.alfPublish(this.publishTopic, publishPayload, (this.publishGlobal === true));
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfBreadcrumbTrail.js
@@ -382,6 +382,25 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * This function can be used to copy the publication configuration from the breadcrumb trail
+       * to an individual [AlfBreadcrumb]{@link module:alfresco/documentlibrary/AlfBreadcrumb}.
+       * 
+       * @instance
+       * @param {object} config The configuration object to copy the publication configuration to
+       * @since 1.0.71
+       */
+      copyPublicationConfig: function alfresco_documentlibrary_AlfBreadcrumbTrail__copyPublicationConfig(config) {
+         config.publishTopic = this.publishTopic;
+         config.publishPayload = this.publishPayload;
+         config.publishPayloadItemMixin = this.publishPayloadItemMixin;
+         config.publishPayloadModifiers = this.publishPayloadModifiers;
+         config.publishPayloadType = this.publishPayloadType;
+         config.publishGlobal = this.publishGlobal;
+         config.publishToParent = this.publishToParent;
+      },
+
+
+      /**
        * Renders an individual [AlfBreadcrumb]{@link module:alfresco/documentlibrary/AlfBreadcrumb} in the breadcrumb trail.
        * 
        * @instance
@@ -407,6 +426,13 @@ define(["dojo/_base/declare",
                };
                config.publishGlobal = true;
             }
+            else if (this.publishTopic)
+            {
+               // If a specific publishTopic has been provided then use this for all the breadcrumbs 
+               // (with the exception of the last breadcrumb as this can be individually
+               // configured)...
+               this.copyPublicationConfig(config);
+            }
             else
             {
                config.publishTopic = this.pathChangeTopic;
@@ -421,6 +447,11 @@ define(["dojo/_base/declare",
             config.publishPayload = this.generatePayload(this.lastBreadcrumbPublishPayload, this.currentItem, null, this.lastBreadcrumbPublishPayloadType, this.lastBreadcrumbPublishPayloadItemMixin, this.lastBreadcrumbPublishPayloadModifiers);
             config.publishGlobal = this.lastBreadcrumbPublishGlobal;
             config.publishToParent = this.lastBreadcrumbPublishToParent;
+         }
+         else if (this.publishTopic)
+         {
+            // Still allows for explicit last breadcrumb configuration to trump global configuration...
+            this.copyPublicationConfig(config);
          }
          this.renderBreadcrumb(config);
       },

--- a/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/BreadcrumbTrailTest.js
@@ -57,6 +57,17 @@ define(["module",
             });
       },
 
+      "Click publication configured breadcrumb": function() {
+         return this.remote.findByCssSelector("#LINKING_PATH_BREADCRUMBS .alfresco-documentlibrary-AlfBreadcrumb:nth-child(3) .breadcrumb")
+            .click()
+         .end()
+
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "url", "documentlibrary#filter=path|/ambition/is/the");
+            });
+      },
+
       "Counting hash breadcrumbs...": function() {
          // Test 1...
          // Check the path is initially displayed...

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/BreadcrumbTrail.get.js
@@ -44,6 +44,20 @@ model.jsonModel = {
          }
       },
       {
+         id: "LINKING_PATH_BREADCRUMBS",
+         name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
+         config: {
+            showRootLabel: false,
+            currentPath: "/ambition/is/the/path/to/success",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayloadType: "PROCESS",
+            publishPayloadModifiers: ["processInstanceTokens"],
+            publishPayload: {
+               url: "documentlibrary#filter=path|/{path}"
+            }
+         }
+      },
+      {
          id: "HASH_BREADCRUMBS",
          name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-992 to provide general support for publication configuration for breadcrumbs within an AlfBreadcrumbTrail. This change will allow the AlfBreadcrumbTrail to be used more effectively when showing the location of an individual Node (i.e. outside of the context of a Document Library). The unit test has been updated. A new page for the Sandpit has also been added to assist with education.