### PR TITLE
AKU-1082: Ensure correct DateTextBox value is published on change

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -48,6 +48,16 @@ define(["dojo/_base/declare",
    return declare([BaseFormControl, TextBoxValueChangeMixin], {
 
       /**
+       * The selector to use for formatting a date. An alternative might be "datetime".
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.84
+       */
+      valueFormatSelector: "date",
+
+      /**
        * An array of the CSS files to use with this widget.
        * 
        * @instance
@@ -125,7 +135,7 @@ define(["dojo/_base/declare",
        */
       getValue: function alfresco_forms_controls_DateTextBox__getValue() {
          var value = this.inherited(arguments);
-         return value && stamp.toISOString(value, { selector: "date" });
+         return value && stamp.toISOString(value, { selector: this.valueFormatSelector });
       },
 
       /**
@@ -142,6 +152,24 @@ define(["dojo/_base/declare",
             return true;
          });
          return dateTextBox;
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#formControlValueChange}
+       * to format the new date value correctly.
+       *
+       * @instance
+       * @param {string} attributeName
+       * @param {object} oldValue
+       * @param {object} value
+       * @since 1.0.84
+       */
+      formControlValueChange: function alfresco_forms_controls_DateTextBox__formControlValueChange(attributeName, oldValue, value) {
+         if (value) 
+         {
+            value = stamp.toISOString(value, { selector: this.valueFormatSelector });
+         }
+         this.inherited(arguments, [attributeName, oldValue, value]);
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
@@ -67,7 +67,7 @@ define(["alfresco/core/topics",
        * @param {object} evt Dojo-normalised event object
        * @since 1.0.49
        */
-      handleKeyUp: function alfresco_forms_controls_TextBox__handleKeyUp(evt) {
+      handleKeyUp: function alfresco_forms_controls_utilities_TextBoxValueChangeMixin__handleKeyUp(evt) {
          if (this.publishTopicOnEnter && evt.keyCode === keys.ENTER) {
             this.alfPublish(this.publishTopicOnEnter, {
                fieldId: this.id
@@ -92,7 +92,7 @@ define(["alfresco/core/topics",
        * @param {*} newValue The new value
        * @since 1.0.49
        */
-      fireChangeEvent: function alfresco_forms_controls_TextBox__fireChangeEvent(name, oldValue, newValue) {
+      fireChangeEvent: function alfresco_forms_controls_utilities_TextBoxValueChangeMixin__fireChangeEvent(name, oldValue, newValue) {
          if (oldValue !== newValue) {
             this.onValueChangeEvent(name, oldValue, newValue);
          }
@@ -105,7 +105,7 @@ define(["alfresco/core/topics",
        * 
        * @instance
        */
-      setupChangeEvents: function alfresco_forms_controls_TextBox__setupChangeEvents() {
+      setupChangeEvents: function alfresco_forms_controls_utilities_TextBoxValueChangeMixin__setupChangeEvents() {
          if (this.wrappedWidget)
          {
             this.wrappedWidget.on("keyup", lang.hitch(this, this.handleKeyUp));

--- a/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfFilteredList.js
@@ -378,7 +378,7 @@ define(["dojo/_base/declare",
        * @instance
        * @since 1.0.54
        */
-      onFiltersUpdated: function alfresco_lists_AlfHashList__onFiltersUpdated() {
+      onFiltersUpdated: function alfresco_lists_AlfFilteredList__onFiltersUpdated() {
          this.inherited(arguments);
          this.alfPublish(topics.FILTERS_APPLIED, this.dataFilters);
       },

--- a/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/DateTextBoxTest.js
@@ -25,10 +25,8 @@
 define(["module",
         "alfresco/defineSuite",
         "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"],
-        function(module, defineSuite, assert, require, TestCommon, keys) {
+        function(module, defineSuite, assert, keys) {
 
    defineSuite(module, {
       name: "DateTextBox Tests",
@@ -60,21 +58,21 @@ define(["module",
             .then(function(value) {
                assert.equal(value, "", "Initial value of letters should present empty date box");
             })
-            .end()
+         .end()
 
          .findById("EMPTY_DATE_VALUE_CONTROL")
             .getProperty("value")
             .then(function(value) {
                assert.equal(value, "", "Initial value of empty should present empty date box");
             })
-            .end()
+         .end()
 
          .findById("NULL_DATE_VALUE_CONTROL")
             .getProperty("value")
             .then(function(value) {
                assert.equal(value, "", "Initial value of null should present empty date box");
             })
-            .end()
+         .end()
 
          .findById("UNDEFINED_DATE_VALUE_CONTROL")
             .getProperty("value")
@@ -91,11 +89,11 @@ define(["module",
          return this.remote.findByCssSelector("#VALID_DATE_VALUE_2 .dijitArrowButton") // Click down arrow
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#VALID_DATE_VALUE_2_CONTROL_popup tr:nth-child(3) td:nth-child(3)") // Choose third date on third row
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#VALID_DATES_FORM .confirmationButton .dijitButtonNode") // Submit the form
             .click()
@@ -106,11 +104,30 @@ define(["module",
             });
       },
 
+      "Value change publications contain correct value": function() {
+         // Open the first date pop-up...
+         return this.remote.findByCssSelector("#VALID_DATE_VALUE_1 .dijitArrowButtonInner")
+            .click()
+         .end()
+
+         .clearLog()
+
+         // Select a date...
+         .findDisplayedByCssSelector("#VALID_DATE_VALUE_1_CONTROL_popup .dijitCalendarDateLabel")
+            .click()
+         .end()
+
+         .getLastPublish("FORM1__valueChangeOf_VALID1")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "2012-11-25");
+            });
+      },
+
       "Entering invalid date produces correct error": function() {
          return this.remote.findById("VALID_DATE_VALUE_1_CONTROL")
             .clearValue()
             .type("foo")
-            .end()
+         .end()
 
          .findByCssSelector("#VALID_DATE_VALUE_1 .validation-message")
             .isDisplayed()
@@ -135,8 +152,9 @@ define(["module",
          return this.remote.findById("RULES_CHECKER_CONTROL")
             .click()
             .type("05/05/1946")
-            .end()
-            .findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
+         .end()
+            
+         .findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
             .isDisplayed()
             .then(function(displayed) {
                assert.isTrue(displayed, "The requirement indicator should be displayed on date entry via keyboard");
@@ -148,8 +166,9 @@ define(["module",
             .clearValue() // Clear the value, makes it less to delete via backspace...
             .type("1") // ...add a single character to be deleted with backspace...
             .pressKeys(keys.BACKSPACE) // ...and delete
-            .end()
-            .findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
+         .end()
+         
+         .findByCssSelector("#RULES_SUBSCRIBER .requirementIndicator")
             .isDisplayed()
             .then(function(displayed) {
                assert.isFalse(displayed, "The requirement indicator should be hidden when the date field is cleared");

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/DateTextBox.get.js
@@ -17,15 +17,17 @@ model.jsonModel = {
          config: {
             widgets: [
                {
-                  name: "alfresco/forms/Form",
                   id: "VALID_DATES_FORM",
+                  name: "alfresco/forms/Form",
                   config: {
+                     pubSubScope: "FORM1_",
                      okButtonPublishTopic: "VALID_DATES_FORM_SUBMIT",
                      widgets: [
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "VALID_DATE_VALUE_1",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
+                              fieldId: "VALID1",
                               name: "validDate1",
                               value: "2012-12-25",
                               label: "Valid date",
@@ -33,8 +35,8 @@ model.jsonModel = {
                            }
                         },
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "VALID_DATE_VALUE_2",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "validDate2",
                               value: "2015-10-31",
@@ -46,8 +48,8 @@ model.jsonModel = {
                            }
                         },
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "TODAYS_DATE",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "todaysDate",
                               value: "TODAY",
@@ -59,14 +61,14 @@ model.jsonModel = {
                   }
                },
                {
-                  name: "alfresco/forms/Form",
                   id: "OTHER_DATES_FORM",
+                  name: "alfresco/forms/Form",
                   config: {
                      okButtonPublishTopic: "OTHER_DATES_FORM_SUBMIT",
                      widgets: [
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "DATE_WITH_PLACEHOLDER",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "dateWithPlaceholder",
                               label: "Date with placeholder",
@@ -109,14 +111,14 @@ model.jsonModel = {
                   }
                },
                {
-                  name: "alfresco/forms/Form",
                   id: "INVALID_DATES_FORM",
+                  name: "alfresco/forms/Form",
                   config: {
                      okButtonPublishTopic: "INVALID_DATES_FORM_SUBMIT",
                      widgets: [
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "LETTERS_DATE_VALUE",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "lettersDate",
                               value: "letters",
@@ -128,8 +130,8 @@ model.jsonModel = {
                            }
                         },
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "EMPTY_DATE_VALUE",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "emptyDate",
                               value: "",
@@ -138,8 +140,8 @@ model.jsonModel = {
                            }
                         },
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "NULL_DATE_VALUE",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "nullDate",
                               value: null,
@@ -148,8 +150,8 @@ model.jsonModel = {
                            }
                         },
                         {
-                           name: "alfresco/forms/controls/DateTextBox",
                            id: "UNDEFINED_DATE_VALUE",
+                           name: "alfresco/forms/controls/DateTextBox",
                            config: {
                               name: "undefinedDate",
                               value: undefined,


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1082 to ensure that the valueChange publication for a DateTextBox contains the correct formatted value. The unit test has been updated to ensure the behaviour is correct.