### PR TITLE
AKU-1037: Remove unnecessary opacity styling from Dashlet.css

### DIFF
--- a/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
+++ b/aikau/src/main/resources/alfresco/dashlets/css/Dashlet.css
@@ -82,7 +82,6 @@
    }
    &__title-bar-actions {
       height: 16px;
-      opacity: 0;
       position: absolute;
       right: 4px;
       top: 1px;

--- a/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
+++ b/aikau/src/test/resources/alfresco/dashlets/DashletTest.js
@@ -32,6 +32,11 @@ define(["module",
       name: "Dashlet Tests",
       testPage: "/Dashlet",
 
+      // See AKU-1037
+      "Title bar actions shown": function() {
+         return this.remote.findDisplayedById("TITLE_BAR_ACTION");
+      },
+
       "Toolbars and body display when widgets provided": function() {
          return this.remote.findByCssSelector("#NO_ID_DASHLET .alfresco-dashlets-Dashlet__toolbar")
             .isDisplayed()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/Dashlet.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/dashlets/Dashlet.get.js
@@ -66,6 +66,7 @@ model.jsonModel = {
                      bodyHeight: 500,
                      widgetsForTitleBarActions: [
                         {
+                           id: "TITLE_BAR_ACTION",
                            name: "alfresco/html/Label",
                            config: {
                               label: "Title-bar actions"


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1037 / #1151 to remove an unnecessary opacity style from the Dashlet CSS. The unit tests have been updated to verify this change.