### PR TITLE
AKU-983: Progress indicator off by default

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -92,7 +92,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.72
        */
-      showProgressIndictor: false,
+      showProgressIndicator: false,
 
       /**
        * Sets up the subscriptions for the NotificationService
@@ -111,7 +111,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe(this.displayPromptTopic, lang.hitch(this, this.onDisplayPrompt));
          this.alfSubscribe(topics.DISPLAY_STICKY_PANEL, lang.hitch(this, this.onDisplayStickyPanel));
 
-         if (this.showProgressIndictor)
+         if (this.showProgressIndicator)
          {
             this.alfSubscribe(topics.PROGRESS_INDICATOR_ADD_ACTIVITY, lang.hitch(this, this.onAddProgressActivity));
             this.alfSubscribe(topics.PROGRESS_INDICATOR_REMOVE_ACTIVITY, lang.hitch(this, this.onRemoveProgressActivity));

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -84,6 +84,17 @@ define(["dojo/_base/declare",
       displayPromptTopic: topics.DISPLAY_PROMPT,
 
       /**
+       * Controls whether or not the subscriptions are created for progress indicator requests so if this
+       * is configured to be false then the progress indicator will never be shown.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.72
+       */
+      showProgressIndictor: false,
+
+      /**
        * Sets up the subscriptions for the NotificationService
        *
        * @instance
@@ -99,9 +110,13 @@ define(["dojo/_base/declare",
          this.alfSubscribe(this.displayNotificationTopic, lang.hitch(this, this.onDisplayNotification));
          this.alfSubscribe(this.displayPromptTopic, lang.hitch(this, this.onDisplayPrompt));
          this.alfSubscribe(topics.DISPLAY_STICKY_PANEL, lang.hitch(this, this.onDisplayStickyPanel));
-         this.alfSubscribe(topics.PROGRESS_INDICATOR_ADD_ACTIVITY, lang.hitch(this, this.onAddProgressActivity));
-         this.alfSubscribe(topics.PROGRESS_INDICATOR_REMOVE_ACTIVITY, lang.hitch(this, this.onRemoveProgressActivity));
-         this.alfSubscribe(topics.PROGRESS_INDICATOR_REMOVE_ALL_ACTIVITIES, lang.hitch(this, this.onRemoveAllProgressActivities));
+
+         if (this.showProgressIndictor)
+         {
+            this.alfSubscribe(topics.PROGRESS_INDICATOR_ADD_ACTIVITY, lang.hitch(this, this.onAddProgressActivity));
+            this.alfSubscribe(topics.PROGRESS_INDICATOR_REMOVE_ACTIVITY, lang.hitch(this, this.onRemoveProgressActivity));
+            this.alfSubscribe(topics.PROGRESS_INDICATOR_REMOVE_ALL_ACTIVITIES, lang.hitch(this, this.onRemoveAllProgressActivities));
+         }
       },
 
       /**

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
@@ -34,7 +34,12 @@ model.jsonModel = {
             }
       },
       "alfresco/services/NavigationService",
-      "alfresco/services/NotificationService"
+      {
+         name: "alfresco/services/NotificationService",
+         config: {
+            showProgressIndicator: true
+         }
+      }
    ],
    widgets: [
       label,


### PR DESCRIPTION
This PR is a further update to https://issues.alfresco.com/jira/browse/AKU-983 to add configuration support for showing the progress indicator and the default has been updated to be false. Unit tests have been updated so verify the change.