### PR TITLE
Allow valid 0-value in renderUI of Progress widget 

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Progress.js
+++ b/aikau/src/main/resources/alfresco/renderers/Progress.js
@@ -344,7 +344,10 @@ define(["dojo/_base/declare",
          filesAdded = parseInt(filesAdded, 10);
          totalFiles = parseInt(totalFiles, 10);
 
-         if (!total || !done || !filesAdded || !totalFiles)
+         // 0 is a legal numeric value (e.g. initial "start" progress)
+         // can't use simple truthy vs non-truthy check
+         if (isNaN(total) || total < 0 || isNaN(done) || done < 0 ||
+                 isNaN(filesAdded) || filesAddded < 0 || isNaN(totalFiles) || totalFiles < 0)
          {
             this.alfLog("error", "Missing required data for progress: done=" + done + 
                ", total=" + total + 

--- a/aikau/src/main/resources/alfresco/renderers/Progress.js
+++ b/aikau/src/main/resources/alfresco/renderers/Progress.js
@@ -347,7 +347,7 @@ define(["dojo/_base/declare",
          // 0 is a legal numeric value (e.g. initial "start" progress)
          // can't use simple truthy vs non-truthy check
          if (isNaN(total) || total < 0 || isNaN(done) || done < 0 ||
-                 isNaN(filesAdded) || filesAddded < 0 || isNaN(totalFiles) || totalFiles < 0)
+                 isNaN(filesAdded) || filesAdded < 0 || isNaN(totalFiles) || totalFiles < 0)
          {
             this.alfLog("error", "Missing required data for progress: done=" + done + 
                ", total=" + total + 


### PR DESCRIPTION
Currently the Progress widget is only displaying/tracking any progress if at least one "item" (may not be used for file-based actions) has been "done". The simple truthy-check within a condition of renderUI eliminates 0 as a valid value despite it being perfectly valid for an initial progress update at the start of a long running operation.

This PR allows 0-values in renderUI by adapting the check to consider all non-negative integers as valid and explicitly checking for NaN.