### PR TITLE
Support for custom format in Date renderer

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Date.js
+++ b/aikau/src/main/resources/alfresco/renderers/Date.js
@@ -67,6 +67,17 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/Date.properties"}],
       
       /**
+       * An optional format to apply to the date. This is only used when 
+       * [simple]{@link module:alfresco/renderers/Date#simple} is configured to be true.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.88
+       */
+      format: null,
+
+      /**
        * This can be set to override the default property to use to get the ISO 8601 
        * modification date which (in dot-notation) will be "jsNode.properties.modified.iso8601".
        * This is the property that is typically available when dealing with standard
@@ -161,7 +172,7 @@ define(["dojo/_base/declare",
             {
                this.renderPropertyNotFound = false;
                var dateProperty = lang.getObject(this.propertyToRender, false, this.currentItem);
-               this.originalRenderedValue = this.renderedValue = this.renderDate(dateProperty);
+               this.originalRenderedValue = this.renderedValue = this.renderDate(dateProperty, this.format);
             }
             else
             {

--- a/aikau/src/test/resources/alfresco/renderers/DateTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/DateTest.js
@@ -96,6 +96,14 @@ define(["module",
             .then(function(visibleText) {
                assert.equal(visibleText, "No Description:");
             });
+      },
+
+      "Date rendered in custom format": function() {
+         return this.remote.findByCssSelector("#FORMATTED .value")
+            .getVisibleText()
+            .then(function(visibleText) {
+               assert.equal(visibleText, "11/4/00");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Date.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Date.get.js
@@ -122,6 +122,26 @@ model.jsonModel = {
          }
       },
       {
+         name: "alfresco/html/Heading",
+         config: {
+            level: 3,
+            label: "Not available"
+         }
+      },
+      {
+         id: "FORMATTED",
+         name: "alfresco/renderers/Date",
+         config: {
+            currentItem: {
+               date: "2000-04-11T12:42:02+00:00"
+            },
+            simple: true,
+            propertyToRender: "date",
+            renderOnNewLine: true,
+            format: "shortDate"
+         }
+      },
+      {
          name: "alfresco/logging/DebugLog"
       }
    ]

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Date.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Date.get.js
@@ -125,7 +125,7 @@ model.jsonModel = {
          name: "alfresco/html/Heading",
          config: {
             level: 3,
-            label: "Not available"
+            label: "Custom Format"
          }
       },
       {


### PR DESCRIPTION
This PR makes an update to the Date renderer to provide support for custom formats as provided via TemporalUtils. A unit test has been added to verify this works.