### PR TITLE
AKU-995: Layout tutorial and ClassicWindow updates

### DIFF
--- a/aikau/src/main/resources/alfresco/layout/css/ClassicWindow.css
+++ b/aikau/src/main/resources/alfresco/layout/css/ClassicWindow.css
@@ -17,6 +17,10 @@
       padding: 10px;
    }
 
+   &.no-margin {
+      margin: 0
+   }
+
    &.shadow {
       box-shadow: @standard-box-shadow;
    }

--- a/aikau/src/test/resources/alfresco/layout/ClassicWindowTest.js
+++ b/aikau/src/test/resources/alfresco/layout/ClassicWindowTest.js
@@ -75,6 +75,17 @@ define(["module",
          //       console.log("Scroll width=" + element.scrollWidth + ", client width=" + element.clientWidth);
          //       assert(element.scrollWidth > element.clientWidth, "Scroll bar is not displayed");
          //    });
+      },
+
+      "Check margin removal": function() {
+         return this.remote.findById("WINDOW4")
+            .getComputedStyle("margin")
+            .then(function(margin) {
+               // NOTE: Depending upon the browser, this should return either "0px" or "" - it should definitely
+               //       NOT return anything suggesting that a margin is set (which is neither value that is being
+               //       checked for)...
+               assert(margin === "0px" || margin === "");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ClassicWindow.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/ClassicWindow.get.js
@@ -59,6 +59,29 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  id: "WINDOW4",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "One",
+                     additionalCssClasses: "no-margin"
+                  }
+               },
+               {
+                  id: "WINDOW5",
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Two",
+                     additionalCssClasses: "no-margin"
+                  }
+               }
+            ]
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]

--- a/tutorial/chapters/Tutorial13.md
+++ b/tutorial/chapters/Tutorial13.md
@@ -20,13 +20,15 @@ Add the following as the first entry in the “widgets” array attribute of you
       {
         name: "alfresco/layout/ClassicWindow",
         config: {
-          title: "Groups"
+          title: "Groups",
+          additionalCssClasses: "no-margin"
         }
       },
       {
         name: "alfresco/layout/ClassicWindow",
         config: {
-          title: "Users"
+          title: "Users",
+          additionalCssClasses: "no-margin"
         }
       }
     ]
@@ -89,14 +91,16 @@ Each window is given an equal share of the available horizontal space by default
             name: "alfresco/layout/ClassicWindow",
             widthPc: "75",
             config: {
-               title: "Groups"
+               title: "Groups",
+               additionalCssClasses: "no-margin"
             }
          },
          {
             name: "alfresco/layout/ClassicWindow",
             widthPc: "25",
             config: {
-               title: "Users"
+               title: "Users",
+               additionalCssClasses: "no-margin"
             }
          }
       ]
@@ -119,14 +123,16 @@ widgets: [
       name: "alfresco/layout/ClassicWindow",
       widthPc: "75",
       config: {
-         title: "Groups"
+         title: "Groups",
+         additionalCssClasses: "no-margin"
       }
    },
    {
       name: "alfresco/layout/ClassicWindow",
       widthPx: "500",
       config: {
-         title: "Users"
+         title: "Users",
+         additionalCssClasses: "no-margin"
       }
    }
 ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-995 / #1108 to update the ClassicWindow widget so that it supports an additionalCssClasses class called "no-margin" that removes the default margin of 10px from being added around a ClassicWindow. This style change was introduced after the tutorial was written and this creates confusion when describing how to create gaps between widgets in a horizontal layout (because it appears there is always a gap!). A new unit test has been added to verify the change and prevent regressions. 