### PR TITLE
Avoid showing progress indicator when setting hash parameters through NavigationService

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -190,9 +190,22 @@ define(["dojo/_base/declare",
                }
                else if (!data.target || data.target === this.currentTarget)
                {
-                  this.displayProgressIndicator().then(function(){
+                  // Make a good attempt at ensuring that we're not trying to go back to the same page
+                  // This has been added to ensure that the progress indicator is not shown when entering
+                  // new search terms in the SearchBox when already on the Search page (in Share)... 
+                  // This may require further enhancement...
+                  var hashIndex = url.indexOf("#");
+                  if ((hashIndex !== -1 && url.substring(0, hashIndex) === window.location.pathname) ||
+                      (url === window.location.pathname))
+                  {
                      window.location = url;
-                  });
+                  }
+                  else
+                  {
+                     this.displayProgressIndicator().then(function(){
+                        window.location = url;
+                     });
+                  }
                }
                else if (data.target === this.newTarget)
                {

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -245,6 +245,18 @@ define(["module",
             .then(function(url) {
                assert.include(url, "page/tp/ws/NavigationService", "Loaded URL incorrect");
             });
+      },
+
+      "Same page with hash doesn't show progress": function() {
+         return this.remote.findDisplayedById("SAME_PAGE_BUT_WITH_HASHES_text")
+            .clearLog()
+            .click()
+         .end()
+
+         .getAllPublishes("ALF_PROGRESS_INDICATOR_ADD_ACTIVITY")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
@@ -248,7 +248,27 @@ model.jsonModel = {
                         
                      }
                   }
+               },
+               {
+                  id: "SAME_PAGE_BUT_WITH_HASHES",
+                  name: "alfresco/menus/AlfMenuBarItem",
+                  config: {
+                     label: "Page relative no site with hash",
+                     publishTopic: "ALF_NAVIGATE_TO_PAGE",
+                     publishPayload: {
+                        url: "tp/ws/NavigationService#hash=test",
+                        type: "PAGE_RELATIVE",
+                        target: "CURRENT"
+                     },
+                     publishPayloadType: "PROCESS",
+                     publishPayloadModifiers: ["processCurrentItemTokens"],
+                     publishPayloadItemMixin: true,
+                     currentItem: {
+                        
+                     }
+                  }
                }
+
             ]
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1001 to ensure that the progress indicator is not shown on navigation when only the URL hash is being changed. A unit test has been added to verify the behaviour and prevent regressions.