### PR TITLE
AKU-1084: Ensure that "Recent Sites" is pre-selected in Copy/Move pickers

### DIFF
--- a/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
+++ b/aikau/src/main/resources/alfresco/pickers/ContainerPicker.js
@@ -28,7 +28,46 @@ define(["dojo/_base/declare",
         "alfresco/core/topics"],
         function(declare, Picker, topics) {
 
+   var recentSitesPayload = {
+      currentPickerDepth: 0,
+      pickerLabel: "Sites",
+      picker: [
+         {
+            name: "alfresco/pickers/SingleItemPicker",
+            config: {
+               currentPickerDepth: 1,
+               widgetsForSubPicker: [
+                  {
+                     name: "alfresco/navigation/PathTree",
+                     config: {
+                        showRoot: false,
+                        rootNode: "{siteNodeRef}",
+                        filterPaths: ["^/documentLibrary/(.*)$"],
+                        publishTopic: "ALF_ITEM_SELECTED"
+                     }
+                  }
+               ],
+               requestItemsTopic: topics.GET_RECENT_SITES
+            }
+         }
+      ]
+   };
+
    return declare([Picker], {
+
+      /**
+       * An array of publications that will be published when the picker is ready. By default there
+       * are none specified.
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       * @since 1.0.85
+       */
+      publishOnReady: [{
+         publishTopic: "ALF_ADD_PICKER",
+         publishPayload: recentSitesPayload
+      }],
 
       /**
        *
@@ -123,30 +162,7 @@ define(["dojo/_base/declare",
                      config: {
                         label: "picker.recentSites.label",
                         publishTopic: "ALF_ADD_PICKER",
-                        publishPayload: {
-                           currentPickerDepth: 0,
-                           pickerLabel: "Sites",
-                           picker: [
-                              {
-                                 name: "alfresco/pickers/SingleItemPicker",
-                                 config: {
-                                    currentPickerDepth: 1,
-                                    widgetsForSubPicker: [
-                                       {
-                                          name: "alfresco/navigation/PathTree",
-                                          config: {
-                                             showRoot: false,
-                                             rootNode: "{siteNodeRef}",
-                                             filterPaths: ["^/documentLibrary/(.*)$"],
-                                             publishTopic: "ALF_ITEM_SELECTED"
-                                          }
-                                       }
-                                    ],
-                                    requestItemsTopic: topics.GET_RECENT_SITES
-                                 }
-                              }
-                           ]
-                        }
+                        publishPayload: recentSitesPayload
                      }
                   },
                   {

--- a/aikau/src/main/resources/alfresco/pickers/Picker.js
+++ b/aikau/src/main/resources/alfresco/pickers/Picker.js
@@ -37,8 +37,9 @@ define(["dojo/_base/declare",
         "alfresco/core/Core",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/core/topics",
+        "dojo/_base/array",
         "dojo/_base/lang"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, topics, lang) {
+        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, CoreWidgetProcessing, topics, array, lang) {
 
    return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing], {
 
@@ -132,6 +133,17 @@ define(["dojo/_base/declare",
       repoNodeRef: "alfresco://company/home",
 
       /**
+       * An array of publications that will be published when the picker is ready. By default there
+       * are none specified.
+       * 
+       * @instance
+       * @type {object}
+       * @default
+       * @since 1.0.85
+       */
+      publishOnReady: null,
+
+      /**
        *
        *
        * @instance
@@ -159,6 +171,20 @@ define(["dojo/_base/declare",
             if (this.subPickersLabel) {
                this.subPickersLabelNode.innerHTML = this.message(this.subPickersLabel);
             }
+         }
+
+         if (this.publishOnReady)
+         {
+            array.forEach(this.publishOnReady, function(publication) {
+               if (publication.publishTopic)
+               {
+                  this.alfPublish(publication.publishTopic,
+                                  publication.publishPayload, 
+                                  publication.publishGlobal,
+                                  publication.publishToParent,
+                                  publication.publishScope);
+               }
+            }, this);
          }
       },
 

--- a/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
@@ -37,6 +37,9 @@ define(["module",
          
          .findAllByCssSelector("#ALF_COPY_MOVE_DIALOG.dialogDisplayed")
          .end()
+
+         .findDisplayedByCssSelector(".alfresco-pickers-SingleItemPicker")
+         .end()
          
          .findByCssSelector(".dijitDialogTitle")
             .getVisibleText()


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1084 to ensure that the "Recent Sites" item in the ContainerPicker is displayed when the Copy/Move action dialog is displayed. The unit test has been updated to verify this change.