### PR TITLE
Use site for loading of actions via Xhr and allow client specifying view

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/_XhrActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_XhrActionsMixin.js
@@ -46,6 +46,29 @@ define(["dojo/_base/declare",
        * @since 1.0.46
        */
       i18nRequirements: [{i18nFile: "./i18n/_XhrActionsMixin.properties"}],
+      
+      /**
+       * The lookup key into current item to retrieve the short name of the site in which the current item is
+       * located. This may be relevant to correctly obtain all item actions if evaluation of these actions is
+       * dependant on the site scope.
+       * 
+       * @instance
+       * @type {string}
+       * @default null
+       * @since 1.0.8x
+       */
+      currentItemSiteShortNameKey : null,
+      
+      /**
+       * The name of the view for which to load actions. Depending on the backend loading actions this may
+       * allow a differentiation between various scopes that actions have been associated with.
+       * 
+       * @instance
+       * @type {string}
+       * @default null
+       * @since 1.0.8x
+       */
+      actionView : null,
 
       /**
        * Overrides the [inherited function]{@link module:alfresco/renderers/_ActionsMixin#createDropDownMenu}
@@ -99,13 +122,28 @@ define(["dojo/_base/declare",
          var nodeRef = lang.getObject("nodeRef", false, this.currentItem);
          if (nodeRef)
          {
+            // depending on how item was loaded site can be coded in different ways
+            var site;
+            if (this.currentItemSiteShortNameKey)
+            {
+                site = lang.getObject(this.currentItemSiteShortNameKey, false, this.currentItem);
+            }
+            else
+            {
+                // default fallbacks for search and doclib data web scripts (JsNode vs. bare)
+                site = site || lang.getObject("site.shortName", false, this.currentItem);
+                site = site || lang.getObject("node.location.site.name", false, this.currentItem);
+                site = site || lang.getObject("location.site.name", false, this.currentItem);
+            }
             // Generate a UUID for the response to the publication to ensure that only this widget
             // handles to the XHR data...
             var responseTopic = this.generateUuid();
             this._xhrDataRequestHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onXhrData, callback), true);
             this.alfPublish(topics.GET_DOCUMENT, {
                alfResponseTopic: responseTopic,
-               nodeRef: nodeRef
+               nodeRef: nodeRef,
+               site : site,
+               view : this.actionView
             }, true);
          }
          else

--- a/aikau/src/main/resources/alfresco/renderers/_XhrActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_XhrActionsMixin.js
@@ -54,8 +54,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {string}
-       * @default null
-       * @since 1.0.8x
+       * @since 1.0.79
        */
       currentItemSiteShortNameKey : null,
       
@@ -65,8 +64,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @type {string}
-       * @default null
-       * @since 1.0.8x
+       * @since 1.0.79
        */
       actionView : null,
 

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -187,7 +187,7 @@ define(["dojo/_base/declare",
             // View mode and No-cache
             var params = "?view=";
             params += encodeURIComponent(payload.view || "browse");
-    		params += "&noCache=" + new Date().getTime() + "&includeThumbnails=true";
+            params += "&noCache=" + new Date().getTime() + "&includeThumbnails=true";
 
             var alfTopic = payload.alfResponseTopic || topics.GET_DOCUMENT;
             var url;

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -200,7 +200,7 @@ define(["dojo/_base/declare",
                url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/";
                if (payload.site)
                {
-                   url += 'site/' + encodeURIComponent(payload.site) + '/';
+                   url += "site/" + encodeURIComponent(payload.site) + "/";
                }
                url += "node/" + targetNodeUri + params;
             }
@@ -328,7 +328,7 @@ define(["dojo/_base/declare",
             url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/";
             if (payload.site)
             {
-                url += 'site/' + encodeURIComponent(payload.site) + '/';
+                url += "site/" + encodeURIComponent(payload.site) + "/";
             }
             url += "doclist/" + params;
          }

--- a/aikau/src/main/resources/alfresco/services/DocumentService.js
+++ b/aikau/src/main/resources/alfresco/services/DocumentService.js
@@ -184,21 +184,10 @@ define(["dojo/_base/declare",
             var nodeRef = NodeUtils.processNodeRef(payload.nodeRef),
             targetNodeUri = nodeRef.uri;
 
-            // Construct the URI for the request...
-            var uriPart = payload.site ? "{type}/site/{site}/{container}" : "{type}/node/" + targetNodeUri;
-            if (payload.filter && payload.filter.filterId === "path")
-            {
-               // If a path has been provided in the filter then it is necessary to perform some special
-               // encoding. We need to ensure that the data is URI encoded, but we want to preserve the
-               // forward slashes. We also need to "double encode" all % characters because FireFox has
-               // a nasty habit of decoding them *before* they've actually been posted back... this
-               // guarantees that the user will be able to bookmark valid URLs...
-               var encodedPath = encodeURIComponent(payload.filter.filterData).replace(/%2F/g, "/").replace(/%25/g,"%2525");
-               uriPart += this.combinePaths("/", encodedPath) + "/";
-            }
-
             // View mode and No-cache
-            var params = "?view=browse&noCache=" + new Date().getTime() + "&includeThumbnails=true";
+            var params = "?view=";
+            params += encodeURIComponent(payload.view || "browse");
+    		params += "&noCache=" + new Date().getTime() + "&includeThumbnails=true";
 
             var alfTopic = payload.alfResponseTopic || topics.GET_DOCUMENT;
             var url;
@@ -208,7 +197,12 @@ define(["dojo/_base/declare",
             }
             else
             {
-               url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/node/" + targetNodeUri + params;
+               url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/";
+               if (payload.site)
+               {
+                   url += 'site/' + encodeURIComponent(payload.site) + '/';
+               }
+               url += "node/" + targetNodeUri + params;
             }
             var config = {
                alfTopic: alfTopic,
@@ -318,7 +312,9 @@ define(["dojo/_base/declare",
          }
 
          // View mode and No-cache
-         params += "&view=browse&noCache=" + new Date().getTime();
+         params += "&view=";
+         params += encodeURIComponent(payload.view || "browse");
+         params += "&noCache=" + new Date().getTime();
 
          var alfTopic = payload.alfResponseTopic || topics.GET_DOCUMENT_LIST;
 
@@ -329,7 +325,12 @@ define(["dojo/_base/declare",
          }
          else
          {
-            url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/doclist/" + params;
+            url = AlfConstants.URL_SERVICECONTEXT + "components/documentlibrary/data/";
+            if (payload.site)
+            {
+                url += 'site/' + encodeURIComponent(payload.site) + '/';
+            }
+            url += "doclist/" + params;
          }
          var config = {
             requestId: payload.requestId,

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FullDocLibMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FullDocLibMockXhr.js
@@ -41,7 +41,7 @@ define(["dojo/_base/declare",
          try
          {
             this.server.respondWith("GET",
-                                    /\/aikau\/service\/components\/documentlibrary\/data\/doclist\/all\/site\/site1\/documentlibrary\?filter=path(.*)/,
+                                    /\/aikau\/service\/components\/documentlibrary\/data\/site\/site1\/doclist\/all\/site\/site1\/documentlibrary\?filter=path(.*)/,
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      documents]);
@@ -57,7 +57,7 @@ define(["dojo/_base/declare",
                                      tree]);
 
             this.server.respondWith("GET",
-                                    /\/aikau\/service\/components\/documentlibrary\/data\/doclist\/all\/site\/site1\/documentlibrary\?filter=favourites(.*)/,
+                                    /\/aikau\/service\/components\/documentlibrary\/data\/site\/site1\/doclist\/all\/site\/site1\/documentlibrary\?filter=favourites(.*)/,
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      favourites]);


### PR DESCRIPTION
When using the XhrActions module (as it is done in the faceted search page) some actions may not be listed as "available" if
- the  document / item is located within a site, and
- uses an evaluator based on "evaluator.doclib.action.groupMembership", and
- data is requested in a non-raw format
This is due to the fact that the code for handling XhrActions and retrieval of single document data is not handling the site of the document / item.

This PR addresses the issue above by adding site handling to the XhrActionsMixin and the DocumentService modules to ensure the call to the Share-tier data web script is passed the specific site of the document / item. Additionally, it allows a client module to request a specific view instead of the default "browse" (e.g. if actions are associated with a different action group than XY-browse, i.e. XY-details).