### PR TITLE
AKU-1020: Focus items on list load

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -960,6 +960,9 @@ define([],function() {
        * @type {string}
        * @default
        * @since 1.0.34
+       *
+       * @event
+       * @property {string} [focusItemKey=null] An item to focus on if it is in the data that is reloaded
        */
       RELOAD_DATA_TOPIC: "ALF_DOCLIST_RELOAD_DATA",
 

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -235,6 +235,40 @@ define(["dojo/_base/declare",
       widgetsForNoDataDisplay: null,
 
       /**
+       * This can be called to focus on a specific item in the view. The itemKey provided must match
+       * the value of the [itemKey property]{@link module:alfresco/lists/views/AlfListView#itemKey}
+       * of an item in the rendered data.
+       * 
+       * @instance
+       * @param {string} itemKey The key of the item to focus on.
+       * @since 1.0.77
+       */
+      focusOnItem: function alfresco_lists_views_AlfListView__focusOnItem(itemKey) {
+         if (this.docListRenderer && this.docListRenderer._renderedItemWidgets)
+         {
+            array.some(this.docListRenderer._renderedItemWidgets, function(widgets) {
+               return array.some(widgets, function(widget) {
+                  var found = false;
+                  if (widget && 
+                      widget.currentItem && 
+                      (widget.currentItem[this.itemKey] || widget.currentItem[this.itemKey] === 0) &&
+                      widget.currentItem[this.itemKey].toString() === itemKey)
+                  {
+                     if (widget.domNode)
+                     {
+                        widget.domNode.click();
+                     }
+                     found = true;
+                  }
+                  return found;
+               }, this);
+            }, this);
+         }
+         
+
+      },
+
+      /**
        * Implements the widget life-cycle method to add drag-and-drop upload capabilities to the root DOM node.
        * This allows files to be dragged and dropped from the operating system directly into the browser
        * and uploaded to the location represented by the document list.

--- a/aikau/src/main/resources/alfresco/services/CrudService.js
+++ b/aikau/src/main/resources/alfresco/services/CrudService.js
@@ -91,7 +91,21 @@ define(["dojo/_base/declare",
          var noRefresh = lang.getObject("data.noRefresh", false, originalRequestConfig);
          if (noRefresh !== true)
          {
-           this.alfPublish("ALF_DOCLIST_RELOAD_DATA", null, false, false, originalRequestConfig.responseScope);
+            // See AKU-1020
+            // Check the original request for a "createdItemKey" attribute, this will be passed on in 
+            // the reload data request to give the list an opportunity to select the created item...
+            var payload = null;
+            if (originalRequestConfig.createdItemKey)
+            {
+               var itemKey = lang.getObject(originalRequestConfig.createdItemKey, false, response);
+               if (itemKey)
+               {
+                  payload = {
+                     focusItemKey: itemKey
+                  };
+               }
+            }
+            this.alfPublish("ALF_DOCLIST_RELOAD_DATA", payload, false, false, originalRequestConfig.responseScope);
          }
       },
 
@@ -142,7 +156,7 @@ define(["dojo/_base/declare",
        * @returns {object} The cloned payload
        */
       clonePayload: function alfresco_services_CrudService__clonePayload(payload) {
-         return this.alfCleanFrameworkAttributes(payload, false, ["url"]);
+         return this.alfCleanFrameworkAttributes(payload, false, ["url","createdItemKey"]);
       },
 
       /**
@@ -231,6 +245,7 @@ define(["dojo/_base/declare",
          var url = this.getUrlFromPayload(payload);
          this.serviceXhr({
             url: url,
+            createdItemKey: payload.createdItemKey,
             responseScope: payload.alfResponseScope,
             data: this.clonePayload(payload),
             method: "POST",

--- a/aikau/src/test/resources/alfresco/lists/ListItemFocusTest.js
+++ b/aikau/src/test/resources/alfresco/lists/ListItemFocusTest.js
@@ -1,0 +1,92 @@
+/*jshint browser:true*/
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * HashList test
+ *
+ * @author Dave Draper
+ * @author Martin Doyle
+ */
+define(["module",
+        "alfresco/TestCommon",
+        "intern/chai!assert",
+        "alfresco/defineSuite"],
+        function(module, TestCommon, assert, defineSuite) {
+
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+   var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
+   
+   var selectors = {
+      buttons: {
+         addItem: TestCommon.getTestSelector(buttonSelectors, "button.label", ["ADD_ITEM_BUTTON_ITEM_0"]),
+      },
+      dialogs: {
+         newItem: {
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["ADD_ITEM_DIALOG"]),
+            displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["ADD_ITEM_DIALOG"]),
+            hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["ADD_ITEM_DIALOG"])
+         }
+      },
+      textBoxes: {
+         newItemName: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["NEW_ITEM_NAME"]),
+         }
+      }
+   };
+
+   defineSuite(module, {
+      name: "List Item Focus Tests",
+      testPage: "/ListItemFocus",
+
+      "Create a new item and check that it is focused": function() {
+         // Click on the button in the appendix item to request a dialog for adding a new item...
+         return this.remote.getLastPublish("ALF_DOCLIST_REQUEST_FINISHED").clearLog()
+
+         .findDisplayedByCssSelector(selectors.buttons.addItem)
+            .click()
+         .end()
+
+         // When the dialog is displayed...
+         .findByCssSelector(selectors.dialogs.newItem.displayed)
+         .end()
+
+         // Find the text box and enter a name...
+         .findByCssSelector(selectors.textBoxes.newItemName.input)
+            .clearValue()
+            .type("test")
+         .end()
+
+         // Confirm the dialog...
+         .findByCssSelector(selectors.dialogs.newItem.confirmationButton)
+            .click()
+         .end()
+
+         // Check the reload request (following the create request) contains the item to focus on...
+         .getLastPublish("ALF_DOCLIST_RELOAD_DATA")
+            .then(function(payload) {
+               assert.property(payload, "focusItemKey", "No item to focus on was provided in the reload request");
+            })
+
+         // Check the expanded section is displayed...
+         .findDisplayedByCssSelector(".alfresco-lists-views-layouts-Grid__cell--focused");
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -188,6 +188,7 @@ define(function() {
       "alfresco/lists/FilteredListTest",
       "alfresco/lists/FilteredListUseCaseTest",
       "alfresco/lists/InfiniteScrollTest",
+      "alfresco/lists/ListItemFocusTest",
       "alfresco/lists/LocalStorageFallbackTest",
       "alfresco/lists/PaginatorVisibilityTest",
       "alfresco/lists/SortControlsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/ListItemFocus.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/ListItemFocus.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfList (item focus on load)</shortname>
+  <description>Demonstrates how an item can be focused on load</description>
+  <family>aikau-unit-tests</family>
+  <url>/ListItemFocus</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/ListItemFocus.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/ListItemFocus.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/ListItemFocus.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/ListItemFocus.get.js
@@ -1,0 +1,118 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/DialogService",
+      "alfresco/services/CrudService"
+   ],
+   widgets: [
+      {
+         id: "LIST",
+         name: "alfresco/lists/AlfList",
+         config: {
+            loadDataPublishTopic: "ALF_CRUD_GET_ALL",
+            loadDataPublishPayload: {
+               url: "resources"
+            },
+            widgets: [
+               {
+                  name: "alfresco/documentlibrary/views/AlfGalleryView",
+                  config: {
+                     enableHighlighting: true,
+                     itemKeyProperty: "nodeRef",
+                     expandTopics: ["EXPAND"],
+                     widgets: [
+                        {
+                           id: "CELL_CONTAINER",
+                           name: "alfresco/lists/views/layouts/CellContainer",
+                           config: {
+                              publishTopic: "EXPAND",
+                              publishPayload: {
+                                 widgets: [
+                                    {
+                                       name: "alfresco/layout/ClassicWindow",
+                                       config: {
+                                          title: "{name}"
+                                       }
+                                    }
+                                 ]
+                              },
+                              publishPayloadType: "PROCESS",
+                              publishPayloadModifiers: ["processCurrentItemTokens"],
+                              publishPayloadItemMixin: true,
+                              widgets: [
+                                 {
+                                    name: "alfresco/renderers/Property",
+                                    config: {
+                                       propertyToRender: "name"
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ],
+                     widgetsForAppendix: [
+                        {
+                           id: "CELL_CONTAINER",
+                           name: "alfresco/lists/views/layouts/CellContainer",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "ADD_ITEM_BUTTON",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Add Tag",
+                                       publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+                                       publishPayload: {
+                                          dialogId: "ADD_ITEM_DIALOG",
+                                          dialogTitle: "Add Tag",
+                                          formSubmissionTopic: "ALF_CRUD_CREATE",
+                                          formSubmissionPayloadMixin: {
+                                             url: "api/tag/workspace/SpacesStore",
+                                             createdItemKey: "nodeRef"
+                                          },
+                                          formSubmissionGlobal: true,
+                                          widgets: [
+                                             {
+                                                id: "NEW_ITEM_NAME",
+                                                name: "alfresco/forms/controls/TextBox",
+                                                config: {
+                                                   name: "name",
+                                                   label: "Name",
+                                                   value: "",
+                                                   placeHolder: "Name",
+                                                   requirementConfig: {
+                                                      initialValue: true
+                                                   }
+                                                }
+                                             }
+                                          ]
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/DataMockXhr"
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/DataMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/DataMockXhr.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/DataMockXhr
+ * @author Dave Draper
+ * @since 1.0.77
+ */
+define(["dojo/_base/declare",
+        "alfresco/testing/MockXhr",
+        "dojo/_base/lang"],
+        function(declare, MockXhr, lang) {
+
+      return declare([MockXhr], {
+
+         data: null,
+
+         /**
+          * This sets up the fake server with all the responses it should provide.
+          *
+          * @instance
+          */
+         setupServer: function alfresco_testing_mockservices_DataMockXhr__setupServer() {
+
+            if (!this.data)
+            {
+               this.data = [];
+            }
+
+            try {
+               this.server.respondWith("POST", /(.*)/, lang.hitch(this, this.onCreate));
+               this.server.respondWith("GET", /(.*)/, lang.hitch(this, this.onGet));
+               this.alfPublish("ALF_MOCK_XHR_SERVICE_READY", {});
+            } catch (e) {
+               this.alfLog("error", "The following error occurred setting up the mock server", e);
+            }
+         },
+
+         /**
+          * Returns the configured data.
+          * 
+          * @instance
+          * @param {object} request The request object
+          * @since 1.0.77
+          */
+         onGet: function alfresco_testing_mockservices_DataMockXhr__onGet(request) {
+            var response = {
+               items: this.data
+            };
+            request.respond(200, {
+               "Content-Type": "application/json;charset=UTF-8"
+            }, JSON.stringify(response));
+         },
+
+         /**
+          * Handles the creation of a new item and generates a new NodeRef for that item.
+          * 
+          * @instance
+          * @param {object} request The request object
+          * @since 1.0.77
+          */
+         onCreate: function alfresco_testing_mockservices_DataMockXhr__onCreate(request) {
+            var item = JSON.parse(request.requestBody);
+            var nodeRef = "workspace://SpacesStore/" + this.generateUuid();
+            item.nodeRef = nodeRef;
+            
+            this.data.push(item);
+
+            request.respond(200, {
+               "Content-Type": "application/json;charset=UTF-8"
+            }, JSON.stringify(item));
+         }
+      });
+   });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1020 to provide support for item focus in lists (to typically address the use case of selecting an item that has just been created). A unit test has been updated to verify the change.