### PR TITLE
AKU-982 - Add support for disabling click actions in Indicators

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Indicators.js
+++ b/aikau/src/main/resources/alfresco/renderers/Indicators.js
@@ -81,6 +81,15 @@ define(["dojo/_base/declare",
       propertyToRender: null,
 
       /**
+       * Whether this indicator is clickable and publishes a action request or not.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      supportActions: true,
+
+      /**
        * This is an auto-populated instance property that holds a cleaned-up array of indicators for the current item.
        *
        * @instance
@@ -203,7 +212,7 @@ define(["dojo/_base/declare",
          }
          var label = this.message(indicator.label, messageArgs),
             classes = ["indicator"];
-         if (indicator.action) {
+         if (this.supportActions && indicator.action) {
             classes.push("has-action");
          }
          var img = domConstruct.create("img", {
@@ -212,7 +221,7 @@ define(["dojo/_base/declare",
             "alt": indicator.id,
             "class": classes.join(" ")
          }, this.containerNode);
-         if (indicator.action) {
+         if (this.supportActions && indicator.action) {
             on(img, "click", lang.hitch(this, this.onActionClick, indicator));
          }
       },


### PR DESCRIPTION
Simply added a boolean flag to torn off actions on indicators. Default value is current behaviour.