### PR TITLE
Add missing selected payload attribute for pageBack / pageForward

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -391,7 +391,8 @@ define(["dojo/_base/declare",
              
              this.alfPublish(this.pageSelectionTopic, {
                 label: label,
-                value: this.currentPage
+                value: this.currentPage,
+                selected : true
              });
          }
       },
@@ -427,7 +428,8 @@ define(["dojo/_base/declare",
              
              this.alfPublish(this.pageSelectionTopic, {
                 label: label,
-                value: this.currentPage
+                value: this.currentPage,
+                selected : true
              });
          }
       },


### PR DESCRIPTION
While working on one performance aspect of #958 (overhead of paginator page selector menu update - https://github.com/AFaust/Aikau/tree/Paginator-pageSelectorRefreshPerformance) I noticed that the payload used during pageBack / pageForward in the Paginator module is missing the ```selected``` payload attribute that AlfCheckableMenuItem requires to be set to ```true``` to properly update an existing instance (see https://github.com/Alfresco/Aikau/blob/4529a6f41641378e54850285e6041696f793c75d/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js#L235). The lack of the attribute does not affect the page selector menu right now as the menu items are currently always recreated - which is exactly the overhead an upcoming PR of mine will aim to eliminate (unless necessary).

This PR adds the missing ```selected``` payload attribute with a value of ```true``` for pageBack / pageForward publications.