### PR TITLE
AKU-1018: Specific Firefox handling of click in PublishAction

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -37,9 +37,10 @@ define(["dojo/_base/declare",
         "alfresco/enums/urlTypes", 
         "alfresco/util/urlUtils",
         "alfresco/core/Core",
-        "dojo/dom-class"], 
+        "dojo/dom-class",
+        "dojo/_base/event"], 
         function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, 
-                 template, urlTypes, urlUtils, AlfCore, domClass) {
+                 template, urlTypes, urlUtils, AlfCore, domClass, event) {
 
    return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, AlfCore], {
       
@@ -184,9 +185,10 @@ define(["dojo/_base/declare",
        * @param {object} evt The click event object
        */
       onClick: function alfresco_renderers_PublishAction__onClick(evt) {
+         evt && event.stop(evt);
+
          this.publishPayload = this.getGeneratedPayload();
          this.alfPublish(this.publishTopic, this.publishPayload, !!this.publishGlobal, !!this.publishToParent);
-         evt.stopPropagation();
       }
    });
 });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1018. I'm not sure why the original code was failing in Firefox (and only Firefox) but this does seem to fix the problem. 