### PR TITLE
AKU-1090: Update copy/move error messages

### DIFF
--- a/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
+++ b/aikau/src/main/resources/alfresco/services/actions/CopyMoveService.js
@@ -285,7 +285,7 @@ define(["dojo/_base/declare",
             {
                failures = failures.substring(0, failures.length - 2);
             }
-            var messageKey = payload.requestConfig.copy ? "copyMoveService.copy.partialSuccess" : "copyMoveService.move.partialSuccess";
+            var messageKey = payload.requestConfig.copy ? "copyMoveService.copy.multiple.failure" : "copyMoveService.move.multiple.failure";
             var message = this.message(messageKey);
             this.alfPublish("ALF_DISPLAY_PROMPT", {
                message: message

--- a/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
+++ b/aikau/src/test/resources/alfresco/services/actions/CopyMoveTest.js
@@ -142,7 +142,7 @@ define(["module",
          
          .getLastPublish("ALF_DISPLAY_PROMPT")
             .then(function(payload) {
-               assert.propertyVal(payload, "message", "Move partially successful, but not all of the files or folders could be moved");
+               assert.propertyVal(payload, "message", "The files or folders couldn't be moved right now. Check they're not locked for editing and try again.");
             });
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1090 to change the way that error messages are reported. The original implementation was based on the mistaken assumption that a partial success actually partially succeeded. Whereas actually although the REST API response reports that some actions have been successful, none have been applied. The unit tests have been updated.