### PR TITLE
AKU-1010: Don't show failure message when request is pending

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1483,7 +1483,13 @@ define(["dojo/_base/declare",
       onDataLoadFailure: function alfresco_lists_AlfList__onDataLoadFailure(response, originalRequestConfig) {
          this.alfLog("error", "Data Load Failed", response, originalRequestConfig);
          this.currentData = null;
-         this.showDataLoadFailure();
+
+         // Only show a failure if there is not another request pending...
+         if (!this.pendingLoadRequest)
+         {
+            this.showDataLoadFailure();
+         }
+         
          this.alfPublish(this.documentLoadFailedTopic, {});
          this.alfPublish(this.requestFinishedTopic, {});
       },


### PR DESCRIPTION
This PR is an additional update on https://issues.alfresco.com/jira/browse/AKU-1010 ( #1137 ) which makes a small change so that the failure message is not displayed on a failed load when another request is pending. The unit test has not been updated because it is not possible to verify this in automated testing because the Sinon mock server does not support the ability to cancel in-flight requests.