### PR TITLE
AKU-1068: Update copy/move failure messages

### DIFF
--- a/aikau/src/main/resources/alfresco/services/actions/i18n/CopyMoveService.properties
+++ b/aikau/src/main/resources/alfresco/services/actions/i18n/CopyMoveService.properties
@@ -10,8 +10,12 @@ services.ActionService.copyTo.ok=Copy
 services.ActionService.moveTo.ok=Move
 
 copyMoveService.copy.completeSuccess=Copy completed successfully
-copyMoveService.copy.partialSuccess=Copy partially successful, the following files or folders couldn't be copied: {0}
+copyMoveService.copy.partialSuccess=Copy partially successful, but not all of the files or folders could be copied
 copyMoveService.move.completeSuccess=Move completed successfully
-copyMoveService.move.partialSuccess=Move partially successful, the following files or folders couldn't be moved: {0}
+copyMoveService.move.partialSuccess=Move partially successful, but not all of the files or folders could be moved
+
 copyMoveService.copy.failure=The file or folder couldn't be copied right now. Check it's not locked for editing and try again.
 copyMoveService.move.failure=The file or folder couldn't be moved right now. Check it's not locked for editing and try again.
+
+copyMoveService.copy.multiple.failure=The files or folders couldn't be copied right now. Check they're not locked for editing and try again.
+copyMoveService.move.multiple.failure=The files or folders couldn't be moved right now. Check they're not locked for editing and try again.


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1068 to update the messages displayed when copy/move actions fail. The actions can actually be reported by the API as being a success (e.g. HTTP 200) despite nothing actually being copied or moved. Also, the messages now take into account multiplicity for selected items action handling, and partial failure message no longer attempt to report the individual failures due to a lack of available data on the XHR response.