### PR TITLE
AKU-1041: Increase gap in control row for list filters

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -54,7 +54,7 @@
    }
    > .control-row > .control {
       display: inline-block;
-      margin-right: 5px;
+      margin-right: 10px;
    }
    > .title-row {
       display: block;


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1041 to make the gap between form controls in the ControlRow slightly bigger (as directed by XD). No unit test updates made for this minor cosmetic change.