### PR TITLE
AKU-996: Improve sorting menu widgets and update tutorial

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -107,6 +107,20 @@ define(["dojo/_base/declare",
       sortField: "cm:name",
 
       /**
+       * The initial label of the sort field. It is not necessary to set this if no other widgets require
+       * it. However, it will be updated on external sort requests if a "label" attribute is provided. The
+       * reason for setting it is so that other widgets (such as an 
+       * [AlfMenuBarSelect]{@link module:alfresco/menus/AlfMenuBarSelect}) used to control the sort field
+       * can be updated with the appropriate label.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.73
+       */
+      sortFieldLabel: "",
+
+      /**
        * Extends the [inherited function]{@link module:alfresco/lists/AlfList#showView} to set the sort data for
        * any [HeaderCell]{@link module:alfresco/lists/views/layouts/HeaderCell} widgets that might be included in the
        * view.
@@ -123,6 +137,7 @@ define(["dojo/_base/declare",
             this.alfPublish(topics.SORT_LIST, {
                direction: (this.sortAscending) ? "ascending" : "descending",
                value: this.sortField,
+               label: this.sortFieldLabel,
                requester: this
             });
          }
@@ -232,6 +247,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The details of the request
        */
       onSortRequest: function alfresco_lists_AlfSortablePaginatedList__onSortRequest(payload) {
+         /* jshint maxcomplexity:false */
          this.alfLog("log", "Sort requested: ", payload);
          if (payload && payload.requester !== this && (payload.direction !== null || payload.value !== null))
          {
@@ -242,6 +258,10 @@ define(["dojo/_base/declare",
             if (payload.value)
             {
                this.sortField = payload.value;
+            }
+            if (payload.label)
+            {
+               this.sortFieldLabel = payload.label;
             }
             if (this._readyToLoad === true)
             {

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
@@ -253,7 +253,8 @@ define(["dojo/_base/declare",
          this.alfPublish(topics.SORT_LIST, {
             direction: (this.sortedAscending) ? "ascending" : "descending",
             value: this.sortValue,
-            requester: this
+            requester: this,
+            label: this.label
          });
       },
 

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -927,7 +927,7 @@ function getDocLibSortOptions(options, sortingConfigItems) {
                label: msg.get(sortLabel),
                value: valueTokens[0],
                group: "DOCUMENT_LIBRARY_SORT_FIELD",
-               publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+               publishTopic: "ALF_DOCLIST_SORT",
                checked: options.docLibPreferences.sortField === valueTokens[0],
                publishPayload: {
                   label: msg.get(sortLabel),

--- a/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/InfiniteScrollDocumentListTest.js
@@ -44,6 +44,12 @@ define(["module",
             ascending: TestCommon.getTestSelector(headerCellSelectors, "ascending.indicator", ["TABLE_VIEW_NAME_HEADING"]),
             descending: TestCommon.getTestSelector(headerCellSelectors, "descending.indicator", ["TABLE_VIEW_NAME_HEADING"]),
             label: TestCommon.getTestSelector(headerCellSelectors, "label", ["TABLE_VIEW_NAME_HEADING"])
+         },
+         description: {
+            indicators: TestCommon.getTestSelector(headerCellSelectors, "indicator", ["TABLE_VIEW_DESCRIPTION_HEADING"]),
+            ascending: TestCommon.getTestSelector(headerCellSelectors, "ascending.indicator", ["TABLE_VIEW_DESCRIPTION_HEADING"]),
+            descending: TestCommon.getTestSelector(headerCellSelectors, "descending.indicator", ["TABLE_VIEW_DESCRIPTION_HEADING"]),
+            label: TestCommon.getTestSelector(headerCellSelectors, "label", ["TABLE_VIEW_DESCRIPTION_HEADING"])
          }
       },
       sortMenu: {
@@ -110,9 +116,9 @@ define(["module",
 
       "Sort via menu": function() {
          // Open the sort menu...
-         return this.remote.findByCssSelector(selectors.sortMenu.label)
+         return this.remote.findDisplayedByCssSelector(selectors.sortMenu.label)
             .click()
-            .end()
+         .end()
 
          .clearLog()
 
@@ -123,7 +129,7 @@ define(["module",
          // Click the fourth sort item...
          .findDisplayedByCssSelector(selectors.sortItems.fourth)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
@@ -175,10 +181,10 @@ define(["module",
          return this.remote.findByCssSelector(selectors.headerCells.name.label)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
-            .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
          .findAllByCssSelector(selectors.rows.all)
             .then(function(elements) {
@@ -194,7 +200,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.headerCells.name.label)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
             .then(function(payload) {
@@ -210,7 +216,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.headerCells.name.label)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
             .then(function(payload) {
@@ -220,6 +226,49 @@ define(["module",
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
          .findDisplayedByCssSelector(selectors.headerCells.name.ascending);
+      }
+   });
+
+   defineSuite(module, {
+      name: "AlfDocumentList Sorting Tests (no hash, no infinite scroll)",
+      testPage: "/InfiniteScrollDocumentList?useHash=false&includeSortMenu=true",
+
+      "Sort on description, check menu is updated": function() {
+         return this.remote.findDisplayedByCssSelector(selectors.sortMenu.label)
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Name");
+            })
+         .end()
+
+         .findByCssSelector(selectors.headerCells.description.label)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+         .findDisplayedByCssSelector(selectors.sortMenu.label)
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Description");
+            });
+      },
+
+      "Change sort order via header, check toggle is updated": function() {
+         return this.remote.findDisplayedByCssSelector("#SORT_TOGGLE img.alf-sort-ascending-icon")
+         .end()
+
+         .findByCssSelector(selectors.headerCells.description.label)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
+
+         .findDisplayedByCssSelector("#SORT_TOGGLE img.alf-sort-descending-icon");
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/InfiniteScrollDocumentList.get.js
@@ -44,6 +44,9 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/html/HR"
+      },
+      {
          id: "DOCUMENT_LIST",
          name: "alfresco/documentlibrary/AlfDocumentList",
          config: {
@@ -73,15 +76,19 @@ model.jsonModel = {
 
 if (includeSortMenu)
 {
-   model.jsonModel.widgets.splice(1, 0, {
+   model.jsonModel.widgets.splice(2, 0, {
       name: "alfresco/menus/AlfMenuBar",
       config: {
          widgets: [
             {
+               name: "alfresco/documentlibrary/AlfSelectDocumentListItems"
+            },
+            {
                id: "DOCLIB_SORT_FIELD_SELECT",
                name: "alfresco/menus/AlfMenuBarSelect",
                config: {
-                  selectionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+                  title: "Sort By",
+                  selectionTopic: "ALF_DOCLIST_SORT",
                   widgets: [
                      {
                         id: "DOCLIB_SORT_FIELD_SELECT_GROUP",
@@ -91,6 +98,34 @@ if (includeSortMenu)
                         }
                      }
                   ]
+               }
+            },
+            {
+               id: "SORT_TOGGLE",
+               name: "alfresco/menus/AlfMenuBarToggle",
+               config: {
+                  subscriptionTopic: "ALF_DOCLIST_SORT",
+                  subscriptionAttribute: "direction",
+                  checked: true,
+                  checkedValue: "ascending",
+                  onConfig: {
+                     title: "Change sort order to descending",
+                     iconClass: "alf-sort-ascending-icon",
+                     iconAltText: "Sorted ascending",
+                     publishTopic: "ALF_DOCLIST_SORT",
+                     publishPayload: {
+                        direction: "ascending"
+                     }
+                  },
+                  offConfig: {
+                     title: "Change sort order to ascending",
+                     iconClass: "alf-sort-descending-icon",
+                     iconAltText: "Sorted descending",
+                     publishTopic: "ALF_DOCLIST_SORT",
+                     publishPayload: {
+                        direction: "descending"
+                     }
+                  }
                }
             }
          ]

--- a/tutorial/chapters/Tutorial12.md
+++ b/tutorial/chapters/Tutorial12.md
@@ -37,7 +37,7 @@ We can now do something similar to provide an alternative approach to setting th
    name: "alfresco/menus/AlfMenuBarSelect",
    config: {
       title: "Sort By",
-      selectionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+      selectionTopic: "ALF_DOCLIST_SORT",
       widgets: [
          {
             name: "alfresco/menus/AlfMenuGroup",
@@ -50,7 +50,7 @@ We can now do something similar to provide an alternative approach to setting th
                         title: "Sort By Group Identifier",
                         value: "shortName",
                         group: "GROUP_SORT_FIELDS",
-                        publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
+                        publishTopic: "ALF_DOCLIST_SORT",
                         checked: true,
                         publishPayload: {
                            label: "Identifier",
@@ -108,6 +108,9 @@ Add the following to the page model before the `alfresco/menus/AlfMenuBarSelect`
 {
    name: "alfresco/menus/AlfMenuBarToggle",
    config: {
+      subscriptionTopic: "ALF_DOCLIST_SORT",
+      subscriptionAttribute: "direction",
+      checkedValue: "ascending",
       checked: true,
       onConfig: {
          title: "Change sort order to descending",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-996 / #1107 to improve how menus can handle sorting information. The updates are to the Document Library lib file as well as the HeaderCell and AlfSortablePaginatedList. Unit tests have been updated to verify the changes and the tutorial has been modified to get better results in the sample application that is built.