### PR TITLE
AKU-1051: Optional PushButtons label when no options

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/PushButtons.js
@@ -38,8 +38,9 @@ define(["alfresco/core/CoreWidgetProcessing",
         "dojo/_base/lang",
         "dojo/dom-attr",
         "dojo/dom-class",
+        "dojo/dom-construct",
         "alfresco/forms/controls/PushButtonsControl"],
-       function(CoreWidgetProcessing, BaseFormControl, declare, array, lang, domAttr, domClass) {
+       function(CoreWidgetProcessing, BaseFormControl, declare, array, lang, domAttr, domClass, domConstruct) {
 
    return declare([BaseFormControl, CoreWidgetProcessing], {
 
@@ -54,6 +55,16 @@ define(["alfresco/core/CoreWidgetProcessing",
        * @since 1.0.65
        */
       firstValueIsDefault: false,
+
+      /**
+       * An optional message to display when there are no buttons available for display.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.80
+       */
+      noButtonsLabel: null,
 
       /**
        * Extends the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#alfDisabled}
@@ -144,6 +155,30 @@ define(["alfresco/core/CoreWidgetProcessing",
             name: "alfresco/forms/controls/PushButtonsControl",
             config: config
          });
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#setOptions}
+       * to make use of any configured [noButtonsLabel]{@link module:alfresco/forms/controls/PushButtons#noButtonsLabel}
+       * when an empty options array is provided.
+       * 
+       * @instance
+       * @param {object[]} options An array of the options to be added.
+       * @since 1.0.80
+       */
+      setOptions: function alfresco_forms_controls_BaseFormControl__setOptions(options) {
+         this.inherited(arguments);
+
+         if (options && 
+             options.length === 0 && 
+             this.noButtonsLabel && 
+             this.wrappedWidget)
+         {
+            var span = domConstruct.create("span", {
+               "class": "alfresco-forms-controls-PushButtons__noOptionsLabel"
+            }, this.wrappedWidget.domNode);
+            span.appendChild(document.createTextNode(this.message(this.noButtonsLabel)));
+         }
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -186,6 +186,14 @@ define(["module",
             .then(function(payloads) {
                assert.lengthOf(payloads, 1);
             });
+      },
+
+      "No buttons label displayed": function() {
+         return this.remote.findByCssSelector("#NO_OPTIONS_CONTROL .alfresco-forms-controls-PushButtons__noOptionsLabel")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "No buttons available");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -306,8 +306,8 @@ model.jsonModel = {
                                     }
                                  },
                                  {
-                                    name: "alfresco/forms/controls/PushButtons",
                                     id: "DISABLED",
+                                    name: "alfresco/forms/controls/PushButtons",
                                     config: {
                                        fieldId: "DISABLED",
                                        name: "disabled",
@@ -337,6 +337,24 @@ model.jsonModel = {
                                                 is: [true]
                                              }
                                           ]
+                                       }
+                                    }
+                                 },
+                                 {
+                                    id: "NO_OPTIONS",
+                                    name: "alfresco/forms/controls/PushButtons",
+                                    config: {
+                                       fieldId: "NO_OPTIONS",
+                                       name: "nooptions",
+                                       label: "Option-less",
+                                       description: "What PushButtons look like with no options",
+                                       maxLineLength: 3,
+                                       noWrap: true,
+                                       simpleLayout: true,
+                                       multiMode:true,
+                                       noButtonsLabel: "No buttons available",
+                                       optionsConfig: {
+                                          fixed: []
                                        }
                                     }
                                  }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1051 to add support for an optional label that can be displayed when no options are available for the PushButtons control. A unit test has been added to verify that the label is displayed.