### PR TITLE
Correct I18n/encoding handling of page title, esp. prefix

### DIFF
--- a/aikau/src/main/resources/alfresco/header/Title.js
+++ b/aikau/src/main/resources/alfresco/header/Title.js
@@ -132,22 +132,23 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_header_Title__postMixInProperties() {
+         if (this.browserTitlePrefix)
+         {
+            this.browserTitlePrefix = this.message(this.browserTitlePrefix);
+         }
+
          if (this.label)
          {
             var label = this.label ? this.label : "";
             if (this.setBrowserTitle === true)
             {
-               document.title = this.browserTitlePrefix + " \u00bb " + this.label; // Set the browser title
+               document.title = this.browserTitlePrefix + " \u00bb " + this.message(this.label); // Set the browser title
             }
          
             // Preserve a copy of the original label for resetting the title (in the case where 
             // only a new prefix or a request to hide the prefix is made)...
             this._originalLabel = this.label;
             this.label = this.encodeHTML(this.message(label));
-         }
-         if (this.browserTitlePrefix)
-         {
-            this.browserTitlePrefix = this.encodeHTML(this.message(this.browserTitlePrefix));
          }
       },
       


### PR DESCRIPTION
Recreation of #1170 



This PR addresses some issues when trying to use the alfresco/header/Title module for customizing the title of the page. For one, the prefix and label for the browser title were previously not looked up before actually being used during page initialisation. This resulted in a message key being included in the browser title bar unless the "updatePageTitle" pubSub was triggered. Additionally, the HTML encoding of the prefix during postMixInProperties was redundant and caused character sequences like "Ä" to appear in the browser title bar when a German umlaut or other non-ascii/ansi characters are contained in the localized message.