### PR TITLE
AKU-1072: Support options for hiding validation in form controls

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -87,6 +87,8 @@
 // Used for dialog label width area
 @dialog-label-section: 160px;
 @dialog-control-section: 530px;
+// The minimum width of a dialog (unless overridden in the request to the DialogService)
+@dialog-min-width: 580px;
 
 // Font Colours
 @general-font-color: #333;

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -166,6 +166,17 @@ define(["dojo/_base/declare",
       handleOverflow: true,
 
       /**
+       * Indicates the the default minimum width rules for the dialog (controlled through LESS
+       * variables) can be ignored.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.84
+       */
+      noMinWidth: false,
+
+      /**
        * A placeholder for the resize-listener that's enabled while the dialog is visible. This
        * value is set automatically.
        *
@@ -306,6 +317,10 @@ define(["dojo/_base/declare",
          if (this.additionalCssClasses)
          {
             domClass.add(this.domNode, this.additionalCssClasses);
+         }
+         if (this.noMinWidth)
+         {
+            domClass.add(this.domNode, "alfresco-dialog-AlfDialog--no-min-width");
          }
 
          // Set a width for the dialog

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -10,7 +10,7 @@
       box-shadow: 0 3px 8px rgba(0,0,0,.1);
       font-family: @standard-font;
       font-size: @normal-font-size;
-      min-width: 580px;
+      min-width: @dialog-min-width;
       &.tinymce-dialog {
          min-width: 540px;
          .control {
@@ -42,6 +42,14 @@
          font-weight: normal;
       }
    }
+   &--no-min-width {
+      &.dijitDialog {
+         min-width: 0;
+         .dialog-body {
+            min-width: 0;
+         }
+      }
+   }
    &.iefooter {
       .dialog-body {
          height: auto;
@@ -70,7 +78,7 @@
    }
    .dialog-body {
       margin-bottom: 40px; // NOTE: If this is changed, the associated margin adjustment in the JS needs updating
-      min-width: 580px;
+      min-width: @dialog-min-width;
       overflow: auto;
       padding: 12px; // NOTE: If this is changed, the associated paddingAdjustment in the JS needs updating
       min-height: 76px; // See AKU-1023, compensated for title

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -374,6 +374,18 @@ define(["dojo/_base/declare",
       valueDelimiter: null,
 
       /**
+       * This indicates whether or not the validation elements are hidden (for example the invalid
+       * field indicator and any validation messages). This would typically be used for form dialogs
+       * where the fields have no label.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.84
+       */
+      hideValidation: false,
+
+      /**
        * The default visibility status is always true (this can be overridden by extending controls).
        *
        * @instance
@@ -1191,6 +1203,11 @@ define(["dojo/_base/declare",
          if (this.additionalCssClasses)
          {
             domClass.add(this.domNode, this.additionalCssClasses);
+         }
+
+         if (this.hideValidation)
+         {
+            domClass.add(this.domNode, "alfresco-forms-controls-BaseFormControl--validation-hidden");
          }
 
          if (this.inlineHelp)

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -110,6 +110,18 @@
    &.long > .control-row > div.control > div {
       width: 472px;
    }
+
+   &--validation-hidden {
+      > .title-row {
+         .alfresco-forms-controls-BaseFormControl__validation-error,
+         .requirementIndicator.required,
+         .validation-message,
+         .validationInProgress {
+            display: none;
+         }
+      }
+   }
+
    div.control {
       div.dijitComboBox.dijitTextBoxHover, .dijitTextBoxHover, .dijitTextAreaHover, .dijitTextBoxFocused, .dijitTextAreaFocused, .dijitTextBoxActive, .dijitTextAreaActive {
          background-color: inherit;
@@ -169,6 +181,10 @@
                &--no-label {
                   > .title-row {
                      display: none;
+
+                     > label:after {
+                        content: "";
+                     }
                   }
                   > .description-row {
                      > .description {
@@ -189,8 +205,39 @@
                      }
                   }
                }
+               &--validation-hidden {
+                  > .title-row {
+                     span.validation-message {
+                        display: none;
+                     }
+                  }
+               }
+               &--validation-hidden.alfresco-forms-controls-BaseFormControl--no-label {
+                  > .title-row {
+                     display: none;
+                  }
+                  > .control-row {
+                     width: initial;
+                  }
+                  > .description-row {
+                     > .description {
+                        margin: 0;
+                     }
+                  }
+               }
                > .control-row {
                   width: ~"calc(100% -" @dialog-label-section ~"- 10px)";
+               }
+            }
+         }
+      }
+   }
+   &--no-min-width {
+      .dialog-body {
+         .alfresco-forms-Form.root-dialog-form {
+            > form {
+               > .alfresco-forms-controls-BaseFormControl {
+                  min-width: 0
                }
             }
          }

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -155,6 +155,7 @@
  * @property {boolean} [showValidationErrorsImmediately=true] Indicates whether or not to display form errors immediately
  * @property {object} [customFormConfig=null] Any additional configuration that can be applied to a [Form]{@link module:alfresco/forms/Form} (please note that the following form configuration
  * attributes will always be overridden by specific form dialog configuration: "additionalCssClasses", "displayButtons", "widgets", "value", "warnings" and "warningsPosition")
+ * @property {boolean} [noMinWidth=false] Indicates whether the minimum width restriction should be lifted
  */
 
 /**
@@ -175,6 +176,7 @@
  * @property {Array} [publishOnShow=null] - An array of publications objects to make when the dialog is displayed
  * @property {boolean} [fullScreenMode=false] Whether or not to create the dialog the size of the screen
  * @property {boolean} [fullScreenPadding=10] The padding to leave around the dialog when in full screen mode
+ * @property {boolean} [noMinWidth=false] Indicates whether the minimum width restriction should be lifted
  */
 
 define(["dojo/_base/declare",
@@ -479,7 +481,8 @@ define(["dojo/_base/declare",
             contentWidth: payload.contentWidth ? payload.contentWidth : null,
             contentHeight: payload.contentHeight ? payload.contentHeight : null,
             handleOverflow: handleOverflow,
-            fixedWidth: fixedWidth
+            fixedWidth: fixedWidth,
+            noMinWidth: payload.noMinWidth || false
          };
 
          // Ensure that text content is center aligned (see AKU-368)...
@@ -723,6 +726,7 @@ define(["dojo/_base/declare",
             duration: config.duration || 0,
             handleOverflow: handleOverflow,
             fixedWidth: fixedWidth,
+            noMinWidth: config.noMinWidth || false,
             fullScreenMode: config.fullScreenMode || false,
             fullScreenPadding: !isNaN(config.fullScreenPadding) ? config.fullScreenPadding : 10,
             parentPubSubScope: config.parentPubSubScope,

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -482,7 +482,7 @@ define(["dojo/_base/declare",
             contentHeight: payload.contentHeight ? payload.contentHeight : null,
             handleOverflow: handleOverflow,
             fixedWidth: fixedWidth,
-            noMinWidth: payload.noMinWidth || false
+            noMinWidth: !!payload.noMinWidth
          };
 
          // Ensure that text content is center aligned (see AKU-368)...
@@ -726,7 +726,7 @@ define(["dojo/_base/declare",
             duration: config.duration || 0,
             handleOverflow: handleOverflow,
             fixedWidth: fixedWidth,
-            noMinWidth: config.noMinWidth || false,
+            noMinWidth:  !!config.noMinWidth,
             fullScreenMode: config.fullScreenMode || false,
             fullScreenPadding: !isNaN(config.fullScreenPadding) ? config.fullScreenPadding : 10,
             parentPubSubScope: config.parentPubSubScope,

--- a/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
@@ -63,7 +63,10 @@ define(["module",
          dialogTextBox: {
             validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["DIALOG_FORM_TEXTBOX"])
          },
-         
+         hiddenValidation: {
+            requirementIndicator: TestCommon.getTestSelector(formControlSelectors, "requirement.indicator", ["VALIDATION_HIDDEN_TEXTBOX"]),
+            invalidIndicator: TestCommon.getTestSelector(formControlSelectors, "invalid.indicator", ["VALIDATION_HIDDEN_TEXTBOX"])
+         }
       },
       buttons: {
          blockResponse: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BLOCK_RESPONSE"]),
@@ -76,6 +79,14 @@ define(["module",
             disabledConfirmationButton: TestCommon.getTestSelector(dialogSelectors, "disabled.form.dialog.confirmation.button", ["VALIDATION_DIALOG"]),
             displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["VALIDATION_DIALOG"]),
             hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["VALIDATION_DIALOG"]),
+            cancelButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.cancellation.button", ["VALIDATION_DIALOG"])
+         },
+         hiddenValidation: {
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["VALIDATION_DIALOG_2"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(dialogSelectors, "disabled.form.dialog.confirmation.button", ["VALIDATION_DIALOG_2"]),
+            displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["VALIDATION_DIALOG_2"]),
+            hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["VALIDATION_DIALOG_2"]),
+            cancelButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.cancellation.button", ["VALIDATION_DIALOG_2"])
          }
       }
    };
@@ -333,7 +344,30 @@ define(["module",
          .findByCssSelector(selectors.dialogs.checkMessage.displayed)
          .end()
 
-         .findDisplayedByCssSelector(selectors.textBoxes.dialogTextBox.validationMessage);
+         .findDisplayedByCssSelector(selectors.textBoxes.dialogTextBox.validationMessage)
+         .end();
+      },
+
+      "Validation indicators can be hidden on request": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.hiddenValidation.requirementIndicator)
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            })
+         .end()
+
+         .findByCssSelector(selectors.textBoxes.hiddenValidation.invalidIndicator)
+            .isDisplayed()
+            .then(function(displayed) {
+               assert.isFalse(displayed);
+            })
+         .end()
+
+         .findByCssSelector(selectors.dialogs.checkMessage.cancelButton)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.checkMessage.hidden);
       }
    });
 });

