### PR TITLE
AKU-1052: Non truthy dynamic payload button values

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfDynamicPayloadButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfDynamicPayloadButton.js
@@ -196,9 +196,9 @@ define(["dojo/_base/declare",
             if (dataMapping.hasOwnProperty(key))
             {
                // Check that the data actually exists...
-               var value = lang.getObject(key, false, data);
-               if (value)
+               if (lang.exists(key, data))
                {
+                  var value = lang.getObject(key, false, data);
                   // ...and then set it as requested
                   lang.setObject(dataMapping[key], value, this.publishPayload);
                }

--- a/aikau/src/test/resources/alfresco/buttons/DynamicPayloadButtonTest.js
+++ b/aikau/src/test/resources/alfresco/buttons/DynamicPayloadButtonTest.js
@@ -23,8 +23,18 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!assert"],
-        function(module, defineSuite, assert) {
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(module, defineSuite, assert, TestCommon) {
+
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var selectors = {
+      buttons: {
+         dynamicWithNonTruthy: TestCommon.getTestSelector(buttonSelectors, "button.label", ["DYNAMIC_WITH_NON_TRUTHY"]),
+         setTruthy: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_TRUTHY"]),
+         setNonTruthy: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_NON_TRUTHY"])
+      }
+   };
 
    defineSuite(module, {
       name: "Dynamic Payload Button Tests",
@@ -204,6 +214,36 @@ define(["module",
          .getLastPublish("SCOPE_DYNAMIC_BUTTON_TOPIC_3")
             .then(function(payload) {
                assert.deepPropertyVal(payload, "data.default", "default");
+            });
+      },
+
+      "Non-truthy values can be set": function() {
+         return this.remote.findByCssSelector(selectors.buttons.setTruthy)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.buttons.dynamicWithNonTruthy)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("NON_TRUTHY_EXECUTE_JS")
+            .then(function(payload) {
+               assert.propertyVal(payload, "selectedJavaScriptSource", "print(10);");
+            })
+
+         .findByCssSelector(selectors.buttons.setNonTruthy)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.buttons.dynamicWithNonTruthy)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("NON_TRUTHY_EXECUTE_JS")
+            .then(function(payload) {
+               assert.propertyVal(payload, "selectedJavaScriptSource", null);
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/DynamicPayloadButton.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/buttons/DynamicPayloadButton.get.js
@@ -225,6 +225,57 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
+            pubSubScope: "NON_TRUTHY_",
+            title: "Non-truthy values",
+            widgets: [
+               {
+                  id: "DYNAMIC_WITH_NON_TRUTHY",
+                  name: "alfresco/buttons/AlfDynamicPayloadButton",
+                  config: {
+                     label: "Execute",
+                     publishTopic: "EXECUTE_JS",
+                     publishPayload: {},
+                     publishPayloadSubscriptions: [ 
+                        {
+                           topic: "UPDATE_JS_SOURCE",
+                           dataMapping: {
+                              content: "javaScriptSource",
+                              selectedContent: "selectedJavaScriptSource"
+                           }
+                        }
+                     ]
+                  }
+               }, 
+               {
+                  id: "SET_TRUTHY",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "setSource (with selected code)",
+                     publishTopic: "UPDATE_JS_SOURCE",
+                     publishPayload: {
+                        content: "print(10);",
+                        selectedContent: "print(10);"
+                     }
+                  }
+               },
+               {
+                  id: "SET_NON_TRUTHY",
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: "removeCodeSelection",
+                     publishTopic: "UPDATE_JS_SOURCE",
+                     publishPayload : {
+                        content: "print(10);",
+                        selectedContent: null
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1052 (building on PR #1167) to support non-truthy values being set as the payload of an AlfDynamicPayloadButton. The original PR commit has been included along with unit test updates.