### PR TITLE
Paginator pageBack / pageForward is not setting page label via publication payload

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -377,10 +377,23 @@ define(["dojo/_base/declare",
        */
       onPageBack: function alfresco_lists_Paginator__onPageBack(payload) {
          // jshint unused:false
-         this.currentPage--;
-         this.alfPublish(this.pageSelectionTopic, {
-            value: this.currentPage
-         });
+         var label, pageStart, pageEnd;
+         
+         // pageBack is only disabled in processLoadedDocuments so user could trigger it again during load
+         // prevent passing first page
+         if (this.currentPage > 1)
+         {
+             this.currentPage--;
+             
+             pageStart = (this.currentPage - 1) * parseInt(this.documentsPerPage, 10) + 1;
+             pageEnd = pageStart + parseInt(this.documentsPerPage, 10) - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
+             label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords})
+             
+             this.alfPublish(this.pageSelectionTopic, {
+                label: label,
+                value: this.currentPage
+             });
+         }
       },
       
       /**
@@ -392,10 +405,31 @@ define(["dojo/_base/declare",
        */
       onPageForward: function alfresco_lists_Paginator__onPageForward(payload) {
          // jshint unused:false
-         this.currentPage++;
-         this.alfPublish(this.pageSelectionTopic, {
-            value: this.currentPage
-         });
+         var label, pageStart, pageEnd;
+         
+         // pageForward is only disabled in processLoadedDocuments so user could trigger it again during load
+         // prevent passing last page
+         if (this.currentPage !== this.totalPages)
+         {
+             this.currentPage++;
+             
+             pageStart = (this.currentPage - 1) * parseInt(this.documentsPerPage, 10) + 1;
+             if (this.currentPage === this.totalPages)
+             {
+                 // ...for the last page just count up to the last document
+                 pageEnd = this.totalRecords;
+             }
+             else
+             {
+                 pageEnd = pageStart + parseInt(this.documentsPerPage, 10) - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
+             }
+             label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords})
+             
+             this.alfPublish(this.pageSelectionTopic, {
+                label: label,
+                value: this.currentPage
+             });
+         }
       },
       
       /**


### PR DESCRIPTION
When the pageBack and pageForward menu items of the Paginator are used, the payload is lacking the ```label``` attribute that the menu items in the page drop down include. This results in the ```value``` of the payload being used as the page label (briefly) until processLoadedDocuments corrects this again. This leads to an unstable layout as text grows / shrinks which users may perceive negatively. Additionally, it is technically possible for the user to trigger multiple pageBack / pageForward events before the first load request has been completed (and the pageBack/pageForward items can be disabled), which may cause the value of ```currentPage``` to exceed the valid value range / page count bounds.

This PR adds the precaclulated labels to pageBack / pageForward and a guard to avoid ```currentPage``` exceeding the value range. Due to #1185 I have not run the unit tests but have tested this branch manually via the Aikau Unit Testing page.