### PR TITLE
AKU-1000: Add support to SetTitle for hiding and changing document prefix

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1476,6 +1476,11 @@ define([],function() {
        * @instance
        * @type {string}
        * @default
+       *
+       * @event
+       * @property {string}  [title] The new title for the browser window
+       * @property {string}  [browserTitlePrefix] The new prefix for the title of the browser window
+       * @property {boolean} [hideBrowserTitlePrefix] Indicates whether or not the title prefix should be hidden
        */
       UPDATE_PAGE_TITLE: "ALF_UPDATE_PAGE_TITLE",
 

--- a/aikau/src/main/resources/alfresco/header/SetTitle.js
+++ b/aikau/src/main/resources/alfresco/header/SetTitle.js
@@ -52,13 +52,41 @@ define(["dojo/_base/declare",
        * @default
        */
       title: "",
+
+      /**
+       * Indicates whether or not the browser title prefix as defined by
+       * [browserTitlePrefix]{@link module:alfresco/header/Title#browserTitlePrefix} should be hidden
+       * or not.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.73
+       */
+      hideBrowserTitlePrefix: false,
       
       /**
+       * A new prefix to replace the one defined by
+       * [browserTitlePrefix]{@link module:alfresco/header/Title#browserTitlePrefix}.
+       * 
        * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.73
+       */
+      browserTitlePrefix: null,
+
+      /**
+       * Publishes a request to update the title of the page.
+       * 
+       * @instance
+       * @fires module:alfresco/core/topics#UPDATE_PAGE_TITLE
        */
       postCreate: function alfresco_header_SetTitle__postCreate() {
          this.alfPublish(topics.UPDATE_PAGE_TITLE, {
-            title: this.message(this.title)
+            title: this.message(this.title),
+            hideBrowserTitlePrefix: this.hideBrowserTitlePrefix,
+            browserTitlePrefix: this.browserTitlePrefix
          });
       }
    });

--- a/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
+++ b/aikau/src/test/resources/alfresco/header/HeaderWidgetsTest.js
@@ -376,7 +376,21 @@ define(["module",
       "Test document title": function() {
          return this.remote.execute("return document.title;")
             .then(function(title) {
-               assert(title.indexOf("Unit Tests" === 0), "The document title was not updated");
+               assert.include(title, "Updated Title", "The document title was not updated");
+               assert.include(title, "New prefix", "The document title prefix was not updated");
+            });
+      }
+   });
+
+   defineSuite(module, {
+      name: "Set Title Tests (Hide Prefix)",
+      testPage: "/SetTitle?hidePrefix=true",
+
+      "Prefix is hidden": function() {
+         return this.remote.execute("return document.title;")
+            .then(function(title) {
+               assert.include(title, "Updated Title", "The document title was not updated");
+               assert.notInclude(title, "New prefix", "The document title prefix was not hidden");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SetTitle.get.js
@@ -1,3 +1,11 @@
+/* global page */
+/* jshint sub:true */
+var hidePrefix = false;
+if (page.url.args["hidePrefix"])
+{
+   hidePrefix = page.url.args["hidePrefix"] === "true";
+}
+
 model.jsonModel = {
    services: [
       {
@@ -28,7 +36,9 @@ model.jsonModel = {
       {
          name: "alfresco/header/SetTitle",
          config: {
-            title: "test.page.updated.title"
+            title: "test.page.updated.title",
+            hideBrowserTitlePrefix: hidePrefix,
+            browserTitlePrefix: "New prefix"
          }
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1000 / #1112 to update the alfresco/header/SetTitle widget to support the ability to both change and hide the document prefix. The unit tests have been updated to verify this change.