### PR TITLE
AKU-1076: Ensure filteringTopics do not need to be configured for AlfFilteredList

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -466,6 +466,8 @@ define(["dojo/_base/declare",
       setupFilteringTopics: function alfresco_lists_AlfFilteredList__setupFilteringTopics(filter) {
          if (filter && filter.config && filter.config.fieldId)
          {
+            // See AKU-1076 - ensure filteringTopics do not require explicit configuration
+            !!!this.filteringTopics && (this.filteringTopics = []);
             this.filteringTopics.push("_valueChangeOf_" + filter.config.fieldId);
             if (this.mapHashVarsToPayload) 
             {

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -467,7 +467,7 @@ define(["dojo/_base/declare",
          if (filter && filter.config && filter.config.fieldId)
          {
             // See AKU-1076 - ensure filteringTopics do not require explicit configuration
-            !!!this.filteringTopics && (this.filteringTopics = []);
+            this.filteringTopics = this.filteringTopics || [];
             this.filteringTopics.push("_valueChangeOf_" + filter.config.fieldId);
             if (this.mapHashVarsToPayload) 
             {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
@@ -89,7 +89,6 @@ model.jsonModel = {
                            config: {
                               pubSubScope: "COMPOSITE_",
                               useHash: true,
-                              filteringTopics: ["_valueChangeOf_FILTER"],
                               showFilterSummary: true,
                               widgetsForFilters: [
                                  {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1076 to ensure that it is not necessary to explicitly configure the filteringTopics array for an AlfFilteredList. It was not necessary to add an existing unit test - the existing tests failed when the filteringTopics configuration is removed from the current test page - updating the code resolved those failures.