### PR TITLE
Expose simple value for FilePicker in "single selection" mode

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1917,64 +1917,9 @@ define(["dojo/_base/declare",
             var addedName = this.name + this.addedNameSuffix;
             var removedName = this.name + this.removedNameSuffix;
 
-            if (this.initialFileSelection)
-            {
-               var initialPick = this.initialFileSelection;
-               var currentPick = this.getValue();
-               if (this.valueDelimiter)
-               {
-                  initialPick = this.initialFileSelection.split(this.valueDelimiter);
-                  currentPick = currentPick.split(this.valueDelimiter);
-               }
-               
-               var added = [];
-               var removed = [];
-
-               array.forEach(currentPick, function(currFile) {
-                  // If the current picked file was in the inital selection it has not been added...
-                  // ... BUT if the current pick was NOT in the inital selection it HAS been added
-                  if (array.some(initialPick, function(initialFile) {
-                     return currFile === initialFile;
-                  })) {
-                     // No action required, the current pick was also in the initial pick...
-                  }
-                  else
-                  {
-                     // The current pick was not an initial pick so has been added...
-                     added.push(currFile);
-                  }
-               }, this);
-
-               array.forEach(initialPick, function(initialFile) {
-                  // If the initially picked file is in the current selection it has not been removed...
-                  // ... BUT if the initially picked file is NOT in the current selection it HAS been removed
-                  if (array.some(currentPick, function(currFile) {
-                     return currFile === initialFile;
-                  })) {
-                     // No action required, the current pick was also in the initial pick...
-                  }
-                  else
-                  {
-                     // The initial pick is not a current pick so has been removed...
-                     removed.push(initialFile);
-                  }
-               }, this);
-
-               if (this.valueDelimiter)
-               {
-                  added = added.join(this.valueDelimiter);
-                  removed = removed.join(this.valueDelimiter);
-               }
-
-               lang.setObject(addedName, added, values);
-               lang.setObject(removedName, removed, values);
-            }
-            else
-            {
-               // Nothing removed, everything added...
-               lang.setObject(addedName, this.getValue(), values);
-               lang.setObject(removedName, (this.valueDelimiter ? "": []), values);
-            }
+            // special form controls may store initial value but by default we consider everything as "added"
+            lang.setObject(addedName, this.getValue(), values);
+            lang.setObject(removedName, (this.valueDelimiter ? "": []), values);
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1656,11 +1656,15 @@ define(["dojo/_base/declare",
                });
             }
          }
-         else
+         else if (!this.___addedToDocument)
          {
             // If passed a deferred object then save it for resolving once the widget is added to
             // the document...
             this.deferredValuePublication = deferred;
+         }
+         else
+         {
+            deferred.resolve();
          }
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
@@ -441,6 +441,114 @@ define(["dojo/_base/declare",
             this.alfLog("warn", "Non-array value tried to be set for FilePicker", value, this);
          }
       },
+      
+      /**
+       * This is called from [addFormControlValue]{@link module:alfresco/forms/controls/BaseFormControl#addFormControlValue}
+       * when evaluation of the field configuration and state confirms the value can be set. This override adds handling
+       * related to the stored initialFileSelection.
+       * 
+       * @instance
+       * @param {object} values The object to update with the current value of the control
+       * @since 1.0.84
+       * @overridable
+       */
+      setFormControlValue: function alfresco_forms_controls_FilePicker__setFormControlValue(values) {
+          var addedName, removedName, initialPick, currentPick, added, removed;
+          
+          if (this.addedAndRemovedValues)
+          {
+              addedName = this.name + this.addedNameSuffix;
+              removedName = this.name + this.removedNameSuffix;
+              
+              if (this.initialFileSelection)
+              {
+                  initialPick = this.initialFileSelection;
+                  currentPick = this.getValue() || [];
+                  
+                  if (this.valueDelimiter)
+                  {
+                     if (ObjectTypeUtils.isString(initialPick))
+                     {
+                         initialPick = initialPick.split(this.valueDelimiter);
+                     }
+                     if (ObjectTypeUtils.isString(currentPick))
+                     {
+                         currentPick = currentPick.split(this.valueDelimiter);
+                     }
+                  }
+                  else if (!this.multipleItemSelection && ObjectTypeUtils.isString(currentPick))
+                  {
+                      currentPick = [currentPick];
+                  }
+                  
+                  added = [];
+                  removed = [];
+                  
+                  array.forEach(currentPick, function(currFile) {
+                      // If the current picked file was in the inital selection it has not been added...
+                      // ... BUT if the current pick was NOT in the inital selection it HAS been added
+                      if (array.some(initialPick, function(initialFile) {
+                         return currFile === initialFile;
+                      })) {
+                         // No action required, the current pick was also in the initial pick...
+                      }
+                      else
+                      {
+                         // The current pick was not an initial pick so has been added...
+                         added.push(currFile);
+                      }
+                   }, this);
+
+                   array.forEach(initialPick, function(initialFile) {
+                      // If the initially picked file is in the current selection it has not been removed...
+                      // ... BUT if the initially picked file is NOT in the current selection it HAS been removed
+                      if (array.some(currentPick, function(currFile) {
+                         return currFile === initialFile;
+                      })) {
+                         // No action required, the current pick was also in the initial pick...
+                      }
+                      else
+                      {
+                         // The initial pick is not a current pick so has been removed...
+                         removed.push(initialFile);
+                      }
+                   }, this);
+                   
+                   if (this.valueDelimiter)
+                   {
+                      added = added.join(this.valueDelimiter);
+                      removed = removed.join(this.valueDelimiter);
+                   }
+                   else if (!this.multipleItemSelection)
+                   {
+                       added = added[0] || null;
+                       removed = removed[0] || null;
+                   }
+
+                   lang.setObject(addedName, added, values);
+                   lang.setObject(removedName, removed, values);
+              }
+              else
+              {
+                  this.inherited(arguments);
+                  
+                  // BaseFormControl#setFormControlValue adds empty array as "removed" value
+                  // (only has valueDelimiter and not multipleItemSelection to go on)
+                  if (this.valueDelimiter && !this.multipleItemSelection)
+                  {
+                      removed = lang.getObject(removedName, false, values);
+                      if (ObjectTypeUtils.isArray(removed))
+                      {
+                          lang.setObject(removedName, null, values);
+                      }
+                  }
+              }
+          }
+          else
+          {
+              this.inherited(arguments);
+          }
+      },
 
       /**
        * 


### PR DESCRIPTION
Currently the FilePicker always exposes an array of (removed/added) values, even though the picker may be configured to only allow a single selection. For single-valued fields it is common (and expected) that the value is provided as a simple value and not wrapped inside a "dummy" array of a single element. This PR adds special handling for the case that multipleItemSelection is configured to false, yielding only the value of the itemKey without a wrapping array as the (added/removed) value of the field.

This PR also moves code that was specific to FilePicker from the BaseFormControl module (where it didn't belong) to the FilePicker itself.

Additionally it addresses a minor bug found during testing that could result in forms not being initialized correctly: calls to publishValue providing a Deferred may occur AFTER the widget has already been added to the DOM tree, resulting in the Deferred to never be resolved and thus the form to never complete its initialization.