### PR TITLE
AKU-1070: Support for added/removed values in form controls

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1905,7 +1905,7 @@ define(["dojo/_base/declare",
        * @instance
        * @param {object} values The object to update with the current value of the control
        * @since 1.0.82
-       * @overidable
+       * @overridable
        */
       setFormControlValue: function alfresco_forms_controls_BaseFormControl__setFormControlValue(values) {
          if (this.addedAndRemovedValues)

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -246,15 +246,6 @@ define(["dojo/_base/declare",
       name: "",
 
       /**
-       * The value to submit as the value of the field when the form is submitted.
-       *
-       * @instance
-       * @type {string}
-       * @default
-       */
-      value: "",
-
-      /**
        * The list of static options (TODO: We need to provide support for dynamic options via XHR or callback).
        *
        * @instance
@@ -262,6 +253,15 @@ define(["dojo/_base/declare",
        * @default
        */
       options: null,
+
+      /**
+       * The value to submit as the value of the field when the form is submitted.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      value: "",
 
       /**
        * By default if a field is hidden or disabled then it's value should not be posted. This allows multiple controls
@@ -324,6 +324,54 @@ define(["dojo/_base/declare",
        * @since 1.0.65
        */
       supportsMultiValue: false,
+
+      /**
+       * Indicates whether values should be set as separate properties for the files added and removed 
+       * (from the initial state) rather than just a single value representing the files selected.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.82
+       */
+      addedAndRemovedValues: false,
+
+      /**
+       * The suffix added to the form control [name]{@link module:alfresco/forms/controls/BaseFormControl#name}
+       * when [addedAndRemovedValues]{@link module:alfresco/forms/controls/FilePicker#addedAndRemovedValues}
+       * is configured to be true. The concatenated value is then used as the property for the files
+       * that have been added to the form controls initial value.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.82
+       */
+      addedNameSuffix: "_added",
+
+      /**
+       * The suffix added to the form control [name]{@link module:alfresco/forms/controls/BaseFormControl#name}
+       * when [addedAndRemovedValues]{@link module:alfresco/forms/controls/FilePicker#addedAndRemovedValues}
+       * is configured to be true. The concatenated value is then used as the property for the files
+       * that have been removed from the form controls initial value.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.82
+       */
+      removedNameSuffix: "_removed",
+
+      /**
+       * An optional token that can be provided for splitting the supplied value. This should be configured
+       * when the value is provided as a string that needs to be converted into an array.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.82
+       */
+      valueDelimiter: null,
 
       /**
        * The default visibility status is always true (this can be overridden by extending controls).
@@ -1846,7 +1894,86 @@ define(["dojo/_base/declare",
          }
          else
          {
-            // Process dot-notation property names...
+            this.setFormControlValue(values);
+         }
+      },
+
+      /**
+       * This is called from [addFormControlValue]{@link module:alfresco/forms/controls/BaseFormControl#addFormControlValue}
+       * when evaluation of the field configuration and state confirms the value can be set.
+       * 
+       * @instance
+       * @param {object} values The object to update with the current value of the control
+       * @since 1.0.82
+       * @overidable
+       */
+      setFormControlValue: function alfresco_forms_controls_BaseFormControl__setFormControlValue(values) {
+         if (this.addedAndRemovedValues)
+         {
+            var addedName = this.name + this.addedNameSuffix;
+            var removedName = this.name + this.removedNameSuffix;
+
+            if (this.initialFileSelection)
+            {
+               var initialPick = this.initialFileSelection;
+               var currentPick = this.getValue();
+               if (this.valueDelimiter)
+               {
+                  initialPick = this.initialFileSelection.split(this.valueDelimiter);
+                  currentPick = currentPick.split(this.valueDelimiter);
+               }
+               
+               var added = [];
+               var removed = [];
+
+               array.forEach(currentPick, function(currFile) {
+                  // If the current picked file was in the inital selection it has not been added...
+                  // ... BUT if the current pick was NOT in the inital selection it HAS been added
+                  if (array.some(initialPick, function(initialFile) {
+                     return currFile === initialFile;
+                  })) {
+                     // No action required, the current pick was also in the initial pick...
+                  }
+                  else
+                  {
+                     // The current pick was not an initial pick so has been added...
+                     added.push(currFile);
+                  }
+               }, this);
+
+               array.forEach(initialPick, function(initialFile) {
+                  // If the initially picked file is in the current selection it has not been removed...
+                  // ... BUT if the initially picked file is NOT in the current selection it HAS been removed
+                  if (array.some(currentPick, function(currFile) {
+                     return currFile === initialFile;
+                  })) {
+                     // No action required, the current pick was also in the initial pick...
+                  }
+                  else
+                  {
+                     // The initial pick is not a current pick so has been removed...
+                     removed.push(initialFile);
+                  }
+               }, this);
+
+               if (this.valueDelimiter)
+               {
+                  added = added.join(this.valueDelimiter);
+                  removed = removed.join(this.valueDelimiter);
+               }
+
+               lang.setObject(addedName, added, values);
+               lang.setObject(removedName, removed, values);
+            }
+            else
+            {
+               // Nothing removed, everything added...
+               lang.setObject(addedName, this.getValue(), values);
+               lang.setObject(removedName, (this.valueDelimiter ? "": []), values);
+            }
+         }
+         else
+         {
             lang.setObject(this.get("name"), this.getValue(), values);
          }
       },

--- a/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
@@ -175,21 +175,14 @@ define(["dojo/_base/declare",
       showRepository: true,
 
       /**
-       * An optional token that can be provided for splitting the supplied value. This should be configured
-       * when the value is provided as a string that needs to be converted into an array.
-       * 
-       * @instance
-       * @type {string}
-       * @default
-       */
-      valueDelimiter: null,
-
-         /**
        * 
        * 
        * @instance
        */
       createFormControl: function alfresco_forms_controls_FilePicker__createFormControl() {
+         
+         this.initialFileSelection = this.initialValue;
+
          this.setupPubSubData();
 
          // We need to process the widgets for the search view to ensure the generated topics are available...

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -46,7 +46,7 @@ define(["dojo/_base/declare",
         "alfresco/renderers/Boolean",
         "alfresco/forms/controls/CheckBox",
         "alfresco/forms/controls/DateTextBox",
-        "alfresco/forms/controls/DocumentPicker",
+        "alfresco/forms/controls/FilePicker",
         "alfresco/forms/controls/MultiSelectInput",
         "alfresco/forms/controls/NumberSpinner",
         "alfresco/forms/controls/Select",
@@ -85,6 +85,7 @@ define(["dojo/_base/declare",
                config: {
                   width: "400px",
                   valueDelimiter: ",",
+                  addedAndRemovedValues: true,
                   optionsConfig: {
                      labelAttribute: "name",
                      queryAttribute: "name",
@@ -141,7 +142,11 @@ define(["dojo/_base/declare",
                }
             },
             "/org/alfresco/components/form/controls/workflow/packageitems.ftl": {
-               name: "alfresco/forms/controls/DocumentPicker"
+               name: "alfresco/forms/controls/FilePicker",
+               config: {
+                  valueDelimiter: ",",
+                  addedAndRemovedValues: true
+               }
             },
             "/org/alfresco/components/form/controls/percentage-approve.ftl": {
                name: "alfresco/forms/controls/NumberSpinner",

--- a/aikau/src/main/resources/webscripts/forms-runtime-tester.get.js
+++ b/aikau/src/main/resources/webscripts/forms-runtime-tester.get.js
@@ -9,6 +9,7 @@ model.jsonModel = {
                }
             }
       },
+      "alfresco/services/SearchService",
       "alfresco/services/FormsRuntimeService",
       "alfresco/services/CrudService",
       "alfresco/services/NotificationService",

--- a/aikau/src/test/resources/alfresco/forms/controls/FilePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/FilePickerTest.js
@@ -46,6 +46,10 @@ define(["module",
          delimitedValuePicker: {
             openDialog: TestCommon.getTestSelector(buttonSelectors, "button.label",   ["MULTI_ITEM_DELIMITED_VALUE_SHOW_FILE_PICKER_DIALOG"]),
             confirmation: TestCommon.getTestSelector(buttonSelectors, "button.label", ["MULTI_ITEM_DELIMITED_VALUE_SHOW_FILE_PICKER_CONFIRMATION_BUTTON"])
+         },
+         addedAndRemovedValuesPicker: {
+            openDialog: TestCommon.getTestSelector(buttonSelectors, "button.label",   ["DELIMITED_ADDED_REMOVED_VALUES_SHOW_FILE_PICKER_DIALOG"]),
+            confirmation: TestCommon.getTestSelector(buttonSelectors, "button.label", ["DELIMITED_ADDED_REMOVED_VALUES_CONFIRMATION_BUTTON"])
          }
       },
       dialogs: {
@@ -60,6 +64,10 @@ define(["module",
          delimitedValuePicker: {
             displayed: TestCommon.getTestSelector(DialogSelectors, "visible.dialog", ["MULTI_ITEM_DELIMITED_VALUE_SHOW_FILE_PICKER_DIALOG"]),
             hidden: TestCommon.getTestSelector(DialogSelectors, "hidden.dialog", ["MULTI_ITEM_DELIMITED_VALUE_SHOW_FILE_PICKER_DIALOG"]),
+         },
+         addedAndRemovedValuesPicker: {
+            displayed: TestCommon.getTestSelector(DialogSelectors, "visible.dialog", ["DELIMITED_ADDED_REMOVED_VALUES_FILE_PICKER_DIALOG"]),
+            hidden: TestCommon.getTestSelector(DialogSelectors, "hidden.dialog", ["DELIMITED_ADDED_REMOVED_VALUES_FILE_PICKER_DIALOG"]),
          }
       },
       forms: {
@@ -87,6 +95,8 @@ define(["module",
                assert.include(payload.multiFile, {nodeRef :"workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4" });
                assert.include(payload.multiFile, {nodeRef :"workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5" });
                assert.equal(payload.delimitedValue, "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4,workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5");
+               assert.equal(payload.delimited_added, "");
+               assert.equal(payload.delimited_removed, "");
             });
       },
 
@@ -349,6 +359,60 @@ define(["module",
          .getLastPublish("FORM_SCOPE_SAVE")
             .then(function(payload) {
                assert.equal(payload.delimitedValue, "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4");
+            });
+      },
+
+      "Remove file and save to see just the removed files in the payload": function() {
+         return this.remote.findByCssSelector("#DELIMITED_ADDED_REMOVED_VALUES_SELECTED_FILES_REMOVE_ITEM_1 .alfresco-renderers-PublishAction__image")
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.forms.main.confirmationButton)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_SCOPE_SAVE")
+            .then(function(payload) {
+               assert.equal(payload.delimited_added, "");
+               assert.equal(payload.delimited_removed, "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5");
+            }); 
+      },
+
+      "Add a file and save to see added and removed files in the payload": function() {
+         // Open dialog...
+         return this.remote.findByCssSelector(selectors.buttons.addedAndRemovedValuesPicker.openDialog)
+            .click()
+         .end()
+
+         // Wait for dialog to be displayed...
+         .findByCssSelector(selectors.dialogs.addedAndRemovedValuesPicker.displayed)
+         .end()
+
+         // The recent sites tab will be initially displayed because search is hidden, click to add the document...
+         .findDisplayedByCssSelector("#DELIMITED_ADDED_REMOVED_VALUES_BROWSE_ADD_ITEM_4 .alfresco-renderers-PublishAction__image")
+            .click()
+         .end()
+
+         // Confirm selection...
+         .findByCssSelector(selectors.buttons.addedAndRemovedValuesPicker.confirmation)
+            .click()
+         .end()
+
+         // Wait for the dialog to be hidden...
+         .findByCssSelector(selectors.dialogs.addedAndRemovedValuesPicker.hidden)
+         .end()
+
+         // Save the form...
+         .findByCssSelector(selectors.forms.main.confirmationButton)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_SCOPE_SAVE")
+            .then(function(payload) {
+               assert.equal(payload.delimited_added, "workspace://SpacesStore/89366ee4-824d-4d3a-859a-d81a25d9bff3");
+               assert.equal(payload.delimited_removed, "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilePicker.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilePicker.get.js
@@ -63,6 +63,21 @@ model.jsonModel = {
                      valueDelimiter: ",",
                      showSearch: false
                   }
+               },
+               {
+                  id: "DELIMITED_ADDED_REMOVED_VALUES",
+                  name: "alfresco/forms/controls/FilePicker",
+                  config: {
+                     fieldId: "DELIMITED_ADDED_REMOVED_VALUES",
+                     name: "delimited",
+                     label: "Pick more than one file...",
+                     description: "This is a mult-item picker that returns values for both added and removed items",
+                     value: "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4,workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5",
+                     multipleItemSelection: true,
+                     valueDelimiter: ",",
+                     showSearch: false,
+                     addedAndRemovedValues: true
+                  }
                }
             ]
          }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1070 to provide the ability for forms to provide added and removed values instead of a single value. This is required in order to support the mapping of controls required for supporting the Share forms runtime. Unit tests have been added for the FilePicker (for which this is predominantly required).