### PR TITLE
Correct German short date based on DIN 5008 (allowed alt to ISO 8601)

### DIFF
--- a/aikau/src/main/resources/alfresco/core/i18n/TemporalUtils_de.properties
+++ b/aikau/src/main/resources/alfresco/core/i18n/TemporalUtils_de.properties
@@ -10,7 +10,7 @@ months.long=Januar,Februar,M\u00e4rz,April,Mai,Juni,Juli,August,September,Oktobe
 #Used client side (uses Alfresco.util.formatDate)
 date-format.default=ddd d mmm yyyy HH:MM:ss
 date-format.defaultDateOnly=ddd d mmm yyyy
-date-format.shortDate=d/m/yy
+date-format.shortDate=d.m.yy
 date-format.mediumDate=d mmm, yyyy
 date-format.mediumDateNoYear=d mmm
 date-format.longDate=dd mmmm, yyyy


### PR DESCRIPTION
For whatever reason Alfresco has been using an incorrect German locale short date format for ages in Share and this has been transported to Aikau as well. This PR corrects the format based on DIN 5008's revision of 2006 which re-allows the traditional (d)d.(m)m.(yy)yy format as an alternative to the officially recommended DIN ISO 8601 yyyy-mm-dd.
See https://en.wikipedia.org/wiki/Date_and_time_notation_in_Europe and https://en.wikipedia.org/wiki/Date_format_by_country for reference