--- a/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
@@ -4,6 +4,9 @@ disabled.form.dialog.confirmation.button=#{0} .footer .confirmationButton.dijitB
 # The confirmation button on a form dialog
 form.dialog.confirmation.button=#{0} .footer .confirmationButton .dijitButtonNode
 
+# The cancellation button on a form dialog
+form.dialog.cancellation.button=#{0} .footer .cancellationButton .dijitButtonNode
+
 # A hidden dialog
 hidden.dialog=#{0}.dialogHidden
 

--- a/aikau/src/test/resources/test-selectors/alfresco/forms/controls/BaseFormControl.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/forms/controls/BaseFormControl.properties
@@ -4,6 +4,9 @@ help.indicator=#{0} img.inlineHelp
 # A control that is currently in the invalid state
 invalid.state=#{0}.alfresco-forms-controls-BaseFormControl--invalid
 
+# The indicator that the field is in the invalid state
+invalid.indicator=#{0} .alfresco-forms-controls-BaseFormControl__validation-error
+
 # Label
 label=#{0}.alfresco-forms-controls-BaseFormControl .label
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -169,6 +169,64 @@ model.jsonModel = {
                            }
                         ]
                      }
+                  },
+                  {
+                     id: "VALIDATION_HIDDEN_TEXTBOX",
+                     name: "alfresco/forms/controls/TextBox",
+                     config: {
+                        label: null, // PLEASE NOTE: Label left intentionally blank for testing purposes (AKU-951)
+                        description: "Required (but requirement and validation hidden)",
+                        name: "name",
+                        value: "",
+                        requirementConfig: {
+                           initialValue: true
+                        },
+                        hideValidation: true
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
+         id: "SHOW_PICKER_IN_DIALOG",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Show picker with hidden validation in dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogId: "VALIDATION_DIALOG_2",
+               dialogTitle: "SimplePicker",
+               formSubmissionTopic: "POST_DIALOG_FORM",
+               formSubmissionGlobal: true,
+               noMinWidth: true,
+               widgets: [
+                  {
+                     id: "SIMPLE_PICKER",
+                     name: "alfresco/forms/controls/SimplePicker",
+                     config: {
+                        label: null,
+                        description: "SimplePicker in form, without label, required but with hidden validation",
+                        name: "picker1",
+                        reorderable: true,
+                        currentData: {
+                           items: [
+                              {
+                                 name: "One"
+                              },
+                              {
+                                 name: "Two"
+                              },
+                              {
+                                 name: "Three"
+                              }
+                           ]
+                        },
+                        requirementConfig: {
+                           initialValue: true
+                        },
+                        hideValidation: true
+                    }
                   }
                ]
             }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1072 to provide configuration options for hiding the validation indicators and messages for form controls. The use case here is when no label attribute is required (the exact use case being where a SimplePicker is the sole form control in a form dialog) and we want to avoid the requirement asterisk, invalid field indicator being displayed, etc. This is an opt-in feature meaning that all existing implementations should not be impacted. Unit tests have been provided to verify this change.