### PR TITLE
AKU-1079 - CLONE - Search button disabled when pasting a search term using Mouse right click + Paste in Share Search

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
@@ -109,6 +109,14 @@ define(["alfresco/core/topics",
          if (this.wrappedWidget)
          {
             this.wrappedWidget.on("keyup", lang.hitch(this, this.handleKeyUp));
+            // Paste event is called before the pasted value is applied to the source element - we use a setTimeout
+            // to catch the value on the next time around the browser event loop. This is a little messy but works
+            // consistently on all supported browsers.
+            this.wrappedWidget.on("paste", lang.hitch(this, function() {
+               setTimeout(lang.hitch(this, function() {
+                  this.handleKeyUp({keyCode:0});
+               }), 0);
+            }));
             if (typeof this.wrappedWidget.watch === "function")
             {
                this.own(this.wrappedWidget.watch("value", lang.hitch(this, this.fireChangeEvent)));

--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -865,6 +865,14 @@ define(["dojo/_base/declare",
          on(this._searchTextNode, "keydown", lang.hitch(this, function(evt) {
             this.onSearchBoxKeyDown(evt);
          }));
+         // Paste event is called before the pasted value is applied to the source element - we use a setTimeout
+         // to catch the value on the next time around the browser event loop. This is a little messy but works
+         // consistently on all supported browsers.
+         on(this._searchTextNode, "paste", lang.hitch(this, function() {
+            setTimeout(lang.hitch(this, function() {
+               this.onSearchBoxKeyUp({keyCode:0});
+            }), 0);
+         }));
          
          // construct the optional advanced search menu
          if (this.advancedSearch)


### PR DESCRIPTION
Added support for "paste" event into SearchBox component and the TextBoxValueChangeMixin.

Tested in IE10/11, Chrome and FireFox via the following unit test pages by manual "right click + paste" operation in text fields:
SearchBox
TextBox

Doesn't appear to be a way to add a specific automated test for this operation (CTRL+paste in automated test does not help, as there is already a keypress event to handle this).