### PR TITLE
AKU-1014: Added mapping for transitions

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -132,6 +132,17 @@ define(["dojo/_base/declare",
       title: null,
 
       /**
+       * An optional topic that can be provided that when published will call 
+       * [onClick]{@link module:alfresco/buttons/AlfButton#onClick}.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.86
+       */
+      triggerTopic: null,
+
+      /**
        * This attribute has been provided primarily for use when configuring 
        * [widgetsAdditionalButtons]{@link module:alfresco/forms/Form#widgetsAdditionalButtons} in
        * a [form]{@link module:alfresco/forms/Form}. It is a simple marker indicating whether
@@ -192,6 +203,11 @@ define(["dojo/_base/declare",
 
          if (this.title) {
             this.focusNode.setAttribute("title", this.message(this.title));
+         }
+
+         if (this.triggerTopic)
+         {
+            this.alfSubscribe(this.triggerTopic, lang.hitch(this, this.onClick));
          }
       },
 
@@ -257,7 +273,7 @@ define(["dojo/_base/declare",
          {
             this.alfLog("warn", "A widget was clicked but did not provide any information on how to handle the event", this);
          }
-         if (evt)
+         if (evt && typeof evt.preventDefault === "function")
          {
             event.stop(evt);
          }

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1764,6 +1764,20 @@ define([],function() {
       TOGGLE_ON: "ALF_TOGGLE_ON",
 
       /**
+       * This topic is used by the [FormsRuntimeService]{@link module:alfresco/services/FormsRuntimeService}
+       * as a way of allowing other form controls (notably [Transitions]{@link module:alfresco/forms/controls/Transitions})
+       * to request that the form be published.
+       * 
+       * @instance
+       * @type {string}
+       * @default 
+       * @since 1.0.86
+       *
+       * @event
+       */
+      TRIGGER_FORM_SUBMISSION: "ALF_TRIGGER_FORM_SUBMISSION",
+
+      /**
        * This topic can be published to request that the current user unfollow the users provided.
        * 
        * @instance

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -372,6 +372,19 @@ define(["dojo/_base/declare",
       warningsPosition: "top",
 
       /**
+       * This is an optional topic that can be provided to allow other widgets to trigger the submission of 
+       * the form. This was added to support requirements of the
+       * [FormsRuntimeService]{@link module:alfresco/services/FormsRuntimeService} and in particular the
+       * [Transitions]{@link module:alfresco/forms/controls/Transitions} control.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.86
+       */
+      formSubmissionTriggerTopic: null,
+
+      /**
        * @instance
        */
       postCreate: function alfresco_forms_Form__postCreate() {
@@ -479,6 +492,13 @@ define(["dojo/_base/declare",
             array.forEach(this.okButtonEnablementTopics, function(topic) {
                this.setupOkButtonEnablementSubscription(topic);
             }, this);
+         }
+
+         if (this.formSubmissionTriggerTopic && this.okButton)
+         {
+            this.alfSubscribe(this.formSubmissionTriggerTopic, lang.hitch(this, function() {
+               this.okButton.onClick();
+            }));
          }
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/Transitions.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Transitions.js
@@ -1,0 +1,199 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This module has been provided to support the 
+ * [FormsRuntimeService]{@link module:alfresco/services/FormsRuntimeService} to address
+ * the requirements of rendering [buttons]{@link module:alfresco/buttons/AlfButton} for 
+ * each transition available when editing a workflow task.
+ * 
+ * @module alfresco/forms/controls/Transitions
+ * @extends module:alfresco/forms/controls/BaseFormControl
+ * @author Dave Draper
+ * @since 1.0.86
+ */
+define(["dojo/_base/declare",
+        "alfresco/forms/controls/BaseFormControl",
+        "alfresco/core/CoreWidgetProcessing",
+        "alfresco/core/topics",
+        "dojo/_base/array",
+        "dojo/_base/lang",
+        // No callbacks from here...
+        "alfresco/layout/DynamicWidgets",
+        "alfresco/buttons/AlfButton"], 
+        function(declare, BaseFormControl, CoreWidgetProcessing, topics, array, lang) {
+   
+   return declare([BaseFormControl, CoreWidgetProcessing], {
+      
+      /**
+       * This will be set to a generated topic that is published when 
+       * [a value is set]{@link module:alfresco/forms/controls/Transitions#setValue}
+       * and is subscribed to by a [DynamicWidgets]{@link module:alfresco/layout/DynamicWidgets}.
+       * The payload is a widgets model containing a [button]{@link module:alfresco/buttons/AlfButton}
+       * for each transition available.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      transitionButtonsUpdateTopic: null,
+
+      /**
+       * This will be set to a generated topic that is published whenever a user makes a transition.
+       * The transition will be handled by [onTransition]{@link module:alfresco/forms/controls/Transitions#onTransition}.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      transitionTopic: null, 
+
+      /**
+       * This will be set by [onTransition]{@link module:alfresco/forms/controls/Transitions#onTransition} whenever
+       * a user makes a transition and will be returned by 
+       * [getValue]{@link module:alfresco/forms/controls/Transitions#getValue}.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       */
+      transitionValue: null,
+
+      /**
+       * Creates a new [DynamicWidgets]{@link module:alfresco/layout/DynamicWidgets} that is used to 
+       * render [buttons]{@link module:alfresco/buttons/AlfButton} for each transition available.
+       * 
+       * @instance
+       */
+      createFormControl: function alfresco_forms_controls_Transitions__createFormControl(config, /*jshint unused:false*/ domNode) {
+         return this.createWidget({
+            name: "alfresco/layout/DynamicWidgets",
+            config: {
+               subscriptionTopic: this.transitionButtonsUpdateTopic
+            }
+         });
+      },
+
+      /**
+       * Overrides the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#getValue}
+       * to return [transitionValue]{@link module:alfresco/forms/controls/Transitions#transitionValue}.
+       * 
+       * @instance
+       * @returns {string} Returns the transition (if one has been made)
+       */
+      getValue: function alfresco_forms_controls_Transitions__getValue() {
+         return this.transitionValue;
+      },
+
+      /**
+       * Handles the user making a transition. The 
+       * [transition value]{@link module:alfresco/forms/controls/Transitions#transitionValue} is updated
+       * and a [topic]{@link module:alfresco/core/topics#TRIGGER_FORM_SUBMISSION} is published to request
+       * that the [form]{@link module:alfresco/forms/Form} be submitted.
+       *  
+       * @instance
+       * @fires module:alfresco/core/topics#TRIGGER_FORM_SUBMISSION
+       */
+      onTransition: function alfresco_forms_controls_Transitions__onTransition(payload) {
+         this.transitionValue = payload.transition;
+         this.onValueChangeEvent(this.name, null, payload.transition);
+         this.alfPublish(topics.TRIGGER_FORM_SUBMISSION);
+      },
+
+      /**
+       * Generates the [transitionTopic]{@link module:alfresco/forms/controls/Transitions#transitionTopic}
+       * and [transitionButtonsUpdateTopic]{@link module:alfresco/forms/controls/Transitions#transitionButtonsUpdateTopic}
+       * and then sets up the subscription to handle transitions being made.
+       * 
+       * @instance
+       */
+      postCreate: function alfresco_forms_controls_Transitions__postCreate() {
+         this.transitionTopic = this.generateUuid();
+         this.transitionButtonsUpdateTopic = this.generateUuid();
+         this.alfSubscribe(this.transitionTopic, lang.hitch(this, this.onTransition));
+         this.inherited(arguments);
+      },
+
+      /**
+       * Processes the supplied value to derive transitions and then publishes a request to
+       * render each transition as a [button]{@link module:alfresco/buttons/AlfButton}.
+       * 
+       * @instance
+       * @param {string} value The value to derive transitions from.
+       */
+      setTransitions: function alfresco_forms_controls_Transitions__setTransitions(value) {
+         if (value)
+         {
+            var transitions = value.split(",");
+            var widgets = array.map(transitions, function(transition) {
+               var transitionInfo = transition.split("|");
+               return {
+                  name: "alfresco/buttons/AlfButton",
+                  config: {
+                     label: transitionInfo[1],
+                     publishTopic: this.transitionTopic,
+                     publishPayload: {
+                        transition: transitionInfo[0]
+                     }
+                  }
+               };
+            }, this);
+
+            // Publish the generated widgets model so that the DynamicWidgets (the wrappedWidget)
+            // can render them...
+            this.alfPublish(this.transitionButtonsUpdateTopic, {
+               widgets: widgets
+            });
+         }
+      },
+
+      /**
+       * Overrides the 
+       * [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#setupChangeEvents}
+       * to intentionally do nothing.
+       * 
+       * @instance
+       */
+      setupChangeEvents: function alfresco_forms_controls_Transitions__setupChangeEvents() {
+         // No action required.
+      },
+
+      /**
+       * Calls [setTransitions]{@link module:alfresco/forms/controls/Transitions#setTransitions}
+       * to process the transition data render 
+       * [buttons]{@link module:alfresco/buttons/AlfButton} for each transition available.
+       * 
+       * @instance
+       * @param {object} value The value to set.
+       */
+      setValue: function alfresco_forms_controls_Transitions__setValue(value) {
+         if (this.deferValueAssigment)
+         {
+            this.inherited(arguments);
+         }
+         else
+         {
+            if (this.wrappedWidget)
+            {
+               this.setTransitions(value);
+            }
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/services/DialogService.js
+++ b/aikau/src/main/resources/alfresco/services/DialogService.js
@@ -546,7 +546,7 @@ define(["dojo/_base/declare",
        * @param {module:alfresco/services/DialogService~event:ALF_CREATE_FORM_DIALOG_REQUEST} payload The payload published on the request topic.
        */
       onCreateFormDialogRequest: function alfresco_services_DialogService__onCreateFormDialogRequest(payload) {
-         // jshint maxstatements:false
+         // jshint maxstatements:false, maxcomplexity:false
          this.cleanUpAnyPreviousDialog(payload);
          if (!payload.widgets)
          {
@@ -605,6 +605,11 @@ define(["dojo/_base/declare",
                {
                   var enableHandle = this.alfSubscribe(config.dialogEnableTopic, lang.hitch(this, this.onFailedSubmission, dialog));
                   this.mapRequestedIdToHandle(payload, "dialog.enable", enableHandle);
+               }
+               if (payload.formSubmissionTriggerTopic)
+               {
+                  var triggerSubmissionHandle = this.alfSubscribe(pubSubScope + payload.formSubmissionTriggerTopic, lang.hitch(this, this.onCloseDialog, dialog));
+                  this.mapRequestedIdToHandle(payload, "dialog.trigger", triggerSubmissionHandle);
                }
 
                if (payload.dialogRepeats)
@@ -763,7 +768,8 @@ define(["dojo/_base/declare",
                            formSubmissionScope: config.formSubmissionScope,
                            responseScope: config.alfResponseScope,
                            dialogEnableTopic: config.dialogEnableTopic
-                        }
+                        },
+                        triggerTopic: config.formSubmissionTriggerTopic
                      }
                   },
                   {

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -52,6 +52,7 @@ define(["dojo/_base/declare",
         "alfresco/forms/controls/Select",
         "alfresco/forms/controls/TextArea",
         "alfresco/forms/controls/TextBox",
+        "alfresco/forms/controls/Transitions",
         "alfresco/node/MetadataGroups",
         "alfresco/renderers/Date",
         "alfresco/renderers/Property",
@@ -256,6 +257,9 @@ define(["dojo/_base/declare",
          task: {
             edit: {
 
+               "/org/alfresco/components/form/controls/workflow/transitions.ftl": {
+                  name: "alfresco/forms/controls/Transitions"
+               }
             },
 
             view: {
@@ -532,7 +536,8 @@ define(["dojo/_base/declare",
                      okButtonPublishPayload: okButtonPublishPayload,
                      okButtonPublishGlobal: true,
                      value: response.data,
-                     widgets: formControls
+                     widgets: formControls,
+                     formSubmissionTriggerTopic: topics.TRIGGER_FORM_SUBMISSION
                   }
                };
 
@@ -576,7 +581,8 @@ define(["dojo/_base/declare",
                   formSubmissionGlobal: true,
                   formSubmissionPayloadMixin: formConfig.config.okButtonPublishPayload,
                   formValue: formConfig.config.value,
-                  widgets: formConfig.config.widgets
+                  widgets: formConfig.config.widgets,
+                  formSubmissionTriggerTopic: topics.TRIGGER_FORM_SUBMISSION
                });
             }
             else

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
@@ -62,6 +62,27 @@ model.jsonModel = {
          }
       },
       {
+         id: "EDIT_TASK",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Edit task",
+            publishTopic: "ALF_FORM_REQUEST",
+            publishPayload: {
+               itemKind: "task",
+               itemId: "activiti$79",
+               mode: "edit",
+               formConfig: {
+                  useDialog: true,
+                  formId: "EDIT_TASK_FORM",
+                  dialogTitle: "Edit Task",
+                  formSubmissionPayloadMixin: {
+                     alfResponseScope: "EDIT_TASK_SCOPE_"
+                  }
+               }
+            }
+         }
+      },
+      {
          name: "alfresco/layout/DynamicWidgets",
          config: {
             subscriptionTopic: "ALF_FORM_REQUEST_SUCCESS"

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
@@ -31,9 +31,10 @@ define(["dojo/_base/declare",
         "dojo/text!./responseTemplates/FormsRuntime/EditDocLibSimpleMetadata.json",
         "dojo/text!./responseTemplates/FormsRuntime/ViewNodeDefault.json",
         "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflow.json",
-        "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflowSuccess.json"], 
+        "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflowSuccess.json",
+        "dojo/text!./responseTemplates/FormsRuntime/EditTask.json"], 
         function(declare, MockXhr, webScriptDefaults, lang, Authorities, EditDocLibSimpleMetadata, ViewNodeDefault, 
-                 CreateWorkflow, CreateWorkflowSuccess) {
+                 CreateWorkflow, CreateWorkflowSuccess, EditTask) {
    
    return declare([MockXhr], {
 
@@ -74,6 +75,12 @@ define(["dojo/_base/declare",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      CreateWorkflowSuccess]);
+
+            this.server.respondWith("GET",
+                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=task&itemId=activiti$79&formId=null&mode=edit",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     EditTask]);
          }
          catch(e)
          {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/EditTask.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/EditTask.json
@@ -1,0 +1,320 @@
+{
+   "enctype": "multipart/form-data",
+   "method": "post",
+   "data": {
+      "prop_bpm_dueDate": "2016-09-15T00:00:00.000+01:00",
+      "prop_transitions": "Next|Task Done",
+      "prop_bpm_priority": 2,
+      "prop_bpm_packageItemActionGroup": "edit_package_item_actions",
+      "prop_bpm_comment": "Blah",
+      "prop_message": "This is a sample task",
+      "prop_bpm_packageActionGroup": "add_package_item_actions",
+      "prop_bpm_taskId": "79",
+      "assoc_packageItems": "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8",
+      "prop_bpm_status": "On Hold",
+      "prop_taskOwner": "admin|Administrator|"
+   },
+   "constraints": [{
+      "validationHandler": "Alfresco.forms.validation.inList",
+      "id": "LIST",
+      "event": "blur",
+      "message": "Value is not in list.",
+      "params": {
+         "allowedValues": ["1|High", "2|Medium", "3|Low"],
+         "sorted": false,
+         "caseSensitive": true
+      },
+      "fieldId": "prop_bpm_priority"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.number",
+      "id": "NUMBER",
+      "event": "keyup",
+      "message": "Value is not a number.",
+      "params": {},
+      "fieldId": "prop_bpm_priority"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.number",
+      "id": "NUMBER",
+      "event": "keyup",
+      "message": "Value is not a number.",
+      "params": {},
+      "fieldId": "prop_bpm_taskId"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.mandatory",
+      "id": "MANDATORY",
+      "event": "keyup,change",
+      "message": "The value cannot be empty.",
+      "params": {},
+      "fieldId": "prop_bpm_status"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.inList",
+      "id": "LIST",
+      "event": "blur",
+      "message": "Value is not in list.",
+      "params": {
+         "allowedValues": ["Not Yet Started|Not Yet Started", "In Progress|In Progress", "On Hold|On Hold", "Cancelled|Cancelled", "Completed|Completed"],
+         "sorted": false,
+         "caseSensitive": true
+      },
+      "fieldId": "prop_bpm_status"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.length",
+      "id": "LENGTH",
+      "event": "keyup",
+      "message": "Value has incorrect number of characters.",
+      "params": {
+         "minLength": 0,
+         "maxLength": 4000,
+         "crop": true
+      },
+      "fieldId": "prop_bpm_comment"
+   }],
+   "structure": [{
+      "children": [{
+         "kind": "field",
+         "id": "prop_message"
+      }],
+      "id": "",
+      "event": "Info",
+      "params": "title",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "prop_taskOwner"
+      }, {
+         "kind": "field",
+         "id": "prop_bpm_priority"
+      }, {
+         "kind": "field",
+         "id": "prop_bpm_dueDate"
+      }, {
+         "kind": "field",
+         "id": "prop_bpm_taskId"
+      }],
+      "id": "info",
+      "event": "info",
+      "message": "/org/alfresco/components/form/3-column-set.ftl",
+      "params": "",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "prop_bpm_status"
+      }],
+      "id": "progress",
+      "event": "Progress",
+      "params": "title",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "assoc_packageItems"
+      }],
+      "id": "items",
+      "event": "Items",
+      "params": "title",
+      "fieldId": "set"
+   }, {
+      "children": [{
+         "kind": "field",
+         "id": "prop_bpm_comment"
+      }, {
+         "kind": "field",
+         "id": "prop_transitions"
+      }],
+      "id": "response",
+      "event": "Response",
+      "params": "title",
+      "fieldId": "set"
+   }],
+   "showCancelButton": false,
+   "mode": "edit",
+   "showResetButton": false,
+   "showSubmitButton": true,
+   "arguments": {
+      "itemKind": "task",
+      "formId": "null",
+      "itemId": "activiti$79"
+   },
+   "showCaption": false,
+   "submissionUrl": "/share/proxy/alfresco/api/task/activiti%2479/formprocessor",
+   "fields": {
+      "prop_bpm_dueDate": {
+         "configName": "bpm:dueDate",
+         "endpointType": "date",
+         "kind": "field",
+         "dataType": "date",
+         "description": "Due Date",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/info.ftl",
+            "params": {
+               "submitTime": "false"
+            }
+         },
+         "label": "Due",
+         "type": "property",
+         "dataKeyName": "prop_bpm_dueDate",
+         "name": "prop_bpm_dueDate",
+         "id": "prop_bpm_dueDate",
+         "value": "2016-09-15T00:00:00.000+01:00",
+         "helpEncodeHtml": true
+      },
+      "prop_transitions": {
+         "configName": "transitions",
+         "endpointType": "transitions",
+         "kind": "field",
+         "dataType": "transitions",
+         "description": "The transitions available for the task",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/transitions.ftl",
+            "params": {}
+         },
+         "label": "Transitions",
+         "type": "property",
+         "dataKeyName": "prop_transitions",
+         "name": "prop_transitions",
+         "id": "prop_transitions",
+         "value": "Next|Task Done",
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_priority": {
+         "configName": "bpm:priority",
+         "endpointType": "int",
+         "kind": "field",
+         "dataType": "int",
+         "description": "Priority",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/priority.ftl",
+            "params": {
+               "options": "1|High#alf#2|Medium#alf#3|Low",
+               "optionSeparator": "#alf#"
+            }
+         },
+         "label": "Priority",
+         "type": "property",
+         "help": "form.field.constraint.number",
+         "dataKeyName": "prop_bpm_priority",
+         "name": "prop_bpm_priority",
+         "id": "prop_bpm_priority",
+         "value": 2,
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_comment": {
+         "configName": "bpm:comment",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "description": "Comment",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/textarea.ftl",
+            "params": {
+               "maxLength": "4000"
+            }
+         },
+         "label": "Comment",
+         "type": "property",
+         "help": "form.field.constraint.length",
+         "dataKeyName": "prop_bpm_comment",
+         "name": "prop_bpm_comment",
+         "id": "prop_bpm_comment",
+         "value": "Blah",
+         "helpEncodeHtml": true
+      },
+      "prop_message": {
+         "configName": "message",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "description": "Message the user entered when starting the workflow",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/info.ftl",
+            "params": {}
+         },
+         "label": "Message",
+         "type": "property",
+         "dataKeyName": "prop_message",
+         "name": "prop_message",
+         "id": "prop_message",
+         "value": "This is a sample task",
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_taskId": {
+         "configName": "bpm:taskId",
+         "endpointType": "long",
+         "kind": "field",
+         "dataType": "long",
+         "description": "Identifier",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/info.ftl",
+            "params": {}
+         },
+         "label": "Identifier",
+         "type": "property",
+         "help": "form.field.constraint.number",
+         "dataKeyName": "prop_bpm_taskId",
+         "name": "prop_bpm_taskId",
+         "id": "prop_bpm_taskId",
+         "value": "79",
+         "helpEncodeHtml": true
+      },
+      "assoc_packageItems": {
+         "configName": "packageItems",
+         "endpointType": "packageItems",
+         "kind": "field",
+         "dataType": "packageItems",
+         "description": "Items that are part of the workflow",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/packageitems.ftl",
+            "params": {}
+         },
+         "label": "Items",
+         "type": "association",
+         "endpointDirection": "TARGET",
+         "dataKeyName": "assoc_packageItems",
+         "name": "assoc_packageItems",
+         "id": "assoc_packageItems",
+         "value": "workspace://SpacesStore/7bb7bfa8-997e-4c55-8bd9-2e5029653bc8",
+         "helpEncodeHtml": true
+      },
+      "prop_bpm_status": {
+         "configName": "bpm:status",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "description": "Status",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/selectone.ftl",
+            "params": {
+               "options": "Not Yet Started|Not Yet Started#alf#In Progress|In Progress#alf#On Hold|On Hold#alf#Cancelled|Cancelled#alf#Completed|Completed",
+               "optionSeparator": "#alf#"
+            }
+         },
+         "label": "Status",
+         "type": "property",
+         "dataKeyName": "prop_bpm_status",
+         "name": "prop_bpm_status",
+         "id": "prop_bpm_status",
+         "value": "On Hold",
+         "helpEncodeHtml": true
+      },
+      "prop_taskOwner": {
+         "configName": "taskOwner",
+         "endpointType": "taskOwner",
+         "kind": "field",
+         "dataType": "taskOwner",
+         "description": "The user that owns the task",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/workflow/taskowner.ftl",
+            "params": {}
+         },
+         "label": "Owner",
+         "type": "property",
+         "dataKeyName": "prop_taskOwner",
+         "name": "prop_taskOwner",
+         "id": "prop_taskOwner",
+         "value": "admin|Administrator|",
+         "helpEncodeHtml": true
+      }
+   }
+}


### PR DESCRIPTION
This is another update to the Forms Runtime mapping support. This provides a new control for mapping transitions when editing tasks.