### PR TITLE
Picker - fix for null reference error

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/Picker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Picker.js
@@ -162,10 +162,14 @@ define(["alfresco/forms/controls/BaseFormControl",
        */
       getValue: function alfresco_forms_controls_Picker__getValue() {
          var processedItems = [];
-         var items = this.getPickedItemsWidget().currentData.items;
-         array.forEach(items, function(item) {
-            processedItems.push(item[this.itemKey]);
-         }, this);
+         var pickedItemsWidget = this.getPickedItemsWidget();
+         if (pickedItemsWidget)
+         {
+             var items = pickedItemsWidget.currentData.items;
+             array.forEach(items, function(item) {
+                processedItems.push(item[this.itemKey]);
+             }, this);
+         }
          return processedItems;
       },
       


### PR DESCRIPTION
Working on my JavaScript Console Aikau-ification project I encountered a reference error in the getValue function of the Picker module. This PR adds a simple guard for the initialisation of the pickedItemsWidget, which is already checked in a similar way in setValue