### PR TITLE
Respect explicitly empty action arrays (i.e. lack of permissions)

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
@@ -41,9 +41,10 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "service/constants/Default",
         "alfresco/core/ArrayUtils",
-        "alfresco/core/JsNode"],
+        "alfresco/core/JsNode",
+        "alfresco/core/ObjectTypeUtils"],
         function(declare, AlfCore, CoreWidgetProcessing, _AlfDocumentListTopicMixin, _PublishPayloadMixin, ObjectProcessingMixin, 
-                 _AlfPopupCloseMixin, AlfMenuItem, array, lang, AlfConstants, AlfArray, JsNode) {
+                 _AlfPopupCloseMixin, AlfMenuItem, array, lang, AlfConstants, AlfArray, JsNode, ObjectTypeUtils) {
 
    return declare([AlfCore, CoreWidgetProcessing, _AlfDocumentListTopicMixin, _PublishPayloadMixin, ObjectProcessingMixin, _AlfPopupCloseMixin], {
 
@@ -192,19 +193,19 @@ define(["dojo/_base/declare",
          if (this.mergeActions === true)
          {
             // Add the actions on the currentItem and then add additional custom actions...
-            lang.isArray(this.currentItem.actions) && array.forEach(this.currentItem.actions, lang.hitch(this, this.addAction));
-            lang.isArray(this.customActions) && array.forEach(this.customActions, lang.hitch(this, this.addAction));
+            ObjectTypeUtils.isArray(this.currentItem.actions) && array.forEach(this.currentItem.actions, lang.hitch(this, this.addAction));
+            ObjectTypeUtils.isArray(this.customActions) && array.forEach(this.customActions, lang.hitch(this, this.addAction));
             this.processWidgetsForActions();
          }
-         else if (lang.isArray(this.customActions))
+         else if (ObjectTypeUtils.isArray(this.customActions))
          {
             array.forEach(this.customActions, lang.hitch(this, this.addAction));
          }
-         else if (lang.isArray(this.currentItem.actions))
+         else if (ObjectTypeUtils.isArray(this.currentItem.actions))
          {
             array.forEach(this.currentItem.actions, lang.hitch(this, this.addAction));
          }
-         else if (lang.isArray(this.widgetsForActions))
+         else if (ObjectTypeUtils.isArray(this.widgetsForActions))
          {
             // Provide default actions based on sensible defaults evaluated based on the 
             // current item to be actioned...

--- a/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ActionsMixin.js
@@ -192,19 +192,19 @@ define(["dojo/_base/declare",
          if (this.mergeActions === true)
          {
             // Add the actions on the currentItem and then add additional custom actions...
-            this.currentItem.actions && array.forEach(this.currentItem.actions, lang.hitch(this, this.addAction));
-            this.customActions && array.forEach(this.customActions, lang.hitch(this, this.addAction));
+            lang.isArray(this.currentItem.actions) && array.forEach(this.currentItem.actions, lang.hitch(this, this.addAction));
+            lang.isArray(this.customActions) && array.forEach(this.customActions, lang.hitch(this, this.addAction));
             this.processWidgetsForActions();
          }
-         else if (this.customActions && this.customActions.length > 0)
+         else if (lang.isArray(this.customActions))
          {
             array.forEach(this.customActions, lang.hitch(this, this.addAction));
          }
-         else if (this.currentItem.actions && this.currentItem.actions.length > 0)
+         else if (lang.isArray(this.currentItem.actions))
          {
             array.forEach(this.currentItem.actions, lang.hitch(this, this.addAction));
          }
-         else if (this.widgetsForActions)
+         else if (lang.isArray(this.widgetsForActions))
          {
             // Provide default actions based on sensible defaults evaluated based on the 
             // current item to be actioned...


### PR DESCRIPTION
Recreation of #1174 



Any array of item-level actions, either explicitly define or loaded from a backend, must be respected by the alfresco/renderer/Actions module (or any of its derivatives). An empty array of item-level actions loaded from the Share data web script may be the result of a lack of permissions by the current user or simply an action set configured as empty by a developer / administrator in the Share configuration.

Currently, the ActionsMixin will fallback on the default "widgetsForActions" when

-mergeActions is set to false, and
-customActions is either not defined or an empty array, and
-currentItem.actions is either not defined or an empty array

The point of either configuring an explicit empty array for customActions or configuring Share actions in a way that may result in an emty item-level action list is to ensure the user can't perform any action on the item if pre-conditions are not met. Ignoring this valid and explicit state and falling back to a (default) widgetsForActions config is not appropriate.

This PR changes the behaviour to always respect the presence of an actions array even if it may have a length of zero.