### PR TITLE
AKU-1047: Support disabled state in PushButtons

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -418,6 +418,18 @@ define(["dojo/_base/declare",
          {
             this.wrappedWidget.set("disabled", status);
          }
+         if (this.domNode)
+         {
+            if (status)
+            {
+               domClass.add(this.domNode, "alfresco-forms-controls-BaseFormControl--disabled");
+            }
+            else
+            {
+               domClass.remove(this.domNode, "alfresco-forms-controls-BaseFormControl--disabled");
+            }
+         }
+         
          this.validate();
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
@@ -34,10 +34,12 @@
 define(["alfresco/core/CoreWidgetProcessing",
         "alfresco/forms/controls/BaseFormControl",
         "dojo/_base/declare",
+        "dojo/_base/array",
         "dojo/_base/lang",
+        "dojo/dom-attr",
         "dojo/dom-class",
         "alfresco/forms/controls/PushButtonsControl"],
-       function(CoreWidgetProcessing, BaseFormControl, declare, lang, domClass) {
+       function(CoreWidgetProcessing, BaseFormControl, declare, array, lang, domAttr, domClass) {
 
    return declare([BaseFormControl, CoreWidgetProcessing], {
 
@@ -52,6 +54,28 @@ define(["alfresco/core/CoreWidgetProcessing",
        * @since 1.0.65
        */
       firstValueIsDefault: false,
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#alfDisabled}
+       * to ensure that the [control]{@link module:alfresco/forms/controls/PushButtonControl} is disabled.
+       * 
+       * @instance
+       * @param  {boolean} status Whether or not the control should be disabled
+       * @since 1.0.80
+       */
+      alfDisabled: function alfresco_forms_controls_BaseFormControl__alfDisabled(status) {
+         this.inherited(arguments);
+
+         if (this.wrappedWidget && this.wrappedWidget.opts)
+         {
+            array.forEach(this.wrappedWidget.opts, function(option) {
+               if (option.inputNode)
+               {
+                  status ? domAttr.set(option.inputNode, "disabled", true) : domAttr.remove(option.inputNode, "disabled");
+               }
+            }, this);
+         }
+      },
 
       /**
        * Run after widget created.

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -27,6 +27,15 @@ define(["module",
         "intern/dojo/node!leadfoot/keys"],
         function(module, defineSuite, assert, TestCommon, keys) {
 
+   var checkBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/CheckBox");
+   var selectors = {
+      checkBoxes: {
+         toggleDisableState: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["TOGGLE_DISABLE_STATE"])
+         }
+      }
+   };
+
    defineSuite(module, {
       name: "PushButtons Tests",
       testPage: "/PushButtons",
@@ -35,7 +44,7 @@ define(["module",
          return this.remote.findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_POST_FORM", true)
             .then(function(payload) {
@@ -50,20 +59,20 @@ define(["module",
       "Value can be updated by publish": function() {
          return this.remote.findById("CANT_BUILD_VALUE")
             .click()
-            .end()
+         .end()
 
          .findById("RUGBY_UNION_VALUE")
             .click()
-            .end()
+         .end()
 
          .findById("VB_VALUE")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_POST_FORM", true)
             .then(function(payload) {
@@ -77,25 +86,25 @@ define(["module",
       "Keyboard navigation and selection is supported on single-value controls": function() {
          return this.remote.findById("VB_VALUE") // Focus on last button at top
             .click()
-            .end()
+         .end()
 
          .pressKeys(keys.TAB) // Tab to "canbuild" control
             .pressKeys(keys.ARROW_LEFT)
             .pressKeys(keys.SPACE)
-            .end()
+         .end()
 
          .pressKeys(keys.TAB) // Tab to "properfootball" control, first value
             .pressKeys(keys.SPACE)
-            .end()
+         .end()
 
          .pressKeys(keys.TAB) // Tab to "properfootball" control, second value
             .pressKeys(keys.SPACE)
-            .end()
+         .end()
 
          .findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_POST_FORM", true)
             .then(function(payload) {
@@ -108,12 +117,12 @@ define(["module",
       "Can select push button with mouse": function() {
          return this.remote.findByCssSelector("#BEST_LANGUAGE_CONTROL label:nth-of-type(2)")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#LEFT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_POST_FORM", true)
             .then(function(payload) {
@@ -125,7 +134,7 @@ define(["module",
          return this.remote.findByCssSelector("#RIGHT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_POST_FORM", true)
             .then(function(payload) {
@@ -134,20 +143,48 @@ define(["module",
 
          .findByCssSelector("#ONE_DESELECTABLE_CHOICE_CONTROL label:nth-of-type(1)")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#ONE_DESELECTABLE_CHOICE_CONTROL label:nth-of-type(2)")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#RIGHT_FORM .confirmationButton .dijitButtonNode")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_POST_FORM", true)
             .then(function(payload) {
                assert.sameMembers(payload.onedeselectable, ["two"], "Modified state of radio-checkbox invalid");
+            });
+      },
+
+      "Disabled control cannot be used": function() {
+         return this.remote.findByCssSelector("#DISABLED_CONTROL label:nth-of-type(1)")
+            .clearLog()
+            .click()
+         .end()
+
+         .getAllPublishes("SCOPED__valueChangeOf_DISABLED")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 0);
+            });
+      },
+
+      "Enabled control cannot be used": function() {
+         return this.remote.findByCssSelector(selectors.checkBoxes.toggleDisableState.checkBox)
+            .click()
+         .end()
+
+         .findByCssSelector("#DISABLED_CONTROL label:nth-of-type(1)")
+            .clearLog()
+            .click()
+         .end()
+
+         .getAllPublishes("SCOPED__valueChangeOf_DISABLED")
+            .then(function(payloads) {
+               assert.lengthOf(payloads, 1);
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -294,6 +294,51 @@ model.jsonModel = {
                                           ]
                                        }
                                     }
+                                 },
+                                 {
+                                    id: "TOGGLE_DISABLE_STATE",
+                                    name: "alfresco/forms/controls/CheckBox",
+                                    config: {
+                                       fieldId: "TOGGLE_DISABLED",
+                                       label: "Disabled?",
+                                       description: "Use this control to toggle the disable state of the PushButtons below",
+                                       value: true
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    id: "DISABLED",
+                                    config: {
+                                       fieldId: "DISABLED",
+                                       name: "disabled",
+                                       label: "Disabled Display",
+                                       description: "What PushButtons look like disabled",
+                                       maxLineLength: 3,
+                                       noWrap: true,
+                                       simpleLayout: true,
+                                       multiMode:true,
+                                       optionsConfig: {
+                                          fixed: [
+                                             {
+                                                label: "This label gets truncated because it's really quite long",
+                                                value: "1"
+                                             },
+                                             {
+                                                label: "Short Mark",
+                                                value: "2"
+                                             }
+                                          ]
+                                       },
+                                       disablementConfig: {
+                                          initialValue: true,
+                                          rules: [
+                                             {
+                                                targetId: "TOGGLE_DISABLED",
+                                                is: [true]
+                                             }
+                                          ]
+                                       }
+                                    }
                                  }
                               ]
                            }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1047 to ensure that PushButtons can't be used when they're in the disabled state. Unit tests have been updated to verify this change. This doesn't change the disabled appearance as this has been raised by a separate issue.