### PR TITLE
AKU-982: Add support for disabling click actions in Indicators

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Indicators.js
+++ b/aikau/src/main/resources/alfresco/renderers/Indicators.js
@@ -163,6 +163,18 @@ define(["dojo/_base/declare",
       propertyToRender: null,
 
       /**
+       * Indicates whether or not the configured actions for the indicators supported. So if this is configured
+       * to be false then no indicator will be clickable regardless of whether or not an action has been
+       * provided for it.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.72
+       */
+      supportActions: true,
+
+      /**
        * This is an auto-populated instance property that holds a cleaned-up array of indicators for the current item.
        *
        * @instance
@@ -285,7 +297,7 @@ define(["dojo/_base/declare",
          }
          var label = this.message(indicator.label, messageArgs),
             classes = ["indicator"];
-         if (indicator.action) {
+         if (this.supportActions && indicator.action) {
             classes.push("has-action");
          }
 
@@ -316,7 +328,7 @@ define(["dojo/_base/declare",
             "alt": indicator.id,
             "class": classes.join(" ")
          }, this.containerNode);
-         if (indicator.action) {
+         if (this.supportActions && indicator.action) {
             on(img, "click", lang.hitch(this, this.onActionClick, indicator));
          }
       },

--- a/aikau/src/test/resources/alfresco/renderers/IndicatorsTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/IndicatorsTest.js
@@ -114,6 +114,17 @@ define(["module",
             .then(function(src) {
                assert.equal(src, "/aikau/res/some/custom/image.jpg");
             });
+      },
+
+      "Indicators can have actions disabled": function() {
+         return this.remote.findByCssSelector("#INDICATORS4 .indicator")
+            .click()
+         .end()
+
+         .getAllPublishes("CUSTOM_ACTION_2")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0, "Navigation publication should not have been made");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Indicators.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Indicators.get.js
@@ -95,6 +95,31 @@ model.jsonModel = {
          }
       },
       {
+         id: "INDICATORS4",
+         name: "alfresco/renderers/Indicators",
+         config: {
+            supportActions: false,
+            currentItem: {
+               node: {
+                  nodeRef: "some://dummy/node",
+                  properties: {
+                     name: "Test"
+                  }
+               },
+               indicators: [
+                  {
+                     "id": "bob",
+                     "index": "10",
+                     "icon": "locked-16.png",
+                     "label": "Not translated",
+                     "action": "custom",
+                     "publishTopic": "CUSTOM_ACTION_2",
+                     "publishPayload": {}
+                  }
+               ]
+            }
+         }
+      },{
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-982 and replaces #1113 (which was missing a unit test). It adds a configuration option to the Indicators renderer that will prevent any configured actions for the indicator being supported. A unit test has been added to verify this change.