### PR TITLE
AKU-1092: Updated SiteService use the right description for "private"

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1455,7 +1455,7 @@ define(["dojo/_base/declare",
                      },
                      { 
                         label: "create-site.dialog.visibility.private",  
-                        description: "create-site.dialog.visibility.moderated.description",
+                        description: "create-site.dialog.visibility.private.description",
                         value: "PRIVATE" 
                      }
                   ]
@@ -1537,7 +1537,7 @@ define(["dojo/_base/declare",
                      },
                      { 
                         label: "create-site.dialog.visibility.private",  
-                        description: "create-site.dialog.visibility.moderated.description",
+                        description: "create-site.dialog.visibility.private.description",
                         value: "PRIVATE" 
                      }
                   ]


### PR DESCRIPTION
This is an update to https://issues.alfresco.com/jira/browse/AKU-1092 to correct the localization string used for the "private" site option