### PR TITLE
AKU-1054: Ensure that expanded panels remain expanded on Grid resize

### DIFF
--- a/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
+++ b/aikau/src/test/resources/alfresco/lists/views/ExpandableGalleryTest.js
@@ -210,4 +210,26 @@ define(["module",
             });
       }
    });
+
+   defineSuite(module, {
+      name: "Expandable Gallery View Tests (resizeByColumnCount=false)",
+      testPage: "/ExandableGallery?resizeByColumnCount=false",
+
+      "Select an item, check the expanded panel is shown": function() {
+         return this.remote.findDisplayedById("CELL_CONTAINER_ITEM_0")
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel");
+      },
+
+      "Resize window to make sure expanded cell remains the same size": function() {
+         return this.remote.findByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel td")
+         .end()
+
+         .setWindowSize(null, 1500, 768)
+
+         .findDisplayedByCssSelector(".alfresco-lists-views-layouts-Grid__expandedPanel");
+      }
+   });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/views/ExpandableGallery.get.js
@@ -1,3 +1,11 @@
+/* global page */
+/* jshint sub:true */
+var resizeByColumnCount = true;
+if (page.url.args["resizeByColumnCount"])
+{
+   resizeByColumnCount = page.url.args["resizeByColumnCount"] === "true";
+}
+
 model.jsonModel = {
    services: [
       {
@@ -29,7 +37,8 @@ model.jsonModel = {
                {
                   name: "alfresco/documentlibrary/views/AlfGalleryView",
                   config: {
-                     columns: 10,
+                     resizeByColumnCount: resizeByColumnCount,
+                     columns: 5,
                      enableHighlighting: true,
                      itemKeyProperty: "nodeRef",
                      expandTopics: ["EXPAND"],


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1054 to ensure that expanded panels remain expanded (or at least are re-expanded) following re-rendering of data following resize event of the browser window. Unit tests have been updated to verify this change.