### PR TITLE
SHA-1521 Ability to limit the Live search scope

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -147,7 +147,7 @@ define(["dojo/_base/declare",
          this.label.people = this.message(this.searchBox.peopleTitle);
          this.label.more = this.message(this.searchBox.moreTitle);
          this.label.contextRespository = this.message(this.searchBox.contextRepositoryLabel);
-         var site = this.searchBox.site;
+         var site = this.searchBox.siteName ? this.searchBox.siteName : this.searchBox.site;
          this.label.contextSite = this.message(this.searchBox.contextSiteLabel, site);
          this.label.repositoryTooltip = this.message(this.searchBox.repositoryTitle);
          this.label.siteTooltip = this.message(this.searchBox.siteTitle);
@@ -737,6 +737,16 @@ define(["dojo/_base/declare",
        * @default
        */
       sitePage: "dashboard",
+
+      /**
+       * The optional display name label for the current site.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.78
+       */
+      siteName: null,
 
       /**
        * The title to use on the site search toggle.
@@ -1501,6 +1511,14 @@ define(["dojo/_base/declare",
          {
             domStyle.set(this._LiveSearch.titleNodePeople, "display", "none");
             domStyle.set(this._LiveSearch.containerNodePeople, "display", "none");
+         }
+
+         // Site Search options are displyed if a site local context search was last performed - this is to ensure
+         // the user can select the 'Repository' option even if no results are present from the local site search
+         var terms = lang.trim(this._searchTextNode.value);
+         if (this.enableContextLiveSearch === true && this.siteContext === true && terms.length >= this._minimumSearchLength)
+         {
+            anyResults = true;
          }
 
          // Results pane

--- a/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
+++ b/aikau/src/test/resources/alfresco/header/SearchBoxTest.js
@@ -320,6 +320,37 @@ define(["module",
             .then(function(displayed) {
                assert.isTrue(displayed, "Site search context should be active.");
             })
+         .end()
+         
+         // ensure the site/repository options are still displayed  - even if no results returned for site local search
+         .findByCssSelector("#SB1 input.alfresco-header-SearchBox-text")
+            .type("pdf")
+         .end()
+         
+         .sleep(500) // Need a pause to wait for the data reload
+         
+         .findByCssSelector("#SB1 .alf-livesearch-context")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isTrue(displayed, "Site context options should be visible.");
+            })
+         .end();
+      },
+      
+      "Check the Site toggle display label": function() {
+         return this.remote.findByCssSelector("#SB1 input.alfresco-header-SearchBox-text")
+            .type("site")
+         .end()
+         
+         .sleep(500) // Need a pause to wait for the data reload
+         
+         .findByCssSelector("#SB1 .alf-livesearch-context .alf-livesearch-context__site")
+            .findAllByTagName("a")
+               .getVisibleText()
+               .then(function(text) {
+                  assert.equal(text, "Search 'SiteLabel'", "Site display label was not displayed");
+               })
+            .end()
          .end();
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/header/SearchBox.get.js
@@ -11,6 +11,7 @@ if (page.url.templateArgs.site)
       name: "alfresco/header/SearchBox",
       config: {
          site: page.url.templateArgs.site,
+         siteName: "SiteLabel",
          enableContextLiveSearch: true,
          alignment: "right",
          width: "500",


### PR DESCRIPTION
Changes as noted from QA testing:
  - Site display label used instead of ID when building Site search toggle label
  - Repository|Site context options made still visible to user if Site search produces no results - to ensure user can still select Repository for a wider search context.

Updated unit test page to test both changes.