### PR TITLE
AKU-1025: Reduce spacing of inline form buttons

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/css/Form.css
+++ b/aikau/src/main/resources/alfresco/forms/css/Form.css
@@ -10,6 +10,11 @@
    &--single-line {
       >div {
          display: inline-block;
+
+         >.alfresco-buttons-AlfButton {
+            margin-left: 0;
+            margin-right: @standard-column-spacing;
+         }
       }
       >form {
          display: inline-block;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1025 to reduce the spacing between the form buttons when they are displayed inline. As this is a purely cosmetic change no tests have been updated.