### PR TITLE
AKU-945: Break words on form control labels in dialogs

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -151,6 +151,9 @@
                   margin-top: 2px;
                   text-align: right;
                   width: @dialog-label-section - 4;
+                  > .label {
+                     word-break: break-word
+                  }
                   > label:after {
                      content: ":";
                   }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/DialogService.get.js
@@ -62,7 +62,7 @@ model.jsonModel = {
                      name: "alfresco/forms/controls/TextBox",
                      config: {
                         name: "text",
-                        label: "Enter some text",
+                        label: "Classificatieopheffingsgebeurtenis",
                         value: "This is some sample text"
                      }
                   }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-945 to force a word break on long unbroken words used for form control labels in dialogs. I initially considered using an ellipsis and adding a title attribute, but as this is something of an edge case it makes more sense to just break the word.