### PR TITLE
AKU-1091: Minor search result style update

### DIFF
--- a/aikau/src/main/resources/alfresco/search/css/AlfSearchResult.css
+++ b/aikau/src/main/resources/alfresco/search/css/AlfSearchResult.css
@@ -5,6 +5,7 @@
 
 .alfresco-search-AlfSearchResult .selectorCell {
    width: 20px;
+   padding-left: 5px;
 }
 
 .alfresco-search-AlfSearchResult .thumbnailCell {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1091 to make a minor style update to the AlfSearchResult widget to ensure that browser focus highlighting on some browsers (Chrome, Firefox, Safari on Windows - oddly not IE and Edge) is not cropped.