### PR TITLE
AKU-1039: Tab borders

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -323,6 +323,7 @@
 @tab-color-active: #fff;
 @tab-border-radius: 2px 2px 0 0;
 @tab-opacity-disabled: .5;
+@tab-padding: 10px;
 
 // Breadcrumbs
 @breadcrumb-font-color: @general-font-color;

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -241,6 +241,17 @@ define(["dojo/_base/declare",
       doLayout: false,
 
       /**
+       * This can be configured to give all tabs some padding around their content. The amount of
+       * padding is controlled by the LESS variable "tab-padding"
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.79
+       */
+      padded: false,
+
+      /**
        * This array is used to store widgets for delayed processing
        * 
        * @type {array}
@@ -393,6 +404,10 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_layout_AlfTabContainer__postCreate() {
          this.createTabContainer();
          this.alfSetupResizeSubscriptions(this.onResize, this);
+         if (this.padded)
+         {
+            domClass.add(this.domNode, "alfresco-layout-AlfTabContainer--padded");
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/layout/css/AlfTabContainer.css
+++ b/aikau/src/main/resources/alfresco/layout/css/AlfTabContainer.css
@@ -1,31 +1,34 @@
 .alfresco-layout-AlfTabContainer {
    height: 100%;
    width: 100%;
-}
 
-.alfresco-layout-AlfTabContainer .dijitTabContainerTop-tabs .dijitTab {
-   padding: 0.2em 0.5em 0.4em;
-   margin: 0 0 0 0.16em;
-   border: @tab-border;
-   border-bottom-width: 0;
-   border-radius: @tab-border-radius;
-   background: @tab-background;
-   min-width: 22px;
-}
+   .dijitTabContainerTop-tabs {
+      .dijitTab {
+         margin: 0 0 0 0.16em;
+         border: @tab-border;
+         border-bottom-width: 0;
+         border-radius: @tab-border-radius;
+         background: @tab-background;
+         min-width: 22px;
+      }
 
-.alfresco-layout-AlfTabContainer .dijitTabContainerTop-tabs .dijitTab.dijitChecked {
-   background-color: @tab-color-active;
-}
+      .dijitTab.dijitChecked {
+         background-color: @tab-color-active;
+         padding-top: 3px;
+      }
 
-.alfresco-layout-AlfTabContainer .dijitTabContainerTop-tabs .dijitTab.dijitDisabled {
-   opacity: @tab-opacity-disabled;
-}
+      .dijitTab.dijitDisabled {
+         opacity: @tab-opacity-disabled;
+      }
+   }
 
-.alfresco-layout-AlfTabContainer .dijitTabPaneWrapper,
-.alfresco-layout-AlfTabContainer .dijitTabContainerTop-container {
-   border: none;
-}
+   .alfresco-layout-AlfTabContainer__OuterTab {
+      padding: 0;
+   }
 
-.alfresco-layout-AlfTabContainer .alfresco-layout-AlfTabContainer__OuterTab {
-  padding: 0;
+   &--padded {
+      .dijitTabContainerTopChildWrapper {
+         padding: @tab-padding;
+      }
+   }
 }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfTabContainer.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/layout/AlfTabContainer.get.js
@@ -24,6 +24,7 @@ model.jsonModel = {
                            id: "TC",
                            name: "alfresco/layout/AlfTabContainer",
                            config: {
+                              padded: true,
                               tabSelectionTopic: "TABCONTAINER_SELECT_TAB_TOPIC",
                               tabDisablementTopic: "TABCONTAINER_DISABLE_TAB_TOPIC",
                               tabAdditionTopic: "TABCONTAINER_ADD_TAB_TOPIC",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1039 to re-instate the default borders around the panes of an AlfTabContainer. An optional configuration attribute has been provided for simple padding of content.