### PR TITLE
AKU-1043: Update to support TabbedControls in CollapsibleSection

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/TabbedControls.js
+++ b/aikau/src/main/resources/alfresco/forms/TabbedControls.js
@@ -82,8 +82,10 @@ define(["alfresco/layout/AlfTabContainer",
         "alfresco/forms/LayoutMixin",
         "dojo/_base/declare",
         "dojo/_base/lang",
-        "dojo/_base/array"], 
-        function(AlfTabContainer, LayoutMixin, declare, lang, array) {
+        "dojo/_base/array",
+        "dojo/Deferred",
+        "dojo/when"], 
+        function(AlfTabContainer, LayoutMixin, declare, lang, array, Deferred, when) {
    
    return declare([AlfTabContainer, LayoutMixin], {
       
@@ -106,13 +108,14 @@ define(["alfresco/layout/AlfTabContainer",
        * @return {object[]} An array of the form controls to iterate over.
        */
       getFormLayoutChildren: function alfresco_forms_TabbedControls__getFormLayoutChildren() {
-         var _tabbedFormControls = [];
-         if (this.tabContainerWidget)
-         {
-            array.forEach(this.tabContainerWidget.getChildren(), lang.hitch(this, function(contentPane) {
-               _tabbedFormControls = _tabbedFormControls.concat(contentPane.getChildren());
+         var _tabbedFormControls = new Deferred();
+         when(this.getTabContainerChildren(), lang.hitch(this, function(children) {
+            var promisedControls = [];
+            array.forEach(children, lang.hitch(this, function(child) {
+               promisedControls = promisedControls.concat(child.getChildren());
             }));
-         }
+            _tabbedFormControls.resolve(promisedControls);
+         }));
          return _tabbedFormControls;
       }
    });

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -177,13 +177,14 @@ define(["dojo/_base/declare",
         "alfresco/core/topics",
         "dijit/layout/TabContainer",
         "dijit/layout/ContentPane",
+        "dojo/Deferred",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/_base/lang",
         "dojo/_base/array",
         "jquery"], 
         function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, ResizeMixin, 
-                 topics, TabContainer, ContentPane, domConstruct, domClass, lang, array, $) {
+                 topics, TabContainer, ContentPane, Deferred, domConstruct, domClass, lang, array, $) {
    
    return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, ResizeMixin], {
       
@@ -296,6 +297,16 @@ define(["dojo/_base/declare",
       delayProcessingDefault: true,
 
       /**
+       * A promise of the children of the [tabContainerWidget]{@link module:alfresco/layout/AlfTabContainer#tabContainerWidget}
+       * that is resolved when it is created.
+       * 
+       * @instance
+       * @type {object}
+       * @since 1.0.79
+       */
+      _tabContainerChildrenPromise: null,
+
+      /**
        * Creates the "dijit/layout/TabContainer" wrapped by this widget and sets up associated
        * subscriptions, etc.
        * 
@@ -372,10 +383,14 @@ define(["dojo/_base/declare",
                {
                   this.alfSubscribe(this.tabDeletionTopic, lang.hitch(this, this.onTabDelete));
                }
-
                
                this.alfPublishResizeEvent(this.domNode);
                domClass.add(this.domNode, "alfresco-layout-AlfTabContainer--tabsDisplayed");
+
+               if (this._tabContainerChildrenPromise)
+               {
+                  this._tabContainerChildrenPromise.resolve(this.tabContainerWidget.getChildren());
+               }
             }
             catch(e)
             {
@@ -385,12 +400,26 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Returns a promise of the children of the 
+       * [tabContainerWidget]{@link module:alfresco/layout/AlfTabContainer#tabContainerWidget}
+       * that will be resolved when it is created.
+       * 
+       * @instance
+       * @return {promise} A promise of the children of the tab container
+       * @since 1.0.79
+       */
+      getTabContainerChildren: function alfresco_layout_AlfTabContainer__getTabContainerChildren() {
+         return this._tabContainerChildrenPromise;
+      },
+
+      /**
        * Calls [createTabContainer]{@link module:alfresco/layout/AlfTabContainer#createTabContainer}
        * to create the "dijit/layout/TabContainer" that is wrapped by this widget.
        * 
        * @instance
        */
       postCreate: function alfresco_layout_AlfTabContainer__postCreate() {
+         this._tabContainerChildrenPromise = new Deferred();
          this.createTabContainer();
          this.alfSetupResizeSubscriptions(this.onResize, this);
       },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.js
@@ -22,79 +22,131 @@ model.jsonModel = {
             value: {
                tb1: "data",
                tb2: "fail",
-               tb3: ""
+               tb3: "",
+               tb4: "one",
+               tb5: "two"
             },
             widgets: [
                {
-                  id: "TC1",
-                  name: "alfresco/forms/TabbedControls",
+                  name: "alfresco/forms/CollapsibleSection",
                   config: {
+                     label: "Stuff",
                      widgets: [
                         {
-                           name: "alfresco/forms/ControlColumn",
-                           title: "Tab 1",
+                           id: "TC1",
+                           name: "alfresco/forms/TabbedControls",
                            config: {
                               widgets: [
                                  {
-                                    id: "TB1",
-                                    name: "alfresco/forms/controls/TextBox",
+                                    name: "alfresco/forms/ControlColumn",
+                                    title: "Tab 1",
                                     config: {
-                                       fieldId: "TB1",
-                                       name: "tb1",
-                                       label: "First text box",
-                                       description: "Setting this field value to 'break' will make the text box in tab 3 required"
-                                    }
-                                 }
-                              ]
-                           }
-                        },
-                        {
-                           name: "alfresco/forms/ControlColumn",
-                           title: "Tab 2",
-                           config: {
-                              widgets: [
-                                 {
-                                    id: "TB2",
-                                    name: "alfresco/forms/controls/TextBox",
-                                    config: {
-                                       fieldId: "TB2",
-                                       name: "tb2",
-                                       label: "Second text box",
-                                       description: "This is a text box that should be displayed on tab 2",
-                                       validationConfig: [
+                                       widgets: [
                                           {
-                                             validation: "minLength",
-                                             length: 5,
-                                             errorMessage: "Too short"
+                                             id: "TB1",
+                                             name: "alfresco/forms/controls/TextBox",
+                                             config: {
+                                                fieldId: "TB1",
+                                                name: "tb1",
+                                                label: "First text box",
+                                                description: "Setting this field value to 'break' will make the text box in tab 3 required"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/ControlColumn",
+                                    title: "Tab 2",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "TB2",
+                                             name: "alfresco/forms/controls/TextBox",
+                                             config: {
+                                                fieldId: "TB2",
+                                                name: "tb2",
+                                                label: "Second text box",
+                                                description: "This is a text box that should be displayed on tab 2",
+                                                validationConfig: [
+                                                   {
+                                                      validation: "minLength",
+                                                      length: 5,
+                                                      errorMessage: "Too short"
+                                                   }
+                                                ]
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/ControlColumn",
+                                    title: "Tab 3",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "TB3",
+                                             name: "alfresco/forms/controls/TextBox",
+                                             config: {
+                                                fieldId: "TB3",
+                                                name: "tb3",
+                                                label: "Third text box",
+                                                description: "This will because required when the field on tab 1 is set to break",
+                                                requirementConfig: {
+                                                   initialValue: false,
+                                                   rules: [
+                                                      {
+                                                         targetId: "TB1",
+                                                         is: ["break"]
+                                                      }
+                                                   ]
+                                                }
+                                             }
                                           }
                                        ]
                                     }
                                  }
                               ]
                            }
-                        },
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "TC2",
+                  name: "alfresco/forms/TabbedControls",
+                  config: {
+                     widgets: [
                         {
                            name: "alfresco/forms/ControlColumn",
-                           title: "Tab 3",
+                           title: "Tab 4",
                            config: {
                               widgets: [
                                  {
-                                    id: "TB3",
+                                    id: "TB4",
                                     name: "alfresco/forms/controls/TextBox",
                                     config: {
-                                       fieldId: "TB3",
-                                       name: "tb3",
-                                       label: "Third text box",
-                                       description: "This will because required when the field on tab 1 is set to break",
-                                       requirementConfig: {
-                                          initialValue: false,
-                                          rules: [
-                                             {
-                                                targetId: "TB1",
-                                                is: ["break"]
-                                             }
-                                          ]
-                                       }
+                                       fieldId: "TB4",
+                                       name: "tb4",
+                                       label: "Text box"
+                                    }
+                                 }
+                              ]
+                           }
+                        },
+                        {
+                           name: "alfresco/forms/ControlColumn",
+                           title: "Tab 5",
+                           config: {
+                              widgets: [
+                                 {
+                                    id: "TB5",
+                                    name: "alfresco/forms/controls/TextBox",
+                                    config: {
+                                       fieldId: "TB5",
+                                       name: "tb5",
+                                       label: "Another text box"
                                     }
                                  }
                               ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1043 to ensure that an alfresco/forms/TabbedControls widget will work properly within an alfresco/forms/CollapsibleSection. The unit test has been updated to verify this change.