### PR TITLE
AKU-1088: Ensure Form setValueTopic is scoped correctly

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -408,6 +408,12 @@ define(["dojo/_base/declare",
          // Setup some arrays for recording the valid and invalid widgets...
          this.invalidFormControls = [];
          
+         // Generate a new pubSubScope if required...
+         if (this.scopeFormControls === true && this.pubSubScope === "")
+         {
+            this.pubSubScope = this.generateUuid();
+         }
+
          // If requested in the configuration, the value of a form can be set via a publication,
          // however to avoid generating subscriptions unnecessarily the subscription is only
          // set if explicitly requested. Global scope is intentionally used for the subscription
@@ -419,12 +425,6 @@ define(["dojo/_base/declare",
          // Create a subscription that allows fields within the form to request options with a payload
          // that is augmented with the value of the form...
          this.alfSubscribe(topics.GET_FORM_VALUE_DEPENDENT_OPTIONS, lang.hitch(this, this.getFormValueDependantOptions));
-
-         // Generate a new pubSubScope if required...
-         if (this.scopeFormControls === true && this.pubSubScope === "")
-         {
-            this.pubSubScope = this.generateUuid();
-         }
 
          // Create any configured warnings...
          this.createWarnings();

--- a/aikau/src/test/resources/alfresco/forms/FormsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/FormsTest.js
@@ -35,7 +35,8 @@ define(["module",
          setHash: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_HASH"]),
          setForm: TestCommon.getTestSelector(buttonSelectors, "button.label", ["SET_FORM_VALUE"]),
          showLabel4: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BUTTON_1"]),
-         hideLabel4: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BUTTON_2"])
+         hideLabel4: TestCommon.getTestSelector(buttonSelectors, "button.label", ["BUTTON_2"]),
+         reset: TestCommon.getTestSelector(buttonSelectors, "button.label", ["RESET"])
       },
       forms: {
          hashForm: {
@@ -52,6 +53,9 @@ define(["module",
          },
          customFieldsForm: {
             confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["CUSTOM_FIELDS_FORM"])
+         },
+         resetForm: {
+            confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["RESET_FORM"])
          }
       },
       textBoxes: {
@@ -75,6 +79,9 @@ define(["module",
          },
          text6: {
             input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TEXT_BOX_6"])
+         },
+         text8: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TEXT_BOX_8"])
          },
          addText1: {
             input: TestCommon.getTestSelector(textBoxSelectors, "input", ["ADD_TEXT_BOX_1"])
@@ -454,6 +461,49 @@ define(["module",
             .isDisplayed()
             .then(function(displayed) {
                assert.isFalse(displayed);
+            });
+      },
+
+      "Reset a form": function() {
+         return this.remote.findDisplayedByCssSelector(selectors.forms.resetForm.confirmationButton)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("RESETTABLE_OK")
+            .then(function(payload) {
+               assert.propertyVal(payload, "text", "Original");
+            })
+         .end()
+
+         .findByCssSelector(selectors.textBoxes.text8.input)
+            .clearValue()
+            .type("Update")
+         .end()
+
+         .findByCssSelector(selectors.forms.resetForm.confirmationButton)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("RESETTABLE_OK")
+            .then(function(payload) {
+               assert.propertyVal(payload, "text", "Update");
+            })
+         .end()
+
+         .findByCssSelector(selectors.buttons.reset)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.forms.resetForm.confirmationButton)
+            .clearLog()
+            .click()
+         .end()
+
+         .getLastPublish("RESETTABLE_OK")
+            .then(function(payload) {
+               assert.propertyVal(payload, "text", "Original");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/Forms.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/Forms.get.js
@@ -328,6 +328,52 @@ model.jsonModel = {
       {
          name: "alfresco/layout/ClassicWindow",
          config: {
+            title: "Reset Button on Form",
+            widgets: [
+               {
+                  id: "RESET_FORM",
+                  name: "alfresco/forms/Form",
+                  config: {
+                     pubSubScope: "RESETTABLE_",
+                     setValueTopic: "RESET",
+                     setValueTopicGlobalScope: false,
+                     okButtonPublishTopic: "OK",
+                     widgets: [
+                        {
+                           id: "TEXT_BOX_8",
+                           name: "alfresco/forms/controls/TextBox",
+                           config: {
+                              fieldId: "TB8",
+                              name: "text",
+                              label: "Text"
+                           }
+                        }
+                     ],
+                     widgetsAdditionalButtons: [
+                        {
+                           id: "RESET",
+                           name: "alfresco/buttons/AlfButton",
+                           config: {
+                              updatePayload: false,
+                              label: "Reset",
+                              publishTopic: "RESET",
+                              publishPayload: {
+                                 text: "Original"
+                              }
+                           }
+                        }
+                     ],
+                     value: {
+                        text: "Original"
+                     }
+                  }
+               }
+            ]
+         }
+      },
+      {
+         name: "alfresco/layout/ClassicWindow",
+         config: {
             title: "Value Change Tracking",
             widgets: [
                {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1088 to ensure that the setValueTopic value can be subscribed to on the local pubSubScope of the Form. A new unit test has been added to verify this using form reset as a use case.