### PR TITLE
AKU-988: Update visibilityConfig to support scoping

### DIFF
--- a/aikau/src/main/resources/alfresco/core/Core.js
+++ b/aikau/src/main/resources/alfresco/core/Core.js
@@ -647,10 +647,11 @@ define(["dojo/_base/declare",
        * @param {function} [failure] The function to run if unsuccessful
        * @param {boolean} [global] Indicates that the pub/sub scope should not be applied
        * @param {boolean} [parentScope] Indicates that the pub/sub scope inherited from the parent should be applied
+       * @param {string} [customScope] A custom pub/sub scope that should be applied
        * @returns {object} A handle to the subscription
        * @since 1.0.44
        */
-      alfConditionalSubscribe: function alfresco_core_CoreWidgetProcessing__alfConditionalSubscribe(topic, rules, success, failure, global, parentScope) {
+      alfConditionalSubscribe: function alfresco_core_CoreWidgetProcessing__alfConditionalSubscribe(topic, rules, success, failure, global, parentScope, customScope) {
          return this.alfSubscribe(topic, lang.hitch(this, function(payload) {
             var rulesObj = lang.mixin({
                   testObject: payload
@@ -658,7 +659,7 @@ define(["dojo/_base/declare",
                successHandler = success && lang.partial(success, payload),
                failureHandler = failure && lang.partial(failure, payload);
             objUtils.evaluateRules(rulesObj, successHandler, failureHandler);
-         }), global, parentScope);
+         }), global, parentScope, customScope);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -378,7 +378,13 @@ define(["dojo/_base/declare",
                            },
                            successCallback = lang.hitch(this, this.onVisibilityProcessedSuccess, widget),
                            failureCallback = lang.hitch(this, this.onVisibilityProcessedFailure, widget);
-                        widget.alfConditionalSubscribe(topic, rulesObj, successCallback, failureCallback);
+                        widget.alfConditionalSubscribe(topic, 
+                                                       rulesObj, 
+                                                       successCallback, 
+                                                       failureCallback, 
+                                                       rule.subscribeGlobal, 
+                                                       rule.subscribeParent,
+                                                       rule.subscribeScope);
                      }
                   }, this);
                }

--- a/aikau/src/test/resources/alfresco/core/AdvancedVisibilityConfigTest.js
+++ b/aikau/src/test/resources/alfresco/core/AdvancedVisibilityConfigTest.js
@@ -57,8 +57,9 @@ define(["module",
       "Check LOGO1 is still displayed (non-strict)": function() {
          return this.remote.findByCssSelector("#TEST_NON_STRICT_1")
             .click()
-            .end()
-            .findByCssSelector("#LOGO1")
+         .end()
+         
+         .findByCssSelector("#LOGO1")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "LOGO1 was hidden");
@@ -68,8 +69,9 @@ define(["module",
       "Check LOGO2 is still displayed (Current Item Rule)": function() {
          return this.remote.findByCssSelector("#HIDE_LOGO_2")
             .click()
-            .end()
-            .findByCssSelector("#LOGO2")
+         .end()
+      
+         .findByCssSelector("#LOGO2")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "LOGO2 was hidden");
@@ -79,8 +81,9 @@ define(["module",
       "Check LOGO3 is now hidden (Invisibility Rule)": function() {
          return this.remote.findByCssSelector("#HIDE_LOGO_3")
             .click()
-            .end()
-            .findByCssSelector("#LOGO3")
+         .end()
+      
+         .findByCssSelector("#LOGO3")
             .isDisplayed()
             .then(function(result) {
                assert.isFalse(result, "LOGO3 was still displayed");
@@ -90,11 +93,68 @@ define(["module",
       "Check LOGO3 is now displayed (Invisibility Rule)": function() {
          return this.remote.findByCssSelector("#SHOW_LOGO_3")
             .click()
-            .end()
-            .findByCssSelector("#LOGO3")
+         .end()
+       
+         .findByCssSelector("#LOGO3")
             .isDisplayed()
             .then(function(result) {
                assert.isTrue(result, "LOGO3 was not displayed");
+            });
+      },
+
+      "All scoped Logos should be initially displayed": function() {
+         return this.remote.findDisplayedById("LOGO4")
+         .end()
+
+         .findDisplayedById("LOGO5")
+         .end()
+
+         .findDisplayedById("LOGO6")
+         .end();
+      },
+
+      "Global scoped hide should only hide global scope subscribed logo": function() {
+         return this.remote.findByCssSelector("#HIDE_LOGO_4_label")
+            .click()
+         .end()
+
+         .findDisplayedById("LOGO5")
+         .end()
+
+         .findDisplayedById("LOGO6")
+         .end()
+
+         .findById("LOGO4")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            });
+      },
+
+      "Parent scoped hide should only hide parent scope subscribed logo": function() {
+         return this.remote.findByCssSelector("#HIDE_LOGO_5_label")
+            .click()
+         .end()
+
+         .findDisplayedById("LOGO6")
+         .end()
+
+         .findById("LOGO5")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            });
+      },
+
+      "Custom scoped hide should only hide custom scope subscribed logo": function() {
+         return this.remote.findByCssSelector("#HIDE_LOGO_6_label")
+            .click()
+         .end()
+
+         .findById("LOGO6")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
             });
       }
    });

--- a/aikau/src/test/resources/alfresco/core/VisibilityConfigTest.js
+++ b/aikau/src/test/resources/alfresco/core/VisibilityConfigTest.js
@@ -50,8 +50,9 @@ define(["module",
          // Test 2: Check that LOGO1 can be hidden can then displayed by isNot rules
          return this.remote.findByCssSelector("#HIDE_LOGO_1")
             .click()
-            .end()
-            .findByCssSelector("#LOGO1")
+         .end()
+      
+         .findByCssSelector("#LOGO1")
             .getComputedStyle("display")
             .then(function(result) {
                assert.equal(result, "none", "LOGO1 was not hidden");
@@ -61,8 +62,9 @@ define(["module",
       "Check that LOGO1 gets revealed": function() {
          return this.remote.findByCssSelector("#SHOW_LOGO_1")
             .click()
-            .end()
-            .findByCssSelector("#LOGO1")
+         .end()
+         
+         .findByCssSelector("#LOGO1")
             .getComputedStyle("display")
             .then(function(result) {
                assert.equal(result, "block", "LOGO1 was not revealed");
@@ -73,8 +75,9 @@ define(["module",
          // Test 3: Check that LOGO2 can be displayed and then hidden by is rules
          return this.remote.findByCssSelector("#SHOW_LOGO_2_A")
             .click()
-            .end()
-            .findByCssSelector("#LOGO2")
+         .end()
+      
+         .findByCssSelector("#LOGO2")
             .getComputedStyle("display")
             .then(function(result) {
                assert.equal(result, "block", "LOGO2 was not revealed");
@@ -84,8 +87,9 @@ define(["module",
       "Check that LOGO2 gets hidden": function() {
          return this.remote.findByCssSelector("#HIDE_LOGO_2")
             .click()
-            .end()
-            .findByCssSelector("#LOGO2")
+         .end()
+      
+         .findByCssSelector("#LOGO2")
             .getComputedStyle("display")
             .then(function(result) {
                assert.equal(result, "none", "LOGO2 was not hidden");
@@ -95,8 +99,9 @@ define(["module",
       "Check that LOGO2 gets revealed again": function() {
          return this.remote.findByCssSelector("#SHOW_LOGO_2_B")
             .click()
-            .end()
-            .findByCssSelector("#LOGO2")
+         .end()
+      
+         .findByCssSelector("#LOGO2")
             .getComputedStyle("display")
             .then(function(result) {
                assert.equal(result, "block", "LOGO2 was not revaled again");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/AdvancedVisibilityConfig.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/AdvancedVisibilityConfig.get.js
@@ -127,11 +127,112 @@ model.jsonModel = {
             }
          }
       },
+      // TESTS FOR SCOPING...
       {
-         name: "alfresco/logging/SubscriptionLog"
+         id: "SCOPED_TEST_WIDGETS",
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            title: "Scoped Rules",
+            pubSubScope: "WINDOW_SCOPE_",
+            widgets: [
+               {
+                  id: "HIDE_LOGO_4",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Hide (Global Scope)",
+                     publishTopic: "SCOPED_HIDE",
+                     publishPayload: {
+                        value: "HIDE"
+                     },
+                     publishGlobal:true
+                  }
+               },
+               {
+                  id: "HIDE_LOGO_5",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Hide (Parent Scope)",
+                     publishTopic: "SCOPED_HIDE",
+                     publishPayload: {
+                        value: "HIDE"
+                     }
+                  }
+               },
+               {
+                  id: "HIDE_LOGO_6",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "Hide (Custom Scope)",
+                     pubSubScope: "CUSTOM_",
+                     publishTopic: "SCOPED_HIDE",
+                     publishPayload: {
+                        value: "HIDE"
+                     },
+                     publishParent:true
+                  }
+               },
+               {
+                  id: "LOGO4",
+                  name: "alfresco/logo/Logo",
+                  config: {
+                     pubSubScope: "SCOPE_",
+                     logoClasses: "surf-logo-large",
+                     invisibilityConfig: {
+                        initialValue: false,
+                        rules: [
+                           {
+                              topic: "SCOPED_HIDE",
+                              subscribeGlobal: true,
+                              attribute: "value",
+                              is: ["HIDE"]
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  id: "LOGO5",
+                  name: "alfresco/logo/Logo",
+                  config: {
+                     pubSubScope: "SCOPE_",
+                     logoClasses: "surf-logo-large",
+                     invisibilityConfig: {
+                        initialValue: false,
+                        rules: [
+                           {
+                              topic: "SCOPED_HIDE",
+                              subscribeParent: true,
+                              attribute: "value",
+                              is: ["HIDE"]
+                           }
+                        ]
+                     }
+                  }
+               },
+               {
+                  id: "LOGO6",
+                  name: "alfresco/logo/Logo",
+                  config: {
+                     pubSubScope: "SCOPE_",
+                     logoClasses: "surf-logo-large",
+                     invisibilityConfig: {
+                        initialValue: false,
+                        rules: [
+                           {
+                              topic: "SCOPED_HIDE",
+                              subscribeScope: "CUSTOM_",
+                              attribute: "value",
+                              is: ["HIDE"]
+                           }
+                        ]
+                     }
+                  }
+               }
+            ]
+         }
       },
       {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/VisibilityConfig.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/VisibilityConfig.get.js
@@ -138,10 +138,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-988 / #1097 to add additional scoping capabilities to visibilityConfig and invisibilityConfig. Unit tests have been updates to verify the change (only invisibilityConfig is tested but both go through the same code path)