### PR TITLE
AKU-1067: Ensure GalleryThumbnail gets highlight on selection

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
@@ -164,7 +164,10 @@ define(["dojo/_base/declare",
       widgetsForSelectBar: [
          {
             name: "alfresco/renderers/Selector",
-            align: "left"
+            align: "left",
+            config: {
+               updateOnSelection: true
+            }
          },
          {
             name: "alfresco/renderers/MoreInfo",

--- a/aikau/src/main/resources/alfresco/search/SearchGalleryThumbnail.js
+++ b/aikau/src/main/resources/alfresco/search/SearchGalleryThumbnail.js
@@ -34,6 +34,17 @@ define(["dojo/_base/declare",
    return declare([GalleryThumbnail, SearchThumbnailMixin], {
 
       /**
+       * Overrides the [default]{@link module:alfresco/renderers/Thumbnail#itemKey} to
+       * set a value suitable search results.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.82
+       */
+      itemKey: "nodeRef",
+
+      /**
        * Overrides the inherited value to reference the property provided by the search API
        *
        * @instance


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1067 to ensure that both the GalleryThumbnail and the Selector that it uses are consistent in their configuration of updateOnSelection.