### PR TITLE
AKU-997: Edit toggling topic support for InlineEditProperty

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -120,6 +120,22 @@ define(["dojo/_base/declare",
       editOnClickRenderedValue: true,
 
       /**
+       * An optional array of topics to be subscribed to that can trigger editing. The typical use case is when
+       * another widget (a [PublishAcing]{@link module:alfresco/renderers/PublishAction} for example) is provided
+       * that when clicked will toggle editing of the property. The current caveat is that the payload published
+       * must be the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} of this widget. This
+       * would be achieved by setting a 
+       * [publishPayloadType]{@link module:alfresco/renderers/_PublishPayloadMixin#publishPayloadType} of
+       * "CURRENT_ITEM" and for both widgets (the publisher and the subscriber) rendering the same item.
+       * 
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.72
+       */
+      editSubscriptionsTopics: null,
+
+      /**
        * References the widget used for editing. Created by calling the 
        * [getFormWidget]{@link module:alfresco/renderers/InlineEditProperty#getFormWidget}
        * for the first time.
@@ -287,6 +303,19 @@ define(["dojo/_base/declare",
                domClass.add(this.editIconNode, "disabled");
                this._disableEdit = true;
             }
+         }
+
+         // See AKU-997...
+         if (this.editSubscriptionsTopics)
+         {
+            array.forEach(this.editSubscriptionsTopics, lang.hitch(this, function(topic) {
+               this.alfSubscribe(topic, lang.hitch(this, function(payload) {
+                  if (payload === this.currentItem)
+                  {
+                     this.onEditClick();
+                  }
+               }));
+            }));
          }
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyTest.js
@@ -377,6 +377,21 @@ define(["module",
 
       "Check that faded style has been reapplied": function() {
          return this.remote.findByCssSelector("#INLINE_EDIT_NO_VALUE_WITH_WARNING_ITEM_0 > .alfresco-renderers-Property.faded");
+      },
+
+      "Edit via publish": function() {
+         return this.remote.findByCssSelector("#EDIT_ACTION_ITEM_0 .alfresco-renderers-PublishAction__image")
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.inlineEditProperties.first.editInput)
+            .then(null, function() {
+               assert(false, "No edit field found");
+            })
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Edit field not displayed");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditProperty.get.js
@@ -76,7 +76,8 @@ model.jsonModel = {
                                              is: ["New"]
                                           }
                                        ],
-                                       renderOnNewLine: true
+                                       renderOnNewLine: true,
+                                       editSubscriptionsTopics: ["EDIT_PROPERTY"]
                                     }
                                  },
                                  {
@@ -152,6 +153,21 @@ model.jsonModel = {
                                        renderedValueSuffix: ")",
                                        warnIfNotAvailable: true,
                                        warnIfNotAvailableMessage: "No property set"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/lists/views/layouts/Cell",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "EDIT_ACTION",
+                                    name: "alfresco/renderers/PublishAction",
+                                    config: {
+                                       publishTopic: "EDIT_PROPERTY",
+                                       publishPayloadType: "CURRENT_ITEM"
                                     }
                                  }
                               ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-997 to add support to the alfresco/renderers/InlineEditProperty for editSubscriptionTopics that will toggle edit mode. A unit test has been added to verify this behaviour and prevent future regressions.