### PR TITLE
Fix redundant vertical scrollbars in FilePicker (and likely other dialogs with handleOverflow=false)

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -250,7 +250,7 @@ define(["dojo/_base/declare",
          var simplePanelHeight = null;
          if (this.contentHeight)
          {
-            simplePanelHeight = (parseInt(this.contentHeight, 10) - paddingAdjustment) + "px";
+            simplePanelHeight = (Math.min(maxHeight, parseInt(this.contentHeight, 10)) - paddingAdjustment) + "px";
          }
          
          calculatedHeights.documentHeight = docHeight;
@@ -361,7 +361,7 @@ define(["dojo/_base/declare",
                assignTo: "_dialogPanel",
                config: {
                   handleOverflow: this.handleOverflow,
-                  height: calculatedHeights.simplePanelHeight,
+                  height: !this.handleOverflow && this.contentHeight ? "100%" : calculatedHeights.simplePanelHeight,
                   widgets: this.widgetsContent
                }
             }];

--- a/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
@@ -224,6 +224,7 @@ define(["dojo/_base/declare",
                            widgetsContent: widgets,
                            contentWidth: "800px",
                            contentHeight: "700px",
+                           handleOverflow : false,
                            widgetsButtons: [
                               {
                                  id: this.id + "_CONFIRMATION_BUTTON",

--- a/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
+++ b/aikau/src/main/resources/alfresco/layout/AlfTabContainer.js
@@ -437,6 +437,7 @@ define(["dojo/_base/declare",
          this._tabContainerChildrenPromise = new Deferred();
          this.createTabContainer();
          this.alfSetupResizeSubscriptions(this.onResize, this);
+         this.addResizeListener(this.domNode);
          if (this.padded)
          {
             domClass.add(this.domNode, "alfresco-layout-AlfTabContainer--padded");


### PR DESCRIPTION
The FilePicker shows redundant vertical scrollbars when the content of the currently active tab exceeds the dynamically calculated height of the dialog content panel. This is the result of incorrect calculation of heights (the content panel is larger than it should actually be based on dialog height and buffer for dialog title + toolbar) and a missing parameter when creating the FilePicker dialog to tell the AlfDialog module that the content (FixedHeaderFooter) already handles any overflow.

This PR addresses this layout issue. It:
- adds the handleOverflow parameter to the dialog payload for FilePicker (value: false)
- adds a missing resize watch on the AlfTabContainer (which might be resized either due external constraints, changes in tab contents or addition / removal / activation of tabs)
- adds missing constraints to the dialog content panel height, restricting it to maximum allowed height - either dynamically calculated or (if contents handle overflow) the externally defined height.

Screenshot of original problem with redundant scroll bars:
![aikau-FilePicker-scrolling](https://cloud.githubusercontent.com/assets/2211521/18036254/f8fac50e-6d65-11e6-9078-1faa1e9761e1.png)

Note: No unit tests have been adapted. A new machine will hopefully be delivered in the next 14 days which will be used to retry getting unit tests to work for me.