### PR TITLE
Correct PropertLink CSS typo

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/css/PropertyLink.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/PropertyLink.css
@@ -3,7 +3,7 @@
    text-decoration: @link-text-decoration;
    color: @link-font-color;
    &:hover {
-      colour: @link-font-color-hover;
+      color: @link-font-color-hover;
       text-decoration: @link-text-decoration-hover;
    }
 }


### PR DESCRIPTION
A PropertyLink instance won't use the defined hover color as there is a typo in the CSS. This PR corrects this typo.