### PR TITLE
AKU-1071: PushButtons in dialog width

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -189,6 +189,9 @@
                      }
                   }
                }
+               > .control-row {
+                  width: ~"calc(100% -" @dialog-label-section ~"- 10px)";
+               }
             }
          }
       }

--- a/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/PushButtonsTest.js
@@ -27,11 +27,23 @@ define(["module",
         "intern/dojo/node!leadfoot/keys"],
         function(module, defineSuite, assert, TestCommon, keys) {
 
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
    var checkBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/CheckBox");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
    var selectors = {
+      buttons: {
+         openDialog: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_DIALOG"])
+      },
       checkBoxes: {
          toggleDisableState: {
             checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["TOGGLE_DISABLE_STATE"])
+         }
+      },
+      dialogs: {
+         form: {
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["PUSH_BUTTONS_DIALOG"]),
+            displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["PUSH_BUTTONS_DIALOG"]),
+            hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["PUSH_BUTTONS_DIALOG"]),
          }
       }
    };
@@ -193,6 +205,21 @@ define(["module",
             .getVisibleText()
             .then(function(text) {
                assert.equal(text, "No buttons available");
+            });
+      },
+
+      "Check control width in dialog": function() {
+         return this.remote.findByCssSelector(selectors.buttons.openDialog)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.form.displayed)
+         .end()
+
+         .findDisplayedByCssSelector("#DPB_2 .control-row")
+            .getSize()
+            .then(function(size) {
+               assert.closeTo(size.width, 606, 5);
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/PushButtons.get.js
@@ -15,6 +15,93 @@ model.jsonModel = {
    ],
    widgets: [
       {
+         id: "CREATE_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            additionalCssClasses: "call-to-action",
+            label: "Create Form Dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "PUSH_BUTTONS_DIALOG",
+               dialogTitle: "PushButtons in a Dialog",
+               formSubmissionTopic: "CUSTOM_FORM_TOPIC",
+               contentWidth: "800px",
+               widgets: [
+                  {
+                     id: "DPB_1",
+                     name: "alfresco/forms/controls/PushButtons",
+                     config: {
+                        name: "marks1",
+                        label: "A few example marks",
+                        description: "Config options: noWrap=true, maxLineLength=3",
+                        maxLineLength: 3,
+                        noWrap: true,
+                        simpleLayout: true,
+                        multiMode:true,
+                        optionsConfig: {
+                           fixed: [
+                              {
+                                 label: "This label gets truncated because it's really quite long",
+                                 value: "1"
+                              },
+                              {
+                                 label: "Short Mark",
+                                 value: "2"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  {
+                     id: "DPB_2",
+                     name: "alfresco/forms/controls/PushButtons",
+                     config: {
+                        name: "marks2",
+                        label: "Lots of Example Marks",
+                        description: "Config options: noWrap=true, maxLineLength=3",
+                        maxLineLength: 3,
+                        noWrap: true,
+                        simpleLayout: true,
+                        multiMode:true,
+                        optionsConfig: {
+                           fixed: [
+                              {
+                                 label: "This label gets truncated because it's really quite long",
+                                 value: "1"
+                              },
+                              {
+                                 label: "Short Mark",
+                                 value: "2"
+                              },
+                              {
+                                 label: "A Longer Mark",
+                                 value: "3"
+                              },
+                              {
+                                 label: "Another Longer Mark",
+                                 value: "4"
+                              },
+                              {
+                                 label: "Special Department",
+                                 value: "5"
+                              },
+                              {
+                                 label: "A",
+                                 value: "6"
+                              },
+                              {
+                                 label: "One For Luck",
+                                 value: "7"
+                              }
+                           ]
+                        }
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "alfresco/buttons/AlfButton",
          id: "CANT_BUILD_VALUE",
          config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1071 to update how form controls are displayed in dialogs. In particular it ensures that the control itself cannot flow underneath the label. A unit test has been added to verify this change.