### PR TITLE
'enableContextLiveSearch' toggle added to ensure default is "off"

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -160,7 +160,7 @@ define(["dojo/_base/declare",
        */
       postCreate: function alfresco_header_LiveSearch__postCreate() {
          var site = this.searchBox.site;
-         if (!site) {
+         if (this.searchBox.enableContextLiveSearch === false || !site) {
             domStyle.set(this.contextNode, "display", "none"); 
          }
          
@@ -462,6 +462,16 @@ define(["dojo/_base/declare",
        * @default
        */
       documentsTitle: "search.documents",
+
+      /**
+       * Eanble the context switching feature of live search.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.78
+       */
+      enableContextLiveSearch: false,
 
       /**
        * An optional height that can be configured for the live search results. Without this being set 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
@@ -11,6 +11,7 @@ if (page.url.templateArgs.site)
       name: "alfresco/header/SearchBox",
       config: {
          site: page.url.templateArgs.site,
+         enableContextLiveSearch: true,
          alignment: "right",
          width: "500",
          documentLibraryPage: "custom-document-container",


### PR DESCRIPTION
'enableContextLiveSearch' toggle added to ensure default is "off" for context switching feature

Updated test page