### PR TITLE
AKU-1040: Update to support fixed widths on Select

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/Select.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Select.js
@@ -79,12 +79,29 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @param {Object} option The option object
        * @returns {Object} An appropriate menu item
        */
-      _getMenuItemForOption: function(option) {
+      _getMenuItemForOption: function alfresco_forms_controls_Select_CustomSelect___getMenuItemForOption(option) {
          var menuItem = this.inherited(arguments);
          if (this.truncate && this.forceWidth && option.label) {
             menuItem.domNode.title = option.label;
          }
          return menuItem;
+      },
+
+      /**
+       * Overridden to ensure that width is set if required.
+       *
+       * @instance
+       * @override
+       * @param {Object} option The option object
+       * @returns {Object} An appropriate menu item
+       * @since 1.0.79
+       */
+      _setDisplay: function alfresco_forms_controls_Select_CustomSelect___setDisplay(/*jshint unused:false*/ newDisplay) {
+         this.inherited(arguments);
+         if (this.width)
+         {
+            domStyle.set(this.containerNode.firstChild, "width", this.width);
+         }
       }
    });
    
@@ -98,6 +115,41 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @default [{cssFile:"./css/Select.css"}]
        */
       cssRequirements: [{cssFile:"./css/Select.css"}],
+
+      /**
+       * Indicates whether or not the width of the options drop-down should be constained to the
+       * width of the form control. If the [width]{@link module:alfresco/forms/controls/Select#width}
+       * is not set then this change to the width of the last displayed value.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.37
+       */
+      forceWidth: false,
+
+      /**
+       * Indicates whether or not the options displayed should be truncated. This can be used with
+       * [forceWidth]{@link module:alfresco/forms/controls/Select#forceWidth} to display an
+       * ellipsis on options that are longer than the available width (rather than being displayed
+       * over multiple lines).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.37
+       */
+      truncate: false,
+
+      /**
+       * An optional width to set the value of the form control.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.79
+       */
+      width: null,
 
       /**
        * Adds a new option to the wrapped widget.
@@ -125,7 +177,8 @@ define(["alfresco/forms/controls/BaseFormControl",
             id : this.id + "_CONTROL",
             name: this.name,
             forceWidth: this.forceWidth,
-            truncate: this.truncate
+            truncate: this.truncate,
+            width: this.width
          };
       },
       

--- a/aikau/src/main/resources/alfresco/forms/controls/css/Select.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/Select.css
@@ -1,6 +1,13 @@
 .alfresco-forms-controls-BaseFormControl {
    > .control-row {
       > .control {
+
+         .dijitSelectLabel {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            text-align: left;
+         }
+
          > table {
             background-color: @primary-background-color;
             border-radius: 3px;

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -309,6 +309,14 @@ define(["module",
                assert.isBelow(forcedWidth, normalWidth);
             })
             .pressKeys(keys.ESCAPE);
+      },
+
+      "Width configuration is honoured": function() {
+         return this.remote.findByCssSelector("#LONG_OPTIONS_FORCEWIDTH_CONTROL .dijitSelectLabel")
+            .getSize()
+            .then(function(size) {
+               assert.equal(size.width, "200");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Select.get.js
@@ -291,11 +291,12 @@ model.jsonModel = {
                            config: {
                               name: "longOptionsForceWidth",
                               forceWidth: true,
+                              width: "200px",
                               label: "Long options (forceWidth)",
                               description: "This select field is has some long options values in it and has been set to constrain its with",
                               optionsConfig: {
                                  fixed: [{
-                                    label: "Krill sardonically clung outside and",
+                                    label: "Krill sardonically clung outside and (quick bit of extra text)",
                                     value: "1"
                                  }, {
                                     label: "Forgot folded owing gosh matter-of-factly so hello less bleak gosh contrary precise",
@@ -321,6 +322,7 @@ model.jsonModel = {
                            id: "LONG_OPTIONS_FORCEWIDTH_TRUNCATE",
                            config: {
                               name: "longOptionsForceWidthTruncate",
+                              width: "200px",
                               forceWidth: true,
                               truncate: true,
                               label: "Long options (forceWidth,truncate)",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1040 to add a new `width` configuration option to `alfresco/forms/controls/Select`. This enables the width of the select value to be fixed regardless of the length of the option. A unit test has been added to verify this change.