### PR TITLE
AKU-1050: Update PreferenceService data retrieval

### DIFF
--- a/aikau/src/main/resources/alfresco/services/PreferenceService.js
+++ b/aikau/src/main/resources/alfresco/services/PreferenceService.js
@@ -268,7 +268,7 @@ define(["dojo/_base/declare",
       update: function alfresco_services_PreferenceService__update(payload, add) {
          if (payload.name && payload.value)
          {
-            var url = AlfConstants.PROXY_URI + "api/people/" + encodeURIComponent(AlfConstants.USERNAME) + "/preferences" + (name ? "?pf=" + name : "");
+            var url = AlfConstants.PROXY_URI + "api/people/" + encodeURIComponent(AlfConstants.USERNAME) + "/preferences" + (payload.name ? "?pf=" + payload.name : "");
             this.serviceXhr({
                url: url,
                method: "GET",

--- a/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/SocialRenderersTest.js
@@ -78,12 +78,11 @@ define(["module",
 
       "Like the document": function() {
          return this.remote.findByCssSelector("#LIKES_ITEM_0")
+            .clearLog()
             .click()
-            .end()
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_ADD", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Add rating request not published");
-            });
+         .end()
+
+         .getLastPublish("ALF_RATING_ADD");
       },
 
       "Check ON image is toggled": function() {
@@ -112,12 +111,11 @@ define(["module",
 
       "Unlike the document": function() {
          return this.remote.findByCssSelector("#LIKES_ITEM_0")
+            .clearLog()
             .click()
-            .end()
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_RATING_REMOVE", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Remove rating request not published");
-            });
+         .end()
+         
+         .getLastPublish("ALF_RATING_REMOVE");
       },
 
       "Check ON image is toggled (on unlike)": function() {
@@ -184,11 +182,13 @@ define(["module",
       "Favourite a document": function() {
          return this.remote.findByCssSelector("#FAVOURITES_ITEM_0")
             .click()
-            .end()
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Add favourite request not published");
-            });
+         .end()
+
+         .getLastPublish("ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE");
+      },
+
+      "Check retrieval URL": function() {
+         return this.remote.getLastXhr("aikau/proxy/alfresco/api/people/guest/preferences?pf=org.alfresco.share.documents.favourites");
       },
 
       "Check ON image toggled (add favourite)": function() {
@@ -210,11 +210,9 @@ define(["module",
       "Remove favourite": function() {
          return this.remote.findByCssSelector("#FAVOURITES_ITEM_0")
             .click()
-            .end()
-            .findAllByCssSelector(TestCommon.topicSelector("ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE", "publish", "any"))
-            .then(function(elements) {
-               assert.lengthOf(elements, 1, "Remove favourite request not published");
-            });
+         .end()
+
+         .getLastPublish("ALF_PREFERENCE_REMOVE_DOCUMENT_FAVOURITE");
       },
 
       "Check ON image toggled (remove favourite)": function() {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,7 +31,7 @@ define(function() {
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/renderers/SocialRenderersTest"
+      "alfresco/upload/UploadMonitorTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",
@@ -292,7 +292,6 @@ define(function() {
       "alfresco/services/NavigationServiceTest",
       "alfresco/services/NodePreviewServiceTest",
       "alfresco/services/NotificationServiceTest",
-      "alfresco/services/OptionsServiceTest",
       "alfresco/services/OptionsServiceTest",
       "alfresco/services/SearchServiceTest",
       "alfresco/services/ServiceFilteringTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,11 +27,11 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   runAllTests = false; // Comment/uncomment this line to toggle
+   // runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/services/PreferenceServiceTest"
+      "alfresco/renderers/SocialRenderersTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",
@@ -293,7 +293,7 @@ define(function() {
       "alfresco/services/NodePreviewServiceTest",
       "alfresco/services/NotificationServiceTest",
       "alfresco/services/OptionsServiceTest",
-      "alfresco/services/PreferenceServiceTest",
+      "alfresco/services/OptionsServiceTest",
       "alfresco/services/SearchServiceTest",
       "alfresco/services/ServiceFilteringTest",
       "alfresco/services/ServiceRegistryTest",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,11 +27,11 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   // runAllTests = false; // Comment/uncomment this line to toggle
+   runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/upload/UploadMonitorTest"
+      "alfresco/services/PreferenceServiceTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",
@@ -293,6 +293,7 @@ define(function() {
       "alfresco/services/NodePreviewServiceTest",
       "alfresco/services/NotificationServiceTest",
       "alfresco/services/OptionsServiceTest",
+      "alfresco/services/PreferenceServiceTest",
       "alfresco/services/SearchServiceTest",
       "alfresco/services/ServiceFilteringTest",
       "alfresco/services/ServiceRegistryTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/SocialRenderers.get.js
@@ -92,7 +92,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/SocialMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SocialMockXhr.js
@@ -51,6 +51,11 @@ define(["dojo/_base/declare",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      "{}"]);
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/api/people/guest/preferences?pf=org.alfresco.share.documents.favourites",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     "{}"]);
             this.server.respondWith("POST",
                                     "/aikau/proxy/alfresco/api/people/guest/preferences",
                                     [200,


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1050 to ensure that preferences are retrieved using the correct URL. The unit tests have been updated to verify the change.