### PR TITLE
AKU-1069: Folder links request updated node metadata

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -44,6 +44,7 @@ define(["dojo/_base/declare",
         "dojo/text!./templates/InlineEditProperty.html",
         "dojo/_base/lang",
         "dojo/_base/array",
+        "dojo/Deferred",
         "dojo/on",
         "dojo/dom-class",
         "dojo/html",
@@ -56,7 +57,7 @@ define(["dojo/_base/declare",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
         function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin,
-                 template, lang, array, on, domClass, html, domAttr, keys, event, query) {
+                 template, lang, array, on, Deferred, domClass, html, domAttr, keys, event, query) {
 
    return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin], {
       
@@ -215,6 +216,52 @@ define(["dojo/_base/declare",
       showOkCancelActions: true,
 
       /**
+       * The source file for the image to use to display when an item is being updated. This will
+       * typically only be displayed when an XHR request is made to retrieve the latest data for
+       * the item being edited.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.83
+       */
+      updateInProgressImgSrc: null,
+
+      /**
+       * The alt text label to use for the update in progress indicator.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.83
+       */
+      updateInProgressAltText: "inline-edit.update-in-progress.altText",
+
+      /**
+       * The alt text label to use for the update in progress indicator when the 
+       * [updateInProgressItemLabelProperty]{@link module:alfresco/renderers/InlineEditProperty#updateInProgressItemLabelProperty}
+       * does not match a value in the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.83
+       */
+      updateInProgressNoLabelAltText: "inline-edit.update-in-progress.no-label.altText",
+
+      /**
+       * The property to to retrieve from the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem}
+       * to insert into the [updateInProgressAltText]{@link module:alfresco/renderers/InlineEditProperty#updateInProgressAltText}
+       * that identifies the overall item being updated (rather than just the individual property that is being changed).
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.83
+       */
+      updateInProgressItemLabelProperty: "displayName",
+
+      /**
        * The topic to publish when a property edit should be persisted. For convenience it is assumed that document
        * or folder properties are being edited so this function is called whenever a 'publishTopic' attribute
        * has not been set. The defaults are to publish on the "ALF_CRUD_CREATE" topic which will publish a payload
@@ -247,6 +294,24 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_renderers_InlineEditProperty__postMixInProperties() {
          this.inherited(arguments);
          
+         // NOTE: We're just re-using the same progress indicator as used for forms validation here,
+         //       although this could be updated in the future to be something else...
+         if (!this.updateInProgressImgSrc)
+         {
+            this.updateInProgressImgSrc = require.toUrl("alfresco/forms/controls/css/images/ajax_anim.gif");
+         }
+         var itemLabel = lang.getObject(this.updateInProgressItemLabelProperty, false, this.currentItem);
+         if (itemLabel)
+         {
+            this.updateInProgressAltText = this.message(this.updateInProgressAltText, {
+               0: itemLabel
+            });
+         }
+         else
+         {
+            this.updateInProgressAltText = this.message(this.updateInProgressNoLabelAltText);
+         }
+
          // If no topic has been provided then assume the default behaviour of editing document/folder properties
          if (!this.publishTopic)
          {
@@ -476,6 +541,8 @@ define(["dojo/_base/declare",
        */
       onSave: function alfresco_renderers_InlineEditProperty__onSave(formPayload) {
          /*jshint unused:false*/
+         domClass.add(this.domNode, "alfresco-renderers-InlineEditProperty--updating");
+
          var responseTopic = this.generateUuid();
          var payload = lang.clone(this.getGeneratedPayload(false, null));
          payload.alfResponseTopic = responseTopic;
@@ -515,15 +582,49 @@ define(["dojo/_base/declare",
          // form, etc)
          if (this.refreshCurrentItem === true)
          {
-            lang.setObject(this.propertyToRender, this.originalRenderedValue, this.currentItem);
+            this.updateCurrentItem(payload).then(lang.hitch(this, this.reRenderProperty));
          }
-         
+         else
+         {
+            this.reRenderProperty();
+         }
+      },
+
+      /**
+       * This function is called from [onSaveSuccess]{@link module:alfresco/renderers/InlineEditProperty#onSaveSuccess}
+       * to re-render the property after an edit has successfully been saved.
+       * 
+       * @instance
+       * @param {object} payload The success payload
+       * @since 1.0.83
+       */
+      reRenderProperty: function alfresco_renderers_InlineEditProperty__reRenderProperty() {
          this.renderedValue = this.generateRendering(this.renderedValue);
          html.set(this.renderedValueNode, this.renderedValue);
          domClass.remove(this.renderedValueNode, "hidden");
          domClass.add(this.editNode, "hidden");
          this.updateCssClasses();
          this.renderedValueNode.focus();
+
+         domClass.remove(this.domNode, "alfresco-renderers-InlineEditProperty--updating");
+      },
+
+      /**
+       * This function is called from [onSaveSuccess]{@link module:alfresco/renderers/InlineEditProperty#onSaveSuccess}
+       * when [refreshCurrentItem]{@link module:alfresco/renderers/InlineEditProperty#refreshCurrentItem} is true
+       * and allows the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} to be updated
+       * with the latest data following the update.
+       * 
+       * @instance
+       * @param {object} payload The success payload
+       * @since 1.0.83
+       * @overridable
+       */
+      updateCurrentItem: function alfresco_renderers_InlineEditProperty__updateCurrentItem(/*jshint unused:false*/ payload) {
+         var d = new Deferred();
+         lang.setObject(this.propertyToRender, this.originalRenderedValue, this.currentItem);
+         d.resolve();
+         return d;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -617,6 +617,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @param {object} payload The success payload
+       * @returns {object} A promise of the udpate that by default is immediately resolved.
        * @since 1.0.83
        * @overridable
        */

--- a/aikau/src/main/resources/alfresco/renderers/_ItemLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ItemLinkMixin.js
@@ -29,8 +29,9 @@ define(["dojo/_base/declare",
         "alfresco/core/UrlUtilsMixin",
         "alfresco/core/topics",
         "dojo/_base/lang",
-        "dojo/_base/event"], 
-        function(declare, AlfConstants, UrlUtilsMixin, topics, lang, event) {
+        "dojo/_base/event",
+        "dojo/Deferred"], 
+        function(declare, AlfConstants, UrlUtilsMixin, topics, lang, event, Deferred) {
    
    return declare([UrlUtilsMixin], {
 
@@ -57,6 +58,33 @@ define(["dojo/_base/declare",
          event.stop(evt);
          this.alfLog("log", "Item link clicked: ", payload, this);
          this.alfPublish(this.linkClickTopic, payload);
+      },
+
+      /**
+       * Overrides the [inherited function]{@link module:alfresco/renderers/InlineEditProperty#updateCurrentItem}
+       * to reload the metadata for the item.
+       * 
+       * @instance
+       * @since 1.0.83
+       */
+      updateCurrentItem: function alfresco_renderers__ItemLinkMixin__updateCurrentItem() {
+         var d = new Deferred();
+         
+         var responseTopic = this.generateUuid();
+         var handle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, function(payload) {
+            this.alfUnsubscribe(handle);
+            this.currentItem = payload.response.item;
+            this.originalRenderedValue = this.getRenderedProperty(lang.getObject(this.propertyToRender, false, this.currentItem));
+            this.renderedValue = this.mapValueToDisplayValue(this.originalRenderedValue);
+            d.resolve();
+         }), true);
+
+         this.alfServicePublish(topics.GET_DOCUMENT, {
+            alfResponseTopic: responseTopic,
+            nodeRef: this.currentItem.nodeRef
+         });
+
+         return d;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/_ItemLinkMixin.js
+++ b/aikau/src/main/resources/alfresco/renderers/_ItemLinkMixin.js
@@ -66,6 +66,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @since 1.0.83
+       * @fires module:alfresco/core/topics#GET_DOCUMENT
        */
       updateCurrentItem: function alfresco_renderers__ItemLinkMixin__updateCurrentItem() {
          var d = new Deferred();

--- a/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/InlineEditProperty.css
@@ -49,4 +49,14 @@
          }
       }
    }
+
+   &__progress {
+      display: none;
+   }
+
+   &--updating {
+      .alfresco-renderers-InlineEditProperty__progress {
+         display: inline-block;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/renderers/i18n/InlineEditProperty.properties
+++ b/aikau/src/main/resources/alfresco/renderers/i18n/InlineEditProperty.properties
@@ -3,3 +3,5 @@ inline-edit.edit.altTextNoValue=Click to edit
 inline-edit.edit.label=Click to edit
 inline-edit.save.label=Save
 inline-edit.cancel.label=Cancel
+inline-edit.update-in-progress.altText=Getting the latest values for {0}
+inline-edit.update-in-progress.no-label.altText=Getting the latest values

--- a/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
+++ b/aikau/src/main/resources/alfresco/renderers/templates/InlineEditProperty.html
@@ -5,4 +5,5 @@
       <span data-dojo-attach-point="formWidgetNode"></span>
    </span>
    <img class="editIcon" src="${editIconImageSrc}" alt="${editAltText}" title="${editAltText}" data-dojo-attach-point="editIconNode" data-dojo-attach-event="ondijitclick:onEditClick"/>
+   <img class="alfresco-renderers-InlineEditProperty__progress" src="${updateInProgressImgSrc}" alt="${updateInProgressAltText}">
 </span>

--- a/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/InlineEditPropertyLinkTest.js
@@ -56,7 +56,9 @@ define(["module",
             editIcon: TestCommon.getTestSelector(inlineEditSelectors, "edit.icon", ["INLINE_EDIT_3_ITEM_0"]),
             editSave: TestCommon.getTestSelector(inlineEditSelectors, "edit.save", ["INLINE_EDIT_3_ITEM_0"]),
             editCancel: TestCommon.getTestSelector(inlineEditSelectors, "edit.cancel", ["INLINE_EDIT_3_ITEM_0"]),
-            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_3_ITEM_0"])
+            editInput: TestCommon.getTestSelector(inlineEditSelectors, "edit.input", ["INLINE_EDIT_3_ITEM_0"]),
+            progressIndicator: TestCommon.getTestSelector(inlineEditSelectors, "edit.progress", ["INLINE_EDIT_3_ITEM_0"])
+            
          },
          fourth: {
             readValue: TestCommon.getTestSelector(inlineEditSelectors, "readonly.value", ["INLINE_EDIT_4_ITEM_0"]),
@@ -135,7 +137,7 @@ define(["module",
       "Icon appears on mouseover": function() {
          return this.remote.findByCssSelector(selectors.inlineEditProperties.first.readValue)
             .moveMouseTo()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
             .isDisplayed()
@@ -160,7 +162,7 @@ define(["module",
       "Edit widgets are created on edit": function() {
          return this.remote.findByCssSelector(selectors.inlineEditProperties.first.editIcon)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.first.editForm);
       },
@@ -183,7 +185,7 @@ define(["module",
       "Escape key cancels editing": function() {
          return this.remote.findByCssSelector(selectors.inlineEditProperties.first.editInput)
             .pressKeys([keys.ESCAPE])
-            .end()
+         .end()
 
          .findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue);
       },
@@ -191,7 +193,7 @@ define(["module",
       "Clicking on property fires topic": function() {
          return this.remote.findByCssSelector(selectors.inlineEditProperties.first.readValue)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("TEST_PROPERTY_LINK_CLICK", "Property link topic not published on click");
       },
@@ -211,18 +213,18 @@ define(["module",
                return this.remote.end()
                   .findByCssSelector(selectors.inlineEditProperties.first.editIcon)
                   .click()
-                  .end()
+               .end()
 
                .findByCssSelector(selectors.inlineEditProperties.first.readValue)
                   .isDisplayed()
                   .then(function(result) {
                      assert.isFalse(result, "Edit mode not entered when clicking on icon");
                   })
-                  .end()
+               .end()
 
                .findByCssSelector(selectors.inlineEditProperties.first.editCancel)
                   .click()
-                  .end()
+               .end()
 
                .findDisplayedByCssSelector(selectors.inlineEditProperties.first.readValue);
             });
@@ -232,7 +234,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.inlineEditProperties.first.readValue)
             .pressKeys([keys.CONTROL, "e"])
             .pressKeys(keys.NULL)
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.first.editInput)
             .isDisplayed()
@@ -245,11 +247,11 @@ define(["module",
          return this.remote.findDisplayedByCssSelector(selectors.inlineEditProperties.first.editInput)
             .clearValue()
             .type("New")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.first.editSave)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_CRUD_UPDATE", true, "Property update not requested")
             .then(function(payload) {
@@ -270,16 +272,16 @@ define(["module",
       "Scoped property link update has response scoped": function() {
          return this.remote.findByCssSelector(selectors.inlineEditProperties.second.editIcon)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.second.editInput)
             .type("New2")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.second.editSave)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_CRUD_UPDATE", true, "Property update not requested")
             .then(function(payload) {
@@ -291,29 +293,29 @@ define(["module",
          return this.remote.findByCssSelector(selectors.inlineEditProperties.first.readValue)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("TEST_PROPERTY_LINK_CLICK", true, "'Test item (topic, no scope)' did not publish correct topic")
             .then(function(payload) {
                assert.propertyVal(payload, "alfResponseScope", "", "'Test item (topic, no scope)' generated incorrect alfResponseScope");
             })
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.second.readValue)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_TEST_PROPERTY_LINK_CLICK", true, "'Test item (topic, scoped)' did not publish correct topic")
             .then(function(payload) {
                assert.propertyVal(payload, "alfResponseScope", "SCOPED_", "'Test item (topic, scoped)' generated incorrect alfResponseScope");
             })
-            .end()
+         .end()
 
          .findByCssSelector(selectors.inlineEditProperties.third.readValue)
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SCOPED_ALF_NAVIGATE_TO_PAGE", true, "'Test item (no topic, scoped)' did not publish correct topic")
             .then(function(payload) {
@@ -342,12 +344,12 @@ define(["module",
          // Move the mouse over the hidden edit icon...
          return this.remote.findByCssSelector(selectors.inlineEditProperties.fifth.editIcon)
             .moveMouseTo()
-            .end()
+         .end()
 
          // Wait for it to appear and clikc it...
          .findDisplayedByCssSelector(selectors.inlineEditProperties.fifth.editIcon)
             .click()
-            .end()
+         .end()
 
          // Check that the edit value isn't encoded...
          .findDisplayedByCssSelector(selectors.inlineEditProperties.fifth.editInput)
@@ -360,20 +362,75 @@ define(["module",
       "Save value and check XSS is not injected": function() {
          return this.remote.findByCssSelector(selectors.inlineEditProperties.fifth.editSave)
             .click()
-            .end()
+         .end()
 
          .findDisplayedByCssSelector(selectors.inlineEditProperties.fifth.readValue)
             .getVisibleText()
             .then(function(visibleText) {
                assert.equal(visibleText, "<img src=\"1\" onerror=\"window.hackedProperty=true\">");
             })
-            .end()
+         .end()
 
          .execute(function() {
                return !!window.hackedProperty;
             })
             .then(function(isHacked) {
                assert.isFalse(isHacked);
+            });
+      },
+
+      "Update progress indicators are not initially displayed": function() {
+         return this.remote.findByCssSelector(".alfresco-renderers-InlineEditProperty__progress")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            });
+      },
+
+      "Alt text on progress image contains item label": function() {
+         return this.remote.findByCssSelector(selectors.inlineEditProperties.third.progressIndicator)
+            .getAttribute("alt")
+            .then(function(alt) {
+               assert.equal(alt, "Getting the latest values for Item");
+            });
+      },
+
+      "Edit item with async refresh": function() {
+         return this.remote.findByCssSelector(selectors.inlineEditProperties.third.readValue)
+            .moveMouseTo()
+         .end()
+
+         .findDisplayedByCssSelector(selectors.inlineEditProperties.third.editIcon)
+            .click()
+         .end()
+
+         // No need to update field, new data will be returned by mock service...
+         .findDisplayedByCssSelector(selectors.inlineEditProperties.third.editSave)
+            .click()
+         .end()
+
+         // The progress indicator should be displayued to indicate that new data is being retrieved...
+         .findDisplayedByCssSelector(selectors.inlineEditProperties.third.progressIndicator)
+         .end()
+
+         .sleep(2000) // Matching the async delay on the mock response
+
+         .findDisplayedByCssSelector(selectors.inlineEditProperties.third.readValue)
+            .getVisibleText()
+            .then(function(readValue) {
+               assert.equal(readValue, "UpdatedFolderName");
+            });
+      },
+
+      "Link path is updated with name": function() {
+         return this.remote.findByCssSelector(selectors.inlineEditProperties.third.readValue)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("SCOPED_ALF_DOCUMENTLIST_PATH_CHANGED")
+            .then(function(payload) {
+               assert.propertyVal(payload, "path", "/Shared/UpdatedFolderName");
             });
       }
    });

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -31,7 +31,7 @@ define(function() {
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/documentlibrary/AlfDocumentActionMenuItemTest"
+      "alfresco/renderers/InlineEditPropertyLinkTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",

--- a/aikau/src/test/resources/test-selectors/alfresco/renderers/InlineEditProperty.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/renderers/InlineEditProperty.properties
@@ -18,3 +18,6 @@ edit.cancel=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-F
 
 # The input field used for editing the property value
 edit.input=#{0}.alfresco-renderers-InlineEditProperty .editor .alfresco-forms-Form .alfresco-forms-controls-TextBox .dijitInputContainer input
+
+# The progress indicator (only displayed when update is in progress)
+edit.progress=#{0} .alfresco-renderers-InlineEditProperty__progress

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/InlineEditPropertyLink.get.js
@@ -42,7 +42,7 @@ function getPropertyLinkWidgets(id) {
    ];
 }
 
-function getPropertyLinkWidgetsNoTopic(id) {
+function getPropertyLinkWidgetsNoTopic(id, propertyToRender) {
    return [
       {
          name: "alfresco/lists/views/layouts/Row",
@@ -57,7 +57,7 @@ function getPropertyLinkWidgetsNoTopic(id) {
                            name: "alfresco/renderers/InlineEditPropertyLink",
                            config: {
                               permissionProperty: null,
-                              propertyToRender: "name",
+                              propertyToRender: propertyToRender,
                               publishTopic: "ALF_CRUD_UPDATE",
                               publishPayloadType: "PROCESS",
                               publishPayloadModifiers: ["processCurrentItemTokens"],
@@ -65,6 +65,7 @@ function getPropertyLinkWidgetsNoTopic(id) {
                               publishPayload: {
                                  url: "api/solr/facet-config/{name}"
                               },
+                              refreshCurrentItem: true,
                               hiddenDataRules: [
                                  {
                                     name: "hiddenData",
@@ -96,6 +97,7 @@ model.jsonModel = {
          }
       },
       "aikauTesting/mockservices/MockCrudService",
+      "alfresco/services/DocumentService",
       "alfresco/services/ErrorReporter"
    ],
    widgets:[
@@ -136,11 +138,18 @@ model.jsonModel = {
             currentData: {
                items: [
                   {
-                     name: "Test item (no topic, scoped)"
+                     displayName: "Item",
+                     nodeRef: "workspace://SpacesStore/900c59d8-f59b-46d0-a5d8-cd123ad629c7",
+                     node: {
+                        nodeRef: "workspace://SpacesStore/900c59d8-f59b-46d0-a5d8-cd123ad629c7",
+                        properties: {
+                           "cm:name": "Test item (no topic, scoped)"
+                        }
+                     }
                   }
                ]
             },
-            widgets: getPropertyLinkWidgetsNoTopic("INLINE_EDIT_3")
+            widgets: getPropertyLinkWidgetsNoTopic("INLINE_EDIT_3", "node.properties.cm:name")
          }
       },
       {
@@ -169,6 +178,12 @@ model.jsonModel = {
                ]
             },
             widgets: getPropertyLinkWidgets("INLINE_EDIT_5")
+         }
+      },
+      {
+         name: "aikauTesting/mockservices/FolderNodeMockXhr",
+         config: {
+            respondAfter: 2000
          }
       },
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FolderNodeMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FolderNodeMockXhr.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module aikauTesting/mockservices/FolderNodeMockXhr
+ * @author Dave Draper
+ */
+define(["dojo/_base/declare",
+        "alfresco/testing/MockXhr",
+        "dojo/text!./responseTemplates/FolderNodes/Folder1.json"], 
+        function(declare, MockXhr, Folder1) {
+   
+   return declare([MockXhr], {
+
+      /**
+       * This sets up the fake server with all the responses it should provide.
+       *
+       * @instance
+       */
+      setupServer: function alfresco_testing_mockservices_PreviewMockXhr__setupServer() {
+         try
+         {
+
+            // PDF
+            this.server.respondWith("GET",
+                                    /\/aikau\/service\/components\/documentlibrary\/data\/node\/workspace\/SpacesStore\/900c59d8-f59b-46d0-a5d8-cd123ad629c7(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     Folder1]);
+
+         }
+         catch(e)
+         {
+            this.alfLog("error", "The following error occurred setting up the mock server", e);
+         }
+      }
+   });
+});

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FolderNodes/Folder1.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FolderNodes/Folder1.json
@@ -1,0 +1,254 @@
+{
+   "metadata": {
+      "repositoryId": "b1cca06d-c198-4d37-bd05-f7d6be067d6e",
+      "custom": {
+         "vtiServer": null
+      },
+      "onlineEditing": false,
+      "workingCopyLabel": " (Working Copy)",
+      "shareURL": "http:\/\/dave-Precision-5510:8080\/share",
+      "serverURL": "http:\/\/localhost:8080",
+      "parent": {
+         "permissions": {
+            "user": {},
+            "roles": []
+         }
+      }
+   },
+   "item": {
+      "thumbnailDefinitions": [],
+      "node": {
+         "isLink": false,
+         "nodeRef": "workspace:\/\/SpacesStore\/900c59d8-f59b-46d0-a5d8-cd123ad629c7",
+         "permissions": {
+            "inherited": true,
+            "roles": ["ALLOWED;GROUP_EVERYONE;Contributor;INHERITED"],
+            "user": {
+               "Delete": true,
+               "Write": true,
+               "CancelCheckOut": false,
+               "ChangePermissions": true,
+               "CreateChildren": true,
+               "Unlock": false
+            }
+         },
+         "isLocked": false,
+         "aspects": ["cm:titled", "cm:auditable", "sys:referenceable", "sys:localized"],
+         "isContainer": true,
+         "type": "cm:folder",
+         "properties": {
+            "cm:title": "",
+            "cm:creator": {
+               "firstName": "Administrator",
+               "lastName": "",
+               "displayName": "Administrator",
+               "userName": "admin"
+            },
+            "cm:modifier": {
+               "firstName": "Administrator",
+               "lastName": "",
+               "displayName": "Administrator",
+               "userName": "admin"
+            },
+            "cm:created": {
+               "iso8601": "2016-08-19T07:57:48.446Z",
+               "value": "Fri Aug 19 08:57:48 BST 2016"
+            },
+            "cm:name": "UpdatedFolderName",
+            "sys:store-protocol": null,
+            "sys:node-dbid": null,
+            "sys:store-identifier": null,
+            "sys:locale": null,
+            "cm:modified": {
+               "iso8601": "2016-08-19T07:57:48.446Z",
+               "value": "Fri Aug 19 08:57:48 BST 2016"
+            },
+            "cm:description": "",
+            "sys:node-uuid": null
+         }
+      },
+      "parent": {
+         "isLink": false,
+         "nodeRef": "workspace:\/\/SpacesStore\/fe724c3d-e069-4cbd-85fc-1e795a94a247",
+         "permissions": {
+            "inherited": false,
+            "roles": ["ALLOWED;GROUP_EVERYONE;Contributor;DIRECT"],
+            "user": {
+               "Delete": true,
+               "Write": true,
+               "CancelCheckOut": false,
+               "ChangePermissions": true,
+               "CreateChildren": true,
+               "Unlock": false
+            }
+         },
+         "isLocked": false,
+         "aspects": ["cm:titled", "cm:auditable", "sys:referenceable", "sys:localized", "app:uifacets"],
+         "isContainer": true,
+         "type": "cm:folder",
+         "properties": {
+            "cm:title": "Shared Folder",
+            "cm:creator": {
+               "firstName": "System",
+               "lastName": "User",
+               "displayName": "System User",
+               "userName": "System"
+            },
+            "cm:modifier": {
+               "firstName": "Administrator",
+               "lastName": "",
+               "displayName": "Administrator",
+               "userName": "admin"
+            },
+            "cm:created": {
+               "iso8601": "2016-08-18T09:53:10.235Z",
+               "value": "Thu Aug 18 10:53:10 BST 2016"
+            },
+            "sys:store-protocol": null,
+            "sys:store-identifier": null,
+            "cm:description": "Folder to store shared stuff ",
+            "sys:node-uuid": null,
+            "cm:name": "Shared",
+            "sys:node-dbid": null,
+            "sys:locale": null,
+            "cm:modified": {
+               "iso8601": "2016-08-19T07:57:48.503Z",
+               "value": "Fri Aug 19 08:57:48 BST 2016"
+            },
+            "app:icon": "space-icon-default"
+         }
+      },
+      "version": "1.0",
+      "webdavUrl": "\/webdav\/Shared\/UpdatedFolderName",
+      "isFavourite": false,
+      "likes": {
+         "isLiked": false,
+         "totalLikes": 0
+      },
+      "location": {
+         "repositoryId": "b1cca06d-c198-4d37-bd05-f7d6be067d6e",
+         "path": "\/Shared",
+         "repoPath": "\/Shared",
+         "file": "UpdatedFolderName",
+         "parent": {}
+      },
+      "nodeRef": "workspace:\/\/SpacesStore\/900c59d8-f59b-46d0-a5d8-cd123ad629c7",
+      "fileName": "UpdatedFolderName",
+      "displayName": "UpdatedFolderName",
+      "actionGroupId": "folder-browse",
+      "actions": [{
+         "id": "folder-download",
+         "icon": "document-download",
+         "type": "javascript",
+         "label": "actions.folder.download",
+         "params": {
+            "function": "onActionFolderDownload"
+         },
+         "index": 99100.0,
+         "subgroup": 99.0
+      }, {
+         "id": "folder-view-details",
+         "icon": "folder-view-details",
+         "type": "pagelink",
+         "label": "actions.folder.view-details",
+         "params": {
+            "page": "folder-details?nodeRef={node.nodeRef}"
+         },
+         "index": 99105.0,
+         "subgroup": 99.0
+      }, {
+         "id": "document-edit-properties",
+         "icon": "folder-edit-properties",
+         "type": "javascript",
+         "label": "actions.folder.edit-metadata",
+         "params": {
+            "function": "onActionDetails"
+         },
+         "index": 99110.0,
+         "subgroup": 99.0
+      }, {
+         "id": "document-copy-to",
+         "icon": "folder-copy-to",
+         "type": "javascript",
+         "label": "actions.folder.copy-to",
+         "params": {
+            "function": "onActionCopyTo"
+         },
+         "index": 99150.0,
+         "subgroup": 99.0
+      }, {
+         "id": "document-move-to",
+         "icon": "folder-move-to",
+         "type": "javascript",
+         "label": "actions.folder.move-to",
+         "params": {
+            "function": "onActionMoveTo"
+         },
+         "index": 99160.0,
+         "subgroup": 99.0
+      }, {
+         "id": "folder-manage-rules",
+         "icon": "folder-manage-rules",
+         "type": "pagelink",
+         "label": "actions.folder.rules",
+         "params": {
+            "page": "folder-rules?nodeRef={node.nodeRef}"
+         },
+         "index": 99170.0,
+         "subgroup": 99.0
+      }, {
+         "id": "document-delete",
+         "icon": "folder-delete",
+         "type": "javascript",
+         "label": "actions.folder.delete",
+         "params": {
+            "function": "onActionDelete"
+         },
+         "index": 99180.0,
+         "subgroup": 99.0
+      }, {
+         "id": "document-manage-repo-permissions",
+         "icon": "folder-manage-permissions",
+         "type": "link",
+         "label": "actions.folder.manage-permissions",
+         "params": {
+            "href": "{managePermissionsUrl}"
+         },
+         "index": 99200.0,
+         "subgroup": 99.0
+      }, {
+         "id": "document-manage-aspects",
+         "icon": "document-manage-aspects",
+         "type": "javascript",
+         "label": "actions.folder.manage-aspects",
+         "params": {
+            "function": "onActionManageAspects"
+         },
+         "index": 99210.0,
+         "subgroup": 99.0
+      }],
+      "indicators": [],
+      "metadataTemplate": {
+         "id": "default",
+         "title": null,
+         "banners": [],
+         "lines": [{
+            "index": "10",
+            "template": "{date}{size}",
+            "view": ""
+         }, {
+            "index": "20",
+            "template": "{description}",
+            "view": "detailed"
+         }, {
+            "index": "30",
+            "template": "{tags}",
+            "view": "detailed"
+         }, {
+            "index": "50",
+            "template": "{social}",
+            "view": "detailed"
+         }]
+      }
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1069 to provide the ability for the InlineEditPropertyLink widget to make a request for the latest metadata for the current item. This is required because changing the name of a folder results in the location metadata changing which cannot be refreshed manually safely. The most reliable approach is to support the ability to reload the data after saving so the most recent changes are displayed on the client. This ensures that linking is correct. The unit tests have been updated to support this change.