### PR TITLE
AKU-1077: Add support for filter summary label mapping

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -210,6 +210,29 @@ define(["dojo/_base/declare",
       summaryWidgetsMappingId: "FILTER_SUMMARY",
 
       /**
+       * This is an optional map of filter values to labels. The map should have filter name attributes that are 
+       * mapped to a sub-map of values to labels, e.g. 
+       *
+       * @example
+       * filterSummaryLabelMapping: {
+       *   name: {
+       *     ted: "Edward",
+       *     bob: "Robert"
+       *   },
+       *   age: {
+       *     10: "Ten",
+       *     20: "Twenty"
+       *   }
+       * }
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       * @since 1.0.84
+       */
+      filterSummaryLabelMapping: null,
+
+      /**
        * The filter widgets
        *
        * @instance
@@ -512,7 +535,10 @@ define(["dojo/_base/declare",
       widgetsForFilterSummary: [
          {
             id: "{id}_FILTER_SUMMARY",
-            name: "alfresco/lists/utilities/FilterSummary"
+            name: "alfresco/lists/utilities/FilterSummary",
+            config: {
+               labelMap: "{filterSummaryLabelMapping}"
+            }
          }
       ]
    });

--- a/aikau/src/main/resources/alfresco/lists/utilities/FilterSummary.js
+++ b/aikau/src/main/resources/alfresco/lists/utilities/FilterSummary.js
@@ -85,6 +85,29 @@ define(["dojo/_base/declare",
       label: "filter-summary.label",
 
       /**
+       * This is an optional map of filter values to labels. The map should have filter name attributes that are 
+       * mapped to a sub-map of values to labels, e.g. 
+       *
+       * @example
+       * labelMapping: {
+       *   name: {
+       *     ted: "Edward",
+       *     bob: "Robert"
+       *   },
+       *   age: {
+       *     10: "Ten",
+       *     20: "Twenty"
+       *   }
+       * }
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       * @since 1.0.84
+       */
+      labelMapping: null,
+
+      /**
        * Processes the [label]{@link module:alfresco/lists/utilities/Label} to ensure that it is localized.
        * 
        * @instance
@@ -208,10 +231,22 @@ define(["dojo/_base/declare",
        * @param    {item} item The filter whose "name" attribute should be returned as the label
        * @returns {object} An object representing the filter name.
        */
-      _getLabel: function alfresco_forms_controls_MultiSelect___getLabel(item) {
+      _getLabel: function alfresco_lists_utilities_FilterSummary__getLabel(item) {
+
+         var labels, label;
+         if (this.labelMap)
+         {
+            labels = lang.getObject(item.name, false, this.labelMap);
+            if (labels)
+            {
+               label = lang.getObject(item.value, false, labels);
+            }
+         }
+
+         var choice = (label || item.value);
          return {
-            choice: item.value,
-            full: item.value
+            choice: choice,
+            full: choice
          };
       },
 
@@ -224,7 +259,7 @@ define(["dojo/_base/declare",
        * @fires module:alfresco/core/topics#FILTER_REMOVED
        * @fires module:alfresco/core/topics#FILTER_VALUE_CHANGE
        */
-      _removeChoice: function alfresco_forms_controls_MultiSelect___removeChoice(choiceToRemove) {
+      _removeChoice: function alfresco_lists_utilities_FilterSummary__removeChoice(choiceToRemove) {
          this.inherited(arguments);
 
          // Publish information indicating that the filter has been removed and that the value of the filter has changed...

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -39,13 +39,13 @@ define(["module",
             .then(function(elements) {
                assert.lengthOf(elements, 8, "The wrong number of results were displayed");
             })
-            .end()
+         .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
                assert.lengthOf(elements, 5, "Did not load first page of results");
             })
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-selector [id$=PAGE_SELECTOR_text]")
             .getVisibleText()
@@ -58,11 +58,11 @@ define(["module",
          return this.remote.findByCssSelector("#TEXTBOX .dijitInputContainer input")
             .clearLog()
             .type("one")
-            .end()
+         .end()
 
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
+         .end()
 
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
@@ -75,10 +75,10 @@ define(["module",
             .clearLog()
             .type(keys.BACKSPACE)
             .type(keys.BACKSPACE)
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
+         .end()
 
          .findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
@@ -108,11 +108,11 @@ define(["module",
          return this.remote.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
             .clearLog()
             .type("t")
-            .end()
+         .end()
 
          // Use the implicit wait for the loading data to return to ensure that the filtered results have returned
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
+         .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
@@ -141,7 +141,7 @@ define(["module",
             .clearLog()
             .get(updatedUrl)
             .getLastPublish("COMPOSITE_ALF_DOCLIST_REQUEST_FINISHED")
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
             .getVisibleText()
@@ -165,19 +165,19 @@ define(["module",
          return this.remote.findByCssSelector("body")
             .clearLog()
             .get(updatedUrl)
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", "Didn't reload list after hash change")
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
             .clearLog()
             .clearValue()
             .pressKeys(keys.TAB)
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_DOCUMENTS_LOADED", 1500, "Didn't reload list after filter removal")
-            .end()
+         .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
@@ -188,7 +188,7 @@ define(["module",
       "Going to next page displays second page of results (useHash=true)": function() {
          return this.remote.findByCssSelector("#COMPOSITE .alfresco-lists-Paginator__page-forward")
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500, "Going to next page did not reload list")
 
@@ -202,23 +202,23 @@ define(["module",
          return this.remote.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
             .clearLog()
             .type("five and")
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED", 1500)
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputInner")
             .getProperty("value")
             .then(function(value) {
                assert.equal(value, "five and", "Incorrect filter field value");
             })
-            .end()
+         .end()
 
          .findAllByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "One result should be displayed for filter 'five and'");
             })
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE .alfresco-lists-views-layouts-Cell:nth-child(2) .alfresco-renderers-Property .value")
             .getVisibleText()
@@ -232,15 +232,15 @@ define(["module",
             returnUrl = TestCommon.generateWebscriptUrl("/FilteredList#description=woof");
          return this.remote.findByCssSelector("body")
             .clearLog()
-            .end()
+         .end()
 
          .get(anotherPageUrl)
             .findByCssSelector("body")
-            .end()
+         .end()
 
          .get(returnUrl)
             .findByCssSelector("body")
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE .alfresco-lists-views-AlfListView table")
             .getVisibleText()
@@ -266,7 +266,7 @@ define(["module",
          return this.remote.findByCssSelector(".alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
             .getVisibleText()
             .then(function(text) {
-               assert.equal(text, "woof");
+               assert.equal(text, "A dog says");
             });
       },
 
@@ -282,7 +282,7 @@ define(["module",
          return this.remote.findByCssSelector(".alfresco-forms-controls-utilities-ChoiceMixin__choice__close-button")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST");
       },
@@ -306,7 +306,7 @@ define(["module",
          return this.remote.findByCssSelector("#COMPOSITE_TEXTBOX .dijitInputContainer input")
             .clearLog()
             .type("e")
-            .end()
+         .end()
 
          .findByCssSelector(".alfresco-forms-controls-utilities-ChoiceMixin__choice__content")
             .getVisibleText()
@@ -319,14 +319,14 @@ define(["module",
          return this.remote.findByCssSelector("#COMPOSITE_DROPDOWN .dijitArrowButtonInner")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#COMPOSITE_DROPDOWN_CONTROL_popup1")
             .click()
-            .end()
+         .end()
 
          .getLastPublish("COMPOSITE_ALF_DOCLIST_REQUEST_FINISHED")
-            .end()
+         .end()
 
          .findAllByCssSelector(".alfresco-forms-controls-utilities-ChoiceMixin__choice")
             .then(function(elements) {
@@ -338,7 +338,7 @@ define(["module",
          return this.remote.findByCssSelector(".alfresco-lists-utilities-FilterSummary__choices .alfresco-renderers-PropertyLink")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_RETRIEVE_DOCUMENTS_REQUEST")
             .end()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/lists/FilteredList.get.js
@@ -91,6 +91,12 @@ model.jsonModel = {
                               useHash: true,
                               filteringTopics: ["_valueChangeOf_FILTER"],
                               showFilterSummary: true,
+                              filterSummaryLabelMapping: {
+                                 description: {
+                                    moo: "A cow Goes",
+                                    woof: "A dog says"
+                                 }
+                              },
                               widgetsForFilters: [
                                  {
                                     id: "COMPOSITE_TEXTBOX",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1077 to provide support for mapping filter values to labels. The unit tests have been updated to verify this works.