### PR TITLE
AKU-1036: Added Users renderer to map to taskowner.ftl

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/User.js
+++ b/aikau/src/main/resources/alfresco/renderers/User.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This renderer can be used for rendering a clickable display of the user where the display name
+ * and user name are derived from splitting the 
+ * [propertyToRender]{@link module:alfresco/renderers/Property#propertyToRender} on the "|"
+ * delimitter. 
+ * 
+ * @module alfresco/renderers/User
+ * @extends alfresco/renderers/PropertyLink
+ * @author Dave Draper
+ * @since 1.0.86
+ */
+define(["dojo/_base/declare",
+        "alfresco/renderers/PropertyLink",
+        "dojo/_base/lang"], 
+        function(declare, PropertyLink, lang) {
+
+   return declare([PropertyLink], {
+
+      /**
+       * Overrides the [inherited attribute]{@link module:alfresco/renderers/PropertyLink#useCurrentItemAsPayload}
+       * so that the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem} is not used as
+       * the published payload by default.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       */
+      useCurrentItemAsPayload: false,
+
+      /**
+       * The property within the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem}
+       * to set the user name.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      userNameProperty: "userName",
+
+      /**
+       * The property within the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem}
+       * to set the display name.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      displayNameProperty: "displayName",
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/renderers/Property#getRenderedProperty}
+       * to establish the userName and displayName from the tokenised value. If the value supplied is
+       * not delimited by "|" it is set as both the userName and displayName. The 
+       * [displayNameProperty]{@link module:alfresco/renderers/User#displayNameProperty} and
+       * [userNameProperty]{@link module:alfresco/renderers/User#userNameProperty} are set in the
+       * [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#currentItem}.
+       * 
+       * @instance
+       * @param {string} property The name of the property to render
+       * @returns {string} The rendered property
+       */
+      getRenderedProperty: function alfresco_renderers_Property__getRenderedProperty(property) {
+         var displayName = property;
+         var userName = property;
+         if (property)
+         {
+            var tokens = property.split("|");
+            if (tokens.length > 1)
+            {
+               userName = tokens[0];
+               displayName = tokens[1];
+
+               if (tokens.length === 3)
+               {
+                  displayName += (" " + tokens[2]);
+               }
+            }
+         }
+
+         lang.setObject(this.userNameProperty, userName, this.currentItem);
+         lang.setObject(this.displayNameProperty, displayName, this.currentItem);
+         return this.inherited(arguments, [displayName]);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -152,6 +152,14 @@ define(["dojo/_base/declare",
                   permittedDecimalPlaces: 10
                }
             },
+
+            "/org/alfresco/components/form/controls/workflow/taskowner.ftl": {
+               name: "alfresco/renderers/User",
+               config: {
+
+               }
+            },
+
             "/org/alfresco/components/form/controls/workflow/packageitems.ftl": {
                name: "alfresco/forms/controls/FilePicker",
                config: {

--- a/aikau/src/main/resources/webscript-libs/tasks/tasks.lib.js
+++ b/aikau/src/main/resources/webscript-libs/tasks/tasks.lib.js
@@ -50,36 +50,18 @@ function getTaskDialogRequestPayload(data) {
    data = data || {};
 
    return {
-      dialogId: data.dialogId || "CREATE_TASK_DIALOG",
-      dialogTitle: data.dialogTitle || "View Task",
-      contentWidth: "1000px",
-      hideTopic: "ALF_CRUD_CREATE",
-      widgetsContent: [
-         {
-            name: "alfresco/layout/DynamicWidgets",
-            config: {
-               subscribeGlobal: true,
-               subscriptionTopic: "TASK_FORM_RETRIEVED"
-            }
+      itemId: data.itemId || "{id}",
+      itemKind: data.itemKind || "task",
+      mode: data.mode || "view",
+      alfSuccessTopic: "TASK_FORM_RETRIEVED",
+      formConfig: {
+         useDialog: true,
+         formId: data.dialogId || "CREATE_TASK_DIALOG",
+         dialogTitle: data.dialogTitle || "View Task",
+         formSubmissionPayloadMixin: {
+            alfResponseScope: "TASKS_"
          }
-      ],
-      publishOnShow: [
-         {
-            publishTopic: "ALF_FORM_REQUEST",
-            publishPayload: {
-               itemId: data.itemId || "{id}",
-               itemKind: data.itemKind || "task",
-               mode: data.mode || "view",
-               alfSuccessTopic: "TASK_FORM_RETRIEVED",
-               formConfig: {
-                  formSubmissionPayloadMixin: {
-                     alfResponseScope: "TASKS_"
-                  }
-               }
-            },
-            publishGlobal: true
-         }
-      ]
+      }
    };
 }
 
@@ -102,7 +84,7 @@ function getTaskListView() {
                                  config: {
                                     propertyToRender: "properties.bpm_description",
                                     renderSize: "large",
-                                    publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                                    publishTopic: "ALF_FORM_REQUEST",
                                     publishPayloadType: "PROCESS",
                                     publishPayloadModifiers: ["processCurrentItemTokens"],
                                     useCurrentItemAsPayload: false,
@@ -170,7 +152,7 @@ function getTaskListView() {
                                  name: "alfresco/renderers/Link",
                                  config: {
                                     linkLabel: "Edit task",
-                                    publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                                    publishTopic: "ALF_FORM_REQUEST",
                                     publishPayloadType: "PROCESS",
                                     publishPayloadModifiers: ["processCurrentItemTokens"],
                                     useCurrentItemAsPayload: false,
@@ -186,7 +168,7 @@ function getTaskListView() {
                                  name: "alfresco/renderers/Link",
                                  config: {
                                     linkLabel: "View task",
-                                    publishTopic: "ALF_CREATE_DIALOG_REQUEST",
+                                    publishTopic: "ALF_FORM_REQUEST",
                                     publishPayloadType: "PROCESS",
                                     publishPayloadModifiers: ["processCurrentItemTokens"],
                                     useCurrentItemAsPayload: false,

--- a/aikau/src/test/resources/alfresco/renderers/UserTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/UserTest.js
@@ -1,0 +1,70 @@
+/*jshint browser:true*/
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Dave Draper
+ * @since 1.0.85
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
+
+   defineSuite(module, {
+      name: "User Renderer Tests",
+      testPage: "/User",
+
+      "No delimiters in value shows userName": function() {
+         return this.remote.findDisplayedByCssSelector("#USER1")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "test");
+            });
+      },
+
+      "Single delimiter in value shows firstName only": function() {
+         return this.remote.findDisplayedByCssSelector("#USER2")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Administrator");
+            });
+      },
+
+      "Two delimiters in value shows full displayName only": function() {
+         return this.remote.findDisplayedByCssSelector("#USER3")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Alice Beecher");
+            });
+      },
+
+      "Clicking name publishes expected values": function() {
+         return this.remote.findDisplayedByCssSelector("#USER3 .inner .value")
+            .click()
+         .end()
+
+         .getLastPublish("USER3")
+            .then(function(payload) {
+               assert.propertyVal(payload, "userIs", "abeecher");
+               assert.propertyVal(payload, "displayedAs", "Alice Beecher");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -269,6 +269,7 @@ define(function() {
       "alfresco/renderers/ThumbnailTest",
       "alfresco/renderers/ThumbnailAspectAndSizeTest",
       "alfresco/renderers/ToggleStateActionsTest",
+      "alfresco/renderers/UserTest",
       "alfresco/renderers/XhrActionsTest",
 
       "alfresco/renderers/actions/CopyToActionTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Actions.get.desc.xml
@@ -1,7 +1,6 @@
 <webscript>
   <shortname>Actions Renderer</shortname>
   <description>Shows examples of action rendering using REST API actions and custom actions</description>
-  <description></description>
   <family>aikau-unit-tests</family>
   <url>/ActionsRenderer</url>
 </webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/User.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/User.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>User Renderer</shortname>
+  <description>Shows examples rendering a clikable user name.</description>
+  <family>aikau-unit-tests</family>
+  <url>/User</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/User.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/User.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/User.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/User.get.js
@@ -1,0 +1,58 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      }
+   ],
+   widgets:[
+      {
+         id: "USER1",
+         name: "alfresco/renderers/User",
+         config: {
+            currentItem: {
+               user: "test"
+            },
+            propertyToRender: "user",
+            renderOnNewLine: true
+         }
+      },
+      {
+         id: "USER2",
+         name: "alfresco/renderers/User",
+         config: {
+            currentItem: {
+               person: "admin|Administrator"
+            },
+            propertyToRender: "person",
+            renderOnNewLine: true
+         }
+      },
+      {
+         id: "USER3",
+         name: "alfresco/renderers/User",
+         config: {
+            currentItem: {
+               userName: "abeecher|Alice|Beecher"
+            },
+            propertyToRender: "userName",
+            renderOnNewLine: true,
+            userNameProperty: "user",
+            displayNameProperty: "displayedAs",
+            publishTopic: "USER3",
+            publishPayload: {
+               userIs: "{user}",
+               displayedAs: "{displayedAs}"
+            }
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1036 to provide the alfresco/renderers/User widget that is then mapped against the taskowner.ftl component in the FormsRuntimeService. Unit tests have been added.