### PR TITLE
AKU-1063: Update SelectedItemStateMixin to publish empty array instead of null selected items

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
@@ -83,7 +83,6 @@ define(["dojo/_base/declare",
          // Subscribe to topics for detecting individual changes...
          this.alfSubscribe(this.documentSelectionTopic, lang.hitch(this, this.onDocumentSelected));
          this.alfSubscribe(this.documentDeselectionTopic, lang.hitch(this, this.onDocumentDeselected));
-         this.alfSubscribe(this.selectedDocumentsChangeTopic, lang.hitch(this, this.onFilesSelected));
       },
       
       /**
@@ -126,19 +125,6 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Called when [selectedDocumentsChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#selectedDocumentsChangeTopic} is
-       * published on and disables the menu if no files have been selected. 
-       * 
-       * @instance
-       * @param {object} payload The details of the selected files.
-       * @since 1.0.82
-       */
-      onFilesSelected: function alfresco_documentlibrary_AlfSelectDocumentListItems__onFilesSelected(payload) {
-         this.set("disabled", (payload && payload.selectedItems && payload.selectedItems.length === 0));
-         this.selectedItems = payload.selectedItems;
-      },
-
-      /**
        * Handles the deselection of an individual document
        *
        * @instance
@@ -169,6 +155,7 @@ define(["dojo/_base/declare",
          {
             this.documentsAvailable = payload.documents.length;
          }
+         this.set("disabled", (payload && payload.totalRecords === 0));
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
@@ -83,6 +83,7 @@ define(["dojo/_base/declare",
          // Subscribe to topics for detecting individual changes...
          this.alfSubscribe(this.documentSelectionTopic, lang.hitch(this, this.onDocumentSelected));
          this.alfSubscribe(this.documentDeselectionTopic, lang.hitch(this, this.onDocumentDeselected));
+         this.alfSubscribe(this.selectedDocumentsChangeTopic, lang.hitch(this, this.onFilesSelected));
       },
       
       /**
@@ -122,6 +123,19 @@ define(["dojo/_base/declare",
                length: this.documentsSelected
             }
          });
+      },
+
+      /**
+       * Called when [selectedDocumentsChangeTopic]{@link module:alfresco/documentlibrary/_AlfDocumentListTopicMixin#selectedDocumentsChangeTopic} is
+       * published on and disables the menu if no files have been selected. 
+       * 
+       * @instance
+       * @param {object} payload The details of the selected files.
+       * @since 1.0.82
+       */
+      onFilesSelected: function alfresco_documentlibrary_AlfSelectDocumentListItems__onFilesSelected(payload) {
+         this.set("disabled", (payload && payload.selectedItems && payload.selectedItems.length === 0));
+         this.selectedItems = payload.selectedItems;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/SelectedItemStateMixin.js
@@ -266,10 +266,10 @@ define(["dojo/_base/declare",
        */
       publishSelectedItems: function alfresco_lists_SelectedItemStateMixin__publishSelectedItems() {
          this.alfPublish(this.selectedDocumentsChangeTopic, {
-            selectedItems: this.selectedItems
+            selectedItems: this.selectedItems || []
          });
          this.alfPublish(this.documentSelectionTopic, {
-            selectedItems: this.selectedItems
+            selectedItems: this.selectedItems || []
          });
       },
 

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -118,34 +118,41 @@ define(["dojo/_base/declare",
       handleIconClick: function alfresco_menus_AlfMenuBarSelectItems__handleIconClick(evt) {
          this.alfLog("log", "Icon node clicked");
          
-         // Close the popup if it's open...
-         this.closePopupMenu();
-         if (this._itemsSelected === this._NONE)
+         if (this.get("disabled"))
          {
-            // Select all...
-            this.renderAllSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectAll" });
-         }
-         else if (this._itemsSelected === this._SOME)
-         {
-            // Select all...
-            this.renderAllSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectAll" });
-         }
-         else if (this._itemsSelected === this._ALL)
-         {
-            // Select none...
-            this.renderNoneSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectNone" });
+            // No action required - the widget is disabled...
          }
          else
          {
-            // Select none...
-            this.renderNoneSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectNone" });
+            // Close the popup if it's open...
+            this.closePopupMenu();
+            if (this._itemsSelected === this._NONE)
+            {
+               // Select all...
+               this.renderAllSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectAll" });
+            }
+            else if (this._itemsSelected === this._SOME)
+            {
+               // Select all...
+               this.renderAllSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectAll" });
+            }
+            else if (this._itemsSelected === this._ALL)
+            {
+               // Select none...
+               this.renderNoneSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectNone" });
+            }
+            else
+            {
+               // Select none...
+               this.renderNoneSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectNone" });
+            }
+            event.stop(evt); // Prevent the click event from going any further...
+            domClass.remove(this.domNode, "dijitMenuItemSelected"); // Ensure that the menu bar item isn't marked as selected
          }
-         event.stop(evt); // Prevent the click event from going any further...
-         domClass.remove(this.domNode, "dijitMenuItemSelected"); // Ensure that the menu bar item isn't marked as selected
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -124,34 +124,35 @@ define(["dojo/_base/declare",
          }
          else
          {
-         // Close the popup if it's open...
-         this.closePopupMenu();
-         if (this._itemsSelected === this._NONE)
-         {
-            // Select all...
-            this.renderAllSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectAll" });
+            // Close the popup if it's open...
+            this.closePopupMenu();
+            if (this._itemsSelected === this._NONE)
+            {
+               // Select all...
+               this.renderAllSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectAll" });
+            }
+            else if (this._itemsSelected === this._SOME)
+            {
+               // Select all...
+               this.renderAllSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectAll" });
+            }
+            else if (this._itemsSelected === this._ALL)
+            {
+               // Select none...
+               this.renderNoneSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectNone" });
+            }
+            else
+            {
+               // Select none...
+               this.renderNoneSelected();
+               this.alfPublish(this.notificationTopic, { value: "selectNone" });
+            }
+            event.stop(evt); // Prevent the click event from going any further...
+            domClass.remove(this.domNode, "dijitMenuItemSelected"); // Ensure that the menu bar item isn't marked as selected
          }
-         else if (this._itemsSelected === this._SOME)
-         {
-            // Select all...
-            this.renderAllSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectAll" });
-         }
-         else if (this._itemsSelected === this._ALL)
-         {
-            // Select none...
-            this.renderNoneSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectNone" });
-         }
-         else
-         {
-            // Select none...
-            this.renderNoneSelected();
-            this.alfPublish(this.notificationTopic, { value: "selectNone" });
-         }
-         event.stop(evt); // Prevent the click event from going any further...
-         domClass.remove(this.domNode, "dijitMenuItemSelected"); // Ensure that the menu bar item isn't marked as selected
       },
       
       /**

--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarSelectItems.js
@@ -124,35 +124,34 @@ define(["dojo/_base/declare",
          }
          else
          {
-            // Close the popup if it's open...
-            this.closePopupMenu();
-            if (this._itemsSelected === this._NONE)
-            {
-               // Select all...
-               this.renderAllSelected();
-               this.alfPublish(this.notificationTopic, { value: "selectAll" });
-            }
-            else if (this._itemsSelected === this._SOME)
-            {
-               // Select all...
-               this.renderAllSelected();
-               this.alfPublish(this.notificationTopic, { value: "selectAll" });
-            }
-            else if (this._itemsSelected === this._ALL)
-            {
-               // Select none...
-               this.renderNoneSelected();
-               this.alfPublish(this.notificationTopic, { value: "selectNone" });
-            }
-            else
-            {
-               // Select none...
-               this.renderNoneSelected();
-               this.alfPublish(this.notificationTopic, { value: "selectNone" });
-            }
-            event.stop(evt); // Prevent the click event from going any further...
-            domClass.remove(this.domNode, "dijitMenuItemSelected"); // Ensure that the menu bar item isn't marked as selected
+         // Close the popup if it's open...
+         this.closePopupMenu();
+         if (this._itemsSelected === this._NONE)
+         {
+            // Select all...
+            this.renderAllSelected();
+            this.alfPublish(this.notificationTopic, { value: "selectAll" });
          }
+         else if (this._itemsSelected === this._SOME)
+         {
+            // Select all...
+            this.renderAllSelected();
+            this.alfPublish(this.notificationTopic, { value: "selectAll" });
+         }
+         else if (this._itemsSelected === this._ALL)
+         {
+            // Select none...
+            this.renderNoneSelected();
+            this.alfPublish(this.notificationTopic, { value: "selectNone" });
+         }
+         else
+         {
+            // Select none...
+            this.renderNoneSelected();
+            this.alfPublish(this.notificationTopic, { value: "selectNone" });
+         }
+         event.stop(evt); // Prevent the click event from going any further...
+         domClass.remove(this.domNode, "dijitMenuItemSelected"); // Ensure that the menu bar item isn't marked as selected
       },
       
       /**

--- a/aikau/src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest.js
@@ -159,4 +159,14 @@ define(["module",
             });
       }
    });
+
+   defineSuite(module, {
+         name: "Selected Items Menu Test (Passive)",
+         testPage: "/SelectedItemsMenu?passive=true",
+
+         "Test Menu Initially Disabled": function() {
+            return this.remote.findByCssSelector("#SELECTED_ITEMS.dijitDisabled");
+         }
+   });
+
 });

--- a/aikau/src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/SelectedItemsMenuTest.js
@@ -166,6 +166,10 @@ define(["module",
 
          "Test Menu Initially Disabled": function() {
             return this.remote.findByCssSelector("#SELECTED_ITEMS.dijitDisabled");
+         },
+
+         "Select items menu initially disabled": function() {
+            return this.remote.findByCssSelector("#UPDATE_SELECTED_ITEMS.dijitDisabled");
          }
    });
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SelectedItemsMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SelectedItemsMenu.get.js
@@ -1,3 +1,11 @@
+/* global page */
+/* jshint sub:true */
+var passive = false;
+if (page.url.args["passive"])
+{
+   passive = page.url.args["passive"] === "true";
+}
+
 model.jsonModel = {
    services: [
       {
@@ -70,7 +78,7 @@ model.jsonModel = {
                            name: "alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup",
                            config: {
                               debounceTime: 0, // Remove debounce time to aid testing
-                              passive: false,
+                              passive: passive,
                               itemKeyProperty: "itemKey",
                               label: "Selected items...",
                               widgets: [
@@ -101,6 +109,19 @@ model.jsonModel = {
                                  }
                               ]
                            }
+                        }
+                     ]
+                  }
+               },
+               {
+                  name: "alfresco/lists/AlfList",
+                  config: {
+                     currentData: {
+                        items: []
+                     },
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/HtmlListView"
                         }
                      ]
                   }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SelectedItemsMenu.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/SelectedItemsMenu.get.js
@@ -74,6 +74,15 @@ model.jsonModel = {
                   config: {
                      widgets: [
                         {
+                           id: "UPDATE_SELECTED_ITEMS",
+                           name: "alfresco/documentlibrary/AlfSelectDocumentListItems",
+                           config: {
+                              widgets: [
+                                 
+                              ]
+                           }
+                        },
+                        {
                            id: "SELECTED_ITEMS",
                            name: "alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup",
                            config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1063 to ensure that the SelectedItemStateMixin always publishes an empty array rather than just `null`. This ensures that the 
AlfSelectedItemsMenuBarPopup will have it's state properly initialised. The unit tests have been updated to reproduce the original failure and ensure it has been fixed.

This PR has also been updated to address https://issues.alfresco.com/jira/browse/AKU-1064 as it builds upon the same test page changes.