### PR TITLE
AKU-1061: Updates to bulk action filtering to support file types

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentActionMenuItem.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfDocumentActionMenuItem.js
@@ -85,7 +85,11 @@ define(["dojo/_base/declare",
          // Defaulting to show
          var hide = false,
              i, ii;
-         if (payload && payload.userAccess && payload.commonAspects && payload.allAspects)
+         if (payload && 
+             payload.userAccess && 
+             payload.commonAspects && 
+             payload.allAspects &&
+             payload.fileTypes)
          {
             if (this.permission)
             {
@@ -130,16 +134,24 @@ define(["dojo/_base/declare",
                   }
                }
             }
-         }
-         
-         // Hide the menu item if disabled and 
-         if (hide)
-         {
-            this.hide();
-         }
-         else
-         {
-            this.show();
+
+            if (!hide && this.asset)
+            {
+               array.some(payload.fileTypes, function(type) {
+                  hide = this.asset !== type;
+                  return hide;
+               }, this);
+            }
+            
+            // Hide the menu item if disabled and 
+            if (hide)
+            {
+               this.hide();
+            }
+            else
+            {
+               this.show();
+            }
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/services/ActionService.js
+++ b/aikau/src/main/resources/alfresco/services/ActionService.js
@@ -453,7 +453,8 @@ define(["dojo/_base/declare",
             selectedItems: files,
             userAccess: userAccess,
             commonAspects: commonAspects,
-            allAspects: allAspects
+            allAspects: allAspects,
+            fileTypes: fileTypes
          });
       },
 

--- a/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentActionMenuItemTest.js
+++ b/aikau/src/test/resources/alfresco/documentlibrary/AlfDocumentActionMenuItemTest.js
@@ -1,0 +1,84 @@
+/*jshint browser:true*/
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ * @since 1.0.82
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
+
+   defineSuite(module, {
+      name: "AlfDocumentActionMenuItem Tests",
+      testPage: "/AlfDocumentActionMenuItem",
+
+      "Select folder and start workflow action is hidden": function() {
+         return this.remote.findDisplayedByCssSelector("#SELECTOR_ITEM_0")
+            .click()
+         .end()
+
+         // Wait for the selected items menu to be enabled...
+         .waitForDeletedByCssSelector("#SELECTED_ITEMS_MENU.dijitDisabled")
+         .end()
+
+         .findByCssSelector("#SELECTED_ITEMS_MENU_text")
+            .click()
+         .end()
+
+         .findByCssSelector("#SELECTED_ITEMS_MENU_dropdown #onActionAssignWorkflow")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            });
+      },
+
+      "Select document (with folder still selectd) and start workflow actio is still hidden": function() {
+         return this.remote.findDisplayedByCssSelector("#SELECTOR_ITEM_1")
+            .click()
+         .end()
+
+         .findByCssSelector("#SELECTED_ITEMS_MENU_text")
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector("#SELECTED_ITEMS_MENU_dropdown")
+            .findByCssSelector("#onActionAssignWorkflow")
+               .isDisplayed()
+               .then(function(displayed) {
+                  assert.isFalse(displayed);
+               });
+      },
+
+      "De-Select folder to reveal start workflow action": function() {
+         return this.remote.findDisplayedByCssSelector("#SELECTOR_ITEM_0")
+            .click()
+         .end()
+
+         .findByCssSelector("#SELECTED_ITEMS_MENU_text")
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector("#SELECTED_ITEMS_MENU_dropdown #onActionAssignWorkflow")
+            .click();
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,7 +31,7 @@ define(function() {
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/forms/controls/FilePickerTest"
+      "alfresco/documentlibrary/AlfDocumentActionMenuItemTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",
@@ -85,6 +85,7 @@ define(function() {
       "alfresco/dnd/NestedConfigurationTest",
       "alfresco/dnd/NestedReorderTest",
 
+      "alfresco/documentlibrary/AlfDocumentActionMenuItemTest",
       "alfresco/documentlibrary/AlfDocumentTest",
       "alfresco/documentlibrary/AlfDocumentFiltersTest",
       "alfresco/documentlibrary/AlfDocumentListTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentActionMenuItem.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentActionMenuItem.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>AlfDocumentActionMenuItem</shortname>
+  <description>Tests the filtering of document library actions based on selected items.</description>
+  <family>aikau-unit-tests</family>
+  <url>/AlfDocumentActionMenuItem</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentActionMenuItem.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentActionMenuItem.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentActionMenuItem.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/documentlibrary/AlfDocumentActionMenuItem.get.js
@@ -1,0 +1,199 @@
+var createAlfDocumentActionMenuItem = function (config) {
+   return {
+      id: config.id,
+      name: "alfresco/documentlibrary/AlfDocumentActionMenuItem",
+      config: {
+         id: config.actionType,
+         label: config.label,
+         iconImage: config.icon,
+         type: "action-link",
+         permission: config.permission || "",
+         asset: "document",
+         href: "",
+         hasAspect: config.hasAspect || "",
+         notAspect: config.notAspect || "",
+         publishTopic: "ALF_SELECTED_DOCUMENTS_ACTION_REQUEST",
+         publishPayload: {
+            action: config.actionType
+         }
+      }
+   };
+};
+
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      },
+      "alfresco/services/ActionService"
+   ],
+   widgets: [
+      {
+         id: "MENU_BAR",
+         name: "alfresco/menus/AlfMenuBar",
+         config: {
+            widgets: [
+               {
+                  id: "SELECTED_ITEMS_MENU",
+                  name: "alfresco/documentlibrary/AlfSelectedItemsMenuBarPopup",
+                  config: {
+                     label: "Selected Items",
+                     itemKeyProperty: "nodeRef",
+                     widgets: [
+                        {
+                           id: "SELECTED_ITEMS_ACTIONS_GROUP",
+                           name: "alfresco/menus/AlfMenuGroup",
+                           config: {
+                              widgets: [
+                                 createAlfDocumentActionMenuItem({
+                                    id: "DOWNLOAD",
+                                    actionType: "onActionDownload",
+                                    icon: "document-download",
+                                    label: "Download"
+                                 }),
+                                 createAlfDocumentActionMenuItem({
+                                    id: "COPY",
+                                    actionType: "onActionCopyTo",
+                                    icon: "document-copy-to",
+                                    label: "Copy",
+                                    notAspect: "smf:smartFolder,smf:smartFolderChild"
+                                 }),
+                                 createAlfDocumentActionMenuItem({
+                                    id: "MOVE",
+                                    actionType: "onActionMoveTo",
+                                    icon: "document-move-to",
+                                    label: "Move",
+                                    notAspect: "smf:smartFolder,smf:smartFolderChild",
+                                    permission: "Delete"
+                                 }),
+                                 createAlfDocumentActionMenuItem({
+                                    id: "START_WORKFLOW",
+                                    actionType: "onActionAssignWorkflow",
+                                    icon: "document-assign-workflow",
+                                    label: "Start workflow",
+                                    asset: "document"
+                                 }),
+                                 createAlfDocumentActionMenuItem({
+                                    id: "CLOUD_SYNC",
+                                    actionType: "onActionCloudSyncRequest",
+                                    icon: "document-request-sync",
+                                    label: "Request Cloud Sync",
+                                    hasAspect: "sync:syncSetMemberNode",
+                                    notAspect: "smf:smartFolder,smf:smartFolderChild",
+                                    syncMode: "ON_PREMISE"
+                                 })
+                              ]
+                           }
+                        } 
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         id: "LIST",
+         name: "alfresco/lists/AlfList",
+         config: {
+            currentData: {
+               items: [
+                  {
+                     displayName: "Folder",
+                     node: {
+                        nodeRef: "some://fake/node1",
+                        isContainer: true,
+                        permissions: {
+                           inherited: false,
+                           roles: ["ALLOWED;GROUP_EVERYONE;Contributor;DIRECT"],
+                           user: {
+                              Delete: true,
+                              Write: true,
+                              CancelCheckOut: false,
+                              ChangePermissions: true,
+                              CreateChildren: true,
+                              "Unlock": false
+                           }
+                        },
+                        aspects: ["cm:titled", "cm:auditable", "sys:referenceable", "sys:localized", "app:uifacets"]
+                     }
+                  },
+                  {
+                     displayName: "Document",
+                     node: {
+                        nodeRef: "some://fake/node2",
+                        isContainer: false,
+                        permissions: {
+                           inherited: false,
+                           roles: ["ALLOWED;GROUP_EVERYONE;Contributor;DIRECT"],
+                           user: {
+                              Delete: true,
+                              Write: true,
+                              CancelCheckOut: false,
+                              ChangePermissions: true,
+                              CreateChildren: true,
+                              "Unlock": false
+                           }
+                        },
+                        aspects: ["cm:titled", "cm:auditable", "sys:referenceable", "sys:localized", "app:uifacets"]
+                     }
+                  }
+               ]
+            },
+            widgets: [
+               {
+                  id: "VIEW",
+                  name: "alfresco/lists/views/AlfListView",
+                  config: {
+                     widgets: [
+                        {
+                           name: "alfresco/lists/views/layouts/Row",
+                           config: {
+                              widgets: [
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       width: "20px",
+                                       widgets: [
+                                          {
+                                             id: "SELECTOR",
+                                             name: "alfresco/renderers/Selector"
+                                          }
+                                       ]
+                                    }
+                                 },
+                                 {
+                                    name: "alfresco/lists/views/layouts/Cell",
+                                    config: {
+                                       widgets: [
+                                          {
+                                             id: "PROPERTY",
+                                             name: "alfresco/renderers/Property",
+                                             config: {
+                                                propertyToRender: "displayName"
+                                             }
+                                          }
+                                       ]
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1061 to update the `alfresco/documentlibrary/AlfDocumentActionMenuItem` to also filter on supported file type (or "asset" as it is called). A new unit test has been added to verify the filtering based on the specific use-case that generated the bug.