### PR TITLE
AKU-1044: Support for additional form buttons without form values

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -132,6 +132,20 @@ define(["dojo/_base/declare",
       title: null,
 
       /**
+       * This attribute has been provided primarily for use when configuring 
+       * [widgetsAdditionalButtons]{@link module:alfresco/forms/Form#widgetsAdditionalButtons} in
+       * a [form]{@link module:alfresco/forms/Form}. It is a simple marker indicating whether
+       * or not the configured payload should be updated with additional data (such as the
+       * form value) or if it should be left with the original data.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.81
+       */
+      updatePayload: true,
+
+      /**
        * The topic to listen to to determine when the button should be enabled
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -61,10 +61,10 @@
  *                   initialValue: true
  *                }
  *             }
- *           }
- *        ]
- *     }
- *  }
+ *          }
+ *       ]
+ *    }
+ * }
  *
  * @example <caption>Example configuration for form that does not show validation errors on initial display:</caption>
  * {
@@ -83,10 +83,55 @@
  *                   initialValue: true
  *                }
  *             }
- *           }
- *        ]
- *     }
- *  }
+ *          }
+ *       ]
+ *    }
+ * }
+ *
+ * @example <caption>Example configuration for form with additional buttons:</caption>
+ * {
+ *    name: "alfresco/forms/Form",
+ *    config: {
+ *       okButtonPublishTopic: "SAVE_FORM",
+ *       okButtonLabel: "Save",
+ *       showValidationErrorsImmediately: false,
+ *       widgets: [
+ *          {
+ *             name: "alfresco/forms/controls/TextBox",
+ *             config: {
+ *                name: "control",
+ *                label: "Name",
+ *                requirementConfig: {
+ *                   initialValue: true
+ *                }
+ *             }
+ *          }
+ *       ],
+ *       widgetsAdditionalButtons: [
+ *          {
+ *             name: "alfresco/buttons/AlfButton",
+ *             config: {
+ *                label: "Button 1 (includes form values)",
+ *                publishTopic: "CUSTOM_TOPIC_1",
+ *                publishPayload: {
+ *                   additional: "data"
+ *                } 
+ *             }
+ *          },
+ *          {
+ *             name: "alfresco/buttons/AlfButton",
+ *             config: {
+ *                updatePayload: false,
+ *                label: "Button 1 (does not include form values)",
+ *                publishTopic: "CUSTOM_TOPIC_2",
+ *                publishPayload: {
+ *                   only: "data"
+ *                } 
+ *             }
+ *          }
+ *       ]
+ *    }
+ * }
  * 
  * @module alfresco/forms/Form
  * @extends external:dijit/_WidgetBase
@@ -591,7 +636,11 @@ define(["dojo/_base/declare",
          // it will provide the current form data...
          var formValue = this.getValue();
          array.forEach(this.additionalButtons, function(button) {
-            if (button._alfOriginalButtonPayload)
+            if (!button.updatePayload)
+            {
+               // No action required, leave the payload as is
+            }
+            else if (button._alfOriginalButtonPayload)
             {
                var newPayload = {};
                lang.mixin(newPayload, button._alfOriginalButtonPayload, formValue);
@@ -1012,7 +1061,7 @@ define(["dojo/_base/declare",
          // (e.g. a field has become disabled since the last payload update and is configured to not have its value
          // included when it is hidden, therefore we need to ensure its previous value is NOT included in the payload)
          array.forEach(this.additionalButtons, function(button) {
-            if (button.publishPayload)
+            if (button.publishPayload && button.updatePayload)
             {
                button._alfOriginalButtonPayload = lang.clone(button.publishPayload);
             }
@@ -1123,7 +1172,11 @@ define(["dojo/_base/declare",
        */
       updateButtonPayloads: function alfresco_forms_Form__updateButtonPayloads(values) {
          array.forEach(this.additionalButtons, function(button) {
-            if (button._alfOriginalButtonPayload)
+            if (!button.updatePayload)
+            {
+               // No action required. Leave the payload as is.
+            }
+            else if (button._alfOriginalButtonPayload)
             {
                var payload = {};
                lang.mixin(payload, button._alfOriginalButtonPayload, values);

--- a/aikau/src/test/resources/alfresco/forms/FormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormsTest.js
@@ -210,6 +210,19 @@ define(["module",
             });
       },
 
+      "Additional button can omit form values": function() {
+         return this.remote.findByCssSelector("#ADD_BUTTON_3")
+            .click()
+         .end()
+
+         .getLastPublish("CUSTOM_SCOPE_AddButton3")
+            .then(function(payload) {
+               assert.notProperty(payload, "field5");
+               assert.notProperty(payload, "field6");
+               assert.propertyVal(payload, "original", "only");
+            });
+      },
+
       "Test global scope set correctly": function() {
          return this.remote.getLastPublish("SET_HASH");
       },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/Forms.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/Forms.get.js
@@ -192,6 +192,18 @@ model.jsonModel = {
                               label: "Additional 2",
                               publishTopic: "AddButton2"
                            }
+                        },
+                        {
+                           name:"alfresco/buttons/AlfButton",
+                           id: "ADD_BUTTON_3",
+                           config: {
+                              updatePayload: false,
+                              label: "Additional 3 (no form values)",
+                              publishTopic: "AddButton3",
+                              publishPayload: {
+                                 original: "only"
+                              }
+                           }
                         }
                      ]
                   }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1044 to support additional form buttons that do not include the form value in the published payload. JSDoc has been updated to show the new option and unit tests have been added to verify the change and prevent future regressions.