### PR TITLE
AKU-1010: Ensure that pending list requests are handled

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -26,6 +26,7 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
+        "alfresco/core/topics",
         "service/constants/Default",
         "webscripts/defaults",
         "dijit/registry",
@@ -38,7 +39,7 @@ define(["dojo/_base/declare",
         "dojo/json",
         "dojo/date/stamp",
         "dojo/cookie"],
-        function(declare, AlfConstants, webScriptDefaults, registry, pubSub, array, lang, domConstruct, uuid, xhr, JSON, stamp, dojoCookie) {
+        function(declare, topics, AlfConstants, webScriptDefaults, registry, pubSub, array, lang, domConstruct, uuid, xhr, JSON, stamp, dojoCookie) {
 
    return declare(null, {
 
@@ -67,11 +68,14 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {object} args The constructor arguments.
+       * @listens module:alfresco/core/topics#STOP_XHR_REQUEST
        */
       constructor: function(args){
          lang.mixin(this, args);
          this.csrfProperties = AlfConstants.CSRF_POLICY.properties || {};
          this.serviceRequests = {};
+
+         this.alfSubscribe(topics.STOP_XHR_REQUEST, lang.hitch(this, this.onStopRequest));
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1375,6 +1375,19 @@ define([],function() {
       STICKY_PANEL_SET_TITLE: "ALF_STICKY_PANEL_SET_TITLE",
 
       /**
+       * This topic can be used to stop an XHR request that is in progress.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.75
+       *
+       * @event
+       * @property {string} requestId The id of the request to be stopped
+       */
+      STOP_XHR_REQUEST: "ALF_STOP_XHR_REQUEST",
+
+      /**
        * This topic is published in order to make the actual request to sync a node or nodes
        * with the Cloud.
        * 

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -332,6 +332,7 @@ define(["dojo/_base/declare",
             url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/doclist/" + params;
          }
          var config = {
+            requestId: payload.requestId,
             alfTopic: alfTopic,
             url: url,
             method: "GET",

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -1188,11 +1188,18 @@ function getDocLibToolbar(options) {
  * This creates the breadcrumb trail for the document list
  */
 function getDocLibBreadcrumbTrail(options) {
+   
+   var hideBreadcrumbTrail = false;
+   if (options.docLibPreferences)
+   {
+      hideBreadcrumbTrail = options.docLibPreferences.hideBreadcrumbTrail;
+   }
+
    var breadcrumbTrail = {
       id: (options.idPrefix || "") + "DOCLIB_BREADCRUMB_TRAIL",
       name: "alfresco/documentlibrary/AlfBreadcrumbTrail",
       config: {
-         hide: options.docLibPreferences.hideBreadcrumbTrail,
+         hide: hideBreadcrumbTrail,
          rootLabel: options.rootLabel || "root.label",
          lastBreadcrumbIsCurrentNode: true,
          useHash: (options.useHash !== false),

--- a/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentListTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentListTest.js
@@ -1,0 +1,67 @@
+/*jshint browser:true*/
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
+
+   defineSuite(module, {
+      name: "AlfDocumentList (with AlfBreadcrumbTrail) Tests",
+      testPage: "/AlfDocumentList",
+
+      // See AKU-1010 for the background on these tests...
+      "Browse sub-folder": function() {
+         return this.remote.getLastPublish("ALF_DOCLIST_REQUEST_FINISHED").clearLog()
+
+         .findDisplayedByCssSelector("#SIMPLE_VIEW_NAME_ITEM_0")
+            .click()
+         .end()
+
+         .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED").clearLog()
+
+         // Need to wait for the loading message to be hidden to stop Firefox test failures!
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading");
+      },
+
+      "Browse to sub-folder and immediately select root breadcrumb": function() {
+         // Click the first item in the list...
+         return this.remote.findDisplayedByCssSelector("#SIMPLE_VIEW_NAME_ITEM_0")
+            .click()
+         .end()
+
+         // ...then click the root breadcrumb...
+         .findDisplayedByCssSelector(".alfresco-documentlibrary-AlfBreadcrumb:first-child .breadcrumb")
+            .click()
+         .end()
+
+         // We need to wait for the mock server delayed response (of which there should be two)...
+         .sleep(2000)
+
+         .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
+            .then(function(payload) {
+               assert.deepPropertyVal(payload, "filter.path", "/");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -86,6 +86,7 @@ define(function() {
 
       "alfresco/documentlibrary/AlfDocumentTest",
       "alfresco/documentlibrary/AlfDocumentFiltersTest",
+      "alfresco/documentlibrary/AlfDocumentListTest",
       "alfresco/documentlibrary/AlfGalleryViewSliderTest",
       "alfresco/documentlibrary/BreadcrumbTrailTest",
       "alfresco/documentlibrary/CreateContentTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Document List with Breadcrumb</shortname>
+  <description>This page was created for verifying the loading behaviour with multiple breadcrumb navigation clicks.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfDocumentList</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.js
@@ -1,0 +1,51 @@
+<import resource="classpath:alfresco/site-webscripts/org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib.js">
+
+var pageServices = [
+   {
+      name: "alfresco/services/LoggingService",
+      config: {
+         loggingPreferences: {
+            enabled: true,
+            all: true
+         }
+      }
+   }];
+
+var docLibServices = getDocumentLibraryServices();
+var services = pageServices.concat(docLibServices);
+
+
+var options = {
+   useHash: false, // For the purposes of this test, we need hashing off...
+   siteId: null, 
+   containerId: null, 
+   rootNode: "alfresco://company/home", 
+   rootLabel: "Documents",
+   getUserPreferences: false
+};
+var breadcrumbTrail = getDocLibBreadcrumbTrail(options);
+var documentList = getDocLibList(options);
+documentList.config.widgets = [
+   {
+   id: "SIMPLE_VIEW",
+   name: "alfresco/documentlibrary/views/AlfSimpleView"
+}];
+
+model.jsonModel = {
+   services: services,
+   widgets: [
+      breadcrumbTrail,
+      documentList,
+      {
+         name: "alfresco/testing/NodesMockXhr",
+         config: {
+            respondAfter: 2000, // In order to reproduce the test case the server needs to delay in responding
+            totalItems: 10,
+            folderRatio: [50,50]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.properties
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentList.get.properties
@@ -1,0 +1,1 @@
+surf.include.resources=org/alfresco/aikau/{aikauVersion}/libs/doclib/doclib.lib


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1010 to ensure that it is possible for AlfList to make an attempt to cancel an in-flight request (although this relies on the service supporting it) and for pending requests to be issued.

In particular this solves the issue of a breadcrumb trail being used when a document list is loading data. This is what the unit test has been set up to verify (using TDD I proved the unit test failed before fixing)