### PR TITLE
AKU-1009: Sort controls

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/SortFieldSelect.js
+++ b/aikau/src/main/resources/alfresco/lists/SortFieldSelect.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A specialization of the [AlfMenuBarSelect]{@link module:alfresco/menus/AlfMenuBarSelect} that should
+ * be used for selecting the field on which an
+* [AlfSortablePaginatedList]{@link module:alfresco/lists/AlfSortablePaginatedList} should be sorted.
+ *
+ * @module alfresco/lists/SortFieldSelect
+ * @extends module:alfresco/menus/AlfMenuBarSelect
+ * @author Dave Draper
+ * @since 1.0.75
+ */
+define(["dojo/_base/declare",
+        "alfresco/menus/AlfMenuBarSelect",
+        "alfresco/core/topics",
+        "dojo/_base/array",
+        "dojo/_base/lang",
+        "alfresco/menus/AlfCheckableMenuItem"], 
+        function(declare, AlfMenuBarToggle, topics, array, lang) {
+
+   return declare([AlfMenuBarToggle], {
+      
+      /**
+       * @instance
+       * @typedef {object} SortFieldOption
+       * @property {string} label The label to render for the option
+       * @property {string} value The value of the option
+       * @property {boolean} selected Indicates whether or not the option should be initially selected
+       * @property {string} direction The direction to sort in when the option is used (either "ascending" or "descending").
+       */
+
+      /**
+       * An array of the sort options to be rendered.
+       * 
+       * @instance
+       * @type {SortFieldOption[]}
+       * @default
+       */
+      sortFieldOptions: null,
+
+      /**
+       * Overrides the default [selectionTopic]{@link module:alfresco/menus/AlfMenuBarSelect#selectionTopic} 
+       * attribute to be the expected sort topic.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      selectionTopic: topics.UPDATE_LIST_SORT_FIELD,
+      
+      /**
+       * 
+       * @instance
+       */
+      getSortFieldOptions: function alfresco_lists_SortFieldSelect__getSortFieldOptions() {
+         var sortFieldOptions = [];
+
+         array.forEach(this.sortFieldOptions, lang.hitch(this, function(option) {
+            if (option.label && option.value)
+            {
+               var label = this.message(option.label);
+               sortFieldOptions.push({
+                  name: "alfresco/menus/AlfCheckableMenuItem",
+                  config: {
+                     label: label,
+                     value: option.value,
+                     group: "ALF_SORT_FIELD_SELECTION_GROUP",
+                     publishTopic: topics.UPDATE_LIST_SORT_FIELD,
+                     checked: option.selected || false,
+                     publishPayload: {
+                        label: label,
+                        direction: option.direction || null
+                     }
+                  }
+               });
+
+               if (option.selected)
+               {
+                  this.label = option.label;
+               }
+            }
+         }));
+
+         return sortFieldOptions;
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/menus/AlfMenuBarSelect#postCreate}
+       * to call [getSortFieldOptions]{@link module:alfresco/lists/SortFieldSelect#getSortFieldOptions}
+       * to generate the [AlfCheckableMenuItems]{@link module:alfresco/menus/AlfCheckableMenuItem}
+       * to populate the menu with.
+       * 
+       * @instance
+       */
+      postMixInProperties: function alfresco_lists_SortFieldSelect__postMixInProperties() {
+         this.widgets = [
+            {
+               name: "alfresco/menus/AlfMenuGroup",
+               config: {
+                  widgets: this.getSortFieldOptions()
+               }
+            }
+         ];
+         this.inherited(arguments);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/lists/SortFieldSelect.js
+++ b/aikau/src/main/resources/alfresco/lists/SortFieldSelect.js
@@ -40,10 +40,11 @@ define(["dojo/_base/declare",
       /**
        * @instance
        * @typedef {object} SortFieldOption
+       * @property {id} [propName=null] An to give the menu item for the option
        * @property {string} label The label to render for the option
        * @property {string} value The value of the option
-       * @property {boolean} selected Indicates whether or not the option should be initially selected
-       * @property {string} direction The direction to sort in when the option is used (either "ascending" or "descending").
+       * @property {boolean} [selected=false] Indicates whether or not the option should be initially selected
+       * @property {string} [direction=null] The direction to sort in when the option is used (either "ascending" or "descending").
        */
 
       /**
@@ -77,6 +78,7 @@ define(["dojo/_base/declare",
             {
                var label = this.message(option.label);
                sortFieldOptions.push({
+                  id: option.id || null,
                   name: "alfresco/menus/AlfCheckableMenuItem",
                   config: {
                      label: label,

--- a/aikau/src/main/resources/alfresco/lists/SortOrderToggle.js
+++ b/aikau/src/main/resources/alfresco/lists/SortOrderToggle.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A specialization of the [AlfMenubarToggle]{@link module:alfresco/menus/AlfMenuBarToggle} that should
+ * be used for changing the sort order of an
+ * [AlfSortablePaginatedList]{@link module:alfresco/lists/AlfSortablePaginatedList}.
+ *
+ * @module alfresco/lists/SortOrderToggle
+ * @extends module:alfresco/menus/AlfMenuBarToggle
+ * @author Dave Draper
+ * @since 1.0.75
+ */
+define(["dojo/_base/declare",
+        "alfresco/menus/AlfMenuBarToggle",
+        "alfresco/core/topics"], 
+        function(declare, AlfMenuBarToggle, topics) {
+
+   return declare([AlfMenuBarToggle], {
+      
+      /**
+       * Overrides the default [checked]{@link module:alfresco/menus/AlfMenuBarToggle#checked} value to be
+       * true.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      checked: true,
+
+      /**
+       * Overrides the default [checkedValue]{@link module:alfresco/menus/AlfMenuBarToggle#checkedValue} attribute
+       * to be "ascending" to match the value in sort request payloads.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      checkedValue: "ascending",
+
+      /**
+       * Overrides the default [subscriptionAttribute]{@link module:alfresco/menus/AlfMenuBarToggle#subscriptionAttribute} 
+       * attribute to be "direction" to match the key in sort request payloads.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      subscriptionAttribute: "direction", 
+
+      /**
+       * Overrides the default [subscriptionTopic]{@link module:alfresco/menus/AlfMenuBarToggle#subscriptionTopic} 
+       * attribute to be the expected sort topic.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      subscriptionTopic: topics.SORT_LIST,
+      
+      /**
+       * Overrides and explicitly sets the [onConfig]{@link module:alfresco/menus/AlfMenuBarToggle#onConfig}
+       * for sorting.
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       */
+      onConfig: {
+         iconClass: "alf-sort-ascending-icon",
+         publishTopic: topics.SORT_LIST,
+         publishPayload: {
+            direction: "ascending"
+         }
+      },
+      
+      /**
+       * Overrides and explicitly sets the [offConfig]{@link module:alfresco/menus/AlfMenuBarToggle#offConfig}
+       * for sorting.
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       */
+      offConfig: {
+         iconClass: "alf-sort-descending-icon",
+         publishTopic: topics.SORT_LIST,
+         publishPayload: {
+            direction: "descending"
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/lists/SortControlsTest.js
+++ b/aikau/src/test/resources/alfresco/lists/SortControlsTest.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
+
+   defineSuite(module, {
+      name: "Sort Controlb Tests",
+      testPage: "/SortControls",
+
+      "Check initial sort parameters": function() {
+         return this.remote.getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sortField", "index");
+               assert.propertyVal(payload, "sortAscending", true);
+            });
+      },
+
+      "Toggle sort order": function() {
+         return this.remote.findDisplayedByCssSelector("#SORT_ORDER_TOGGLE img.alf-sort-ascending-icon")
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sortAscending", false);
+            });
+      },
+
+      "Change sort field": function() {
+         return this.remote.findDisplayedByCssSelector("#SORT_FIELD_SELECT_text")
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector("#SORT_BY_NAME_text")
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.propertyVal(payload, "sortField", "name");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -189,6 +189,7 @@ define(function() {
       "alfresco/lists/InfiniteScrollTest",
       "alfresco/lists/LocalStorageFallbackTest",
       "alfresco/lists/PaginatorVisibilityTest",
+      "alfresco/lists/SortControlsTest",
       "alfresco/lists/views/AddableViewTest",
       "alfresco/lists/views/AlfListViewTest",
       "alfresco/lists/views/ExpandableGalleryTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Sort Controls</shortname>
+  <description>Shows an AlfSortablePaginatedList along with the controls that can be used for selecting sort field and sort order.</description>
+  <family>aikau-unit-tests</family>
+  <url>/SortControls</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.js
@@ -1,0 +1,105 @@
+var view = {
+   name: "alfresco/lists/views/AlfListView",
+   config: {
+      widgets: [
+         {
+            name: "alfresco/lists/views/layouts/Row",
+            config: {
+               widgets: [
+                  {
+                     name: "alfresco/lists/views/layouts/Cell",
+                     config: {
+                        widgets: [
+                           {
+                              name: "alfresco/renderers/Property",
+                              config: {
+                                 propertyToRender: "index"
+                              }
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+      ]
+   }
+};
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/PaginationService",
+         config: {
+            loadDataSubscriptionTopic: "ALF_RETRIEVE_DOCUMENTS_REQUEST"
+         }
+      },
+      "alfresco/services/NavigationService"
+   ],
+   widgets: [
+      {
+         name: "alfresco/layout/HorizontalWidgets",
+         config: {
+            widgets: [
+               {
+                  name: "alfresco/layout/ClassicWindow",
+                  config: {
+                     title: "Custom page sizes",
+                     widgets: [
+                        {
+                           id: "PAGINATOR",
+                           name: "alfresco/lists/Paginator",
+                           config: {
+                              documentsPerPage: 10,
+                              pageSizes: [5,10,20],
+                              widgetsAfter: [
+                                 {
+                                    id: "SORT_FIELD_SELECT",
+                                    name: "alfresco/lists/SortFieldSelect",
+                                    config: {
+                                       sortFieldOptions: [
+                                          { label: "Display Name", value: "name" },
+                                          { label: "Index", value: "index", selected: true }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    id: "SORT_ORDER_TOGGLE",
+                                    name: "alfresco/lists/SortOrderToggle"
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           id: "LIST",
+                           name: "alfresco/lists/AlfSortablePaginatedList",
+                           config: {
+                              sortField: "index",
+                              sortFieldLabel: "Index",
+                              itemKeyProperty: "index",
+                              currentPageSize: 10,
+                              widgets: [view]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/SortControls.get.js
@@ -69,8 +69,8 @@ model.jsonModel = {
                                     name: "alfresco/lists/SortFieldSelect",
                                     config: {
                                        sortFieldOptions: [
-                                          { label: "Display Name", value: "name" },
-                                          { label: "Index", value: "index", selected: true }
+                                          { id: "SORT_BY_NAME", label: "Display Name", value: "name" },
+                                          { id: "SORT_BY_INDEX", label: "Index", value: "index", selected: true }
                                        ]
                                     }
                                  },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1009 to provide specializations of the AlfMenuBarSelect and AlfMenuBarToggle that are pre-configured to work with AlfSortablePaginatedLists (in much the same way that the Paginator is). This will make it much easier to add sorting controls to a list. Unit tests have been added to verify that they work as expected.