### PR TITLE
Lazy initialisation and re-use of page selector menu items (Paginator)

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -509,6 +509,8 @@ define(["dojo/_base/declare",
                   
                   domClass.remove(this.pageMarker.domNode, "dijitDisabled dijitMenuItemDisabled");
                }
+               
+               this.checkAndUpdatePageSelectionMenu(this.currentPage);
             }
          }
       },
@@ -702,87 +704,90 @@ define(["dojo/_base/declare",
        *  Handles initialization and necessary updates of the page selection menu items when the popup is opened.
        * 
        *  @instance
+       *  @param {number} ensurePage The page number that must be ensured to exist. This parameter allows for pre-
+       *        initialization during processDocumentsLoaded while still offloading performance hit until selector
+       *        is opened.
        */
-      checkAndUpdatePageSelectionMenu : function alfresco_lists_Paginator__checkAndUpdatePageSelectionMenu() {
-          var firstPage, pageStart, pageEnd, i, label, menuItem;
+      checkAndUpdatePageSelectionMenu : function alfresco_lists_Paginator__checkAndUpdatePageSelectionMenu(ensurePage) {
+          var firstPage, lastPreloadedPage, pageStart, pageEnd, i, label, menuItem;
 
           // only need to act if not initialized yet or change occurred
-          if (this._pageSelectionDocsPerPage === undefined
-                  || this._pageSelectionDocsPerPage !== this.documentsPerPage
-                  || this._pageSelectionTotalRecords === undefined
-                  || this._pageSelectionTotalRecords !== this.totalRecords)
-          {
-              firstPage = 0;
+          firstPage = 0;
+          lastPreloadedPage = -1;
+          
+          // Delete the (obsolete) previous page selector group contents...
+          array.forEach(this.pageSelectorGroup.getChildren(), function(widget, index, arr) {
+              var virtPageEnd;
               
-              // Delete the (obsolete) previous page selector group contents...
-              array.forEach(this.pageSelectorGroup.getChildren(), function(widget, index, arr) {
-                  var virtPageEnd;
-                  
-                  // need to destroy every existing menu item if documentsPerPage has changed
-                  // or state hasn't been fully initialized yet
-                  if (this._pageSelectionDocsPerPage === undefined
-                          || this._pageSelectionDocsPerPage !== this.documentsPerPage
-                          || this._pageSelectionTotalRecords === undefined)
+              // need to destroy every existing menu item if documentsPerPage has changed
+              // or state hasn't been fully initialized yet
+              if (this._pageSelectionDocsPerPage === undefined
+                      || this._pageSelectionDocsPerPage !== this.documentsPerPage
+                      || this._pageSelectionTotalRecords === undefined)
+              {
+                  this.pageSelectorGroup.removeChild(widget);
+                  widget.destroy();
+              }
+              // otherwise if totalRecords changed we need to destroy last page and any obsolete page before
+              // calculate pageEnd for existing page and compare
+              else
+              {
+                  virtPageEnd = (index + 1) * parseInt(this.documentsPerPage, 10);
+                  if (index === arr.length - 1 || virtPageEnd > this.totalRecords)
                   {
                       this.pageSelectorGroup.removeChild(widget);
                       widget.destroy();
-                  }
-                  // otherwise if totalRecords changed we need to destroy last page and any obsolete page before
-                  // calculate pageEnd for existing page and compare
-                  else
-                  {
-                      virtPageEnd = (index + 1) * parseInt(this.documentsPerPage, 10);
-                      if (index === arr.length - 1 || virtPageEnd > this.totalRecords)
+                      
+                      // mark the first page that needs re-creation
+                      if (firstPage === 0)
                       {
-                          this.pageSelectorGroup.removeChild(widget);
-                          widget.destroy();
-                          
-                          // mark the first page that needs re-creation
-                          if (firstPage === 0)
-                          {
-                             firstPage = index; 
-                          }
+                         firstPage = index; 
                       }
                   }
-               }, this);
-    
-              // Create the page labels, which for English will be along the lines of 1-25
-              pageStart = firstPage * parseInt(this.documentsPerPage, 10) + 1;
-              for (i = firstPage; i < this.totalPages; i++)
-              {
-                 // Comments below assume 25 docs per page...
-                 if (i+1 !== this.totalPages)
-                 {
-                    // If we're not getting the labels for the last page...
-                    pageEnd = pageStart + parseInt(this.documentsPerPage, 10) - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
-                 }
-                 else
-                 {
-                    // ...for the last page just count up to the last document
-                    pageEnd = this.totalRecords;
-                 }
-    
-                 label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords});
-                 menuItem = new AlfCheckableMenuItem({
-                    label: label,
-                    value: i+1,
-                    group: "PAGE_SELECTION_GROUP",
-                    checked: this.currentPage === i+1,
-                    publishTopic: this.pubSubScope + this.pageSelectionTopic,
-                    publishPayload: {
-                       label: label,
-                       value: i+1
-                    }
-                 });
-                 
-                 this.pageSelectorGroup.addChild(menuItem);
-    
-                 pageStart = pageEnd + 1; // Add the 1 back on because the next page starts at 26
+                  else
+                  {
+                      lastPreloadedPage = index;
+                  }
               }
-              
-              this._pageSelectionDocsPerPage = this.documentsPerPage;
-              this._pageSelectionTotalRecords = this.totalRecords;
+           }, this);
+
+          // Create the page labels, which for English will be along the lines of 1-25
+          firstPage = firstPage || (lastPreloadedPage + 1);
+          pageStart = firstPage * parseInt(this.documentsPerPage, 10) + 1;
+          for (i = firstPage; i < Math.min(this.totalPages, ensurePage || this.totalPages); i++)
+          {
+             // Comments below assume 25 docs per page...
+             if (i+1 !== this.totalPages)
+             {
+                // If we're not getting the labels for the last page...
+                pageEnd = pageStart + parseInt(this.documentsPerPage, 10) - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
+             }
+             else
+             {
+                // ...for the last page just count up to the last document
+                pageEnd = this.totalRecords;
+             }
+
+             label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords});
+             menuItem = new AlfCheckableMenuItem({
+                label: label,
+                value: i+1,
+                group: "PAGE_SELECTION_GROUP",
+                checked: this.currentPage === i+1,
+                publishTopic: this.pubSubScope + this.pageSelectionTopic,
+                publishPayload: {
+                   label: label,
+                   value: i+1
+                }
+             });
+             
+             this.pageSelectorGroup.addChild(menuItem);
+
+             pageStart = pageEnd + 1; // Add the 1 back on because the next page starts at 26
           }
+          
+          this._pageSelectionDocsPerPage = this.documentsPerPage;
+          this._pageSelectionTotalRecords = this.totalRecords;
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -377,10 +377,24 @@ define(["dojo/_base/declare",
        */
       onPageBack: function alfresco_lists_Paginator__onPageBack(payload) {
          // jshint unused:false
-         this.currentPage--;
-         this.alfPublish(this.pageSelectionTopic, {
-            value: this.currentPage
-         });
+         var label, pageStart, pageEnd;
+         
+         // pageBack is only disabled in processLoadedDocuments so user could trigger it again during load
+         // prevent passing first page
+         if (this.currentPage > 1)
+         {
+             this.currentPage--;
+             
+             pageStart = (this.currentPage - 1) * parseInt(this.documentsPerPage, 10) + 1;
+             pageEnd = pageStart + parseInt(this.documentsPerPage, 10) - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
+             label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords});
+             
+             this.alfPublish(this.pageSelectionTopic, {
+                label: label,
+                value: this.currentPage,
+                selected : true
+             });
+         }
       },
       
       /**
@@ -392,10 +406,32 @@ define(["dojo/_base/declare",
        */
       onPageForward: function alfresco_lists_Paginator__onPageForward(payload) {
          // jshint unused:false
-         this.currentPage++;
-         this.alfPublish(this.pageSelectionTopic, {
-            value: this.currentPage
-         });
+         var label, pageStart, pageEnd;
+         
+         // pageForward is only disabled in processLoadedDocuments so user could trigger it again during load
+         // prevent passing last page
+         if (this.currentPage !== this.totalPages)
+         {
+             this.currentPage++;
+             
+             pageStart = (this.currentPage - 1) * parseInt(this.documentsPerPage, 10) + 1;
+             if (this.currentPage === this.totalPages)
+             {
+                 // ...for the last page just count up to the last document
+                 pageEnd = this.totalRecords;
+             }
+             else
+             {
+                 pageEnd = pageStart + parseInt(this.documentsPerPage, 10) - 1; // Deduct 1 because it's 1 - 25 (not 1 - 26!)
+             }
+             label = this.message("list.paginator.page.label", {0: pageStart, 1: pageEnd, 2: this.totalRecords});
+             
+             this.alfPublish(this.pageSelectionTopic, {
+                label: label,
+                value: this.currentPage,
+                selected : true
+             });
+         }
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -557,10 +557,9 @@ define(["dojo/_base/declare",
                   domClass.remove(this.pageMarker.domNode, "dijitDisabled dijitMenuItemDisabled");
                }
                
-               // in case load of different page was triggered externally (i.e. hash update) we must ensure any
+               // in case load was triggered externally (i.e. hash update) we must ensure any
                // page menu items already initialised are (un)checked according to current state
-               // special case for change of documentsPerPage while on the first page - we can't compare old documentsPerPage with new here
-               if (this.compactMode === false && this.showPageSelector && (oldCurrentPage !== this.currentPage || oldCurrentPage === 1))
+               if (this.compactMode === false && this.showPageSelector)
                {
                    var pageStart = (this.currentPage - 1) * parseInt(this.documentsPerPage, 10) + 1;
                    var pageEnd;

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -365,6 +365,15 @@ define(["dojo/_base/declare",
                preference: this.pageSizePreferenceName,
                value: this.documentsPerPage
             });
+            
+            // need to clear any page selector menu items
+            if (this.compactMode === false && this.showPageSelector)
+            {
+                array.forEach(this.pageSelectorGroup.getChildren(), function(widget, index, arr) {
+                    this.pageSelectorGroup.removeChild(widget);
+                    widget.destroy();
+                }, this);
+            }
          }
       },
       
@@ -550,7 +559,8 @@ define(["dojo/_base/declare",
                
                // in case load of different page was triggered externally (i.e. hash update) we must ensure any
                // page menu items already initialised are (un)checked according to current state
-               if (this.compactMode === false && this.showPageSelector && oldCurrentPage !== this.currentPage)
+               // special case for change of documentsPerPage while on the first page - we can't compare old documentsPerPage with new here
+               if (this.compactMode === false && this.showPageSelector && (oldCurrentPage !== this.currentPage || oldCurrentPage === 1))
                {
                    var pageStart = (this.currentPage - 1) * parseInt(this.documentsPerPage, 10) + 1;
                    var pageEnd;

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -773,6 +773,7 @@ define(["dojo/_base/declare",
        *  Handles initialization and necessary updates of the page selection menu items when the popup is opened.
        * 
        *  @instance
+       *  @since 1.0.82
        *  @param {object} position the position of the selection menu popup when opened
        */
       checkAndUpdatePageSelectionMenu : function alfresco_lists_Paginator__checkAndUpdatePageSelectionMenu() {
@@ -788,9 +789,9 @@ define(["dojo/_base/declare",
               
               // need to destroy every existing menu item if documentsPerPage has changed
               // or state hasn't been fully initialized yet
-              if (this._pageSelectionDocsPerPage === undefined
-                      || this._pageSelectionDocsPerPage !== this.documentsPerPage
-                      || this._pageSelectionTotalRecords === undefined)
+              if (this._pageSelectionDocsPerPage === undefined ||
+                      this._pageSelectionDocsPerPage !== this.documentsPerPage ||
+                      this._pageSelectionTotalRecords === undefined)
               {
                   this.pageSelectorGroup.removeChild(widget);
                   widget.destroy();

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -731,7 +731,7 @@ define(["dojo/_base/declare",
               }
               // otherwise if totalRecords changed we need to destroy last page and any obsolete page before
               // calculate pageEnd for existing page and compare
-              else
+              else if (this._pageSelectionTotalRecords !== this.totalRecords)
               {
                   virtPageEnd = (index + 1) * parseInt(this.documentsPerPage, 10);
                   if (index === arr.length - 1 || virtPageEnd > this.totalRecords)
@@ -749,6 +749,10 @@ define(["dojo/_base/declare",
                   {
                       lastPreloadedPage = index;
                   }
+              }
+              else
+              {
+                  lastPreloadedPage = index;
               }
            }, this);
 

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -779,7 +779,8 @@ define(["dojo/_base/declare",
                 value: i+1,
                 group: "PAGE_SELECTION_GROUP",
                 checked: this.currentPage === i+1,
-                publishTopic: this.pubSubScope + this.pageSelectionTopic,
+                pubSubScope : this.pubSubScope,
+                publishTopic: this.pageSelectionTopic,
                 publishPayload: {
                    label: label,
                    value: i+1

--- a/aikau/src/main/resources/alfresco/lists/Paginator.js
+++ b/aikau/src/main/resources/alfresco/lists/Paginator.js
@@ -510,7 +510,7 @@ define(["dojo/_base/declare",
                   domClass.remove(this.pageMarker.domNode, "dijitDisabled dijitMenuItemDisabled");
                }
                
-               this.checkAndUpdatePageSelectionMenu(this.currentPage);
+               this.checkAndUpdatePageSelectionMenu(null, this.currentPage);
             }
          }
       },
@@ -704,11 +704,12 @@ define(["dojo/_base/declare",
        *  Handles initialization and necessary updates of the page selection menu items when the popup is opened.
        * 
        *  @instance
+       *  @param {object} position the position of the selection menu popup when opened
        *  @param {number} ensurePage The page number that must be ensured to exist. This parameter allows for pre-
        *        initialization during processDocumentsLoaded while still offloading performance hit until selector
        *        is opened.
        */
-      checkAndUpdatePageSelectionMenu : function alfresco_lists_Paginator__checkAndUpdatePageSelectionMenu(ensurePage) {
+      checkAndUpdatePageSelectionMenu : function alfresco_lists_Paginator__checkAndUpdatePageSelectionMenu(position, ensurePage) {
           var firstPage, lastPreloadedPage, pageStart, pageEnd, i, label, menuItem;
 
           // only need to act if not initialized yet or change occurred

--- a/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfCheckableMenuItem.js
@@ -210,6 +210,13 @@ define(["dojo/_base/declare",
 
          if (this.checked)
          {
+            if (this.group)
+            {
+                // publish an event to indicate that all other members of the group must be deselected
+                this.alfPublish("ALF_CHECKABLE_MENU_ITEM__" + this.group, {
+                    value : this.value
+                });
+            }
             this.publishSelection();
          }
 
@@ -244,8 +251,7 @@ define(["dojo/_base/declare",
                   // Clear all group settings if the payload value matches the value represented by the
                   // widget. We need to ensure that only one item in the group is selected...
                   this.alfPublish("ALF_CHECKABLE_MENU_ITEM__" + this.group, {
-                     value: this.value,
-                     selected: false
+                     value: this.value
                   });
                   this.checked = true;
                }
@@ -296,7 +302,9 @@ define(["dojo/_base/declare",
             {
                // If this is currently NOT checked, then allow selection to occur but publish
                // an event to indicate that all other members of the group must be deselected
-               this.alfPublish("ALF_CHECKABLE_MENU_ITEM__" + this.group, {});
+               this.alfPublish("ALF_CHECKABLE_MENU_ITEM__" + this.group, {
+                   value : this.value
+               });
                this.checked = true;
                this.render();
                this.publishSelection();


### PR DESCRIPTION
When (re-)loading a paginated list, there is significant overhead caused by the Paginator widget module which always destroys and re-creates all the page selection menu items. This is a side-issue found in my analysis preluding #958 that can be addressed without any refactoring around the core widget processing.

This PR adds lazy initialisation and re-use of existing menu items to the page selector menu. When the user clicks the page selector drop down in order to select another page, the hook will check which page menu items have already been created and instantiates the missing remainders. Existing page menu items are only invalidated / destroyed when either the ```documentsPerPage``` setting has changed or the page an item refers to no longer exists or its upper bound has changed (i.e. partially filled last page).
A special case handling for loads potentially initiated by external triggers (i.e. hash change) has been added to the ```processLoadedDocuments``` hook to ensure the current page label is always displayed correctly. This was - as far as I could determine - the primary reason / benefit of the previous behaviour of always re-creating the entire page selector menu.

This PR includes a minor change to AlfCheckableMenuItem to ensure its ```onGroupSelection``` subscription handler is properly handling corner-cases when an item in the same group may be added after the others and should be considered the new, "checked" item via its config.

I tried looking into updating unit tests even though my local test setup is not running. Interestingly there does not seem to be a standalone test of Paginator, only one in the context of documentlibrary. As the tests in that context are quite numerous and I'd be changing them "blindly" (without being able to properly run test), I chose not to.
I did run various manual tests on the Aikau Unit Tests page to ensure the end-user behaviour is correct, which resulted (among fixes to the core PR) in the small change to AlfCheckableMenuItem.

The performance impact / benefit is negligible with lists of only a few pages, but can be dramatic in lists with dozens to thousands of pages.
In one project we passed the ```numberFound``` from our SOLR search as ```totalRecords``` to Aikau UI valueing around a couple 100k results, so Paginator would always destroy and re-create menu items for all pages up to the total number of records (page size was 25). This alone frooze the browser for ~30 seconds. (Limiting the number of page menu items is not included in this particular PR as it could conflict with defined UX.)