### PR TITLE
AKU-1098: Ensure failure message is hidden when loading

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -1219,6 +1219,7 @@ define(["dojo/_base/declare",
          }
          else
          {
+            domClass.add(this.dataFailureNode, "share-hidden");
             domClass.remove(this.dataLoadingMoreNode, "share-hidden");
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1098 to ensure that the failure message is hidden on lists when a new loading message is displayed.