### PR TITLE
AKU-1017: Prevent notifications being shown on download related actions

### DIFF
--- a/aikau/src/main/resources/alfresco/services/NavigationService.js
+++ b/aikau/src/main/resources/alfresco/services/NavigationService.js
@@ -184,6 +184,10 @@ define(["dojo/_base/declare",
                   {
                      window.location = url;
                   }
+                  else if (url.indexOf("?a=true") !== -1)
+                  {
+                     window.location = url;
+                  }
                   else
                   {
                      this.alfServicePublish(topics.PROGRESS_INDICATOR_ADD_ACTIVITY);

--- a/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/NavigationServiceTest.js
@@ -257,6 +257,18 @@ define(["module",
             .then(function(payloads) {
                assert.lengthOf(payloads, 0);
             });
+      },
+
+      "Action download links don't show progress": function() {
+         return this.remote.findDisplayedById("ACTION_LINK_FOR_DOWNLOAD_label")
+            .clearLog()
+            .click()
+         .end()
+
+         .getAllPublishes("ALF_PROGRESS_INDICATOR_ADD_ACTIVITY")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/NavigationService.get.js
@@ -150,6 +150,19 @@ model.jsonModel = {
          }
       },
       {
+         id: "ACTION_LINK_FOR_DOWNLOAD",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Simulate action download link",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "tp/ws/NavigationService?a=true",
+               type: "PAGE_RELATIVE",
+               target: "CURRENT"
+            }
+         }
+      },
+      {
          id: "MENU_BAR",
          name: "alfresco/menus/AlfMenuBar",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1017 to ensure that the progress notification isn't shown when using actions such as download or edit offline that use a special request parameter on the URL to trigger a download. A unit test has been added to verify the fix and prevent regressions.