### PR TITLE
AKU-1049: Handle late form field registration

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1318,6 +1318,13 @@ define(["dojo/_base/declare",
                   evt.preventFocusTheft = true;
                }
             }));
+
+            // See AKU-1049 - emit a custom event to be captured by the form to let it know to re-publish
+            // all the field values. This will allow "late" created fields to process rules...
+            on.emit(this.domNode, "ALF_FIELD_ADDED_TO_FORM", {
+               bubbles: true,
+               cancelable: true
+            });
          }
          else
          {

--- a/aikau/src/test/resources/alfresco/forms/LateFieldRegistrationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/LateFieldRegistrationTest.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ * @since 1.0.80
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
+
+   defineSuite(module, {
+      name: "Late Form Field Registration Tests",
+      testPage: "/LateFieldRegistration",
+
+      "Field is enabled": function() {
+         return this.remote.findByCssSelector("#DOWNGRADE_DATE_CONTROL")
+            .getAttribute("aria-disabled")
+            .then(function(disabled) {
+               assert.equal(disabled, "false");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -131,7 +131,7 @@ define(["module",
          .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "Update1_4", "Updated label not set correctly by pub/sub");
+               assert.equal(resultText, "Update1_6", "Updated label not set correctly by pub/sub");
             });
       },
 
@@ -234,7 +234,7 @@ define(["module",
          .findByCssSelector("#HAS_CHANGES_TO_CONTROL_dropdown table tr:nth-child(1) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
-               assert.equal(resultText, "Update1_6", "Updated label not set correctly by pub/sub");
+               assert.equal(resultText, "Update1_8", "Updated label not set correctly by pub/sub");
             });
       },
 

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -122,6 +122,7 @@ define(function() {
       "alfresco/forms/FormsTest",
       "alfresco/forms/FormValidationTest",
       "alfresco/forms/HashFormTest",
+      "alfresco/forms/LateFieldRegistrationTest",
       "alfresco/forms/SingleTextFieldFormTest",
       "alfresco/forms/TabsInFormsTest",
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LateFieldRegistration.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LateFieldRegistration.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Late form field registration</shortname>
+  <description>This test page was provided to specifically target a bug where form fields that register late can process rules.</description>
+  <family>aikau-unit-tests</family>
+  <url>/LateFieldRegistration</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LateFieldRegistration.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LateFieldRegistration.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LateFieldRegistration.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LateFieldRegistration.get.js
@@ -1,0 +1,112 @@
+model.jsonModel = {
+   services: [{
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         "id": "RM_CLASSIFY_FORM",
+         "name": "alfresco/forms/Form",
+         "config": {
+            "okButtonPublishTopic": "RM_EDIT_CLASSIFIED",
+            "value": {
+               "classificationLevelId": "S"
+            },
+            "widgets": [
+               {
+                  "id": "CLASSIFICATION_PANEL",
+                  "name": "alfresco/forms/CollapsibleSection",
+                  "config": {
+                     "label": "Security Classification",
+                     "widgets": [
+                        {
+                           "id": "LEVELSPAGE_CREATE",
+                           "name": "alfresco/forms/controls/PushButtons",
+                           "config": {
+                              "multiMode": false,
+                              "noWrap": true,
+                              "optionsConfig": {
+                                 "fixed": [{
+                                    "value": "TS",
+                                    "label": "Top Secret"
+                                 }, {
+                                    "value": "S",
+                                    "label": "Secret"
+                                 }, {
+                                    "value": "C",
+                                    "label": "Confidential"
+                                 }, {
+                                    "value": "U",
+                                    "label": "Unclassified"
+                                 }]
+                              },
+                              "name": "classificationLevelId",
+                              "simpleLayout": true,
+                              "maxChoices": 1,
+                              "postWhenHiddenOrDisabled": false,
+                              "noPostWhenValueIs": [""],
+                              "label": "Classification",
+                              "fieldId": "LEVELS"
+                           }
+                        },
+                        {
+                           "id": "TAB_CONTAINER",
+                           "name": "alfresco/forms/TabbedControls",
+                           "config": {
+                              "padded": true,
+                              "widgets": [{
+                                 "name": "alfresco/forms/ControlColumn",
+                                 "id": "DOWNGRADE_SCHEDULE",
+                                 "title": "Downgrade Schedule",
+                                 "config": {
+                                    "widgets": [{
+                                       "id": "DOWNGRADE_DATE",
+                                       "name": "alfresco/forms/controls/DateTextBox",
+                                       "config": {
+                                          "name": "downgradeDate",
+                                          "label": "Downgrade Date",
+                                          "disablementConfig": {
+                                             "initialValue": true,
+                                             "rules": [{
+                                                "targetId": "LEVELS",
+                                                "isNot": [{
+                                                   "value": "TS",
+                                                   "label": "Top Secret"
+                                                }, {
+                                                   "value": "S",
+                                                   "label": "Secret"
+                                                }, {
+                                                   "value": "C",
+                                                   "label": "Confidential"
+                                                }, {
+                                                   "value": "U",
+                                                   "label": "Unclassified"
+                                                }]
+                                             }]
+                                          },
+                                          "fieldId": "DOWNGRADE_SCHEDULE_FIELD"
+                                       }
+                                    }]
+                                 }
+                              }]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }, 
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/TabsInForms.get.js
@@ -28,6 +28,17 @@ model.jsonModel = {
             },
             widgets: [
                {
+                  id: "TOGGLE_DISABILITY",
+                  name: "alfresco/forms/controls/CheckBox",
+                  config: {
+                     fieldId: "TOGGLE_DISABILITY",
+                     name: "toggle",
+                     label: "Toggle Disability",
+                     description: "Use this checkbox to toggle disability of fields in the tabs",
+                     value: false
+                  }
+               },
+               {
                   name: "alfresco/forms/CollapsibleSection",
                   config: {
                      label: "Stuff",
@@ -36,6 +47,7 @@ model.jsonModel = {
                            id: "TC1",
                            name: "alfresco/forms/TabbedControls",
                            config: {
+                              padded: true,
                               widgets: [
                                  {
                                     name: "alfresco/forms/ControlColumn",
@@ -49,7 +61,15 @@ model.jsonModel = {
                                                 fieldId: "TB1",
                                                 name: "tb1",
                                                 label: "First text box",
-                                                description: "Setting this field value to 'break' will make the text box in tab 3 required"
+                                                description: "Setting this field value to 'break' will make the text box in tab 3 required",
+                                                disablementConfig: {
+                                                   rules: [
+                                                      {
+                                                         targetId: "TOGGLE_DISABILITY",
+                                                         is: [true]
+                                                      }
+                                                   ]
+                                                }
                                              }
                                           }
                                        ]
@@ -117,6 +137,7 @@ model.jsonModel = {
                   id: "TC2",
                   name: "alfresco/forms/TabbedControls",
                   config: {
+                     padded: true,
                      widgets: [
                         {
                            name: "alfresco/forms/ControlColumn",
@@ -129,7 +150,15 @@ model.jsonModel = {
                                     config: {
                                        fieldId: "TB4",
                                        name: "tb4",
-                                       label: "Text box"
+                                       label: "Text box",
+                                       disablementConfig: {
+                                          rules: [
+                                             {
+                                                targetId: "TOGGLE_DISABILITY",
+                                                is: [true]
+                                             }
+                                          ]
+                                       }
                                     }
                                  }
                               ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1049 to ensure that form fields that are late to register (in this case when added via TabbedControls that do not render immediately) that the form re-publishes all the other field values to give it the late registering field the opportunity to correctly evaluate any dynamic rules (for visibility, disablement and requirement). A unit test based on the real-world RM use case has been provided.