### PR TITLE
AKU-1083: Update Select to support empty string value option

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/Select.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Select.js
@@ -80,7 +80,19 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @returns {Object} An appropriate menu item
        */
       _getMenuItemForOption: function alfresco_forms_controls_Select_CustomSelect___getMenuItemForOption(option) {
-         var menuItem = this.inherited(arguments);
+         var menuItem;
+         if(option.value === "") 
+         {
+            // See AKU-1083
+            // Create a MenuItem with a temporary value and then swap in the requested value
+            menuItem = this.inherited(arguments, [{label: option.label, value: "TMP"}]);
+            menuItem.set("value", option.value);
+         }
+         else
+         {
+            menuItem = this.inherited(arguments);
+         }
+         
          if (this.truncate && this.forceWidth && option.label) {
             menuItem.domNode.title = option.label;
          }
@@ -150,23 +162,6 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @since 1.0.79
        */
       width: null,
-
-      /**
-       * Adds a new option to the wrapped widget.
-       *
-       * @instance
-       * @override
-       * @param {object} option The option to add
-       * @param {number} index The index of the option to add
-       */
-      addOption: function alfresco_forms_controls_Select__addOption(option, /*jshint unused:false*/ index) {
-         // Dijit Select widget does not support empty values! https://bugs.dojotoolkit.org/ticket/9973
-         if (option.value === "") {
-            this.alfLog("error", "Attempted to add option with empty value", option);
-         } else {
-            this.inherited(arguments);
-         }
-      },
 
       /**
        * @instance

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectTest.js
@@ -68,7 +68,7 @@ define(["module",
 
          .findAllByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown .dijitMenuItemLabel")
             .then(function(elements) {
-               assert.lengthOf(elements, 3, "Incorrect number of fixed options found");
+               assert.lengthOf(elements, 4, "Incorrect number of fixed options found");
             });
       },
 
@@ -81,7 +81,7 @@ define(["module",
       },
 
       "Test fixed option label set from value": function() {
-         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(3) td.dijitMenuItemLabel")
+         return this.remote.findByCssSelector("#FIXED_INVALID_CHANGES_TO_CONTROL_dropdown table tr:nth-child(4) td.dijitMenuItemLabel")
             .getVisibleText()
             .then(function(resultText) {
                assert.equal(resultText, "NO LABEL", "Fixed label not set correctly from value");


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1083 to ensure that the Select form control supports options with the empty string as a value. The unit tests have been updated to reflect the change.