### PR TITLE
People Lib Updates

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
+++ b/aikau/src/main/resources/alfresco/core/CoreWidgetProcessing.js
@@ -916,8 +916,13 @@ define(["dojo/_base/declare",
        * @returns {boolean} True if the filter criteria have been met and false otherwise.
        */
       processFilterConfig: function alfresco_core_CoreWidgetProcessing__processFilterConfig(renderFilterConfig, /*jshint unused:false*/ index) {
+         // jshint maxcomplexity:false
          var passesFilter = false;
-         if (this.filterPropertyExists(renderFilterConfig))
+         if (renderFilterConfig.comparator === "currentUser")
+         {
+            passesFilter = AlfConstants.USERNAME === renderFilterConfig.value;
+         }
+         else if (this.filterPropertyExists(renderFilterConfig))
          {
             // Compare the property value against the applicable values...
             var renderFilterProperty = this.getRenderFilterPropertyValue(renderFilterConfig);

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -443,6 +443,19 @@ define([],function() {
       DIALOG_CHANGE_TITLE: "ALF_DIALOG_CHANGE_TITLE",
 
       /**
+       * This topic can be published to disabled the activity feed for a site.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.87
+       *
+       * @event
+       * @parameter {string} siteId The shortName of the site to disable the activitiy feed for.
+       */
+      DISABLE_SITE_ACTIVITY_FEED: "ALF_DISABLE_SITE_ACTIVITY_FEED",
+
+      /**
        * This topic can be published to request that a notification be displayed. It is subscribed to 
        * by the [NotificationService]{@link module:alfresco/services/NotificationService}.
        *
@@ -639,6 +652,19 @@ define([],function() {
        * @parameter {string} site The shortName of the site to be edited
        */
       EDIT_SITE: "ALF_EDIT_SITE",
+
+      /**
+       * This topic can be published to enable the activity feed for a site.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.87
+       *
+       * @event
+       * @parameter {string} siteId The shortName of the site to be enable the activity feed for
+       */
+      ENABLE_SITE_ACTIVITY_FEED: "ALF_ENABLE_SITE_ACTIVITY_FEED",
 
       /**
        * This topic can be fired when the enter key is pressed (but normally is not by default).

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -931,6 +931,7 @@ define([],function() {
        * @since 1.0.81
        *
        * @event
+       * @property {boolean} [includeFeedSettings=false] Indicates whether feed control data should be retrieved
        */
       GET_SITES: "ALF_GET_SITES",
 
@@ -949,6 +950,18 @@ define([],function() {
        * @property {string} alfResponseTopic The topic on which to publish the users data
        */
       GET_USERS: "ALF_GET_USERS",
+
+      /**
+       * This topic can be published to get a list of the sites that a user belongs to.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.87
+       *
+       * @event
+       */
+      GET_USER_SITES: "ALF_GET_USER_SITES",
 
       /**
        * Can be published to initialise the creation of a synchronization between an on-premise node and

--- a/aikau/src/main/resources/alfresco/forms/controls/Password.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Password.js
@@ -27,11 +27,56 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/forms/controls/TextBox"], 
-        function(declare, TextBox) {
+        "alfresco/forms/controls/TextBox",
+        "dojo/_base/lang"], 
+        function(declare, TextBox, lang) {
    
    return declare([TextBox], {
       
+      /**
+       * An array of the i18n files to use with this widget.
+       *
+       * @instance
+       * @type {Array}
+       */
+      i18nRequirements: [{i18nFile: "./i18n/Password.properties"}],
+
+      /**
+       * This can be configured to be the [fieldId]{@link module:alfresco/forms/controls/BaseFormControl#fieldId}
+       * of another form control (preferably another password field!) that the value of this field should
+       * match. The typical use case is when prompting a user to confirm the change of password.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.87
+       */
+      confirmationTargetId: null,
+
+      /**
+       * The error message to display when the entered value does not match that of the 
+       * [field to compare against]{@link module:alfresco/forms/controls/Password#confirmationTargetId}
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.87
+       */
+      confirmationErrorMessage: "password.not.match.error",
+
+      /**
+       * This is a validation callback function that is automatically used when a
+       * [confirmationTargetId]{@link module:alfresco/forms/controls/Password#confirmationTargetId}
+       * is specified.
+       * 
+       * @instance
+       * @return {[type]} [description]
+       */
+      confirmMatchingPassword: function alfresco_forms_controls_Password__confirmMatchingPassword(validationConfig) {
+         var isValid = this.confirmationTargetValue === this.getValue();
+         this.reportValidationResult(validationConfig, isValid);
+      },
+
       /**
        * Extends the [inherited function]{@link module:alfresco/forms/controls/TextBox#getWidgetConfig}
        * to make the text box of type "password".
@@ -42,6 +87,33 @@ define(["dojo/_base/declare",
          var config = this.inherited(arguments);
          config.type = "password";
          return config;
+      },
+
+      /**
+       * 
+       * @instance
+       * @since 1.0.87
+       */
+      postMixInProperties: function alfresco_forms_controls_Password__postMixInProperties() {
+         this.inherited(arguments);
+
+         if (this.confirmationTargetId)
+         {
+            var topic = "_valueChangeOf_" + this.confirmationTargetId;
+            this.alfSubscribe(topic, lang.hitch(this, function(payload) {
+               this.confirmationTargetValue = payload.value;
+               this.validate();
+            }));
+
+            if (!this.validationConfig)
+            {
+               this.validationConfig = [];
+            }
+            this.validationConfig.push({
+               validation: "confirmMatchingPassword",
+               errorMessage: this.confirmationErrorMessage
+            });
+         }
       }
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/Password.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/Password.js
@@ -38,6 +38,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @type {Array}
+       * @since 1.0.87
        */
       i18nRequirements: [{i18nFile: "./i18n/Password.properties"}],
 
@@ -70,7 +71,8 @@ define(["dojo/_base/declare",
        * is specified.
        * 
        * @instance
-       * @return {[type]} [description]
+       * @param {object} validationConfig The configuration for the requested validation
+       * @since 1.0.87
        */
       confirmMatchingPassword: function alfresco_forms_controls_Password__confirmMatchingPassword(validationConfig) {
          var isValid = this.confirmationTargetValue === this.getValue();
@@ -90,6 +92,9 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#postMixInProperties}
+       * to setup validation for any configured 
+       * [confirmationTargetId]{@link module:alfresco/forms/controls/Password#confirmationTargetId}
        * 
        * @instance
        * @since 1.0.87

--- a/aikau/src/main/resources/alfresco/forms/controls/i18n/Password.properties
+++ b/aikau/src/main/resources/alfresco/forms/controls/i18n/Password.properties
@@ -1,0 +1,1 @@
+password.not.match.error=The passwords entered are not the same

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1326,6 +1326,9 @@ define(["dojo/_base/declare",
                };
             }
 
+            !payload.alfSuccessTopic && (payload.alfSuccessTopic = this.pubSubScope + this.loadDataSuccessTopic);
+            !payload.alfFailureTopic && (payload.alfFailureTopic = this.pubSubScope + this.loadDataFailureTopic);
+
             // Generate and set a requestId. If the service supports passing this in the XHR request
             // (which is not guaranteed) then this allows for the opportunity to cancel the request
             // if a second request is made before the first completes...

--- a/aikau/src/main/resources/alfresco/renderers/Toggle.js
+++ b/aikau/src/main/resources/alfresco/renderers/Toggle.js
@@ -466,9 +466,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       toggledOn: function alfresco_renderers_Toggle__toggledOn() {
-         var responseTopic = this.pubSubScope + this.generateUuid();
-         this._successHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onToggleOnSuccess), true);
-         this._failureHandle = this.alfSubscribe(responseTopic + "_FAILURE", lang.hitch(this, this.onToggleOnFailure), true);
+         var responseTopic = this.generateUuid();
+         this._successHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onToggleOnSuccess));
+         this._failureHandle = this.alfSubscribe(responseTopic + "_FAILURE", lang.hitch(this, this.onToggleOnFailure));
          if (this.toggleOnPublishPayload)
          {
             var publishPayload = this.generatePayload(this.toggleOnPublishPayload, 
@@ -478,6 +478,8 @@ define(["dojo/_base/declare",
                                                       this.toggleOnPublishPayloadItemMixin, 
                                                       this.toggleOnPublishPayloadModifiers);
             publishPayload.alfResponseTopic = responseTopic;
+            publishPayload.alfSuccessTopic = responseTopic + "_SUCCESS";
+            publishPayload.alfFailureTopic = responseTopic + "_FAILURE";
             this.alfPublish(this.toggleOnTopic, publishPayload, this.toggleOnPublishGlobal, this.toggleOnPublishToParent, this.toggleOnPublishScope);
          }
          else
@@ -496,9 +498,9 @@ define(["dojo/_base/declare",
        * @instance
        */
       toggledOff: function alfresco_renderers_Toggle__toggledOff() {
-         var responseTopic = this.pubSubScope + this.generateUuid();
-         this._successHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onToggleOffSuccess), true);
-         this._failureHandle = this.alfSubscribe(responseTopic + "_FAILURE", lang.hitch(this, this.onToggleOffFailure), true);
+         var responseTopic = this.generateUuid();
+         this._successHandle = this.alfSubscribe(responseTopic + "_SUCCESS", lang.hitch(this, this.onToggleOffSuccess));
+         this._failureHandle = this.alfSubscribe(responseTopic + "_FAILURE", lang.hitch(this, this.onToggleOffFailure));
          if (this.toggleOffPublishPayload)
          {
             var publishPayload = this.generatePayload(this.toggleOffPublishPayload, 
@@ -508,6 +510,8 @@ define(["dojo/_base/declare",
                                                       this.toggleOffPublishPayloadItemMixin, 
                                                       this.toggleOffPublishPayloadModifiers);
             publishPayload.alfResponseTopic = responseTopic;
+            publishPayload.alfSuccessTopic = responseTopic + "_SUCCESS";
+            publishPayload.alfFailureTopic = responseTopic + "_FAILURE";
             this.alfPublish(this.toggleOffTopic, publishPayload, this.toggleOffPublishGlobal, this.toggleOffPublishToParent, this.toggleOffPublishScope);
          }
          else

--- a/aikau/src/main/resources/alfresco/services/BaseService.js
+++ b/aikau/src/main/resources/alfresco/services/BaseService.js
@@ -90,22 +90,8 @@ define(["dojo/_base/declare",
       mergeTopicsIntoXhrPayload: function alfresco_services_BaseService__mergeTopicsIntoXhrPayload(requestPayload, xhrPayload) {
          if (requestPayload && xhrPayload)
          {
-            var topic;
-            if (requestPayload.alfResponseTopic === requestPayload.alfResponseScope + requestPayload.alfTopic)
-            {
-               topic = requestPayload.alfResponseTopic;
-            }
-            else if (requestPayload.alfResponseTopic)
-            {
-               topic = (requestPayload.alfResponseScope || "") + requestPayload.alfResponseTopic;
-            }
-            else if (requestPayload.responseTopic)
-            {
-               topic = requestPayload.responseTopic;
-            }
-
-            xhrPayload.alfTopic = topic;
-            xhrPayload.alfResponseTopic = topic;
+            xhrPayload.alfResponseTopic = requestPayload.alfResponseTopic;
+            xhrPayload.alfResponseScope = requestPayload.alfResponseScope;
             xhrPayload.alfSuccessTopic = requestPayload.alfSuccessTopic;
             xhrPayload.alfFailureTopic = requestPayload.alfFailureTopic;
          }

--- a/aikau/src/main/resources/alfresco/services/BaseService.js
+++ b/aikau/src/main/resources/alfresco/services/BaseService.js
@@ -91,7 +91,11 @@ define(["dojo/_base/declare",
          if (requestPayload && xhrPayload)
          {
             var topic;
-            if (requestPayload.alfResponseTopic)
+            if (requestPayload.alfResponseTopic === requestPayload.alfResponseScope + requestPayload.alfTopic)
+            {
+               topic = requestPayload.alfResponseTopic;
+            }
+            else if (requestPayload.alfResponseTopic)
             {
                topic = (requestPayload.alfResponseScope || "") + requestPayload.alfResponseTopic;
             }

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -138,6 +138,8 @@ define(["dojo/_base/declare",
          this.alfSubscribe(topics.GET_FAVOURITE_SITES, lang.hitch(this, this.getFavouriteSites));
          this.alfSubscribe(topics.CANCEL_JOIN_SITE_REQUEST, lang.hitch(this, this.cancelJoinSiteRequest));
          this.alfSubscribe(topics.GET_USER_SITES, lang.hitch(this, this.getUserSites));
+         this.alfSubscribe(topics.ENABLE_SITE_ACTIVITY_FEED, lang.hitch(this, this.enableSiteActivityFeed));
+         this.alfSubscribe(topics.DISABLE_SITE_ACTIVITY_FEED, lang.hitch(this, this.disableSiteActivityFeed));
 
          // Make sure that the edit-site.js file is loaded. This is required for as it handles legacy site
          // editing. At some stage this will not be needed when a new edit site dialog is provided.
@@ -145,6 +147,55 @@ define(["dojo/_base/declare",
          require([AlfConstants.URL_RESCONTEXT + "modules/edit-site.js"], function() {
             _this.alfLog("log", "Edit Site JavaScript resource loaded");
          });
+      },
+
+      /**
+       * Handles requests to enable the activity feed for a site (for the current user).
+       * 
+       * @instance
+       * @param {object} payload The details of the site to enable the feed for
+       * @instance 1.0.87
+       */
+      enableSiteActivityFeed: function alfresco_services_SiteService__enableSiteActivityFeed(payload) {
+         if (payload.siteId)
+         {
+            var config = {
+               url: AlfConstants.PROXY_URI + "api/activities/feed/control?s=" + payload.siteId,
+               method: "DELETE"
+            };
+            this.mergeTopicsIntoXhrPayload(payload, config);
+            this.serviceXhr(config);
+         }
+         else
+         {
+            this.alfLog("warn", "A request was made to enable the activity feed for a site, but no 'siteId' attribute was provided", payload, this);
+         }
+      },
+
+      /**
+       * Handles requests to disable the activity feed for a site (for the current user).
+       * 
+       * @instance
+       * @param {object} payload The details of the site to disable the feed for
+       * @instance 1.0.87
+       */
+      disableSiteActivityFeed: function alfresco_services_SiteService__disableSiteActivityFeed(payload) {
+         if (payload.siteId)
+         {
+            var config = {
+               url: AlfConstants.PROXY_URI + "api/activities/feed/control",
+               method: "POST",
+               data: {
+                  siteId: payload.siteId
+               }
+            };
+            this.mergeTopicsIntoXhrPayload(payload, config);
+            this.serviceXhr(config);
+         }
+         else
+         {
+            this.alfLog("warn", "A request was made to disable the activity feed for a site, but no 'siteId' attribute was provided", payload, this);
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -31,10 +31,12 @@ define(["dojo/_base/declare",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/core/topics",
         "alfresco/enums/urlTypes",
+        "dojo/_base/array",
         "dojo/_base/lang",
         "alfresco/buttons/AlfButton",
         "service/constants/Default"],
-        function(declare, BaseService, CoreXhr, ObjectProcessingMixin, NotificationUtils, ObjectTypeUtils, topics, urlTypes, lang, AlfButton, AlfConstants) {
+        function(declare, BaseService, CoreXhr, ObjectProcessingMixin, NotificationUtils, ObjectTypeUtils, topics, 
+                 urlTypes, array, lang, AlfButton, AlfConstants) {
 
    return declare([BaseService, CoreXhr, ObjectProcessingMixin, NotificationUtils], {
 
@@ -111,6 +113,7 @@ define(["dojo/_base/declare",
        * @listens module:alfresco/core/topics#GET_FAVOURITE_SITES
        * @listens module:alfresco/core/topics#GET_RECENT_SITES
        * @listens module:alfresco/core/topics#GET_SITES
+       * @listens module:alfresco/core/topics#GET_USER_SITES
        * @listens module:alfresco/core/topics#SITE_CREATION_REQUEST
        */
       registerSubscriptions: function alfresco_services_SiteService__registerSubscriptions() {
@@ -134,6 +137,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe(topics.GET_RECENT_SITES, lang.hitch(this, this.getRecentSites));
          this.alfSubscribe(topics.GET_FAVOURITE_SITES, lang.hitch(this, this.getFavouriteSites));
          this.alfSubscribe(topics.CANCEL_JOIN_SITE_REQUEST, lang.hitch(this, this.cancelJoinSiteRequest));
+         this.alfSubscribe(topics.GET_USER_SITES, lang.hitch(this, this.getUserSites));
 
          // Make sure that the edit-site.js file is loaded. This is required for as it handles legacy site
          // editing. At some stage this will not be needed when a new edit site dialog is provided.
@@ -151,11 +155,107 @@ define(["dojo/_base/declare",
       getSites: function alfresco_services_SiteService__getSites(payload) {
          // TODO: Clean this up. Choose on or other as the Aikau standard.
          var alfResponseTopic = payload.alfResponseTopic || payload.responseTopic;
-         this.serviceXhr({
+         var config = {
             url: AlfConstants.PROXY_URI + "api/sites",
             method: "GET",
             alfTopic: alfResponseTopic
-         });
+         };
+         this.serviceXhr(config);
+      },
+
+      /**
+       * 
+       * @instance
+       * @param  {payload} payload The details of the user to retrieve sites for
+       * @since 1.0.87
+       */
+      getUserSites: function alfresco_services_SiteService__getSites(payload) {
+         if (payload.userName)
+         {
+            var config = {
+               url: AlfConstants.PROXY_URI + "api/people/admin/sites",
+               method: "GET",
+               successCallback: this.onUserSitesSuccess,
+               failureCallback: this.onUserSitesFailure,
+               callbackScope: this
+            };
+            this.mergeTopicsIntoXhrPayload(payload, config);
+            this.serviceXhr(config);
+         }
+         else
+         {
+            this.alfLog("warn", "A request was made to get the sites for a user but no 'userName' attribute was provided", payload, this);
+         }
+      },
+
+      /**
+       * Handles successful requests to get users filtered by the supplied user name. Makes an additional
+       * XHR request to determine whether or not the user is being followed by the current user.
+       * 
+       * @instance
+       * @param {object} response The response from the request
+       * @param {object} originalRequestConfig The configuration passed on the original request
+       * @since 1.0.86
+       */
+      onUserSitesSuccess: function alfresco_services_SiteService__onUserSitesSuccess(response, originalRequestConfig) {
+         var url = AlfConstants.PROXY_URI + "api/activities/feed/controls";
+         var config = {
+            url: url,
+            sitesData: response,
+            initialRequestConfig: originalRequestConfig,
+            method: "GET",
+            successCallback: this.publishSites,
+            callbackScope: this
+         };
+         this.serviceXhr(config);
+      },
+
+      /**
+       * This is the success callback for [getUserSites]{@link module:alfresco/services/SiteService#getUserSites}.
+       * 
+       * @instance
+       * @param {object} response The response from the request
+       * @param {object} originalRequestConfig The configuration passed on the original request
+       * @since 1.0.86
+       */
+      publishSites: function alfresco_services_SiteService__publishSites(response, originalRequestConfig) {
+         var sites = originalRequestConfig.sitesData;
+         
+         // Update the site data with the activity feed control data...
+         sites = array.map(sites, function(site) {
+            site.activityFeedEnabled = true;
+            if (site.shortName)
+            {
+               site.activityFeedEnabled = !array.some(response, function(feedControl) {
+                  return feedControl.siteId === site.shortName;
+               });
+               return site;
+            }
+         }, this);
+
+         var topic = lang.getObject("initialRequestConfig.alfSuccessTopic", false, originalRequestConfig);
+         if (!topic)
+         {
+            topic = lang.getObject("initialRequestConfig.alfResponseTopic", false, originalRequestConfig);
+         }
+         if (topic)
+         {
+            this.alfPublish(topic, {
+               items: sites
+            });
+         }
+      },
+
+      /**
+       * This is the failure callback for [getUserSites]{@link module:alfresco/services/SiteService#getUserSites}.
+       * 
+       * @instance
+       * @param {object} response The response from the request
+       * @param {object} originalRequestConfig The configuration passed on the original request
+       * @since 1.0.87
+       */
+      onUserSitesFailure: function alfresco_services_UserService__onUserSitesFailure(response, originalRequestConfig) {
+         this.alfLog("error", "It was not possible to retrieve the sites for a user", response, originalRequestConfig, this);
       },
 
       /**

--- a/aikau/src/main/resources/webscript-libs/pages/people.lib.js
+++ b/aikau/src/main/resources/webscript-libs/pages/people.lib.js
@@ -320,11 +320,10 @@ function getUserProfileSitesTab() {
                config: {
                   pubSubScope: "SITES_",
                   waitForPageWidgets: false,
-                  loadDataPublishTopic: "ALF_CRUD_GET_ALL",
+                  loadDataPublishTopic: "ALF_GET_USER_SITES",
                   loadDataPublishPayload: {
-                     url: "api/people/{userName}/sites"
+                     userName: "{userName}"
                   },
-                  itemsProperty: "",
                   widgets: [
                      {
                         name: "alfresco/lists/views/AlfListView",
@@ -368,6 +367,32 @@ function getUserProfileSitesTab() {
                                                    config: {
                                                       propertyToRender: "description",
                                                       renderOnNewLine: true
+                                                   }
+                                                },
+                                                { 
+                                                   name: "alfresco/renderers/Toggle",
+                                                   config: {
+                                                      propertyToRender: "activityFeedEnabled",
+                                                      checkedValue: true,
+                                                      onLabel: "Following actvity",
+                                                      offLabel: "Follow activity",
+                                                      onTooltip: "Disable activity feed for {0}",
+                                                      offTooltip: "Enable activity feed for {0}",
+                                                      tooltipIdProperty: "title",
+                                                      toggleOnTopic: "ALF_ENABLE_SITE_ACTIVITY_FEED",
+                                                      toggleOnPublishPayload: {
+                                                         siteId: ["{shortName}"]
+                                                      },
+                                                      toggleOnPublishGlobal: true,
+                                                      toggleOnPublishPayloadType: "PROCESS",
+                                                      toggleOnPublishPayloadModifiers: ["processCurrentItemTokens"],
+                                                      toggleOffTopic: "ALF_DISABLED_SITE_ACTIVITY_FEED",
+                                                      toggleOffPublishPayload: {
+                                                         siteId: ["{shortName}"]
+                                                      },
+                                                      toggleOffPublishGlobal: true,
+                                                      toggleOffPublishPayloadType: "PROCESS",
+                                                      toggleOffPublishPayloadModifiers: ["processCurrentItemTokens"]
                                                    }
                                                 }
                                              ]
@@ -748,8 +773,16 @@ function getUserProfileInfo() {
                         name: "alfresco/renderers/Property",
                         config: {
                            propertyToRender: "displayName",
-                           renderSize: "large",
-                           renderOnNewLine: true
+                           renderSize: "large"
+                        }
+                     },
+                     {
+                        name: "alfresco/renderers/Property",
+                        config: {
+                           propertyToRender: "userName",
+                           deemphasized: true,
+                           renderedValuePrefix: "(",
+                           renderedValueSuffix: ")"
                         }
                      },
                      {
@@ -883,8 +916,9 @@ function getUserProfilesList() {
            config: {
              fieldId: "FILTER",
              name: "filter",
-             placeHolder: "Enter filter text...",
-             label: "Name"
+             placeHolder: "Search text...",
+             label: "Search for People",
+             description: "To search user profiles (by location, job title, or organization) include the profile property you're searching by, for example, \"location:London\", \"organization:Alfresco\", or \"jobtitle:Manager\"."
            }
          }],
          widgets: [
@@ -944,4 +978,3 @@ function getUserProfileWidgets(data) {
       }
    };
 }
-

--- a/aikau/src/main/resources/webscript-libs/pages/people.lib.js
+++ b/aikau/src/main/resources/webscript-libs/pages/people.lib.js
@@ -556,10 +556,9 @@ function getFollowersTab() {
    };
 }
 
-function getUserProfileChangePasswordTab() {
+function getUserProfileChangePasswordLink() {
    return {
-      name: "alfresco/layout/VerticalWidgets",
-      title: "Change Password",
+      name: "alfresco/renderers/Link",
       config: {
          renderFilter: [
             {
@@ -567,53 +566,50 @@ function getUserProfileChangePasswordTab() {
                values: [user.name]
             }
          ],
-         widgets: [
-            {
-               name: "alfresco/forms/Form",
-               config: {
-                  okButtonPublishTopic: "ALF_CRUD_CREATE",
-                  okButtonPublishLabel: "OK",
-                  okButtonPublishGlobal: true,
-                  okButtonPublishPayload: {
-                     url: "components/profile/change-password",
-                     urlType: "SHARE",
-                     failureMessage: "Incorrect authentication details or not authorised to change password.",
-                     successMessage: "Password updated"
-                  },
-                  showCancelButton: false,
-                  widgets: [
-                     {
-                        name: "alfresco/forms/controls/Password",
-                        config: {
-                           fieldId: "OLD_PASSWORD",
-                           label: "Current Password",
-                           value: "",
-                           name: "-oldpassword"
-                        }
-                     },
-                     {
-                        name: "alfresco/forms/controls/Password",
-                        config: {
-                           fieldId: "NEW_PASSWORD",
-                           label: "New Password",
-                           value: "",
-                           name: "-newpassword1"
-                        }
-                     },
-                     {
-                        name: "alfresco/forms/controls/Password",
-                        config: {
-                           fieldId: "NEW_PASSWORD_CONFIRMATION",
-                           label: "Confirm New Password",
-                           value: "",
-                           name: "-newpassword2",
-                           confirmationTargetId: "NEW_PASSWORD"
-                        }
-                     }
-                  ]
+         linkLabel: "Change Password",
+         renderOnNewLine: true,
+         publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+         publishPayload: {
+            dialogId: "CHANGE_PASSWORD",
+            dialogTitle: "Change Password",
+            formSubmissionTopic: "ALF_CRUD_CREATE",
+            formSubmissionPayloadMixin: {
+               url: "components/profile/change-password",
+               urlType: "SHARE",
+               failureMessage: "Incorrect authentication details or not authorised to change password.",
+               successMessage: "Password updated"
+            },
+            widgets: [
+               {
+                  name: "alfresco/forms/controls/Password",
+                  config: {
+                     fieldId: "OLD_PASSWORD",
+                     label: "Current Password",
+                     value: "",
+                     name: "-oldpassword"
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/Password",
+                  config: {
+                     fieldId: "NEW_PASSWORD",
+                     label: "New Password",
+                     value: "",
+                     name: "-newpassword1"
+                  }
+               },
+               {
+                  name: "alfresco/forms/controls/Password",
+                  config: {
+                     fieldId: "NEW_PASSWORD_CONFIRMATION",
+                     label: "Confirm New Password",
+                     value: "",
+                     name: "-newpassword2",
+                     confirmationTargetId: "NEW_PASSWORD"
+                  }
                }
-            }
-         ]
+            ]
+         }
       }
    };
 }
@@ -873,7 +869,8 @@ function getUserProfileInfo() {
                            propertyToRender: "location",
                            renderOnNewLine: true
                         }
-                     }
+                     },
+                     getUserProfileChangePasswordLink()
                   ]
                }
             }
@@ -930,7 +927,6 @@ function getUserProfileTabContainer() {
             getUserProfileRecentlyModifiedTab(),
             getFollowingTab(),
             getFollowersTab(),
-            getUserProfileChangePasswordTab(),
             getUserProfileNotificationsTab(),
             getUserProfileTrashcan()
          ]

--- a/aikau/src/main/resources/webscript-libs/pages/people.lib.js
+++ b/aikau/src/main/resources/webscript-libs/pages/people.lib.js
@@ -606,7 +606,8 @@ function getUserProfileChangePasswordTab() {
                            fieldId: "NEW_PASSWORD_CONFIRMATION",
                            label: "Confirm New Password",
                            value: "",
-                           name: "-newpassword2"
+                           name: "-newpassword2",
+                           confirmationTargetId: "NEW_PASSWORD"
                         }
                      }
                   ]

--- a/aikau/src/main/resources/webscript-libs/pages/people.lib.js
+++ b/aikau/src/main/resources/webscript-libs/pages/people.lib.js
@@ -372,6 +372,12 @@ function getUserProfileSitesTab() {
                                                 { 
                                                    name: "alfresco/renderers/Toggle",
                                                    config: {
+                                                      renderFilter: [
+                                                         {
+                                                            comparator: "currentUser",
+                                                            value: "{userName}"
+                                                         }
+                                                      ],
                                                       propertyToRender: "activityFeedEnabled",
                                                       checkedValue: true,
                                                       onLabel: "Following actvity",
@@ -381,14 +387,14 @@ function getUserProfileSitesTab() {
                                                       tooltipIdProperty: "title",
                                                       toggleOnTopic: "ALF_ENABLE_SITE_ACTIVITY_FEED",
                                                       toggleOnPublishPayload: {
-                                                         siteId: ["{shortName}"]
+                                                         siteId: "{shortName}"
                                                       },
                                                       toggleOnPublishGlobal: true,
                                                       toggleOnPublishPayloadType: "PROCESS",
                                                       toggleOnPublishPayloadModifiers: ["processCurrentItemTokens"],
-                                                      toggleOffTopic: "ALF_DISABLED_SITE_ACTIVITY_FEED",
+                                                      toggleOffTopic: "ALF_DISABLE_SITE_ACTIVITY_FEED",
                                                       toggleOffPublishPayload: {
-                                                         siteId: ["{shortName}"]
+                                                         siteId: "{shortName}"
                                                       },
                                                       toggleOffPublishGlobal: true,
                                                       toggleOffPublishPayloadType: "PROCESS",
@@ -542,6 +548,67 @@ function getFollowersTab() {
                   itemsProperty: "people",
                   widgets: [
                      getFollowUserListView()
+                  ]
+               }
+            }
+         ]
+      }
+   };
+}
+
+function getUserProfileChangePasswordTab() {
+   return {
+      name: "alfresco/layout/VerticalWidgets",
+      title: "Change Password",
+      config: {
+         renderFilter: [
+            {
+               property: "userName",
+               values: [user.name]
+            }
+         ],
+         widgets: [
+            {
+               name: "alfresco/forms/Form",
+               config: {
+                  okButtonPublishTopic: "ALF_CRUD_CREATE",
+                  okButtonPublishLabel: "OK",
+                  okButtonPublishGlobal: true,
+                  okButtonPublishPayload: {
+                     url: "components/profile/change-password",
+                     urlType: "SHARE",
+                     failureMessage: "Incorrect authentication details or not authorised to change password.",
+                     successMessage: "Password updated"
+                  },
+                  showCancelButton: false,
+                  widgets: [
+                     {
+                        name: "alfresco/forms/controls/Password",
+                        config: {
+                           fieldId: "OLD_PASSWORD",
+                           label: "Current Password",
+                           value: "",
+                           name: "-oldpassword"
+                        }
+                     },
+                     {
+                        name: "alfresco/forms/controls/Password",
+                        config: {
+                           fieldId: "NEW_PASSWORD",
+                           label: "New Password",
+                           value: "",
+                           name: "-newpassword1"
+                        }
+                     },
+                     {
+                        name: "alfresco/forms/controls/Password",
+                        config: {
+                           fieldId: "NEW_PASSWORD_CONFIRMATION",
+                           label: "Confirm New Password",
+                           value: "",
+                           name: "-newpassword2"
+                        }
+                     }
                   ]
                }
             }
@@ -862,6 +929,7 @@ function getUserProfileTabContainer() {
             getUserProfileRecentlyModifiedTab(),
             getFollowingTab(),
             getFollowersTab(),
+            getUserProfileChangePasswordTab(),
             getUserProfileNotificationsTab(),
             getUserProfileTrashcan()
          ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Password.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Password.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Password</shortname>
+  <description>This WebScript defines the Password test page</description>
+  <family>aikau-unit-tests</family>
+  <url>/Password</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Password.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Password.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Password.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Password.get.js
@@ -1,0 +1,50 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true,
+               warn: true,
+               error: true
+            }
+         }
+      }
+   ],
+   widgets: [
+      {
+         name: "alfresco/forms/Form",
+         config: {
+            okButtonPublishTopic: "POST_FORM",
+            scopeFormControls: false,
+            widgets: [
+               {
+                  id: "PW1",
+                  name: "alfresco/forms/controls/Password", 
+                  config: {
+                     fieldId: "PW1",
+                     label: "Enter new password",
+                     name: "pw1",
+                     value: ""
+                  }
+               },
+               {
+                  id: "PW2",
+                  name: "alfresco/forms/controls/Password", 
+                  config: {
+                     fieldId: "PW2",
+                     label: "Confirm new password",
+                     name: "pw2",
+                     value: "",
+                     confirmationTargetId: "PW1"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR provides more updates to the people.lib.js file. It is now possible to get sites that the user is a member of and for the current user the activity feed state will be merged into the results. The ability to enable and disable activity feeds for a site is now supported. A new comparator for renderFilter is provided to allow a simple check against the current user id. Finally the ability to change the password is added to the page model generated and enhancements to the Password widget have been made to support this - namely the ability to confirm a match against another password field.