### PR TITLE
AKU-983: Update generic "processing" indicator

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -924,10 +924,6 @@ define([],function() {
        * @since 1.0.71
        *
        * @event
-       * @property {Function} [displayCallback] This function will be called  once the indicator is on-screen. This can
-       *                                        be used to ensure that the indicator is fully displayed before any
-       *                                        intensive JS could cause the display transition to halt, potentially
-       *                                        preventing the indicator from displaying.
        */
       PROGRESS_INDICATOR_ADD_ACTIVITY: "ALF_PROGRESS_INDICATOR_ADD_ACTIVITY",
 

--- a/aikau/src/main/resources/alfresco/notifications/ProgressIndicator.js
+++ b/aikau/src/main/resources/alfresco/notifications/ProgressIndicator.js
@@ -98,25 +98,6 @@ define(["alfresco/core/Core",
       destroyDeferred: null,
 
       /**
-       * This function will be called once the indicator has been displayed.
-       *
-       * @instance
-       * @type {object}
-       * @default
-       */
-      displayCallback: null,
-
-      /**
-       * How many milliseconds it takes for the indicator to be displayed. This is a reference to the
-       * current CSS transition value for the indicator (i.e. try to keep it in sync with the CSS).
-       *
-       * @instance
-       * @type {number}
-       * @default
-       */
-      displayMs: 500,
-
-      /**
        * The notification ID (helps with customisation)
        *
        * @instance
@@ -167,6 +148,8 @@ define(["alfresco/core/Core",
       postCreate: function alfresco_notifications_ProgressIndicator__postCreate() {
          this.inherited(arguments);
          document.body.appendChild(this.domNode);
+         domClass.add(document.documentElement, this.baseClass + "--displayed");
+         domStyle.set(document.body, "margin-right", this._getScrollbarWidth() + "px");
          this.own(on(document.body, "keydown", this.onKeyPress.bind(this)));
       },
 
@@ -189,9 +172,11 @@ define(["alfresco/core/Core",
        * @returns {Object} A promise that will be resolved when this widget has been destroyed
        */
       hide: function alfresco_notifications_ProgressIndicator___hide() {
+         this.destroyDeferred = new Deferred();
          if (this.domNode && document.body.contains(this.domNode.parentNode)) {
             domStyle.set(document.body, "margin-right", "0");
             domClass.remove(document.documentElement, this.baseClass + "--displayed");
+            domClass.add(this.domNode, this.baseClass + "--hiding");
             setTimeout(function() {
                this.destroy();
             }.bind(this), this.destroyAfterHideMs);
@@ -227,21 +212,6 @@ define(["alfresco/core/Core",
             default:
                // Do not trap the keypress
          }
-      },
-
-      /**
-       * Show the progress indicator.
-       *
-       * @instance
-       * @override
-       */
-      show: function alfresco_notifications_ProgressIndicator__show() {
-         this.destroyDeferred = new Deferred();
-         domStyle.set(document.body, "margin-right", this._getScrollbarWidth() + "px");
-         setTimeout(function() {
-            domClass.add(document.documentElement, this.baseClass + "--displayed");
-            this.displayCallback && setTimeout(this.displayCallback, this.displayMs);
-         }.bind(this)); // Add to page before showing, else transition fails
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/notifications/css/ProgressIndicator.css
+++ b/aikau/src/main/resources/alfresco/notifications/css/ProgressIndicator.css
@@ -9,7 +9,6 @@
    right: 0;
    top: 0;
    transform: translateZ(0);
-   transition: opacity .3s ease-out;
    z-index: 9999; /* This isn't ideal, but searching all z-indexes is even worse (better solution possible?) */
    &__close-button {
       color: #eee;
@@ -32,9 +31,8 @@
       padding: 40px;
       position: absolute;
       text-align: center;
-      top: 55%;
+      top: 50%;
       transform: translate(-50%, -50%);
-      transition: top .3s cubic-bezier(.5,0,1,.75);
    }
    &__loader {
       animation: progress-loader 3s linear infinite;
@@ -76,9 +74,13 @@
    }
    &--displayed {
       overflow: hidden;
+   }
+   &--hiding {
+      opacity: 0;
+      transition: opacity .3s ease-out;
       .alfresco-notifications-ProgressIndicator {
          &__content {
-            top: 50%;
+            top: 60%;
             transition: top .5s cubic-bezier(0,1,.5,1);
          }
       }

--- a/aikau/src/main/resources/alfresco/services/NotificationService.js
+++ b/aikau/src/main/resources/alfresco/services/NotificationService.js
@@ -124,14 +124,10 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @since 1.0.71
-       * @param {Object} payload The publication payload
        */
-      onAddProgressActivity: function alfresco_services_NotificationService__onAddProgressActivity(payload) {
+      onAddProgressActivity: function alfresco_services_NotificationService__onAddProgressActivity() {
          if (numProgressActivities++ === 0) {
-            theProgressIndicator = new ProgressIndicator({
-               displayCallback: payload.displayCallback
-            });
-            theProgressIndicator.show();
+            theProgressIndicator = new ProgressIndicator();
          }
       },
 

--- a/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NotificationServiceTest.js
@@ -275,7 +275,7 @@ define(["module",
             .click()
             .end()
 
-         .findByCssSelector(".alfresco-notifications-ProgressIndicator--displayed");
+         .findByCssSelector(".alfresco-notifications-ProgressIndicator");
       },
 
       "Can cause progress indicator to disappear again": function() {


### PR DESCRIPTION
This PR is related to [AKU-983](https://issues.alfresco.com/jira/browse/AKU-983) and tidies up the code after the removal of display transition, and restores the hide transition. The Notification and Navigation tests have been run and a failure corrected.