### PR TITLE
AKU-1053: Support form control rule grouping

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/LayoutMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/LayoutMixin.js
@@ -42,6 +42,74 @@ define(["alfresco/core/Core",
    return declare([AlfCore], {
       
       /**
+       * Iterates over the child form controls and updates their visibility status
+       *
+       * @instance
+       * @param {boolean} status The boolean value to change the visibility state to.
+       * @since 1.0.83
+       */
+      alfVisible: function alfresco_forms_LayoutMixin__alfVisible(status) {
+         when(this.getFormLayoutChildren(), lang.hitch(this, function(children) {
+            array.forEach(children, function(child) {
+               if (typeof child.alfVisible === "function")
+               {
+                  child.alfVisible(status);
+               }
+            }, this);
+         }));
+      },
+
+      /**
+       * Iterates over the child form controls and updates their requirement status
+       *
+       * @instance
+       * @param {boolean} status The boolean value to change the requirement state to
+       * @since 1.0.83
+       */
+      alfRequired: function alfresco_forms_LayoutMixin__alfRequired(status) {
+         when(this.getFormLayoutChildren(), lang.hitch(this, function(children) {
+            array.forEach(children, function(child) {
+               if (typeof child.alfRequired === "function")
+               {
+                  child.alfRequired(status);
+               }
+            }, this);
+         }));
+      },
+
+      /**
+       * Iterates over the child form controls and updates their disablement status
+       *
+       * @instance
+       * @param {boolean} status The boolean status to set the disablity state of the field to.
+       * @since 1.0.83
+       */
+      alfDisabled: function alfresco_forms_LayoutMixin__alfDisabled(status) {
+         when(this.getFormLayoutChildren(), lang.hitch(this, function(children) {
+            array.forEach(children, function(child) {
+               if (typeof child.alfDisabled === "function")
+               {
+                  child.alfDisabled(status);
+               }
+            }, this);
+         }));
+      },
+
+      /**
+       * Sets up the rules for groups visibility, requirement and disablement.
+       *
+       * @instance
+       * @param {boolean} status The boolean status to set the disablity state of the field to.
+       * @since 1.0.83
+       */
+      postMixInProperties: function alfresco_forms_LayoutMixin__postMixInProperties() {
+         this.inherited(arguments);
+         this.processConfig("alfVisible", this.visibilityConfig);
+         this.processConfig("alfRequired", this.requirementConfig);
+         this.processConfig("alfDisabled", this.disablementConfig);
+      },
+
+      /**
        * Iterates over the array of processed widgets and adds the value of each to the supplied object
        *
        * @instance

--- a/aikau/src/test/resources/alfresco/forms/LayoutRulesTest.js
+++ b/aikau/src/test/resources/alfresco/forms/LayoutRulesTest.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(module, defineSuite, assert, TestCommon) {
+
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var formControlSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/BaseFormControl");
+   var checkBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/CheckBox");
+   var selectors = {
+      checkBoxes: {
+         visibility: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["TOGGLE_VISIBILITY"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["TOGGLE_VISIBILITY"])
+         },
+         requirement: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["TOGGLE_REQUIREMENT"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["TOGGLE_REQUIREMENT"])
+         },
+         disablement: {
+            checkBox: TestCommon.getTestSelector(checkBoxSelectors, "checkbox", ["TOGGLE_DISABLEMENT"]),
+            label: TestCommon.getTestSelector(formControlSelectors, "label", ["TOGGLE_DISABLEMENT"])
+         }
+      },
+      form: {
+         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["FORM"])
+      },
+      formControls: {
+         select: {
+            requirementIndicator: TestCommon.getTestSelector(formControlSelectors, "requirement.indicator", ["SELECT1"]),
+            disabled: TestCommon.getTestSelector(formControlSelectors, "disabled", ["SELECT1"])
+         },
+         textBox: {
+            requirementIndicator: TestCommon.getTestSelector(formControlSelectors, "requirement.indicator", ["TEXTBOX1"]),
+            disabled: TestCommon.getTestSelector(formControlSelectors, "disabled", ["TEXTBOX1"])
+         }
+      }
+   };
+
+   defineSuite(module, {
+      name: "Layout Rules Tests",
+      testPage: "/LayoutRules",
+
+      "Controls are initially displayed": function() {
+         return this.remote.findDisplayedById("SELECT1")
+         .end()
+
+         .findDisplayedById("TEXTBOX1");
+      },
+
+      "Toggle visibility": function() {
+         return this.remote.findByCssSelector(selectors.checkBoxes.visibility.checkBox)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_ALF_FORM_VALIDITY")
+
+         .findById("SELECT1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            })
+         .end()
+
+         .findById("TEXTBOX1")
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            })
+         .end()
+
+         .findByCssSelector(selectors.checkBoxes.visibility.checkBox)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_ALF_FORM_VALIDITY")
+
+         .findDisplayedById("SELECT1")
+         .end()
+
+         .findDisplayedById("TEXTBOX1");
+      },
+
+      "Controls are initially required": function() {
+         return this.remote.findDisplayedByCssSelector(selectors.formControls.select.requirementIndicator)
+         .end()
+
+         .findDisplayedByCssSelector(selectors.formControls.textBox.requirementIndicator);
+      },
+
+      "Toggle requirement": function() {
+         return this.remote.findByCssSelector(selectors.checkBoxes.requirement.checkBox)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_ALF_FORM_VALIDITY")
+
+         .findByCssSelector(selectors.formControls.select.requirementIndicator)
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            })
+         .end()
+
+         .findByCssSelector(selectors.formControls.textBox.requirementIndicator)
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            })
+         .end()
+
+         .findByCssSelector(selectors.checkBoxes.requirement.checkBox)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_ALF_FORM_VALIDITY")
+
+         .findDisplayedByCssSelector(selectors.formControls.select.requirementIndicator)
+         .end()
+
+         .findDisplayedByCssSelector(selectors.formControls.textBox.requirementIndicator);
+      },
+
+      "Controls are initially disabled": function() {
+         return this.remote.findByCssSelector(selectors.formControls.select.disabled)
+         .end()
+
+         .findByCssSelector(selectors.formControls.textBox.disabled);
+      },
+
+      "Toggle disablement": function() {
+         return this.remote.findByCssSelector(selectors.checkBoxes.disablement.checkBox)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_ALF_FORM_VALIDITY")
+
+         .findAllByCssSelector(selectors.formControls.select.disabled)
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            })
+         .end()
+
+         .findAllByCssSelector(selectors.formControls.textBox.disabled)
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            })
+         .end()
+
+         .findByCssSelector(selectors.checkBoxes.disablement.checkBox)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("FORM_ALF_FORM_VALIDITY")
+
+         .findByCssSelector(selectors.formControls.select.disabled)
+         .end()
+
+         .findByCssSelector(selectors.formControls.textBox.disabled);
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -124,6 +124,7 @@ define(function() {
       "alfresco/forms/FormValidationTest",
       "alfresco/forms/HashFormTest",
       "alfresco/forms/LateFieldRegistrationTest",
+      "alfresco/forms/LayoutRulesTest",
       "alfresco/forms/SingleTextFieldFormTest",
       "alfresco/forms/TabsInFormsTest",
 

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/BaseFormControl.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/BaseFormControl.properties
@@ -18,3 +18,6 @@ validating.state=#{0}.alfresco-forms-controls-BaseFormControl .validationInProgr
 
 # Validation message
 validation.message=#{0} span.validation-message
+
+# A disabled form control
+disabled=#{0}.alfresco-forms-controls-BaseFormControl--disabled

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LayoutRules.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LayoutRules.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Form Layout Rule Processing</shortname>
+  <description>This page is used to test that form layout widgets can be configured with dynamic rules that are applied to all their child form controls.</description>
+  <family>aikau-unit-tests</family>
+  <url>/LayoutRules</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LayoutRules.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LayoutRules.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LayoutRules.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/LayoutRules.get.js
@@ -1,0 +1,119 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         id: "FORM",
+         name: "alfresco/forms/Form",
+         config: {
+            pubSubScope: "FORM_",
+            widgets: [
+               {
+                  id: "TOGGLE_VISIBILITY",
+                  name: "alfresco/forms/controls/CheckBox",
+                  config: {
+                     fieldId: "VISIBLE",
+                     label: "Visible?",
+                     description: "Use this checkbox to toggle the visibility of all the fields in the row",
+                     value: true
+                  }
+               },
+               {
+                  id: "TOGGLE_REQUIREMENT",
+                  name: "alfresco/forms/controls/CheckBox",
+                  config: {
+                     fieldId: "REQUIRED",
+                     label: "Required?",
+                     description: "Use this checkbox to toggle the requirement of all the fields in the row",
+                     value: true
+                  }
+               },
+               {
+                  id: "TOGGLE_DISABLEMENT",
+                  name: "alfresco/forms/controls/CheckBox",
+                  config: {
+                     fieldId: "DISABLED",
+                     label: "Disabled?",
+                     description: "Use this checkbox to toggle the requirement of all the fields in the row",
+                     value: true
+                  }
+               },
+               {
+                  id: "CR1",
+                  name: "alfresco/forms/ControlRow",
+                  config: {
+                     title: "Groups Rules",
+                     visibilityConfig: {
+                        rules: [
+                           {
+                              targetId: "VISIBLE",
+                              is: [true]
+                           }
+                        ]
+                     },
+                     requirementConfig: {
+                        rules: [
+                           {
+                              targetId: "REQUIRED",
+                              is: [true]
+                           }
+                        ]
+                     },
+                     disablementConfig: {
+                        rules: [
+                           {
+                              targetId: "DISABLED",
+                              is: [true]
+                           }
+                        ]
+                     },
+                     widgets: [
+                        {
+                           id: "SELECT1",
+                           name: "alfresco/forms/controls/Select",
+                           config: {
+                              fieldId: "SELECT1",
+                              name: "select",
+                              label: "Select option",
+                              description: "Selecting an option should update the dynamic payload button",
+                              optionsConfig: {
+                                 fixed: [
+                                    { label: "One", value: "ONE" },
+                                    { label: "Two", value: "TWO" }
+                                 ]
+                              }
+                           }
+                        },
+                        {
+                           id: "TEXTBOX1",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "TEXTBOX1",
+                              name: "textbox",
+                              label: "Some Text",
+                              description: "Created to ensure that initial value is published",
+                              value: "Initial Value"
+                           }
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1053 to provide support for the visibility, requirement and disablement rules on form layout widgets (like ControlRow). This means that a single rule can be applied to all the child widgets within it. Unit tests have been added to support the change.