### PR TITLE
AKU-1075: Ensure copy/move dialog title is always correct

### DIFF
--- a/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
@@ -125,7 +125,8 @@ define(["dojo/_base/declare",
                responseScope: payload.alfResponseScope
             };
 
-         var fileName = (nodes.length === 1)? documents[0].fileName : this.message("services.ActionService.copyMoveTo.multipleFiles");
+         var firstFileName = documents.length ? documents[0].fileName : null;
+         var fileName = (nodes.length === 1 && firstFileName) ? firstFileName : this.message("services.ActionService.copyMoveTo.multipleFiles");
          this._actionHandle = this.alfSubscribe(responseTopic, lang.hitch(this, this.onCopyMoveLocationSelected, urlPrefix, payload.copy), true);
          this.alfPublish("ALF_CREATE_DIALOG_REQUEST", {
             dialogId: "ALF_COPY_MOVE_DIALOG",

--- a/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
@@ -144,7 +144,22 @@ define(["module",
             .then(function(payload) {
                assert.propertyVal(payload, "message", "Move partially successful, but not all of the files or folders could be moved");
             });
-      }
+      },
+
+      "Dialog title for single item in multiple item request is correct": function() {
+         return this.remote.findByCssSelector("#COPY2_label")
+            .click()
+         .end()
+         
+         .findAllByCssSelector("#ALF_COPY_MOVE_DIALOG.dialogDisplayed")
+         .end()
+
+         .findByCssSelector(".dijitDialogTitle")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Copy files to...");
+            });
+      },
    });
 
    defineSuite(module, {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/actions/CopyMove.get.js
@@ -67,6 +67,25 @@ model.jsonModel = {
          }
       },
       {
+         id: "COPY2",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Multiple Copy (via ActionService)",
+            publishTopic: "ALF_MULTIPLE_DOCUMENT_ACTION_REQUEST",
+            publishPayload: {
+               action: "onActionCopyTo",
+               documents: [
+                  {
+                     displayName: "Node 1",
+                     node: {
+                        nodeRef: "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e"
+                     }
+                  }
+               ]
+            }
+         }
+      },
+      {
          name: "aikauTesting/mockservices/CopyMoveServiceMockXhr"
       },
       {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1075 to ensure that the copy/move action dialog title is correct for bulk actions when only one item is selected and that item has a missing file name. The unit tests have been update to verify the change.