### PR TITLE
Locale generalization so JS_LOCALE of de_DE results in use of de

### DIFF
--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -226,14 +226,23 @@ define(["dojo/_base/declare",
          // Check that the language requested is supported...
          if (config.language) {
             var locales = this.supportedLocales.split(",");
-            var locale = "en";
+            var locale, bestGeneralizedLocale;
             for (var i = 0, j = locales.length; i < j; i++) {
                if (locales[i] === config.language) {
                   locale = config.language;
                   break;
                }
+               
+               if (config.language.indexOf(locales[i]) === 0)
+               {
+                   if (bestGeneralizedLocale === undefined || locales[i].length > bestGeneralizedLocale.length)
+                   {
+                       bestGeneralizedLocale = locales[i];
+                   }
+               }
             }
-            config.language = locale;
+            
+            config.language = locale || bestGeneralizedLocale || 'en';
          }
 
          tinymce.baseURL = AlfConstants.URL_RESCONTEXT + "js/lib/tinymce";

--- a/aikau/src/main/resources/alfresco/editors/TinyMCE.js
+++ b/aikau/src/main/resources/alfresco/editors/TinyMCE.js
@@ -242,7 +242,7 @@ define(["dojo/_base/declare",
                }
             }
             
-            config.language = locale || bestGeneralizedLocale || 'en';
+            config.language = locale || bestGeneralizedLocale || "en";
          }
 
          tinymce.baseURL = AlfConstants.URL_RESCONTEXT + "js/lib/tinymce";


### PR DESCRIPTION
Recreation of #1168 

The languages supported by TinyMCE editor are maintained as two-letter country codes while the JS_LOCALE will typically be the combination of country and language code, i.e. de_DE. The current locale matching in the TinyMCE editor does not detect / select an available, generalized locale and essentially always falls back to English.
This PR adds locale generalization checks during in the locale match code of the TinyMCE editor.