### PR TITLE
AKU-1096: Fix hashing on AlfMenuBarToggle

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarToggle.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarToggle.js
@@ -62,15 +62,16 @@
 define(["dojo/_base/declare",
         "alfresco/menus/AlfMenuBarItem",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
+        "alfresco/documentlibrary/_AlfHashMixin",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/dom-attr",
         "dojo/_base/lang",
         "alfresco/util/hashUtils"], 
-        function(declare, AlfMenuBarItem, _AlfDocumentListTopicMixin, domConstruct, domClass, domAttr, lang, hashUtils) {
+        function(declare, AlfMenuBarItem, _AlfDocumentListTopicMixin, _AlfHashMixin, domConstruct, domClass, domAttr, 
+                 lang, hashUtils) {
    
-   
-   return declare([AlfMenuBarItem, _AlfDocumentListTopicMixin], {
+   return declare([AlfMenuBarItem, _AlfDocumentListTopicMixin, _AlfHashMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -226,7 +227,7 @@ define(["dojo/_base/declare",
          {
             var currHash = hashUtils.getHash();
             this.checked = (currHash[this.hashName] && currHash[this.hashName] === "true");
-            this.alfSubscribe(this.filterChangeTopic, lang.hitch(this, "setState"));
+            this.alfSubscribe(this.hashChangeTopic, lang.hitch(this, this.setState));
          }
 
          this.inherited(arguments);

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarToggleTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarToggleTest.js
@@ -26,12 +26,9 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"],
-        function(module, defineSuite, expect, assert, require, TestCommon, keys) {
+        function(module, defineSuite, assert, keys) {
 
    var alfPause = 200;
    defineSuite(module, {
@@ -42,7 +39,7 @@ define(["module",
          return this.remote.findById("BASIC_MENU_BAR_TOGGLE_text")
             .getVisibleText()
             .then(function(initialValue) {
-               expect(initialValue).to.equal("Off", "The inital label of the basic toggle was not correct");
+               assert.equal(initialValue, "Off");
             });
       },
 
@@ -50,14 +47,14 @@ define(["module",
          return this.remote.findById("MENU_BAR_TOGGLE_CUSTOM_LABEL_text")
             .getVisibleText()
             .then(function(initialValue) {
-               expect(initialValue).to.equal("On (Custom Label)", "The inital label of the custom toggle was not correct: " + initialValue);
+               assert.equal(initialValue, "On (Custom Label)");
             });
       },
 
       "Test label for icon toggle is not displayed": function() {
          return this.remote.findAllByCssSelector("#MENU_BAR_SELECT_WITH_ICON_text")
             .then(function(results) {
-               expect(results).to.have.length(0, "Label for icon toggle was displayed and it shouldn't be");
+               assert.lengthOf(results, 0);
             });
       },
 
@@ -71,35 +68,28 @@ define(["module",
       "Test mouse click on basic toggle": function() {
          return this.remote.findById("BASIC_MENU_BAR_TOGGLE_text")
             .click()
-            .end()
-            .findByCssSelector(TestCommon.topicSelector("ALF_WIDGET_PROCESSING_COMPLETE", "publish", "last"))
-            .then(function() {}, function() {
-               assert(false, "Mouse selection of basic toggle published unexpectedly (although it has no publishTopic)");
-            });
+         .end()
+         
+         .getLastPublish("ALF_WIDGET_PROCESSING_COMPLETE");
       },
 
       "Test label updated after toggle after mouse": function() {
          return this.remote.findById("BASIC_MENU_BAR_TOGGLE_text")
             .getVisibleText()
             .then(function(resultText) {
-               expect(resultText).to.equal("On", "The label was not updated after toggle by mouse: " + resultText);
+               assert.equal(resultText, "On");
             });
       },
 
       "Test value publication of custom toggle after mouse click": function() {
          return this.remote.findById("MENU_BAR_TOGGLE_CUSTOM_LABEL_text")
             .click()
-            .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "OFF"))
-            .then(function() {}, function() {
-               assert(false, "Mouse selection of custom toggle didn't publish value correctly");
-            });
-      },
+         .end()
 
-      "Test id publication of custom toggle after mouse click": function() {
-         return this.remote.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "clicked", "TOGGLE_WITH_LABEL"))
-            .then(function() {}, function() {
-               assert(false, "Mouse selection of custom toggle didn't publish id correctly");
+         .getLastPublish("CLICK")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "OFF");
+               assert.propertyVal(payload, "clicked", "TOGGLE_WITH_LABEL");
             });
       },
 
@@ -107,31 +97,27 @@ define(["module",
          return this.remote.findByCssSelector("#MENU_BAR_TOGGLE_CUSTOM_LABEL_text")
             .getVisibleText()
             .then(function(resultText) {
-               expect(resultText).to.equal("Off (Custom Label)", "The label was not updated after toggle by mouse: " + resultText);
+               assert.equal(resultText, "Off (Custom Label)");
             });
       },
 
       "Test value publication of icon toggle after mouse click": function() {
          return this.remote.findByCssSelector("#MENU_BAR_TOGGLE_WITH_ICON > img")
+            .clearLog()
             .click()
-            .end()
-            .findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "ON"))
-            .then(function() {}, function() {
-               assert(false, "Mouse selection of icon toggle didn't publish value correctly");
-            });
-      },
-
-      "Test id publication of icon toggle after mouse click": function() {
-         return this.remote.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "clicked", "TOGGLE_WITH_ICON"))
-            .then(function() {}, function() {
-               assert(false, "Mouse selection of icon toggle didn't publish id correctly");
+         .end()
+         
+         .getLastPublish("CLICK")
+            .then(function(payload) {
+               assert.propertyVal(payload, "value", "ON");
+               assert.propertyVal(payload, "clicked", "TOGGLE_WITH_ICON");
             });
       },
 
       "Test CSS of icon toggle after mouse click": function() {
          return this.remote.findByCssSelector("#MENU_BAR_TOGGLE_WITH_ICON > img.alf-sort-ascending-icon")
             .then(function() {}, function() {
-               assert(false, "Test #1h - Image for icon toggle had wrong or missing CSS class after update by mouse");
+               assert(false, "Image for icon toggle had wrong or missing CSS class after update by mouse");
             });
       }
    });
@@ -144,77 +130,51 @@ define(["module",
          return this.remote.pressKeys(keys.TAB)
             .sleep(alfPause)
             .pressKeys(keys.SPACE)
-            .end()
-            .findByCssSelector(TestCommon.topicSelector("ALF_WIDGET_PROCESSING_COMPLETE", "publish", "last"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of basic toggle published unexpectedly (although it has no publishTopic)");
-            });
+         .end()
+         
+         .getLastPublish("ALF_WIDGET_PROCESSING_COMPLETE");
       },
 
       "Test label update after basic toggle by keyboard": function() {
          return this.remote.findById("BASIC_MENU_BAR_TOGGLE_text")
             .getVisibleText()
             .then(function(resultText) {
-               expect(resultText).to.equal("On", "The label was not updated after toggle by keyboard: " + resultText);
+               assert.equal(resultText, "On");
             });
       },
 
       "Test publication of basic toggle by keyboard": function() {
          return this.remote.pressKeys(keys.ARROW_RIGHT)
             .sleep(alfPause)
+            .clearLog()
             .pressKeys(keys.RETURN)
-            // .end()
-            .findByCssSelector(TestCommon.topicSelector("CLICK", "publish", "last"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of custom toggle didn't publish topic as expected");
-            });
-      },
-
-      "Test value publication update after custom toggle by keyboard": function() {
-         return this.remote.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "OFF"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of custom toggle didn't publish value correctly");
-            });
-      },
-
-      "Test id publication update after custom toggle by keyboard": function() {
-         return this.remote.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "clicked", "TOGGLE_WITH_LABEL"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of custom toggle didn't publish id correctly");
-            });
+            
+            .getLastPublish("CLICK")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", "OFF");
+                  assert.propertyVal(payload, "clicked", "TOGGLE_WITH_LABEL");
+               });
       },
 
       "Test label update after custom toggle by keyboard": function() {
          return this.remote.findById("MENU_BAR_TOGGLE_CUSTOM_LABEL_text")
             .getVisibleText()
             .then(function(resultText) {
-               expect(resultText).to.equal("Off (Custom Label)", "The custom toggle label was not updated after toggle by keyboard: " + resultText);
-            })
-            .end();
+               assert.equal(resultText, "Off (Custom Label)");
+            });
       },
 
       "Test topic publication after icon toggle by keyboard": function() {
          return this.remote.pressKeys(keys.ARROW_RIGHT)
             .sleep(alfPause)
+            .clearLog()
             .pressKeys(keys.RETURN)
-            .findByCssSelector(TestCommon.topicSelector("CLICK", "publish", "last"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of icon toggle didn't publish topic as expected");
-            });
-      },
 
-      "Test value publication after icon toggle by keyboard": function() {
-         return this.remote.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "value", "ON"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of icon toggle didn't publish value correctly");
-            });
-      },
-
-      "Test id publication after icon toggle by keyboard": function() {
-         return this.remote.findByCssSelector(TestCommon.pubSubDataCssSelector("last", "clicked", "TOGGLE_WITH_ICON"))
-            .then(function() {}, function() {
-               assert(false, "Keyboard selection of icon toggle didn't publish id correctly");
-            });
+            .getLastPublish("CLICK")
+               .then(function(payload) {
+                  assert.propertyVal(payload, "value", "ON");
+                  assert.propertyVal(payload, "clicked", "TOGGLE_WITH_ICON");
+               });
       },
 
       "Test CSS after icon toggle by keyboard": function() {
@@ -223,16 +183,22 @@ define(["module",
                assert(false, "Image for icon toggle had wrong or missing CSS class after keyboard toggle");
             })
             .end();
-      },
+      }
+   });
+
+   defineSuite(module, {
+      name: "AlfMenuBarToggle Tests (Keyboard)",
+      testPage: "/AlfMenuBarToggle",
 
       "Test external publication updates label (basic toggle) ON": function() {
-         return TestCommon.loadTestWebScript(this.remote, "/AlfMenuBarToggle", "AlfMenuBarToggle Set State Tests").findById("TEST_BUTTON_ASC")
+         return this.remote.findById("TEST_BUTTON_ASC")
             .click()
-            .end()
-            .findById("BASIC_MENU_BAR_TOGGLE_text")
+         .end()
+         
+         .findById("BASIC_MENU_BAR_TOGGLE_text")
             .getVisibleText()
             .then(function(initialValue) {
-               expect(initialValue).to.equal("On", "The asc label of the basic toggle was not correct: " + initialValue);
+               assert.equal(initialValue, "On");
             });
       },
 
@@ -240,7 +206,7 @@ define(["module",
          return this.remote.findById("MENU_BAR_TOGGLE_CUSTOM_LABEL_text")
             .getVisibleText()
             .then(function(initialValue) {
-               expect(initialValue).to.equal("On (Custom Label)", "The asc label of the custom toggle was not correct: " + initialValue);
+               assert.equal(initialValue, "On (Custom Label)");
             });
       },
 
@@ -254,11 +220,12 @@ define(["module",
       "Test external publication updates label (basic toggle) OFF": function() {
          return this.remote.findById("TEST_BUTTON_DESC")
             .click()
-            .end()
-            .findById("BASIC_MENU_BAR_TOGGLE_text")
+         .end()
+            
+         .findById("BASIC_MENU_BAR_TOGGLE_text")
             .getVisibleText()
             .then(function(initialValue) {
-               expect(initialValue).to.equal("Off", "Test #1d - The desc label of the basic toggle was not correct: " + initialValue);
+               assert.equal(initialValue, "Off");
             });
       },
 
@@ -266,9 +233,8 @@ define(["module",
          return this.remote.findById("MENU_BAR_TOGGLE_CUSTOM_LABEL_text")
             .getVisibleText()
             .then(function(initialValue) {
-               expect(initialValue).to.equal("Off (Custom Label)", "Test #1e - The desc label of the custom toggle was not correct: " + initialValue);
-            })
-            .end();
+               assert.equal(initialValue, "Off (Custom Label)");
+            });
       },
 
       "Test external publication updates label (icon toggle) OFF": function() {

--- a/aikau/src/test/resources/alfresco/menus/AlfMenuBarToggleTest.js
+++ b/aikau/src/test/resources/alfresco/menus/AlfMenuBarToggleTest.js
@@ -187,8 +187,8 @@ define(["module",
    });
 
    defineSuite(module, {
-      name: "AlfMenuBarToggle Tests (Keyboard)",
-      testPage: "/AlfMenuBarToggle",
+      name: "AlfMenuBarToggle Tests (Publications/Hashing)",
+      testPage: "/AlfMenuBarToggle#sortAscending=true",
 
       "Test external publication updates label (basic toggle) ON": function() {
          return this.remote.findById("TEST_BUTTON_ASC")
@@ -241,6 +241,26 @@ define(["module",
          return this.remote.findByCssSelector("#MENU_BAR_TOGGLE_WITH_ICON > img.alf-sort-descending-icon")
             .then(function() {}, function() {
                assert(false, "Test #1f - Image for desc icon toggle had wrong or missing CSS class");
+            });
+      },
+
+      "Test hash initialises state": function() {
+         return this.remote.findById("MENU_BAR_TOGGLE_USE_HASH_text")
+            .getVisibleText()
+            .then(function(initialValue) {
+               assert.equal(initialValue, "Ascending");
+            });
+      },
+
+      "Update hash changes toggle": function() {
+         return this.remote.findById("SET_HASH_label")
+            .click()
+         .end()
+
+         .findById("MENU_BAR_TOGGLE_USE_HASH_text")
+            .getVisibleText()
+            .then(function(initialValue) {
+               assert.equal(initialValue, "Descending");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarToggle.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarToggle.get.js
@@ -9,7 +9,7 @@ model.jsonModel = {
             }
          }
       },
-      "alfresco/services/ErrorReporter"
+      "alfresco/services/NavigationService"
    ],
    widgets: [
       {
@@ -17,18 +17,18 @@ model.jsonModel = {
          config: {
             widgets: [
                {
+                  id: "BASIC_MENU_BAR_TOGGLE",
                   name: "alfresco/menus/AlfMenuBarToggle",
                   config: {
-                     id: "BASIC_MENU_BAR_TOGGLE",
                      subscriptionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
                      subscriptionAttribute: "direction",
                      checkedValue: "ascending"
                   }
                },
                {
+                  id: "MENU_BAR_TOGGLE_CUSTOM_LABEL",
                   name: "alfresco/menus/AlfMenuBarToggle",
                   config: {
-                     id: "MENU_BAR_TOGGLE_CUSTOM_LABEL",
                      checked: true,
                      subscriptionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
                      subscriptionAttribute: "direction",
@@ -52,10 +52,10 @@ model.jsonModel = {
                   }
                },
                {
+                  id: "MENU_BAR_TOGGLE_WITH_ICON",
                   name: "alfresco/menus/AlfMenuBarToggle",
                   config: {
                      checked: false,
-                     id: "MENU_BAR_TOGGLE_WITH_ICON",
                      subscriptionTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
                      subscriptionAttribute: "direction",
                      checkedValue: "ascending",
@@ -78,14 +78,43 @@ model.jsonModel = {
                         }
                      }
                   }
+               },
+               {
+                  id: "MENU_BAR_TOGGLE_USE_HASH",
+                  name: "alfresco/menus/AlfMenuBarToggle",
+                  config: {
+                     hashName: "sortAscending",
+                     checked: false,
+                     subscriptionTopic: "CUSTOM",
+                     subscriptionAttribute: "sortAscending",
+                     checkedValue: "true",
+                     onConfig: {
+                        label: "Ascending",
+                        iconClass: "alf-sort-ascending-icon",
+                        publishTopic: "CLICK",
+                        publishPayload: {
+                           clicked: "TOGGLE_WITH_ICON",
+                           value: "descending"
+                        }
+                     },
+                     offConfig: {
+                        label: "Descending",
+                        iconClass: "alf-sort-descending-icon",
+                        publishTopic: "CLICK",
+                        publishPayload: {
+                           clicked: "TOGGLE_WITH_ICON",
+                           value: "ascending"
+                        }
+                     }
+                  }
                }
             ]
          }
       },
       {
+         id: "TEST_BUTTON_ASC",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "TEST_BUTTON_ASC",
             label: "Set toggle state ascending",
             publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
             publishPayload: {
@@ -94,13 +123,25 @@ model.jsonModel = {
          }
       },
       {
+         id: "TEST_BUTTON_DESC",
          name: "alfresco/buttons/AlfButton",
          config: {
-            id: "TEST_BUTTON_DESC",
             label: "Set toggle state descending",
             publishTopic: "ALF_DOCLIST_SORT_FIELD_SELECTION",
             publishPayload: {
                direction: "descending"
+            }
+         }
+      },
+      {
+         id: "SET_HASH",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Set Hash",
+            publishTopic: "ALF_NAVIGATE_TO_PAGE",
+            publishPayload: {
+               url: "sortAscending=false",
+               type: "HASH"
             }
          }
       },

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarToggle.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/menus/AlfMenuBarToggle.get.js
@@ -105,11 +105,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
-}
-;
+};


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1096 which resolves a problem with the AlfMenuBarToggle to ensure that URL hashing works properly.  The unit tests have been updated both to use current best practices and add new tests for the fix.