### PR TITLE
AKU-1007: Ensure that infinite scroll events are blocked when load in progress

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -20,7 +20,8 @@
 /**
  *
  * @module alfresco/lists/AlfFilteredList
- * @extends module:alfresco/core/ProcessWidgets
+ * @extends module:alfresco/lists/AlfSortablePaginatedList
+ * @mixes module:alfresco/core/ObjectProcessingMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1378,7 +1378,7 @@ define(["dojo/_base/declare",
        * @param {object} response The response object
        * @param {object} originalRequestConfig The configuration that was passed to the [serviceXhr]{@link module:alfresco/core/CoreXhr#serviceXhr} function
        */
-      onDataLoadFailure: function alfresco_lists_AlfList__onDataLoadSuccess(response, originalRequestConfig) {
+      onDataLoadFailure: function alfresco_lists_AlfList__onDataLoadFailure(response, originalRequestConfig) {
          this.alfLog("error", "Data Load Failed", response, originalRequestConfig);
          this.currentData = null;
          this.showDataLoadFailure();

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -470,7 +470,9 @@ define(["dojo/_base/declare",
          // NOTE: The use of the currentData.totalRecords and currentData.numberFound is only retained to support
          //       AlfSearchList and faceted search in Share - generic infinite scroll should be done via the
          //       totalRecords, startIndex and currentPageSize values...
-         if(this.useInfiniteScroll && 
+         // See AKU-1007 - we also want to prevent loading another page of data when a request is already in progress
+         if(!this.requestInProgress && 
+            this.useInfiniteScroll && 
             ((this.totalRecords > (this.startIndex + this.currentPageSize)) ||
             (this.currentData && (this.currentData.totalRecords < this.currentData.numberFound))))
          {

--- a/aikau/src/test/resources/alfresco/lists/InfiniteScrollTest.js
+++ b/aikau/src/test/resources/alfresco/lists/InfiniteScrollTest.js
@@ -25,13 +25,6 @@ define(["module",
         "intern/chai!assert"],
         function(module, defineSuite, assert) {
 
-   var countResults = function(browser, expected) {
-      browser.findAllByCssSelector(".alfresco-search-AlfSearchResult")
-         .then(function(elements) {
-            assert(elements.length === expected, "Counting Result, expected: " + expected + ", found: " + elements.length);
-         })
-         .end();
-   };
    var scrollToBottom = function(browser) {
       browser.execute("return window.scrollTo(0,Math.max(document.documentElement.scrollHeight,document.body.scrollHeight,document.documentElement.clientHeight))")
          .sleep(2000)
@@ -54,12 +47,32 @@ define(["module",
                scrollToBottom(this.remote);
                scrollToTop(this.remote);
                scrollToBottom(this.remote);
+               scrollToTop(this.remote);
+            })
+            
+            .findAllByCssSelector(".alfresco-renderers-Property")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 50);
+               });
+      },
+
+      "Simulate requests in progress, trigger infinite scroll": function() {
+         return this.remote.sleep(1000).findByCssSelector("#SIMULATE_REQUEST_IN_PROGRESS_label")
+            .click()
+         .end()
+
+         .then(() => {
+               scrollToBottom(this.remote);
+               scrollToTop(this.remote);
+               scrollToBottom(this.remote);
+               scrollToTop(this.remote);
             })
 
-         // Count Results. there should be 50. (Request 2)
-         .then(() => {
-            countResults(this.remote, 50);
-         });
+            .findAllByCssSelector(".alfresco-renderers-Property")
+               .then(function(elements) {
+                  assert.lengthOf(elements, 50);
+               });
+
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/InfiniteScroll.get.js
@@ -21,6 +21,42 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         id: "SIMULATE_REQUEST_IN_PROGRESS",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Simulate Request In Progress",
+            publishTopic: "BLOCK_REQUESTS",
+            publishPayload: {
+               value: true
+            }
+         }
+      },
+      {
+         id: "UNBLOCK_REQUESTS",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Stop Blocking",
+            publishTopic: "BLOCK_REQUESTS",
+            publishPayload: {
+               value: false
+            }
+         }
+      },
+      {
+         name: "alfresco/html/Label",
+         config: {
+            label: "Blocking requests: "
+         }
+      },
+      {
+         name: "alfresco/html/Label",
+         config: {
+            label: "false",
+            subscriptionTopic: "BLOCK_REQUESTS",
+            subscriptionPayloadProperty: "value"
+         }
+      },
+      {
          id: "DEFAULT_CONFIG",
          name: "alfresco/layout/ClassicWindow",
          config: {
@@ -28,7 +64,7 @@ model.jsonModel = {
             widgets: [
                {
                   id: "LIST",
-                  name: "alfresco/lists/AlfSortablePaginatedList",
+                  name: "aikauTesting/widgets/lists/BlockableSortablePaginatedList",
                   config: {
                      useHash: false,
                      useInfiniteScroll: true,

--- a/aikau/src/test/resources/testApp/js/aikau/testing/widgets/lists/BlockableSortablePaginatedList.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/widgets/lists/BlockableSortablePaginatedList.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This extends the regular paginating list to support the ability to simulate that a request is in progress.
+ * 
+ * @module aikauTesting/widgets/lists/BlockableSortablePaginatedList
+ * @extends module:alfresco/lists/AlfSortablePaginatedList
+ * @author Dave Draper
+ * @since 1.0.75
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/AlfSortablePaginatedList",
+        "dojo/_base/lang"], 
+        function(declare, AlfSortablePaginatedList, lang) {
+   
+   return declare([AlfSortablePaginatedList], {
+      
+      /**
+       * Called after properties mixed into instance
+       *
+       * @instance
+       */
+      postMixInProperties: function aikauTesting_widgets_lists_BlockableSortablePaginatedList__postMixInProperties() {
+         this.inherited(arguments);
+
+         // Set up a subscription to block requests...
+         this.alfSubscribe("BLOCK_REQUESTS", lang.hitch(this, function(payload) {
+            this.requestInProgress = payload.value;
+         }));
+      }
+   });
+});


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1007 / #1131 to ensure that infinite scrolling paginated lists to not request another page of data (caused by scrolling) when a request is already in place. Unit tests have been updated (and indeed fixed!) to verify this change.