### PR TITLE
AKU-1020: Reset _renderedItemWidgets for each call to processedWidgets

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
@@ -204,6 +204,8 @@ define(["dojo/_base/declare",
       renderData: function alfresco_lists_views_layout___MultiItemRendererMixin__renderData() {
          /*jshint eqnull:true*/
          
+         this._renderedItemWidgets = [];
+
          // Ensure that an array is created to hold the root widget subscriptions...
          if (!this.rootWidgetSubscriptions)
          {


### PR DESCRIPTION
This PR is a minor update for https://issues.alfresco.com/jira/browse/AKU-1020 to ensure that the _renderedItemsWidgets array is reset for each call to processedWidgets.