### PR TITLE
Feature/markdown with preview editor

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentMenuItemMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfCreateContentMenuItemMixin.js
@@ -119,6 +119,16 @@ define(["dojo/_base/declare",
       publishGlobal: true,
 
       /**
+       * The width of the dialog.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.89
+       */
+      dialogWidth: "550px",
+
+      /**
        * This should be configured to be an array of form control widgets to be placed into the create content dialog.
        *
        * @instance
@@ -137,7 +147,7 @@ define(["dojo/_base/declare",
          {
             // If no explicit payload has been configured then use a default payload to generate a form dialog request...
             publishPayload = {
-               contentWidth: "550px",
+               contentWidth: this.dialogWidth || "550px",
                dialogId: "ALF_CREATE_CONTENT_DIALOG",
                dialogTitle: this.message(this.dialogTitle),
                dialogConfirmationButtonTitle: this.message(this.dialogConfirmationLabel),

--- a/aikau/src/main/resources/alfresco/forms/controls/MarkdownWithPreviewEditor.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MarkdownWithPreviewEditor.js
@@ -18,6 +18,10 @@
  */
 
 /**
+ * This form control provide an [editor]{@link module:alfresco/forms/controls/CodeMirrorEditor} configured
+ * to show content in markdown format with an associated [preview]{@link module:alfresco/html/Markdown} widget
+ * showing what the content is like.
+ * 
  * @module alfresco/forms/controls/MarkdownWithPreviewEditor
  * @extends module:alfresco/forms/controls/CodeMirrorEditor
  * @author Dave Draper
@@ -44,7 +48,9 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/MarkdownWithPreviewEditor.css"}],
 
       /**
-       * 
+       * Overrides the [default configuration]{@link module:alfresco/forms/controls/CodeMirrorEditor#editMode}
+       * to configure the [CodeMirrorEditor]{@link module:alfresco/forms/controls/CodeMirrorEditor} to use
+       * markdown format.
        * 
        * @instance
        * @type {string}
@@ -52,24 +58,15 @@ define(["dojo/_base/declare",
        */
       editMode: "markdown",
 
-      
-
       /**
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/CodeMirrorEditor#createFormControl}
+       * to create a [Markdown]{@link module:alfresco/html/Markdown} widget to use to preview the markdown content.
+       * 
        * @instance
+       * @param {object} config The configuration to create the form control with
+       * @param {element} domNode The element to create the form control in.
        */
-      getWidgetConfig: function alfresco_forms_controls_FileSelect__getWidgetConfig() {
-         // Return the configuration for the widget
-         return {
-            id : this.generateUuid(),
-            name: this.name,
-            filterMimeType: this.filterMimeType
-         };
-      },
-
-      /**
-       * @instance
-       */
-      createFormControl: function alfresco_forms_controls_FileSelect__createFormControl(config, /*jshint unused:false*/ domNode) {
+      createFormControl: function alfresco_forms_controls_MarkdownWithPreviewEditor__createFormControl(config, /*jshint unused:false*/ domNode) {
          var widget = this.inherited(arguments);
 
          // Update the DOM node to include a specific class that we can anchor styles off...
@@ -85,6 +82,7 @@ define(["dojo/_base/declare",
          var preview = this.createWidget({
             name: "alfresco/html/Markdown",
             config: {
+               markdown: this.initialValue,
                subscriptionTopics: [this.generatePreviewTopic]
             }
          });
@@ -92,10 +90,20 @@ define(["dojo/_base/declare",
 
          domStyle.set(this._controlNode, "height", this.height + "px");
 
+         // NOTE: We need to make a one time call here to ensure label and description will be added...
+         this.onWidgetAddedToDocument();
          return widget;
       },
 
-      onEditorChange: function alfresco_forms_controls_CodeMirrorEditor__onEditorChange(editor, changeObject) {
+      /**
+       * Extends the [inherited function]{@link module:alfresco/forms/controls/CodeMirrorEditor#onEditorChange}
+       * to publish the edit changes to the [Markdown]{@link module:alfresco/html/Markdown} widget to update the preview
+       * 
+       * @instance
+       * @param  {object} editor The editor being updated
+       * @param  {object} changeObject An object with the details of the changes
+       */
+      onEditorChange: function alfresco_forms_controls_MarkdownWithPreviewEditor__onEditorChange(editor, changeObject) {
          /*jshint unused:false*/
          this.inherited(arguments);
 
@@ -103,7 +111,5 @@ define(["dojo/_base/declare",
             markdown: this.lastValue
          });
       }
-
-      
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/MarkdownWithPreviewEditor.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MarkdownWithPreviewEditor.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @module alfresco/forms/controls/MarkdownWithPreviewEditor
+ * @extends module:alfresco/forms/controls/CodeMirrorEditor
+ * @author Dave Draper
+ * @since 1.0.89
+ */
+define(["dojo/_base/declare",
+        "alfresco/forms/controls/CodeMirrorEditor",
+        "alfresco/core/CoreWidgetProcessing",
+        "dojo/dom-class",
+        "dojo/dom-construct",
+        "dojo/dom-style",
+        // No callbacks from here
+        "alfresco/html/Markdown"],
+        function(declare, CodeMirrorEditor, CoreWidgetProcessing, domClass, domConstruct, domStyle) {
+
+   return declare([CodeMirrorEditor, CoreWidgetProcessing], {
+
+      /**
+       * An array of the CSS files to use with this widget.
+       * 
+       * @instance
+       * @type {Array}
+       */
+      cssRequirements: [{cssFile:"./css/MarkdownWithPreviewEditor.css"}],
+
+      /**
+       * 
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      editMode: "markdown",
+
+      
+
+      /**
+       * @instance
+       */
+      getWidgetConfig: function alfresco_forms_controls_FileSelect__getWidgetConfig() {
+         // Return the configuration for the widget
+         return {
+            id : this.generateUuid(),
+            name: this.name,
+            filterMimeType: this.filterMimeType
+         };
+      },
+
+      /**
+       * @instance
+       */
+      createFormControl: function alfresco_forms_controls_FileSelect__createFormControl(config, /*jshint unused:false*/ domNode) {
+         var widget = this.inherited(arguments);
+
+         // Update the DOM node to include a specific class that we can anchor styles off...
+         domClass.add(this.domNode, "alfresco-forms-controls-MarkdownWithPreviewEditor");
+
+         this.generatePreviewTopic = this.generateUuid();
+
+         this.previewNode = domConstruct.create("div", { 
+            style: "height:" + this.height + "px;width:" + this.width + "px;",
+            className: "alfresco-forms-controls-MarkdownWithPreviewEditor__previewNode"
+         }, this._controlNode);
+
+         var preview = this.createWidget({
+            name: "alfresco/html/Markdown",
+            config: {
+               subscriptionTopics: [this.generatePreviewTopic]
+            }
+         });
+         preview.placeAt(this.previewNode);
+
+         domStyle.set(this._controlNode, "height", this.height + "px");
+
+         return widget;
+      },
+
+      onEditorChange: function alfresco_forms_controls_CodeMirrorEditor__onEditorChange(editor, changeObject) {
+         /*jshint unused:false*/
+         this.inherited(arguments);
+
+         this.alfPublish(this.generatePreviewTopic, {
+            markdown: this.lastValue
+         });
+      }
+
+      
+   });
+});

--- a/aikau/src/main/resources/alfresco/forms/controls/css/MarkdownWithPreviewEditor.css
+++ b/aikau/src/main/resources/alfresco/forms/controls/css/MarkdownWithPreviewEditor.css
@@ -1,0 +1,18 @@
+.alfresco-forms-controls-MarkdownWithPreviewEditor {
+
+   .control-row {
+      .control {
+         box-sizing: content-box;
+      }
+   }
+
+   div.CodeMirror {
+      display: inline-block;
+   }
+
+   &__previewNode {
+      float: right;
+      border-left: @standard-border;
+      overflow: auto;
+   }
+}

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -295,32 +295,6 @@ var xml = generateCreateContentMenuItem({
 });
 createContent.splice(0, 0, folder, plainText, html, xml);
 
-// Create content by template
-var createContentByTemplateEnabled = true;
-if (docLibXmlConfig["create-content-by-template"] && docLibXmlConfig["create-content-by-template"].value)
-{
-   createContentByTemplateEnabled = docLibXmlConfig["create-content-by-template"].value.toString().equals("true") || false;
-}
-if (createContentByTemplateEnabled)
-{
-   createContent.push({
-      id: "CREATE_NODE_TEMPLATES",
-      name: "alfresco/documentlibrary/AlfCreateTemplateContentMenu",
-      config: {
-         label: msg.get("menu.create-content.by-template-node")
-      }
-   });
-   createContent.push({
-      id: "CREATE_FOLDER_TEMPLATES",
-      name: "alfresco/documentlibrary/AlfCreateTemplateContentMenu",
-      config: {
-         label: msg.get("menu.create-content.by-template-folder"),
-         _templatesUrl: "slingshot/doclib/folder-templates",
-         templateType: "folder"
-      }
-   });
-}
-
 /**
  * Helper function to retrieve configuration values.
  * 
@@ -660,6 +634,34 @@ function getDocLibCategories(options) {
 }
 
 function getDocLibCreateContentMenu(options) {
+   var createContentItems = (options.createContentItems || createContent).concat(options.additionalCreateContentItems || []);
+
+   // Create content by template
+   var createContentByTemplateEnabled = true;
+   if (docLibXmlConfig["create-content-by-template"] && docLibXmlConfig["create-content-by-template"].value)
+   {
+      createContentByTemplateEnabled = docLibXmlConfig["create-content-by-template"].value.toString().equals("true") || false;
+   }
+   if (createContentByTemplateEnabled)
+   {
+      createContentItems.push({
+         id: "CREATE_NODE_TEMPLATES",
+         name: "alfresco/documentlibrary/AlfCreateTemplateContentMenu",
+         config: {
+            label: msg.get("menu.create-content.by-template-node")
+         }
+      });
+      createContentItems.push({
+         id: "CREATE_FOLDER_TEMPLATES",
+         name: "alfresco/documentlibrary/AlfCreateTemplateContentMenu",
+         config: {
+            label: msg.get("menu.create-content.by-template-folder"),
+            _templatesUrl: "slingshot/doclib/folder-templates",
+            templateType: "folder"
+         }
+      });
+   }
+
    var menu = {
       id: (options.idPrefix || "") + "DOCLIB_CREATE_CONTENT_MENU",
       name: "alfresco/documentlibrary/AlfCreateContentMenuBarPopup",
@@ -669,7 +671,7 @@ function getDocLibCreateContentMenu(options) {
                id: (options.idPrefix || "") + "DOCLIB_CREATE_CONTENT_MENU_GROUP1",
                name: "alfresco/menus/AlfMenuGroup",
                config: {
-                  widgets: createContent
+                  widgets: createContentItems
                }
             }
          ]

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.js
@@ -183,15 +183,16 @@ var getMultiActionImage = function(attr) {
 
 var createContent = [];
 
-function generateCreateContentMenuItem(menuItemLabel, dialogTitle, iconClass, modelType, mimeType, contentWidgetName, contentWidgetConfig, additionalWidgets) {
+function generateCreateContentMenuItem(data) {
    var menuItem = {
       name: "alfresco/documentlibrary/AlfCreateContentMenuItem",
       config: {
-         label: menuItemLabel,
-         iconClass: iconClass,
-         dialogTitle: dialogTitle,
-         contentType: modelType,
-         mimeType: mimeType,
+         label: data.menuItemLabel,
+         iconClass: data.iconClass,
+         dialogTitle: data.dialogTitle,
+         dialogWidth: data.dialogWidth,
+         contentType: data.modelType,
+         mimeType: data.mimeType,
          widgets: [
             {
                name: "alfresco/forms/controls/TextBox",
@@ -225,23 +226,23 @@ function generateCreateContentMenuItem(menuItemLabel, dialogTitle, iconClass, mo
    };
    // If a content widget name has been specified then define the additional widget
    // and add in any additionally supplied configuration for it
-   if (contentWidgetName)
+   if (data.contentWidgetName)
    {
       var contentWidget = {
-         name: contentWidgetName,
+         name: data.contentWidgetName,
          config: {
             label: msg.get("create.content.content.label"),
             name: "prop_cm_content",
             value: ""
          }
       };
-      if (contentWidgetConfig)
+      if (data.contentWidgetConfig)
       {
-         for (var key in contentWidgetConfig)
+         for (var key in data.contentWidgetConfig)
          {
-            if (contentWidgetConfig.hasOwnProperty(key))
+            if (data.contentWidgetConfig.hasOwnProperty(key))
             {
-               contentWidget.config[key] = contentWidgetConfig[key];
+               contentWidget.config[key] = data.contentWidgetConfig[key];
             }
          }
       }
@@ -249,15 +250,49 @@ function generateCreateContentMenuItem(menuItemLabel, dialogTitle, iconClass, mo
    }
 
    // Add in any additional widgets requested...
-   menuItem.config.widgets.concat(additionalWidgets || []);
+   menuItem.config.widgets.concat(data.additionalWidgets || []);
    return menuItem;
 }
 
 // Add in the create content options...
-var folder = generateCreateContentMenuItem(msg.get("create.folder.label"), msg.get("create.folder.title"), "alf-showfolders-icon", "cm:folder", null);
-var plainText = generateCreateContentMenuItem(msg.get("create.text-document.label"), msg.get("create.text-document.title"), "alf-textdoc-icon", "cm:content", "text/plain", "alfresco/forms/controls/TextArea");
-var html = generateCreateContentMenuItem(msg.get("create.html-document.label"), msg.get("create.html-document.title"), "alf-htmldoc-icon", "cm:content", "text/html", "alfresco/forms/controls/TinyMCE");
-var xml = generateCreateContentMenuItem(msg.get("create.xml-document.label"), msg.get("create.xml-document.title"), "alf-xmldoc-icon", "cm:content", "text/xml", "alfresco/forms/controls/CodeMirrorEditor", { editMode: "xml", width: 538, height: 250 }); // Dimensions as per defaults in TinyMCE control
+var folder = generateCreateContentMenuItem({
+   menuItemLabel: msg.get("create.folder.label"), 
+   dialogTitle: msg.get("create.folder.title"), 
+   iconClass: "alf-showfolders-icon", 
+   modelType: "cm:folder", 
+   mimeType: null
+});
+var plainText = generateCreateContentMenuItem({
+   menuItemLabel: msg.get("create.text-document.label"), 
+   dialogTitle: msg.get("create.text-document.title"), 
+   iconClass: "alf-textdoc-icon", 
+   modelType: "cm:content", 
+   mimeType: "text/plain", 
+   contentWidgetName: "alfresco/forms/controls/TextArea"
+});
+var html = generateCreateContentMenuItem({
+   menuItemLabel: msg.get("create.html-document.label"), 
+   dialogTitle: msg.get("create.html-document.title"), 
+   iconClass: "alf-htmldoc-icon", 
+   modelType: "cm:content", 
+   mimeType: "text/html",
+   dialogWidth: "800px", 
+   contentWidgetName: "alfresco/forms/controls/TinyMCE"
+});
+var xml = generateCreateContentMenuItem({
+   menuItemLabel: msg.get("create.xml-document.label"), 
+   dialogTitle: msg.get("create.xml-document.title"), 
+   iconClass: "alf-xmldoc-icon", 
+   modelType: "cm:content", 
+   mimeType: "text/xml",
+   dialogWidth: "800px",
+   contentWidgetName: "alfresco/forms/controls/CodeMirrorEditor", 
+   contentWidgetConfig: { 
+      editMode: "xml", 
+      width: 538, 
+      height: 250
+   }
+});
 createContent.splice(0, 0, folder, plainText, html, xml);
 
 // Create content by template

--- a/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.properties
+++ b/aikau/src/main/resources/webscript-libs/doclib/doclib.lib.properties
@@ -20,7 +20,7 @@ create.folder.label=Folder
 create.folder.title=Create Folder
 
 create.content.name.label=Name
-create.content.title.label=title
+create.content.title.label=Title
 create.content.description.label=Description
 create.content.content.label=Content
 
@@ -132,7 +132,7 @@ create.folder.label=Folder
 create.folder.title=Create Folder
 
 create.content.name.label=Name
-create.content.title.label=title
+create.content.title.label=Title
 create.content.description.label=Description
 create.content.content.label=Content
 

--- a/aikau/src/test/resources/alfresco/forms/controls/MarkdownWithPreviewEditorTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MarkdownWithPreviewEditorTest.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ * @author Dave Draper
+ * @since 1.0.89
+ */
+define(["module",
+        "alfresco/defineSuite",
+        "intern/chai!assert",
+        "alfresco/TestCommon"],
+        function(module, defineSuite, assert, TestCommon) {
+
+   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
+   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
+
+   var selectors = {
+      form: {
+         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["FORM1"])
+      },
+      button: TestCommon.getTestSelector(buttonSelectors, "button.label", ["DIALOG_BUTTON"])
+   };
+
+   defineSuite(module, {
+      name: "Markdown with Preview Tests",
+      testPage: "/MarkDownWithPreviewEditor",
+
+      "Initial preview displayed": function() {
+         return this.remote.findByCssSelector(".alfresco-forms-controls-MarkdownWithPreviewEditor .alfresco-html-Markdown h1")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "Heading");
+            });
+      },
+
+      "Updates to editor are shown in preview": function() {
+         this.remote.findByCssSelector("#MDWPE1 .CodeMirror")
+            .click()
+            .executeAsync(function(callback) {
+               require(["dijit/registry"], function(registry) {
+                  registry.byId("MDWPE1").setValue("* item");
+                  callback();
+               });
+            })
+
+            .findByCssSelector(".alfresco-forms-controls-MarkdownWithPreviewEditor .alfresco-html-Markdown li")
+            .getVisibleText()
+            .then(function(text) {
+               assert.equal(text, "item");
+            });
+      }
+   });
+});

--- a/aikau/src/test/resources/alfresco/forms/controls/MarkdownWithPreviewEditorTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/MarkdownWithPreviewEditorTest.js
@@ -24,19 +24,8 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!assert",
-        "alfresco/TestCommon"],
-        function(module, defineSuite, assert, TestCommon) {
-
-   var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
-   var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
-
-   var selectors = {
-      form: {
-         confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["FORM1"])
-      },
-      button: TestCommon.getTestSelector(buttonSelectors, "button.label", ["DIALOG_BUTTON"])
-   };
+        "intern/chai!assert"],
+        function(module, defineSuite, assert) {
 
    defineSuite(module, {
       name: "Markdown with Preview Tests",

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -143,6 +143,7 @@ define(function() {
       "alfresco/forms/controls/FilePickerTest",
       "alfresco/forms/controls/FilteringSelectTest",
       "alfresco/forms/controls/FormButtonDialogTest",
+      "alfresco/forms/controls/MarkdownWithPreviewEditorTest",
       "alfresco/forms/controls/MultipleEntryFormControlTest",
       "alfresco/forms/controls/MultiSelectInputTest",
       "alfresco/forms/controls/NumberSpinnerTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CodeMirror.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/CodeMirror.get.js
@@ -24,6 +24,8 @@ model.jsonModel = {
                   id: "CODE_MIRROR_1",
                   name: "alfresco/forms/controls/CodeMirrorEditor",
                   config: {
+                     label: "Editor",
+                     description: "Code mirror editor",
                      name: "codeMirrorValue"
                   }
                }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.desc.xml
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.desc.xml
@@ -1,0 +1,6 @@
+<webscript>
+  <shortname>Markdown with Preview Editor Test</shortname>
+  <description>Shows the form control for editing markdown with a preview</description>
+  <family>aikau-unit-tests</family>
+  <url>/MarkDownWithPreviewEditor</url>
+</webscript>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.html.ftl
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.html.ftl
@@ -1,0 +1,1 @@
+<@processJsonModel/>

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.js
@@ -23,34 +23,42 @@ model.jsonModel = {
                   id: "MDWPE1",
                   name: "alfresco/forms/controls/MarkdownWithPreviewEditor",
                   config: {
-                     name: "markdown1"
+                     fieldId: "MDWPE1",
+                     label: "Markdown with preview",
+                     description: "This shows an editor configured for markdown format with an associated preview",
+                     name: "markdown1",
+                     value: "# Heading"
                   }
                }
             ]
          }
       },
-      // {
-      //    name: "alfresco/buttons/AlfButton",
-      //    id: "DIALOG_BUTTON",
-      //    config: {
-      //       label: "Display editor in dialog",
-      //       publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
-      //       publishPayload: {
-      //          dialogTitle: "CodeMirror Editor Dialog",
-      //          formSubmissionTopic: "POST_FORM_DIALOG",
-      //          contentWidth: "600px",
-      //          widgets: [
-      //             {
-      //                id: "CODE_MIRROR_2",
-      //                name: "alfresco/forms/controls/CodeMirrorEditor",
-      //                config: {
-      //                   name: "codeMirrorValue2"
-      //                }
-      //             }
-      //          ]
-      //       }
-      //    }
-      // },
+      {
+         id: "DIALOG_BUTTON",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Display editor in dialog",
+            publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+            publishPayload: {
+               dialogTitle: "Markdown with Preview Editor Dialog",
+               formSubmissionTopic: "POST_FORM_DIALOG",
+               contentWidth: "850px",
+               widgets: [
+                  {
+                     id: "MDWPE2",
+                     name: "alfresco/forms/controls/MarkdownWithPreviewEditor",
+                     config: {
+                        fieldId: "MDWPE2",
+                        label: "Markdown with preview",
+                        description: "This shows an editor configured for markdown format with an associated preview",
+                        name: "markdown1",
+                        width: 300
+                     }
+                  }
+               ]
+            }
+         }
+      },
       {
          name: "alfresco/logging/DebugLog"
       }

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/MarkdownWithPreviewEditor.get.js
@@ -1,0 +1,58 @@
+model.jsonModel = {
+   services: [
+      {
+         name: "alfresco/services/LoggingService",
+         config: {
+            loggingPreferences: {
+               enabled: true,
+               all: true
+            }
+         }
+      },
+      "alfresco/services/DialogService"
+   ],
+   widgets: [
+      {
+         id: "FORM1",
+         name: "alfresco/forms/Form",
+         config: {
+            okButtonPublishTopic: "FORM_POST",
+            scopeFormControls: false,
+            widgets: [
+               {
+                  id: "MDWPE1",
+                  name: "alfresco/forms/controls/MarkdownWithPreviewEditor",
+                  config: {
+                     name: "markdown1"
+                  }
+               }
+            ]
+         }
+      },
+      // {
+      //    name: "alfresco/buttons/AlfButton",
+      //    id: "DIALOG_BUTTON",
+      //    config: {
+      //       label: "Display editor in dialog",
+      //       publishTopic: "ALF_CREATE_FORM_DIALOG_REQUEST",
+      //       publishPayload: {
+      //          dialogTitle: "CodeMirror Editor Dialog",
+      //          formSubmissionTopic: "POST_FORM_DIALOG",
+      //          contentWidth: "600px",
+      //          widgets: [
+      //             {
+      //                id: "CODE_MIRROR_2",
+      //                name: "alfresco/forms/controls/CodeMirrorEditor",
+      //                config: {
+      //                   name: "codeMirrorValue2"
+      //                }
+      //             }
+      //          ]
+      //       }
+      //    }
+      // },
+      {
+         name: "alfresco/logging/DebugLog"
+      }
+   ]
+};


### PR DESCRIPTION
This PR adds  new form control for creating/editing markdown (with a preview). It also update the Document Library creation import lib to support easier customization of create content menus