### PR TITLE
AKU-986: Tooltip configuration options

### DIFF
--- a/aikau/src/main/resources/alfresco/misc/AlfTooltip.js
+++ b/aikau/src/main/resources/alfresco/misc/AlfTooltip.js
@@ -127,10 +127,11 @@ define(["dojo/_base/declare",
         "dojo/dom-construct",
         "dojo/dom-style",
         "dojo/on",
+        "dojo/query",
         "dojo/when",
         "dijit/popup"], 
         function(declare, _WidgetBase, _TemplatedMixin, template, TooltipDialog, AlfCore, CoreWidgetProcessing,
-                 lang, array, domConstruct, domStyle, on, when, popup) {
+                 lang, array, domConstruct, domStyle, on, query, when, popup) {
    
    return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
       
@@ -141,6 +142,34 @@ define(["dojo/_base/declare",
        */
       templateString: template,
       
+      /**
+       * <p>This is an optional CSS selector that can be provided to identify a child node that the tooltip
+       * should be anchored to. Ideally this should only match a single node, but if it matches multiple
+       * nodes then the first result will be used. This selector is only used within the DOM that descends
+       * from this widget - not across the entire page.</p>
+       * <p>PLEASE NOTE: Use of this attribute is potentially fragile depending
+       * upon the selector used - there are no guarantees that the CSS classes or HTML structure of widgets
+       * will not change between releases of Aikau! It is strongly recommended that if future proof selectors
+       * are required that feature requests are made to add them.</p>
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.71
+       */
+      anchorSelector: null,
+
+      /**
+       * An optional array of the orientation preferences for the tooltip. An example configuration might
+       * be ["below-centered", "above-centered"] for example.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.71
+       */
+      orientation: null,
+
       /**
        * This is the widget model that will be displayed inside the tooltip.
        * 
@@ -242,9 +271,23 @@ define(["dojo/_base/declare",
                onMouseLeave: lang.hitch(this, this.onTooltipMouseLeave)
             });
          }
+
+         // If a CSS selector has been provided for finding the element to anchor to, then
+         // use it to set the target node...
+         var targetNode = this.domNode;
+         if (this.anchorSelector)
+         {
+            var results = query(this.anchorSelector, this.domNode);
+            if (results.length)
+            {
+               targetNode = results[0];
+            }
+         }
+
          popup.open({
             popup: this._tooltip,
-            around: this.domNode
+            around: targetNode,
+            orient: this.orientation
          });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/misc/AlfTooltip.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/misc/AlfTooltip.get.js
@@ -13,118 +13,127 @@ model.jsonModel = {
    ],
    widgets: [
       {
-         id: "WINDOW",
-         name: "alfresco/layout/ClassicWindow",
+         name: "alfresco/layout/HorizontalWidgets",
          config: {
-            title: "Single tooltip",
             widgets: [
                {
-                  id: "SINGLE_ITEM",
-                  name: "alfresco/misc/AlfTooltip",
+                  id: "WINDOW",
+                  name: "alfresco/layout/ClassicWindow",
                   config: {
+                     title: "Single tooltip",
                      widgets: [
                         {
-                           id: "LOGO1",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ],
-                     widgetsForTooltip: [
-                        {
-                           id: "LABEL1",
-                           name: "alfresco/html/Label",
-                           config: {
-                              label: "This is the tooltip content"
-                           }
-                        }
-                     ],
-                     tooltipStyle: "width: 300px;"
-                  }
-               }
-            ]
-         }
-      },
-      {
-         id: "WINDOW_REQUIRES_CLICK",
-         name: "alfresco/layout/ClassicWindow",
-         config: {
-            title: "Single tooltip with click",
-            widgets: [
-               {
-                  id: "SINGLE_ITEM_REQUIRES_CLICK",
-                  name: "alfresco/misc/AlfTooltip",
-                  config: {
-                     widgets: [
-                        {
-                           id: "LOGO1_REQUIRES_CLICK",
-                           name: "alfresco/logo/Logo"
-                        }
-                     ],
-                     widgetsForTooltip: [
-                        {
-                           id: "LABEL1_REQUIRES_CLICK",
-                           name: "alfresco/html/Label",
-                           config: {
-                              label: "This is the tooltip content when clicked"
-                           }
-                        }
-                     ],
-                     triggeringEvent: "click"
-                  }
-               }
-            ]
-         }
-      },
-      {
-         id: "LIST_WINDOW",
-         name: "alfresco/layout/ClassicWindow",
-         config: {
-            title: "List of tooltips",
-            widgets: [
-               {
-                  id: "LIST1",
-                  name: "alfresco/lists/AlfList",
-                  config: {
-                     currentData: {
-                        items: [
-                           {
-                              name: "one",
-                              description: "the first"
-                           },
-                           {
-                              name: "two",
-                              description: "the second"
-                           }
-                        ]
-                     },
-                     widgets: [
-                        {
-                           name: "alfresco/lists/views/AlfListView",
+                           id: "SINGLE_ITEM",
+                           name: "alfresco/misc/AlfTooltip",
                            config: {
                               widgets: [
                                  {
-                                    name: "alfresco/lists/views/layouts/Row",
+                                    id: "LOGO1",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ],
+                              widgetsForTooltip: [
+                                 {
+                                    id: "LABEL1",
+                                    name: "alfresco/html/Label",
+                                    config: {
+                                       label: "This is the tooltip content"
+                                    }
+                                 }
+                              ],
+                              tooltipStyle: "width: 300px;"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "WINDOW_REQUIRES_CLICK",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Single tooltip with click",
+                     widgets: [
+                        {
+                           id: "SINGLE_ITEM_REQUIRES_CLICK",
+                           name: "alfresco/misc/AlfTooltip",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "LOGO1_REQUIRES_CLICK",
+                                    name: "alfresco/logo/Logo"
+                                 }
+                              ],
+                              widgetsForTooltip: [
+                                 {
+                                    id: "LABEL1_REQUIRES_CLICK",
+                                    name: "alfresco/html/Label",
+                                    config: {
+                                       label: "This is the tooltip content when clicked"
+                                    }
+                                 }
+                              ],
+                              triggeringEvent: "click"
+                           }
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "LIST_WINDOW",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "List of tooltips",
+                     widgets: [
+                        {
+                           id: "LIST1",
+                           name: "alfresco/lists/AlfList",
+                           config: {
+                              currentData: {
+                                 items: [
+                                    {
+                                       name: "one",
+                                       description: "the first"
+                                    },
+                                    {
+                                       name: "two",
+                                       description: "the second"
+                                    }
+                                 ]
+                              },
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/AlfListView",
                                     config: {
                                        widgets: [
                                           {
-                                             name: "alfresco/lists/views/layouts/Cell",
+                                             name: "alfresco/lists/views/layouts/Row",
                                              config: {
                                                 widgets: [
                                                    {
-                                                      name: "alfresco/misc/AlfTooltip",
+                                                      name: "alfresco/lists/views/layouts/Cell",
                                                       config: {
                                                          widgets: [
                                                             {
-                                                               name: "alfresco/renderers/Property",
+                                                               name: "alfresco/misc/AlfTooltip",
                                                                config: {
-                                                                  propertyToRender: "name"
-                                                               }
-                                                            }
-                                                         ],
-                                                         widgetsForTooltip: [
-                                                            {
-                                                               name: "alfresco/renderers/Property",
-                                                               config: {
-                                                                  propertyToRender: "description"
+                                                                  anchorSelector: ".alfresco-renderers-Property span.value",
+                                                                  orientation: ["below-centered", "above-centered"],
+                                                                  widgets: [
+                                                                     {
+                                                                        name: "alfresco/renderers/Property",
+                                                                        config: {
+                                                                           propertyToRender: "name"
+                                                                        }
+                                                                     }
+                                                                  ],
+                                                                  widgetsForTooltip: [
+                                                                     {
+                                                                        name: "alfresco/renderers/Property",
+                                                                        config: {
+                                                                           propertyToRender: "description"
+                                                                        }
+                                                                     }
+                                                                  ]
                                                                }
                                                             }
                                                          ]
@@ -141,71 +150,71 @@ model.jsonModel = {
                         }
                      ]
                   }
-               }
-            ]
-         }
-      },
-      {
-         id: "LIST_WITH_XHR",
-         name: "alfresco/layout/ClassicWindow",
-         config: {
-            title: "List of tooltips that make XHR request for data",
-            widgets: [
+               },
                {
-                  id: "LIST2",
-                  name: "alfresco/lists/AlfList",
+                  id: "LIST_WITH_XHR",
+                  name: "alfresco/layout/ClassicWindow",
                   config: {
-                     currentData: {
-                        items: [
-                           {
-                              name: "one",
-                              nodeRef: "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4"
-                           }
-                        ]
-                     },
+                     title: "List of tooltips that make XHR request for data",
                      widgets: [
                         {
-                           name: "alfresco/lists/views/AlfListView",
+                           id: "LIST2",
+                           name: "alfresco/lists/AlfList",
                            config: {
+                              currentData: {
+                                 items: [
+                                    {
+                                       name: "one",
+                                       nodeRef: "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4"
+                                    }
+                                 ]
+                              },
                               widgets: [
                                  {
-                                    name: "alfresco/lists/views/layouts/Row",
+                                    name: "alfresco/lists/views/AlfListView",
                                     config: {
                                        widgets: [
                                           {
-                                             name: "alfresco/lists/views/layouts/Cell",
+                                             name: "alfresco/lists/views/layouts/Row",
                                              config: {
                                                 widgets: [
                                                    {
-                                                      name: "alfresco/misc/AlfTooltip",
+                                                      name: "alfresco/lists/views/layouts/Cell",
                                                       config: {
                                                          widgets: [
                                                             {
-                                                               name: "alfresco/renderers/Property",
+                                                               name: "alfresco/misc/AlfTooltip",
                                                                config: {
-                                                                  propertyToRender: "name"
-                                                               }
-                                                            }
-                                                         ],
-                                                         widgetsForTooltip: [
-                                                            {
-                                                               name: "alfresco/documentlibrary/AlfDocument",
-                                                               config: {
-                                                                  xhrRequired: true,
-                                                                  rawData: false,
                                                                   widgets: [
                                                                      {
                                                                         name: "alfresco/renderers/Property",
                                                                         config: {
-                                                                           propertyToRender: "displayName",
-                                                                           renderOnNewLine: true
+                                                                           propertyToRender: "name"
                                                                         }
-                                                                     },
+                                                                     }
+                                                                  ],
+                                                                  widgetsForTooltip: [
                                                                      {
-                                                                        name: "alfresco/renderers/Thumbnail",
+                                                                        name: "alfresco/documentlibrary/AlfDocument",
                                                                         config: {
-                                                                           renditionName: "imgpreview",
-                                                                           width: "300px"
+                                                                           xhrRequired: true,
+                                                                           rawData: false,
+                                                                           widgets: [
+                                                                              {
+                                                                                 name: "alfresco/renderers/Property",
+                                                                                 config: {
+                                                                                    propertyToRender: "displayName",
+                                                                                    renderOnNewLine: true
+                                                                                 }
+                                                                              },
+                                                                              {
+                                                                                 name: "alfresco/renderers/Thumbnail",
+                                                                                 config: {
+                                                                                    renditionName: "imgpreview",
+                                                                                    width: "300px"
+                                                                                 }
+                                                                              }
+                                                                           ]
                                                                         }
                                                                      }
                                                                   ]
@@ -233,7 +242,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/PreviewMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-986 to provide additional orientation options for the AlfTooltip widget. 