### PR TITLE
AKU-983: Further update to remove opacity transition

### DIFF
--- a/aikau/src/main/resources/alfresco/notifications/css/ProgressIndicator.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/ProgressIndicator.css
@@ -5,7 +5,6 @@
    background: rgba(0,0,0,.1);
    bottom: 0;
    left: 0;
-   opacity: 0;
    position: fixed;
    right: 0;
    top: 0;
@@ -78,8 +77,6 @@
    &--displayed {
       overflow: hidden;
       .alfresco-notifications-ProgressIndicator {
-         opacity: 1;
-         transition: opacity .5s ease-out;
          &__content {
             top: 50%;
             transition: top .5s cubic-bezier(0,1,.5,1);

--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -147,22 +147,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Display the progress indicator (or at least request it, if NotificationService isn't on the page).
-       *
-       * @instance
-       * @returns {Object} A promise that will resolve once it's (probably) displayed.
-       * @since 1.0.71
-       */
-      displayProgressIndicator: function alfresco_services_NavigationService__displayProgressIndicator() {
-         var dfd = new Deferred();
-         this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY);
-         setTimeout(function() {
-            dfd.resolve();
-         }, 500); // This is to give the progress indicator time to appear
-         return dfd.promise;
-      },
-
-      /**
        * This is the default page navigation handler. It is called when the service receives a publication on
        * the [navigateToPageTopic]{@link module:alfresco/services/_NavigationServiceTopicMixin#navigateToPageTopic} topic. At the moment
        * it makes the assumption that the URL data will be relative to the Share page context.
@@ -202,9 +186,8 @@ define(["dojo/_base/declare",
                   }
                   else
                   {
-                     this.displayProgressIndicator().then(function(){
-                        window.location = url;
-                     });
+                     this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY);
+                     window.location = url;
                   }
                }
                else if (data.target === this.newTarget)
@@ -263,9 +246,8 @@ define(["dojo/_base/declare",
             domConstruct.place(form, document.body);
             if (!data.target || data.target === this.currentTarget)
             {
-               this.displayProgressIndicator().then(function(){
-                  form.submit();
-               });
+               this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY);
+               form.submit();
             }
             else
             {
@@ -284,9 +266,8 @@ define(["dojo/_base/declare",
        */
       reloadPage: function alfresco_services_NavigationService__reloadPage(data) {
          this.alfLog("log", "Page reload request received:", data);
-         this.displayProgressIndicator().then(function(){
-            window.location.reload(true);
-         });
+         this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY);
+         window.location.reload(true);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/ManageAspectsService.js
@@ -124,24 +124,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Get the aspects via XHR and then call the success/failure handlers.
-       *
-       * @instance
-       * @param {object} payload The payload of the initial request
-       * @since 1.0.71
-       */
-      getAspects: function alfresco_services_actions_ManageAspectsService__getAspects(payload) {
-         this.serviceXhr({
-            url: AlfConstants.PROXY_URI + "slingshot/doclib/aspects/node/" + payload.node.nodeRef.replace("://", "/"),
-            method: "GET",
-            item: payload,
-            successCallback: this.onAspectsSuccess,
-            failureCallback: this.onAspectsFailure,
-            callbackScope: this
-         });
-      },
-
-      /**
        * Sets up the service using the configuration provided. This will check to see what aspects are available,
        * addable and removable. If no addble or removable aspects are explicitly configured then it is assumed that
        * all available aspects are both addable and removable. Only aspects that are configured as being available
@@ -165,8 +147,14 @@ define(["dojo/_base/declare",
       onManageAspects: function alfresco_services_actions_ManageAspectsService__onManageAspects(payload) {
          if (payload && payload.node)
          {
-            this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY, {
-               displayCallback: this.getAspects.bind(this, payload)
+            this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY);
+            this.serviceXhr({
+               url: AlfConstants.PROXY_URI + "slingshot/doclib/aspects/node/" + payload.node.nodeRef.replace("://", "/"),
+               method: "GET",
+               item: payload,
+               successCallback: this.onAspectsSuccess,
+               failureCallback: this.onAspectsFailure,
+               callbackScope: this
             });
          }
          else

--- a/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/ManageAspectsTest.js
@@ -136,10 +136,7 @@ define(["module",
          .getLastPublish("ALF_DISPLAY_PROMPT")
             .then(function(payload) {
                assert.propertyVal(payload, "message", "It was not possible to retrieve the aspects applied to No Data Node", "The error prompt was not requested when failing to retrieve aspects");
-            })
-
-         .findByCssSelector("#NOTIFICATION_PROMPT .alfresco-buttons-AlfButton .dijitButtonNode")
-            .click();
+            });
       },
 
       "Test failure to save aspect changes": function() {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NotificationService.get.js
@@ -10,7 +10,12 @@ model.jsonModel = {
                }
             }
       },
-      "alfresco/services/NotificationService",
+      {
+         name: "alfresco/services/NotificationService",
+         config: {
+            showProgressIndicator: true
+         }
+      },
       "alfresco/services/DialogService",
       "alfresco/services/ErrorReporter"
    ],

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/ManageAspects.get.js
@@ -9,7 +9,6 @@ model.jsonModel = {
                }
             }
       },
-      "alfresco/services/NotificationService",
       "alfresco/services/DialogService",
       "alfresco/services/ActionService",
       {


### PR DESCRIPTION
This is a further update to AKU-983 and follows on from #1121 to ensure that the Manage Aspects action works when no NotificationService is present or when it is present but the progress indicator is disabled. This also removes the opacity and related transition to ensure that it always appears without the need for a timeout (which has been removed from the NavigationService).