### PR TITLE
Allow non-truthy values to be mapped in AlfDynamicPayloadButton

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfDynamicPayloadButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfDynamicPayloadButton.js
@@ -196,9 +196,9 @@ define(["dojo/_base/declare",
             if (dataMapping.hasOwnProperty(key))
             {
                // Check that the data actually exists...
-               var value = lang.getObject(key, false, data);
-               if (value)
+               if (lang.exists(key, data))
                {
+                  var value = lang.getObject(key, false, data);
                   // ...and then set it as requested
                   lang.setObject(dataMapping[key], value, this.publishPayload);
                }


### PR DESCRIPTION
During the Aikau-ification of the JavaScript Console addon I encountered an issue where the AlfDynamicPayloadButton would not assume the value I was explicitly providing in my payload. The cause of this was the non-truthy nature of the value (explicit null-value as reset of a previously mapped value).
This PR changes the check for data mapping to ensure the data is explcitly provided but in a way that no longer requires the mapped to be truthy. Other non-truthy variants also include very valid data (boolean false, numerical zero value, empty string) and would be supported after this fix.