### PR TITLE
AKU-1081: Add support for payload mixins into forms runtime

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1121,6 +1121,9 @@ define([],function() {
        * @property {string} itemId The unique identifier for the item for the form (e.g. a NodeRef)
        * @property {string} [formId] The unique identifier of the form to be retrieved
        * @property {string} mode The mode of form to retrieve (e.g. "view" or "edit")
+       * @property {object} [formConfig=null] Some optional configuration for the form
+       * @property {string} [formConfig.formId=null] The ID to give to the rendered form
+       * @property {object} [formConfig.formSubmissionPayloadMixin] Some additional data to include in the form submission
        */
       REQUEST_FORM: "ALF_FORM_REQUEST",
 

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -427,6 +427,7 @@ define(["dojo/_base/declare",
 
             this.serviceXhr({url : url,
                              method: "GET",
+                             formConfig: payload.formConfig,
                              alfSuccessTopic: successTopic,
                              successCallback: this.onFormLoaded,
                              failureCallback: this.onFormLoadFailure,
@@ -479,18 +480,26 @@ define(["dojo/_base/declare",
             }
             else
             {
+               // Check for an optional ID for the form...
+               var formId = lang.getObject("formConfig.formId", false, originalRequestConfig);
+
+               // Mixin in any additional data to include in the payload...
+               var formSubmissionPayloadMixin = lang.getObject("formConfig.formSubmissionPayloadMixin", false, originalRequestConfig);
+               var okButtonPublishPayload = {
+                  url: response.submissionUrl,
+                  urlType: "FULL"
+               };
+               formSubmissionPayloadMixin && lang.mixin(okButtonPublishPayload, formSubmissionPayloadMixin);
+
                var formControls = [];
                var formConfig = {
-
+                  id: formId,
                   name: "alfresco/forms/Form",
                   config: {
                      showOkButton: response.showSubmitButton,
                      showCancelButton: response.showCancelButton,
                      okButtonPublishTopic: response.method === "post" ? "ALF_CRUD_CREATE" : "ALF_CRUD_UPDATE",
-                     okButtonPublishPayload: {
-                        url: response.submissionUrl,
-                        urlType: "FULL"
-                     },
+                     okButtonPublishPayload: okButtonPublishPayload,
                      okButtonPublishGlobal: true,
                      value: response.data,
                      widgets: formControls

--- a/aikau/src/test/resources/alfresco/services/FormsRuntimeServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/FormsRuntimeServiceTest.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ * @since 1.0.84
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(module, defineSuite, assert, TestCommon) {
+
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var multiSelectInputSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/MultiSelectInput");
+
+   var selectors = {
+      buttons: {
+         editNode: TestCommon.getTestSelector(buttonSelectors, "button.label", ["EDIT_NODE"]),
+         viewNode: TestCommon.getTestSelector(buttonSelectors, "button.label", ["VIEW_NODE"]),
+         createWorkflow: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_WORKFLOW"])
+      },
+      authoritySelector: {
+         control: TestCommon.getTestSelector(multiSelectInputSelectors, "control", ["ASSOC_BPM_ASSIGNEE"]),
+         loaded: TestCommon.getTestSelector(multiSelectInputSelectors, "options.loaded.state", ["ASSOC_BPM_ASSIGNEE"]),
+         choice: TestCommon.getTestSelector(multiSelectInputSelectors, "choice", ["ASSOC_BPM_ASSIGNEE"]),
+         firstChoice: {
+            element: TestCommon.getTestSelector(multiSelectInputSelectors, "nth.choice", ["MULTISELECT_1", "1"]),
+            content: TestCommon.getTestSelector(multiSelectInputSelectors, "nth.choice.content", ["MULTISELECT_1", "1"]),
+            delete: TestCommon.getTestSelector(multiSelectInputSelectors, "nth.choice.delete", ["MULTISELECT_1", "1"])
+         },
+         result: TestCommon.getTestSelector(multiSelectInputSelectors, "result", ["ASSOC_BPM_ASSIGNEE"]),
+         loading: TestCommon.getTestSelector(multiSelectInputSelectors, "results.loading.message", ["ASSOC_BPM_ASSIGNEE"]),
+         firstResult: TestCommon.getTestSelector(multiSelectInputSelectors, "nth.result", ["ASSOC_BPM_ASSIGNEE", "1"]),
+         searchbox: TestCommon.getTestSelector(multiSelectInputSelectors, "searchbox", ["ASSOC_BPM_ASSIGNEE"]),
+         noresults: TestCommon.getTestSelector(multiSelectInputSelectors, "no.results.message", ["ASSOC_BPM_ASSIGNEE"])
+      },
+      forms: {
+         createWorkflow: {
+            confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["CREATE_WORKFLOW_FORM"])
+         }
+      },
+   };
+
+   defineSuite(module, {
+      name: "Forms Runtime Service Tests",
+      testPage: "/FormsRuntimeService",
+
+      "Form submissions payload can contain additional data": function() {
+         // Request the form for creating an adhoc workflow...
+         return this.remote.findByCssSelector(selectors.buttons.createWorkflow)
+            .click()
+         .end()
+
+         // Wait for the authority MultiSelectInput control to be displayed (this is the only required field)...
+         .findDisplayedByCssSelector(selectors.authoritySelector.control)
+            .click()
+         .end()
+
+         // Select the first result ("Alice Beecher")...
+         .findDisplayedByCssSelector(selectors.authoritySelector.firstResult)
+            .click()
+         .end()
+
+         // Submit the form...
+         .findByCssSelector(selectors.forms.createWorkflow.confirmationButton)
+            .click()
+         .end()
+
+         // Check the response scope was included...
+         .getLastPublish("ALF_CRUD_CREATE")
+            .then(function(payload) {
+               assert.propertyVal(payload, "alfResponseScope", "CREATE_WORKFLOW_SCOPE_");
+            })
+
+         // ...which should result in the scoped reload request
+         .getLastPublish("CREATE_WORKFLOW_SCOPE_ALF_DOCLIST_RELOAD_DATA");
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -291,6 +291,7 @@ define(function() {
       "alfresco/services/DialogServiceTest",
       "alfresco/services/DocumentServiceTest",
       "alfresco/services/FileUploadServiceTest",
+      "alfresco/services/FormsRuntimeServiceTest",
       "alfresco/services/FullScreenDialogTest",
       "alfresco/services/LoggingServiceTest",
       "alfresco/services/NavigationServiceTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
@@ -10,10 +10,13 @@ model.jsonModel = {
             }
       },
       "alfresco/services/FormsRuntimeService",
-      "alfresco/services/DialogService"
+      "alfresco/services/DialogService",
+      "alfresco/services/UserService",
+      "alfresco/services/CrudService"
    ],
    widgets: [
       {
+         id: "EDIT_NODE",
          name: "alfresco/buttons/AlfButton",
          config: {
             label: "Show Edit Simple DocLib Node",
@@ -27,6 +30,7 @@ model.jsonModel = {
          }
       },
       {
+         id: "VIEW_NODE",
          name: "alfresco/buttons/AlfButton",
          config: {
             label: "Show View Default Node",
@@ -35,6 +39,25 @@ model.jsonModel = {
                itemKind: "node",
                itemId: "some://dummy/node",
                mode: "view"
+            }
+         }
+      },
+      {
+         id: "CREATE_WORKFLOW",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Create workflow",
+            publishTopic: "ALF_FORM_REQUEST",
+            publishPayload: {
+               itemKind: "workflow",
+               itemId: "activiti%24activitiAdhoc",
+               mode: "create",
+               formConfig: {
+                  formId: "CREATE_WORKFLOW_FORM",
+                  formSubmissionPayloadMixin: {
+                     alfResponseScope: "CREATE_WORKFLOW_SCOPE_"
+                  }
+               }
             }
          }
       },

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
@@ -27,9 +27,13 @@ define(["dojo/_base/declare",
         "alfresco/testing/MockXhr",
         "webscripts/defaults",
         "dojo/_base/lang",
+        "dojo/text!./responseTemplates/FormsRuntime/Authorities.json",
         "dojo/text!./responseTemplates/FormsRuntime/EditDocLibSimpleMetadata.json",
-        "dojo/text!./responseTemplates/FormsRuntime/ViewNodeDefault.json"], 
-        function(declare, MockXhr, webScriptDefaults, lang, EditDocLibSimpleMetadata, ViewNodeDefault) {
+        "dojo/text!./responseTemplates/FormsRuntime/ViewNodeDefault.json",
+        "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflow.json",
+        "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflowSuccess.json"], 
+        function(declare, MockXhr, webScriptDefaults, lang, Authorities, EditDocLibSimpleMetadata, ViewNodeDefault, 
+                 CreateWorkflow, CreateWorkflowSuccess) {
    
    return declare([MockXhr], {
 
@@ -42,16 +46,34 @@ define(["dojo/_base/declare",
          try
          {
             this.server.respondWith("GET",
-                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=node&itemId=some/dummy/node&formId=doclib-simple-metadata&mode=edit",
+                                    "/aikau/proxy/alfresco/api/forms/picker/authority/children?searchTerm=&selectableType=cm:person&size=1000",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     Authorities]);
+
+            this.server.respondWith("GET",
+                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=node&itemId=some://dummy/node&formId=doclib-simple-metadata&mode=edit",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      EditDocLibSimpleMetadata]);
 
             this.server.respondWith("GET",
-                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=node&itemId=some/dummy/node&formId=null&mode=view",
+                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=node&itemId=some://dummy/node&formId=null&mode=view",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      ViewNodeDefault]);
+
+            this.server.respondWith("GET",
+                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=workflow&itemId=activiti%24activitiAdhoc&formId=null&mode=create",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     CreateWorkflow]);
+
+            this.server.respondWith("POST",
+                                    "/share/proxy/alfresco/api/workflow/activiti%24activitiAdhoc/formprocessor",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     CreateWorkflowSuccess]);
          }
          catch(e)
          {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/Authorities.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/Authorities.json
@@ -1,0 +1,45 @@
+{
+   "data": {
+      "items": [{
+         "type": "cm:person",
+         "parentType": "",
+         "isContainer": false,
+         "name": "Alice Beecher (abeecher)",
+         "title": "",
+         "description": "",
+         "displayPath": "\/3ed718b5-262c-4b6d-b156-bbfad96e5a9e\/63589dd0-af64-47a9-b660-24be4d5362ae",
+         "nodeRef": "workspace:\/\/SpacesStore\/dc103838-645f-43c1-8a2a-bc187e13c343",
+         "selectable": false
+      }, {
+         "type": "cm:person",
+         "parentType": "",
+         "isContainer": false,
+         "name": "Administrator  (admin)",
+         "title": "",
+         "description": "",
+         "displayPath": "\/3ed718b5-262c-4b6d-b156-bbfad96e5a9e\/63589dd0-af64-47a9-b660-24be4d5362ae",
+         "nodeRef": "workspace:\/\/SpacesStore\/3920bddc-fb2b-4b8c-bf80-5dcc83fa6955",
+         "selectable": true
+      }, {
+         "type": "cm:person",
+         "parentType": "",
+         "isContainer": false,
+         "name": "Guest  (guest)",
+         "title": "",
+         "description": "",
+         "displayPath": "\/3ed718b5-262c-4b6d-b156-bbfad96e5a9e\/63589dd0-af64-47a9-b660-24be4d5362ae",
+         "nodeRef": "workspace:\/\/SpacesStore\/2474cdab-872f-4393-a282-44fbacee769d",
+         "selectable": false
+      }, {
+         "type": "cm:person",
+         "parentType": "",
+         "isContainer": false,
+         "name": "Mike Jackson (mjackson)",
+         "title": "",
+         "description": "",
+         "displayPath": "\/3ed718b5-262c-4b6d-b156-bbfad96e5a9e\/63589dd0-af64-47a9-b660-24be4d5362ae",
+         "nodeRef": "workspace:\/\/SpacesStore\/b6d80d49-21cc-4f04-9c92-e7063037543f",
+         "selectable": false
+      }]
+   }
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/CreateWorkflow.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/CreateWorkflow.json
@@ -1,0 +1,233 @@
+{
+   "enctype": "multipart/form-data",
+   "method": "post",
+   "data": {
+      "assoc_bpm_assignee": "",
+      "prop_bpm_packageActionGroup": "add_package_item_actions",
+      "assoc_packageItems": "",
+      "prop_bpm_workflowPriority": 2,
+      "prop_bpm_packageItemActionGroup": "start_package_item_actions",
+      "prop_bpm_sendEMailNotifications": false
+   },
+   "constraints": [{
+      "validationHandler": "Alfresco.forms.validation.length",
+      "id": "LENGTH",
+      "event": "keyup",
+      "message": "Value has incorrect number of characters.",
+      "params": {
+         "minLength": 0,
+         "maxLength": 250,
+         "crop": true
+      },
+      "fieldId": "prop_bpm_workflowDescription"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.inList",
+      "id": "LIST",
+      "event": "blur",
+      "message": "Value is not in list.",
+      "params": {
+         "allowedValues": ["1|High", "2|Medium", "3|Low"],
+         "sorted": false,
+         "caseSensitive": true
+      },
+      "fieldId": "prop_bpm_workflowPriority"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.number",
+      "id": "NUMBER",
+      "event": "keyup",
+      "message": "Value is not a number.",
+      "params": {},
+      "fieldId": "prop_bpm_workflowPriority"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.mandatory",
+      "id": "MANDATORY",
+      "event": "keyup,change",
+      "message": "The value cannot be empty.",
+      "params": {},
+      "fieldId": "assoc_bpm_assignee"
+   }],
+   "structure": [{
+      "children": [{
+         "kind": "field",
+         "id": "prop_bpm_workflowDescription"
+      }],
+      "id": "",
+      "event": "General",
+      "params": "title",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "prop_bpm_workflowDueDate"
+      }, {
+         "kind": "field",
+         "id": "prop_bpm_workflowPriority"
+      }],
+      "id": "info",
+      "event": "info",
+      "message": "/org/alfresco/components/form/2-column-set.ftl",
+      "params": "",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "assoc_bpm_assignee"
+      }],
+      "id": "assignee",
+      "event": "Assignee",
+      "params": "title",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "assoc_packageItems"
+      }],
+      "id": "items",
+      "event": "Items",
+      "params": "title",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "prop_bpm_sendEMailNotifications"
+      }],
+      "id": "other",
+      "event": "Other Options",
+      "params": "title",
+      "fieldId": "set"
+   }],
+   "showCancelButton": false,
+   "mode": "create",
+   "showResetButton": false,
+   "showSubmitButton": true,
+   "arguments": {
+      "itemKind": "workflow",
+      "formId": "null",
+      "itemId": "activiti$activitiAdhoc"
+   },
+   "showCaption": true,
+   "submissionUrl": "/share/proxy/alfresco/api/workflow/activiti%24activitiAdhoc/formprocessor",
+   "fields": {
+      "prop_bpm_sendEMailNotifications": {
+         "configName": "bpm:sendEMailNotifications",
+         "endpointType": "boolean",
+         "kind": "field",
+         "dataType": "boolean",
+         "description": "Send Email Notifications",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/email-notification.ftl",
+            "params": {}
+         },
+         "label": "Send Email Notifications",
+         "type": "property",
+         "dataKeyName": "prop_bpm_sendEMailNotifications",
+         "name": "prop_bpm_sendEMailNotifications",
+         "id": "prop_bpm_sendEMailNotifications",
+         "value": false,
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_workflowDueDate": {
+         "configName": "bpm:workflowDueDate",
+         "endpointType": "date",
+         "kind": "field",
+         "dataType": "date",
+         "description": "Workflow Due Date",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/date.ftl",
+            "params": {
+               "submitTime": "false",
+               "showTime": "false"
+            }
+         },
+         "label": "Due",
+         "type": "property",
+         "dataKeyName": "prop_bpm_workflowDueDate",
+         "name": "prop_bpm_workflowDueDate",
+         "id": "prop_bpm_workflowDueDate",
+         "value": "",
+         "helpEncodeHtml": true
+      },
+      "assoc_bpm_assignee": {
+         "configName": "bpm:assignee",
+         "endpointType": "cm:person",
+         "kind": "field",
+         "dataType": "cm:person",
+         "description": "Workflow Assignee",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/authority.ftl",
+            "params": {}
+         },
+         "label": "Assign To",
+         "type": "association",
+         "endpointDirection": "TARGET",
+         "dataKeyName": "assoc_bpm_assignee",
+         "name": "assoc_bpm_assignee",
+         "id": "assoc_bpm_assignee",
+         "value": "",
+         "helpEncodeHtml": true
+      },
+      "assoc_packageItems": {
+         "configName": "packageItems",
+         "endpointType": "packageItems",
+         "kind": "field",
+         "dataType": "packageItems",
+         "description": "Items that are part of the workflow",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/packageitems.ftl",
+            "params": {}
+         },
+         "label": "Items",
+         "type": "association",
+         "endpointDirection": "TARGET",
+         "dataKeyName": "assoc_packageItems",
+         "name": "assoc_packageItems",
+         "id": "assoc_packageItems",
+         "value": "",
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_workflowPriority": {
+         "configName": "bpm:workflowPriority",
+         "endpointType": "int",
+         "kind": "field",
+         "dataType": "int",
+         "description": "Workflow Priority",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/priority.ftl",
+            "params": {
+               "options": "1|High#alf#2|Medium#alf#3|Low",
+               "optionSeparator": "#alf#"
+            }
+         },
+         "label": "Priority",
+         "type": "property",
+         "help": "form.field.constraint.number",
+         "dataKeyName": "prop_bpm_workflowPriority",
+         "name": "prop_bpm_workflowPriority",
+         "id": "prop_bpm_workflowPriority",
+         "value": 2,
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_workflowDescription": {
+         "configName": "bpm:workflowDescription",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "description": "Description",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/textarea.ftl",
+            "params": {
+               "style": "width: 95%",
+               "maxLength": "250"
+            }
+         },
+         "label": "Message",
+         "type": "property",
+         "help": "form.field.constraint.length",
+         "dataKeyName": "prop_bpm_workflowDescription",
+         "name": "prop_bpm_workflowDescription",
+         "id": "prop_bpm_workflowDescription",
+         "value": "",
+         "helpEncodeHtml": true
+      }
+   }
+}

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/CreateWorkflowSuccess.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/CreateWorkflowSuccess.json
@@ -1,0 +1,4 @@
+{
+   "persistedObject": "WorkflowInstance[id=activiti$601,active=true,def=WorkflowDefinition[id=activiti$activitiAdhoc:1:4,name=activiti$activitiAdhoc,version=1,title=New Task,startTask=WorkflowTaskDefinition[id=wf:submitAdhocTask,metadata=ClassDef[name={http://www.alfresco.org/model/workflow/1.0}submitAdhocTask]]]]",
+   "message": "Successfully persisted form for item [workflow]activiti$activitiAdhoc"
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1081 to add the ability to include additional data into the submission of forms generated from the FormsRuntimeService. This use case solves the ability to set custom scopes in the form submission. Unit tests have been added for this specific requirement.