### PR TITLE
Feature/aku 1093 create site menu

### DIFF
--- a/aikau/src/main/resources/alfresco/core/CoreXhr.js
+++ b/aikau/src/main/resources/alfresco/core/CoreXhr.js
@@ -373,6 +373,13 @@ define(["dojo/_base/declare",
                response: response
             }, false, false, requestConfig.data.alfResponseScope);
          }
+         else if (requestConfig.alfFailureTopic) {
+            this.alfPublish(requestConfig.alfFailureTopic, {
+               requestConfig: requestConfig,
+               response: response
+            }, false, false, requestConfig.alfResponseScope);
+         }
+         
          if (typeof this.displayMessage === "function" && response.response.text)
          {
             try

--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -1953,6 +1953,21 @@ define([],function() {
       UPLOAD_TO_UNKNOWN_LOCATION: "ALF_UPLOAD_TO_UNKNOWN_LOCATION",
 
       /**
+       * This topic can be published to request whether or not a particular site identifier
+       * (either the title or shortName) has already been used for a site.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.89
+       *
+       * @event
+       * @property {string} [shortName] The shortName to validate
+       * @property {string} [title] The title to validate
+       */
+      VALIDATE_SITE_IDENTIFIER: "ALF_VALIDATE_SITE_IDENTIFIER",
+
+      /**
        * This topic is published to indicate that widget processing has been completed. It is typically
        * fired by widgets that dynamically render widget models.
        *

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -40,6 +40,7 @@
 @large-font-size: 16px;
 @normal-font-size: 13px;
 @small-font-size: 12px;
+@very-small-font-size: 10px;
 @footer-font-size: 8.11px;
 
 // Font families

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -1465,6 +1465,19 @@ define(["dojo/_base/declare",
       _hadFocus: false,
 
       /**
+       * This is used to log whether or not the form control has been updated by the user, typically this would
+       * be set when the user performs an action (such as typing). Unlike 
+       * [_hadFocus]{@link module:alfresco/forms/controls/BaseFormControl#_hadFocus} it is not set by all form
+       * controls.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.89
+       */
+      _hadUserUpdate: false,
+
+      /**
        * This function is called whenever the form control loses focus. When this happens the
        * [_hadFocus]{@link module:alfresco/forms/controls/BaseFormControl#_hadFocus} attribute is set to
        * true and if the
@@ -1870,7 +1883,7 @@ define(["dojo/_base/declare",
        * @instance
        */
       showValidationFailure: function alfresco_forms_controls_BaseFormControl__showValidationFailure() {
-         if (this.showValidationErrorsImmediately || this._hadFocus)
+         if (this.showValidationErrorsImmediately || (this._hadFocus || this._hadUserUpdate))
          {
             domClass.add(this.domNode, "alfresco-forms-controls-BaseFormControl--invalid");
          }

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -794,6 +794,11 @@ define(["dojo/_base/declare",
             this.alfLog("warn", "An option was provided with neither label nor value", option, this);
          }
 
+         if (option.description)
+         {
+            option.description = this.message(option.description);
+         }
+
          // See AKU-844 - also update the value attribute whilst we're here, not the correct location despite
          // the function name !
          if (option[valueAttribute])

--- a/aikau/src/main/resources/alfresco/forms/controls/FormControlValidationMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FormControlValidationMixin.js
@@ -88,6 +88,16 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/FormControlValidationMixin.properties"}],
 
       /**
+       * The time in milliseconds to wait before displaying the validation progress indicator.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.89
+       */
+      validationProgressDisplayTimeout: 1000,
+
+      /**
        * Indicates whether or not validation is currently in-progress or not
        *
        * @instance
@@ -116,6 +126,17 @@ define(["dojo/_base/declare",
        * @default
        */
       _validationInProgressState: true,
+
+      /**
+       * A timeout for showing in-progress validation indicators. Used to debounce the display of the indicator
+       * to prevent "jumping".
+       * 
+       * @instance
+       * @type {object}
+       * @defaul
+       * @since 1.0.89 
+       */
+      _validationInProgressTimeout: null,
 
       /**
        * This is used to build up the overall validation message.
@@ -155,7 +176,11 @@ define(["dojo/_base/declare",
 
             // Hide any previous errors and reveal the in-progress indicator...
             this.hideValidationFailure();
-            domClass.remove(this._validationInProgressIndicator, "hidden");
+
+            clearTimeout(this._validationInProgressTimeout);
+            this._validationInProgressTimeout = setTimeout(lang.hitch(this, function() {
+               domClass.remove(this._validationInProgressIndicator, "hidden");
+            }), this.validationProgressDisplayTimeout);
 
             // Iterate over each validation configuration, start it and add it to a count...
             var validationErrors = [];
@@ -284,6 +309,7 @@ define(["dojo/_base/declare",
             // If all are complete then update validation status
             if (count === 0)
             {
+               clearTimeout(this._validationInProgressTimeout);
                this.validationComplete();
             }
             else

--- a/aikau/src/main/resources/alfresco/forms/controls/RadioButtons.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/RadioButtons.js
@@ -58,6 +58,13 @@ define(["alfresco/forms/controls/BaseFormControl",
          this._radioButton = new DojoRadioButton({name: this.name, value: this.value});
          this._radioButton.placeAt(this._radioButtonNode);
          this._labelNode.innerHTML = this.encodeHTML(this.message(this.label));
+
+         if (this.description)
+         {
+            domConstruct.create("div", {
+               className: "alfresco-forms-controls-RadioButtons__description"
+            }, this._labelNode, "last").appendChild(document.createTextNode(this.description));
+         }
       }
    });
 

--- a/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/BaseFormControl.css
@@ -22,6 +22,8 @@
       height: 16px;
       margin: 0 4px;
       width: 16px;
+      line-height: 20px;
+      vertical-align: text-bottom;
    }
    &--no-label {
       > .title-row {

--- a/aikau/src/main/resources/alfresco/forms/controls/css/RadioButtons.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/RadioButtons.css
@@ -1,3 +1,19 @@
-.alfresco-forms-controls-RadioButtons .radio-button > div {
-   display: inline-block;
+.alfresco-forms-controls-RadioButtons {
+   .radio-button {
+      > div {
+         display: inline-block;
+         vertical-align: top;
+      }
+      
+      .radio-button-label {
+         width: ~"calc(100% - 30px)";
+      }
+
+
+      .alfresco-forms-controls-RadioButtons__description {
+         font-size: @very-small-font-size;
+         color: @de-emphasized-font-color;
+         margin: 5px 0;
+      }
+   }
 }

--- a/aikau/src/main/resources/alfresco/forms/controls/css/RadioButtons.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/RadioButtons.css
@@ -9,11 +9,28 @@
          width: ~"calc(100% - 30px)";
       }
 
+      .radio-button-widget {
+         margin-top: 1px;
+      }
 
       .alfresco-forms-controls-RadioButtons__description {
          font-size: @very-small-font-size;
          color: @de-emphasized-font-color;
          margin: 5px 0;
+      }
+   }
+}
+
+.alfresco-dialog-AlfDialog {
+   .dialog-body {
+      .alfresco-forms-Form.root-dialog-form {
+         > form {
+            .alfresco-forms-controls-RadioButtons {
+               .radio-button {
+                  margin-top: 4px
+               }
+            }
+         }
       }
    }
 }

--- a/aikau/src/main/resources/alfresco/forms/controls/templates/BaseFormControl.html
+++ b/aikau/src/main/resources/alfresco/forms/controls/templates/BaseFormControl.html
@@ -1,7 +1,7 @@
 <div class="alfresco-forms-controls-BaseFormControl wipe" data-dojo-attach-point="containerNode">
    <div data-dojo-attach-point="_titleRowNode" class="title-row">
       <img class="validationInProgress hidden" src="${validationInProgressImgSrc}" alt="${validationInProgressAltText}" data-dojo-attach-point="_validationInProgressIndicator">
-      <img class="alfresco-forms-controls-BaseFormControl__validation-error" src="${validationErrorImgSrc}" alt="${validationErrorAltText}" data-dojo-attach-point="_validationErrorIndicator">
+      <img class="alfresco-forms-controls-BaseFormControl__validation-error" src="${validationErrorImgSrc}" alt="${validationErrorAltText}" title="${validationErrorAltText}" data-dojo-attach-point="_validationErrorIndicator">
       <img class="inlineHelp hidden" src="${inlineHelpImgSrc}" alt="${inlineHelpAltText}" data-dojo-attach-point="_inlineHelpIndicator" data-dojo-attach-event="ondijitclick:showInlineHelp">
       <label class="label" data-dojo-attach-point="_labelNode"></label>
       <span class="requirementIndicator" data-dojo-attach-point="_requirementIndicator">*</span>

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
@@ -68,6 +68,10 @@ define(["alfresco/core/topics",
        * @since 1.0.49
        */
       handleKeyUp: function alfresco_forms_controls_utilities_TextBoxValueChangeMixin__handleKeyUp(evt) {
+         // On key up events indicate that the user has changed the field, this means that 
+         // error messages can be displayed without relying on focus being lost
+         this._hadUserUpdate = true;
+         
          if (this.publishTopicOnEnter && evt.keyCode === keys.ENTER) {
             this.alfPublish(this.publishTopicOnEnter, {
                fieldId: this.id

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -911,17 +911,12 @@ define(["dojo/_base/declare",
                message: this.message("create-site.creating")
             });
 
-            var visibility = payload.visibility;
-            if (visibility === "PUBLIC" && payload.moderated)
-            {
-               visibility = "MODERATED";
-            }
             var url = AlfConstants.URL_SERVICECONTEXT + "modules/create-site";
             this.serviceXhr({
                url : url,
                method: "POST",
                data: {
-                  visibility: visibility,
+                  visibility: payload.visibility,
                   title: payload.title,
                   shortName: payload.shortName,
                   description: payload.description || "",
@@ -1026,13 +1021,6 @@ define(["dojo/_base/declare",
          var shortName = lang.getObject("shortName", false, response);
          if (response)
          {
-            // Set the moderated and visibility attributes appropriately...
-            response.moderated = response.visibility === "MODERATED";
-            if (response.moderated)
-            {
-               response.visibility = "PUBLIC";
-            }
-
             var dialogWidgets = lang.clone(this.widgetsForEditSiteDialog);
             this.processObject(["processInstanceTokens"], dialogWidgets);
             this.alfServicePublish(topics.CREATE_FORM_DIALOG, {
@@ -1069,17 +1057,12 @@ define(["dojo/_base/declare",
                message: this.message("edit-site.saving")
             });
 
-            var visibility = payload.visibility;
-            if (visibility === "PUBLIC" && payload.moderated)
-            {
-               visibility = "MODERATED";
-            }
             var url = AlfConstants.PROXY_URI + "api/sites/" + payload.shortName;
             this.serviceXhr({
                url : url,
                method: "PUT",
                data: {
-                  visibility: visibility,
+                  visibility: payload.visibility,
                   title: payload.title,
                   shortName: payload.shortName,
                   description: payload.description || ""
@@ -1413,25 +1396,8 @@ define(["dojo/_base/declare",
                optionsConfig: {
                   fixed: [
                      { label: "create-site.dialog.visibility.public", value: "PUBLIC" },
+                     { label: "create-site.dialog.visibility.moderated", value: "MODERATED" },
                      { label: "create-site.dialog.visibility.private", value: "PRIVATE" }
-                  ]
-               }
-            }
-         },
-         {
-            id: "CREATE_SITE_FIELD_MODERATED",
-            name: "alfresco/forms/controls/CheckBox",
-            config: {
-               fieldId: "MODERATED",
-               label: "create-site.dialog.moderated.label",
-               description: "create-site.dialog.moderated.description",
-               name: "moderated",
-               visibilityConfig: {
-                  rules: [
-                     {
-                        targetId: "VISIBILITY",
-                        is: ["PUBLIC"]
-                     }
                   ]
                }
             }
@@ -1491,25 +1457,8 @@ define(["dojo/_base/declare",
                optionsConfig: {
                   fixed: [
                      { label: "create-site.dialog.visibility.public", value: "PUBLIC" },
+                     { label: "create-site.dialog.visibility.moderated", value: "MODERATED" },
                      { label: "create-site.dialog.visibility.private", value: "PRIVATE" }
-                  ]
-               }
-            }
-         },
-         {
-            id: "EDIT_SITE_FIELD_MODERATED",
-            name: "alfresco/forms/controls/CheckBox",
-            config: {
-               fieldId: "MODERATED",
-               label: "create-site.dialog.moderated.label",
-               description: "create-site.dialog.moderated.description",
-               name: "moderated",
-               visibilityConfig: {
-                  rules: [
-                     {
-                        targetId: "VISIBILITY",
-                        is: ["PUBLIC"]
-                     }
                   ]
                }
             }

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1315,7 +1315,7 @@ define(["dojo/_base/declare",
          }
          else
          {
-            url += payload.shortName ? ("shortName=" + payload.shortName) : ("title=" + payload.title);
+            url += payload.shortName ? ("shortName=" + encodeURIComponent(payload.shortName)) : ("title=" + encodeURIComponent(payload.title));
             var config = {
                url: url,
                method: "GET",

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1395,9 +1395,21 @@ define(["dojo/_base/declare",
                name: "visibility",
                optionsConfig: {
                   fixed: [
-                     { label: "create-site.dialog.visibility.public", value: "PUBLIC" },
-                     { label: "create-site.dialog.visibility.moderated", value: "MODERATED" },
-                     { label: "create-site.dialog.visibility.private", value: "PRIVATE" }
+                     { 
+                        label: "create-site.dialog.visibility.public", 
+                        description: "create-site.dialog.visibility.public.description",
+                        value: "PUBLIC" 
+                     },
+                     { 
+                        label: "create-site.dialog.visibility.moderated", 
+                        description: "create-site.dialog.visibility.moderated.description",
+                        value: "MODERATED" 
+                     },
+                     { 
+                        label: "create-site.dialog.visibility.private",  
+                        description: "create-site.dialog.visibility.moderated.description",
+                        value: "PRIVATE" 
+                     }
                   ]
                }
             }
@@ -1456,9 +1468,21 @@ define(["dojo/_base/declare",
                name: "visibility",
                optionsConfig: {
                   fixed: [
-                     { label: "create-site.dialog.visibility.public", value: "PUBLIC" },
-                     { label: "create-site.dialog.visibility.moderated", value: "MODERATED" },
-                     { label: "create-site.dialog.visibility.private", value: "PRIVATE" }
+                     { 
+                        label: "create-site.dialog.visibility.public", 
+                        description: "create-site.dialog.visibility.public.description",
+                        value: "PUBLIC" 
+                     },
+                     { 
+                        label: "create-site.dialog.visibility.moderated", 
+                        description: "create-site.dialog.visibility.moderated.description",
+                        value: "MODERATED" 
+                     },
+                     { 
+                        label: "create-site.dialog.visibility.private",  
+                        description: "create-site.dialog.visibility.moderated.description",
+                        value: "PRIVATE" 
+                     }
                   ]
                }
             }

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1020,9 +1020,9 @@ define(["dojo/_base/declare",
        */
       showEditSiteDialog: function alfresco_services_SiteService__showEditSiteDialog(response, originalRequestConfig) {
          // Check that the resposne is the expected siteData...
-         var shortName = lang.getObject("shortName", false, response);
          if (response)
          {
+            var shortName = lang.getObject("shortName", false, response);
             var dialogWidgets = lang.clone(this.widgetsForEditSiteDialog);
             this.processObject(["processInstanceTokens"], dialogWidgets);
             this.alfServicePublish(topics.CREATE_FORM_DIALOG, {
@@ -1039,7 +1039,10 @@ define(["dojo/_base/declare",
                widgets: dialogWidgets
             });
          }
-         this.alfLog("warn", "It was not possible to retrieve the current site data for editing", response, originalRequestConfig, this);
+         else
+         {
+            this.alfLog("warn", "It was not possible to retrieve the current site data for editing", response, originalRequestConfig, this);
+         }
       },
 
       /**
@@ -1346,6 +1349,14 @@ define(["dojo/_base/declare",
                      validation: "maxLength",
                      length: 256,
                      errorMessage: "create-site.dialog.name.maxLength"
+                  },
+                  {
+                     validation: "validationTopic",
+                     validationTopic: topics.VALIDATE_SITE_IDENTIFIER,
+                     validationValueProperty: "title",
+                     negate: true,
+                     validationResultProperty: "response.used",
+                     errorMessage: "create-site-dialog.title.already.used"
                   }
                ]
             }
@@ -1383,6 +1394,14 @@ define(["dojo/_base/declare",
                      validation: "regex",
                      regex: "^[0-9a-zA-Z-]+$",
                      errorMessage: "create-site.dialog.urlname.regex"
+                  },
+                  {
+                     validation: "validationTopic",
+                     validationTopic: topics.VALIDATE_SITE_IDENTIFIER,
+                     validationValueProperty: "shortName",
+                     negate: true,
+                     validationResultProperty: "response.used",
+                     errorMessage: "create-site-dialog.name.already.used"
                   }
                ]
             }
@@ -1471,7 +1490,12 @@ define(["dojo/_base/declare",
                   },
                   {
                      validation: "validationTopic",
-                     validationTopic: topics.VALIDATE_SITE_IDENTIFIER
+                     validationTopic: topics.VALIDATE_SITE_IDENTIFIER,
+                     validationValueProperty: "title",
+                     negate: true,
+                     validateInitialValue: false,
+                     validationResultProperty: "response.used",
+                     errorMessage: "create-site-dialog.title.already.used"
                   }
                ]
             }

--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -43,8 +43,8 @@ create-site.dialog.visibility.private=Private
 create-site.dialog.visibility.private.description=Only people added by a Site Manager can find and use this site.
 create-site.creating=Site is being created...
 
-create-site-dialog.title.already.used=The requested name has already been used
-create-site-dialog.name.already.used=The requested URL name has already been used
+create-site-dialog.title.already.used=This name is already in use
+create-site-dialog.name.already.used=This URL name is already in use
 
 
 edit-site.dialog.title=Edit Site Details

--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -43,6 +43,10 @@ create-site.dialog.visibility.private=Private
 create-site.dialog.visibility.private.description=Only people added by a Site Manager can find and use this site.
 create-site.creating=Site is being created...
 
+create-site-dialog.title.already.used=The requested name has already been used
+create-site-dialog.name.already.used=The requested URL name has already been used
+
+
 edit-site.dialog.title=Edit Site Details
 edit-site.saving=Site details are being saved...
 

--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -34,6 +34,7 @@ create-site.dialog.type.label=Type
 create-site.dialog.type.collaboration=Collaboration Site
 create-site.dialog.visibility.label=Visibility
 create-site.dialog.visibility.public=Public
+create-site.dialog.visibility.moderated=Moderated
 create-site.dialog.moderated.label=Moderated site membership
 create-site.dialog.moderated.description=Site managers can control who joins the site
 create-site.dialog.visibility.private=Private

--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -34,10 +34,13 @@ create-site.dialog.type.label=Type
 create-site.dialog.type.collaboration=Collaboration Site
 create-site.dialog.visibility.label=Visibility
 create-site.dialog.visibility.public=Public
+create-site.dialog.visibility.public.description=Everyone in your organization can access this site.
 create-site.dialog.visibility.moderated=Moderated
+create-site.dialog.visibility.moderated.description=Everyone in your organization can find this site and request access. Access is granted by Site Managers.
 create-site.dialog.moderated.label=Moderated site membership
 create-site.dialog.moderated.description=Site managers can control who joins the site
 create-site.dialog.visibility.private=Private
+create-site.dialog.visibility.private.description=Only people added by a Site Manager can find and use this site.
 create-site.creating=Site is being created...
 
 edit-site.dialog.title=Edit Site Details

--- a/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
@@ -66,6 +66,10 @@ define(["module",
          hiddenValidation: {
             requirementIndicator: TestCommon.getTestSelector(formControlSelectors, "requirement.indicator", ["VALIDATION_HIDDEN_TEXTBOX"]),
             invalidIndicator: TestCommon.getTestSelector(formControlSelectors, "invalid.indicator", ["VALIDATION_HIDDEN_TEXTBOX"])
+         },
+         customTopicValidation: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["CUSTOMIZED_TOPIC_VALIDATION"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["CUSTOMIZED_TOPIC_VALIDATION"])
          }
       },
       buttons: {
@@ -127,11 +131,11 @@ define(["module",
       "Check form confirmation button is enabled": function() {
          return this.remote.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .type("abc")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.invert.input)
             .type("abc")
-            .end()
+         .end()
 
          .findAllByCssSelector(selectors.form.disabledConfirmationButton)
             .then(function(elements) {
@@ -160,7 +164,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .clearValue()
             .type("abcdef")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -178,7 +182,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .clearValue()
             .type("123")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -196,7 +200,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .clearValue()
             .type("One")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -214,7 +218,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.invert.input)
             .clearValue()
             .type("abc>def/")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -231,15 +235,15 @@ define(["module",
       "Test asynchoronous validation indicator gets displayed": function() {
          return this.remote.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .clearValue()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.buttons.blockResponse)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .type("O")
-            .end()
+         .end()
 
          .findDisplayedByCssSelector(selectors.textBoxes.threeLettersOrMore.validating);
       },
@@ -248,7 +252,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.buttons.unblockResponse)
             .click()
             .click() // Needs the 2nd click!
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.threeLettersOrMore.validating)
             .isDisplayed()
@@ -262,12 +266,14 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.threeLettersOrMore.input)
             .clearValue()
             .type("abc")
-            .end()
-            .findByCssSelector(selectors.textBoxes.invert.input)
+         .end()
+            
+         .findByCssSelector(selectors.textBoxes.invert.input)
             .clearValue()
             .type("abc")
-            .end()
-            .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+         .end()
+      
+         .findAllByCssSelector(selectors.form.disabledConfirmationButton)
             .then(function(elements) {
                assert.lengthOf(elements, 0, "The forms confirmation button should be enabled");
             });
@@ -277,7 +283,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.topicValidation.input)
             .clearValue()
             .type("#fail")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -286,7 +292,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.topicValidation.input)
             .clearValue()
             .type("success")
-            .end()
+         .end()
 
          .findAllByCssSelector(selectors.form.disabledConfirmationButton)
             .then(function(elements) {
@@ -298,7 +304,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.matchTarget.input)
             .clearValue()
             .type("ABC")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -307,7 +313,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.matchSource.input)
             .clearValue()
             .type("ABC")
-            .end()
+         .end()
 
          .findAllByCssSelector(selectors.form.disabledConfirmationButton)
             .then(function(elements) {
@@ -319,7 +325,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.matchTarget.input)
             .clearValue()
             .type("AB")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.form.disabledConfirmationButton);
       },
@@ -328,7 +334,7 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.matchSource.input)
             .clearValue()
             .type("AB")
-            .end()
+         .end()
 
          .findAllByCssSelector(selectors.form.disabledConfirmationButton)
             .then(function(elements) {
@@ -368,6 +374,19 @@ define(["module",
          .end()
 
          .findByCssSelector(selectors.dialogs.checkMessage.hidden);
+      },
+
+      "Customized topic validation works": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.customTopicValidation.input)
+            .clearValue()
+            .type("used")
+         .end()
+
+         .findDisplayedByCssSelector(selectors.textBoxes.customTopicValidation.validationMessage)
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Identifier has been used");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -25,9 +25,8 @@
 define(["module",
         "alfresco/TestCommon",
         "alfresco/defineSuite",
-        "intern/chai!assert",
-        "intern/dojo/node!leadfoot/keys"],
-        function(module, TestCommon, defineSuite, assert, keys) {
+        "intern/chai!assert"],
+        function(module, TestCommon, defineSuite, assert) {
 
    var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
    var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -25,8 +25,9 @@
 define(["module",
         "alfresco/TestCommon",
         "alfresco/defineSuite",
-        "intern/chai!assert"],
-        function(module, TestCommon, defineSuite, assert) {
+        "intern/chai!assert",
+        "intern/dojo/node!leadfoot/keys"],
+        function(module, TestCommon, defineSuite, assert, keys) {
 
    var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
    var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
@@ -38,7 +39,10 @@ define(["module",
       },
       dialogs: {
          createSite: {
-            visible: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["CREATE_SITE_DIALOG"])
+            visible: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["CREATE_SITE_DIALOG"]),
+            hidden: TestCommon.getTestSelector(dialogSelectors, "hidden.dialog", ["CREATE_SITE_DIALOG"]),
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["CREATE_SITE_DIALOG"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(dialogSelectors, "disabled.form.dialog.confirmation.button", ["CREATE_SITE_DIALOG"])
          }
       },
       textBoxes: {
@@ -83,6 +87,7 @@ define(["module",
          .end()
 
          .findByCssSelector(selectors.textBoxes.createSiteTitle.input)
+            .clearValue()
             .type("no copying now")
          .end()
 
@@ -96,44 +101,34 @@ define(["module",
       "Create site (duplicate shortName)": function() {
          return this.remote.findByCssSelector(selectors.textBoxes.createSiteTitle.input)
             .clearValue()
-            .type("fail")
+            .type("used")
          .end()
 
-         .findById("CREATE_SITE_DIALOG_OK_label")
-            .click()
-         .end()
-
-         .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible")
-         .end()
-
-         .findDisplayedById("NOTIFICATION_PROMPT")
-         .end()
-
-         .findById("NOTIFCATION_PROMPT_ACKNOWLEDGEMENT_label")
-            .click()
-         .end()
-
-         .findByCssSelector("#NOTIFICATION_PROMPT.dialogHidden");
+         .findByCssSelector(selectors.dialogs.createSite.disabledConfirmationButton);
       },
 
       "Create site success": function() {
-         return this.remote.findByCssSelector("#CREATE_SITE_DIALOG #CREATE_SITE_FIELD_TITLE .dijitInputContainer input")
+         return this.remote.findByCssSelector(selectors.textBoxes.createSiteTitle.input)
             .clearValue()
             .type("pass")
          .end()
 
-         .findByCssSelector("#CREATE_SITE_DIALOG #CREATE_SITE_FIELD_SHORTNAME .dijitInputContainer input")
+         .findByCssSelector(selectors.textBoxes.createSiteShortName.input)
             .clearValue()
             .type("pass")
          .end()
+         
+         .waitForDeletedByCssSelector(selectors.dialogs.createSite.disabledConfirmationButton)
+         .end()
 
-         .clearLog()
-
-         .findById("CREATE_SITE_DIALOG_OK_label")
+         .findByCssSelector(selectors.dialogs.createSite.confirmationButton)
+            .clearLog()
             .click()
+            .click() // For some reason in automated testing a second click is required here
+                     // Adding a long pause and a manual click and it works fine...
          .end()
 
-         .findByCssSelector("#CREATE_SITE_DIALOG.dialogHidden")
+         .findByCssSelector(selectors.dialogs.createSite.hidden)
          .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible")
@@ -161,6 +156,8 @@ define(["module",
 
          .findById("EDIT_SITE_DIALOG_OK_label")
             .click()
+            .click() // For some reason in automated testing a second click is required here
+                     // Adding a long pause and a manual click and it works fine...
          .end()
 
          .findByCssSelector("#EDIT_SITE_DIALOG.dialogHidden")

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -60,14 +60,14 @@ define(["module",
 
          .findByCssSelector(selectors.buttons.createSite)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.dialogs.createSite.visible)
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.createSiteTitle.input)
             .type(" has*odd & chars")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.createSiteShortName.input)
             .getProperty("value")
@@ -80,11 +80,11 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.createSiteShortName.input)
             .clearValue()
             .type("fail")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.createSiteTitle.input)
             .type("no copying now")
-            .end()
+         .end()
 
          .findByCssSelector(selectors.textBoxes.createSiteShortName.input)
             .getProperty("value")
@@ -97,48 +97,47 @@ define(["module",
          return this.remote.findByCssSelector(selectors.textBoxes.createSiteTitle.input)
             .clearValue()
             .type("fail")
-            .end()
+         .end()
 
          .findById("CREATE_SITE_DIALOG_OK_label")
             .click()
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible")
-            .end()
+         .end()
 
          .findDisplayedById("NOTIFICATION_PROMPT")
-            .end()
+         .end()
 
          .findById("NOTIFCATION_PROMPT_ACKNOWLEDGEMENT_label")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector("#NOTIFICATION_PROMPT.dialogHidden")
-            .end();
+         .findByCssSelector("#NOTIFICATION_PROMPT.dialogHidden");
       },
 
       "Create site success": function() {
          return this.remote.findByCssSelector("#CREATE_SITE_DIALOG #CREATE_SITE_FIELD_TITLE .dijitInputContainer input")
             .clearValue()
             .type("pass")
-            .end()
+         .end()
 
          .findByCssSelector("#CREATE_SITE_DIALOG #CREATE_SITE_FIELD_SHORTNAME .dijitInputContainer input")
             .clearValue()
             .type("pass")
-            .end()
+         .end()
 
          .clearLog()
 
          .findById("CREATE_SITE_DIALOG_OK_label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#CREATE_SITE_DIALOG.dialogHidden")
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible")
-            .end()
+         .end()
 
          .getLastPublish("ALF_SITE_CREATION_REQUEST")
             .getLastPublish("ALF_SITE_CREATION_SUCCESS")
@@ -151,24 +150,24 @@ define(["module",
       "Edit site": function() {
          return this.remote.findById("EDIT_SITE_label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#EDIT_SITE_DIALOG #EDIT_SITE_FIELD_TITLE .dijitInputContainer input")
             .clearValue()
             .type("New Site Title")
-            .end()
+         .end()
 
          .clearLog()
 
          .findById("EDIT_SITE_DIALOG_OK_label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector("#EDIT_SITE_DIALOG.dialogHidden")
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification--visible")
-            .end()
+         .end()
 
          .getLastPublish("ALF_SITE_EDIT_REQUEST")
             .getLastPublish("ALF_SITE_EDIT_SUCCESS")
@@ -181,14 +180,10 @@ define(["module",
       "Edit moderated site": function() {
          return this.remote.findById("EDIT_MODERATED_SITE_label")
             .click()
-            .end()
-
-         // The moderated checkbox should be checked
-         .findByCssSelector("#EDIT_SITE_DIALOG #EDIT_SITE_FIELD_MODERATED .dijitCheckBoxChecked")
          .end()
 
-         // The public visibility radio button should be selected
-         .findByCssSelector("#EDIT_SITE_DIALOG #EDIT_SITE_FIELD_VISIBILITY_CONTROL .dijitRadioChecked input[value=PUBLIC]")
+         // The moderated visibility radio button should be selected
+         .findByCssSelector("#EDIT_SITE_DIALOG #EDIT_SITE_FIELD_VISIBILITY_CONTROL .dijitRadioChecked input[value=MODERATED]")
          .end()
 
          .clearLog()
@@ -206,14 +201,14 @@ define(["module",
       "Request to join site navigates user to their dashboard afterwards": function() {
          return this.remote.findById("REQUEST_SITE_MEMBERSHIP_label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(".dialogDisplayed .dijitButtonNode")
             .click()
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".dialogDisplayed")
-            .end()
+         .end()
 
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
@@ -226,14 +221,14 @@ define(["module",
       "Requesting to join site with request already pending displays suitable error message": function() {
          return this.remote.findById("REQUEST_SITE_MEMBERSHIP_ALREADY_PENDING_label")
             .click()
-            .end()
+         .end()
 
          .findDisplayedByCssSelector(".alfresco-notifications-AlfNotification__message")
             .getVisibleText()
             .then(function(visibleText) {
                assert.equal(visibleText, "A request to join this site is already pending");
             })
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification");
       },
@@ -241,14 +236,14 @@ define(["module",
       "Error occurring when requesting to join site displays error message": function() {
          return this.remote.findById("REQUEST_SITE_MEMBERSHIP_ERROR_label")
             .click()
-            .end()
+         .end()
 
          .findDisplayedByCssSelector(".alfresco-notifications-AlfNotification__message")
             .getVisibleText()
             .then(function(visibleText) {
                assert.equal(visibleText, "The request to join the site failed");
             })
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification");
       },
@@ -257,7 +252,7 @@ define(["module",
          return this.remote.findById("CANCEL_PENDING_REQUEST_label")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastXhr("api/sites/my-site/invitations/foo")
 
@@ -266,7 +261,7 @@ define(["module",
             .then(function(visibleText) {
                assert.equal(visibleText, "Successfully cancelled request to join site My Site");
             })
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".alfresco-notifications-AlfNotification")
 
@@ -276,14 +271,14 @@ define(["module",
       "Leave site and confirm user home page override works": function() {
          return this.remote.findById("LEAVE_SITE_label")
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(".dialogDisplayed .dijitButton:first-child .dijitButtonNode")
             .click()
-            .end()
+         .end()
 
          .waitForDeletedByCssSelector(".dialogDisplayed")
-            .end()
+         .end()
 
          .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
@@ -295,7 +290,7 @@ define(["module",
          return this.remote.findById("BECOME_SITE_MANAGER_label")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_RELOAD_DATA");
       },
@@ -304,7 +299,7 @@ define(["module",
          return this.remote.findById("BECOME_SITE_MANAGER_PAGE_RELOAD_label")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_RELOAD_PAGE");
       }

--- a/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
+++ b/aikau/src/test/resources/test-selectors/alfresco/dialogs/AlfDialog.properties
@@ -2,10 +2,10 @@
 disabled.form.dialog.confirmation.button=#{0} .footer .confirmationButton.dijitButtonDisabled .dijitButtonNode
 
 # The confirmation button on a form dialog
-form.dialog.confirmation.button=#{0} .footer .confirmationButton .dijitButtonNode
+form.dialog.confirmation.button=#{0} .footer .confirmationButton .dijitButtonNode .dijitButtonText
 
 # The cancellation button on a form dialog
-form.dialog.cancellation.button=#{0} .footer .cancellationButton .dijitButtonNode
+form.dialog.cancellation.button=#{0} .footer .cancellationButton .dijitButtonNode .dijitButtonText
 
 # A hidden dialog
 hidden.dialog=#{0}.dialogHidden

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/RadioButtons.get.js
@@ -61,11 +61,13 @@ model.jsonModel = {
                         fixed: [
                            {
                               label: "Yes",
-                              value: true
+                              value: true,
+                              description: "Affirmative"
                            },
                            {
                               label: "No",
-                              value: false
+                              value: false,
+                              description: "Negative"
                            }
                         ]
                      }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -12,6 +12,7 @@ model.jsonModel = {
          }
       },
       "alfresco/services/DialogService",
+      "alfresco/services/SiteService",
       "aikauTesting/mockservices/FormControlValidationTestService",
       "alfresco/services/ErrorReporter"
    ],
@@ -23,7 +24,7 @@ model.jsonModel = {
             widgets: [
                {
                   id: "TEST_CONTROL",
-                  name: "alfresco/forms/controls/DojoValidationTextBox",
+                  name: "alfresco/forms/controls/TextBox",
                   config: {
                      label: null, // PLEASE NOTE: Label left intentionally blank for testing purposes (AKU-951)
                      description: "Three Letters Or More",
@@ -56,7 +57,7 @@ model.jsonModel = {
                },
                {
                   id: "TEST_CONTROL_INVERT",
-                  name: "alfresco/forms/controls/DojoValidationTextBox",
+                  name: "alfresco/forms/controls/TextBox",
                   config: {
                      label: "No illegal characters",
                      name: "name",
@@ -83,7 +84,7 @@ model.jsonModel = {
                },
                {
                   id: "MATCH_TARGET",
-                  name: "alfresco/forms/controls/DojoValidationTextBox",
+                  name: "alfresco/forms/controls/TextBox",
                   config: {
                      fieldId: "MATCH_TARGET",
                      label: "Field to match against",
@@ -92,7 +93,7 @@ model.jsonModel = {
                },
                {
                   id: "MATCH_SOURCE",
-                  name: "alfresco/forms/controls/DojoValidationTextBox",
+                  name: "alfresco/forms/controls/TextBox",
                   config: {
                      fieldId: "MATCH_SOURCE",
                      label: "Field to test match",
@@ -108,16 +109,40 @@ model.jsonModel = {
                },
                {
                   id: "TOPIC_VALIDATION",
-                  name: "alfresco/forms/controls/DojoValidationTextBox",
+                  name: "alfresco/forms/controls/TextBox",
                   config: {
                      fieldId: "TOPIC_VALIDATION",
                      label: "Validation Topic",
+                     description: "Enter #fail as value to put into error state",
                      value: "",
                      validationConfig: [
                         {
                            validation: "validationTopic",
                            validationTopic: "ALF_VALIDATE_TOPIC_TEST",
                            errorMessage: "Value should not be #fail"
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "CUSTOMIZED_TOPIC_VALIDATION",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "TOPIC_VALIDATION",
+                     label: "Customized validation Topic",
+                     description: "This simulates validating uniqueness of site identifier",
+                     value: "",
+                     validationConfig: [
+                        {
+                           validation: "validationTopic",
+                           validationTopic: "ALF_VALIDATE_SITE_IDENTIFIER",
+                           validationValueProperty: "title",
+                           validationPayload: {
+                              title: null
+                           },
+                           negate: true,
+                           validationResultProperty: "response.used",
+                           errorMessage: "Identifier has been used"
                         }
                      ]
                   }
@@ -231,6 +256,9 @@ model.jsonModel = {
                ]
             }
          }
+      },
+      {
+         name: "aikauTesting/mockservices/SiteMockXhr"
       },
       {
          name: "alfresco/logging/DebugLog"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -131,7 +131,7 @@ model.jsonModel = {
                      fieldId: "TOPIC_VALIDATION",
                      label: "Customized validation Topic",
                      description: "This simulates validating uniqueness of site identifier",
-                     value: "",
+                     value: "test",
                      validationConfig: [
                         {
                            validation: "validationTopic",
@@ -140,6 +140,7 @@ model.jsonModel = {
                            validationPayload: {
                               title: null
                            },
+                           validateInitialValue: false,
                            negate: true,
                            validationResultProperty: "response.used",
                            errorMessage: "Identifier has been used"

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormControlValidationTestService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormControlValidationTestService.js
@@ -59,7 +59,7 @@ define(["dojo/_base/declare",
             this.alfSubscribe("GET_DUMMY_VALUES", lang.hitch(this, this.onGetDummyValues));
             this.alfSubscribe("BLOCK_RESPONSES", lang.hitch(this, this.onBlockResponses));
             this.alfSubscribe("UNBLOCK_RESPONSES", lang.hitch(this, this.onUnblockResponses));
-            this.alfSubscribe("ALF_VALIDATE_TOPIC_TEST", lang.hitch(this,  this.onValidateTopicTest));
+            this.alfSubscribe("ALF_VALIDATE_TOPIC_TEST", lang.hitch(this, this.onValidateTopicTest));
          },
 
          /**
@@ -68,7 +68,7 @@ define(["dojo/_base/declare",
           * @instance
           * @param {object} payload The published payload.
           */
-         onBlockResponses: function alfresco_testing_mockservices_FormControlValidationTestService__onBlockResponses(payload) {
+         onBlockResponses: function alfresco_testing_mockservices_FormControlValidationTestService__onBlockResponses(/*jshint unused:false*/payload) {
             this.responsesBlocked = true;
          },
 
@@ -79,8 +79,8 @@ define(["dojo/_base/declare",
           * @instance
           * @param {object} payload The published payload
           */
-         onUnblockResponses: function alfresco_testing_mockservices_FormControlValidationTestService__onBlockResponses(payload) {
-            array.forEach(this.responses, function(response, index) {
+         onUnblockResponses: function alfresco_testing_mockservices_FormControlValidationTestService__onBlockResponses(/*jshint unused:false*/payload) {
+            array.forEach(this.responses, function(response) {
                this.alfPublish(response.publishTopic, response.publishPayload);
             }, this);
             this.responsesBlocked = false;
@@ -90,8 +90,8 @@ define(["dojo/_base/declare",
           * @instance
           */
          onGetDummyValues: function alfresco_testing_mockservices_FormControlValidationTestService__onGetDummyValues(payload) {
-            var alfTopic = ((payload.alfResponseTopic != null) ? payload.alfResponseTopic : "NO_ALFRESPONSETOPIC") + "_SUCCESS";
-            var payload = {
+            var alfTopic = ((payload.alfResponseTopic) ? payload.alfResponseTopic : "NO_ALFRESPONSETOPIC") + "_SUCCESS";
+            payload = {
                someData: [
                   {
                      name: "One"
@@ -123,7 +123,7 @@ define(["dojo/_base/declare",
           */
          onValidateTopicTest: function alfresco_testing_mockservices_FormControlValidationTestService__onValidateTopicTest(payload) {
             var isValid = (payload.value !== "#fail");
-            this.alfPublish(payload.alfResponseTopic, {isValid: isValid}, true);
+            this.alfPublish(payload.alfResponseTopic, {isValid: isValid}, false, false, payload.alfResponseScope);
          }
       });
    });

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SiteMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SiteMockXhr.js
@@ -72,61 +72,33 @@ define(["dojo/_base/declare",
                                     "/aikau/service/modules/create-site",
                                     lang.hitch(this, this.createSite));
             
-            this.server.respondWith(
-               "GET",
-               /\/aikau\/proxy\/alfresco\/api\/sites\/[^\/]*/,
-               [
-                  200,
-                  {"Content-Type":"application/json;charset=UTF-8"},
-                  getSite
-               ]
-            );
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/api\/sites\/[^\/]*/,
+                                    [200,{"Content-Type":"application/json;charset=UTF-8"},getSite]);
 
-            this.server.respondWith(
-               "GET",
-               "/aikau/proxy/alfresco/api/sites/site2",
-               [
-                  200,
-                  {"Content-Type":"application/json;charset=UTF-8"},
-                  getModeratedSite
-               ]
-            );
+            this.server.respondWith("GET",
+                                    "/aikau/proxy/alfresco/api/sites/site2",
+                                    [200,{"Content-Type":"application/json;charset=UTF-8"},getModeratedSite]);
 
-            this.server.respondWith(
-               "PUT",
-               /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)/,
-               [
-                  200,
-                  {"Content-Type":"application/json;charset=UTF-8"},
-                  putSite
-               ]
-            );
+            this.server.respondWith("PUT",
+                                    /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)/,
+                                    [200,{"Content-Type":"application/json;charset=UTF-8"},putSite]);
 
-            this.server.respondWith(
-               "DELETE",
-               /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)/,
-               [
-                  200,
-                  {"Content-Type":"application/json;charset=UTF-8"},
-                  deleteSite
-               ]
-            );
+            this.server.respondWith("DELETE",
+                                    /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)/,
+                                    [200,{"Content-Type":"application/json;charset=UTF-8"},deleteSite]);
 
-            this.server.respondWith(
-               "POST",
-               /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)\/memberships/,
-               [
-                  200,
-                  {"Content-Type":"application/json;charset=UTF-8"},
-                  postBecomeSiteManager
-               ]
-            );
+            this.server.respondWith("POST",
+                                    /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)\/memberships/,
+                                    [200,{"Content-Type":"application/json;charset=UTF-8"},postBecomeSiteManager]);
 
-            this.server.respondWith(
-               "POST",
-               /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)\/invitations/,
-               lang.hitch(this, this.requestSiteMembership)
-            );
+            this.server.respondWith("POST",
+                                    /\/aikau\/proxy\/alfresco\/api\/sites\/(.*)\/invitations/,
+                                    lang.hitch(this, this.requestSiteMembership));
+
+            this.server.respondWith("GET",
+                                    /\/aikau\/proxy\/alfresco\/slingshot\/site-identifier-used/,
+                                    lang.hitch(this, this.validateSiteIdentifier));
 
          }
          catch(e)
@@ -162,6 +134,37 @@ define(["dojo/_base/declare",
                "Content-Type": "application/json;charset=UTF-8"
             }, JSON.stringify(postRequestSiteMembership));
          }
+      },
+
+      /**
+       * Handles site identifier validation.
+       *
+       * @instance
+       * @param  {object} request The request object
+       * @since 1.0.89
+       */
+      validateSiteIdentifier: function alfresco_testing_SiteMockXhr__validateSiteIdentifier(request) {
+         var url = request.url;
+         var id = (url.indexOf("shortName=") !== -1 && url.substring(url.lastIndexOf("shortName=") + 10)) ||
+                  (url.indexOf("title=") !== -1 && url.substring(url.lastIndexOf("title=") + 6));
+
+         var used = false;
+         switch(id) {
+            case "used": 
+               used = true;
+               break;
+
+            default:
+               used = false;
+         }
+
+         var response = {
+            used: used
+         };
+
+         request.respond(200, {
+            "Content-Type": "application/json;charset=UTF-8"
+         }, JSON.stringify(response));
       }
    });
 });

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SiteMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/SiteMockXhr.js
@@ -162,7 +162,12 @@ define(["dojo/_base/declare",
             used: used
          };
 
-         request.respond(200, {
+         var statusCode = 200;
+         if (id === "500")
+         {
+            statusCode = 500;
+         }
+         request.respond(statusCode, {
             "Content-Type": "application/json;charset=UTF-8"
          }, JSON.stringify(response));
       }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1092 to update the SiteService so that create and edit site support inline validation of the uniqueness of both the title and shortName. The dialog has been reconfigured to be displayed as in 5.1 rather than 5.0 Share. Form validation has been updated to better support validation by topic. This also includes minor styling tweaks. Unit tests have been updated.