### PR TITLE
AKU-1014: Further updates to FormsRuntimeService

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -164,10 +164,11 @@ define(["dojo/_base/declare",
         "dojo/dom-construct",
         "dojo/dom-class",
         "dojo/_base/event",
-        "dojo/on"], 
+        "dojo/on",
+        "jquery"], 
         function(declare, _Widget, _Templated, Form, AlfCore, CoreWidgetProcessing, topics, _AlfHashMixin, RulesEngineMixin, 
                  template, ioQuery, Warning, hashUtils, lang, AlfButton, array, registry, Deferred, domConstruct, domClass, 
-                 Event, on) {
+                 Event, on, $) {
    
    return declare([_Widget, _Templated, AlfCore, CoreWidgetProcessing, _AlfHashMixin, RulesEngineMixin], {
       
@@ -627,7 +628,10 @@ define(["dojo/_base/declare",
 
             autoSavePayload = lang.mixin(this.autoSavePublishPayload || {}, {
                alfValidForm: isValid
-            }, this.getValue());
+            });
+
+            $.extend(true, autoSavePayload, this.getValue());
+
             this.alfPublish(this.autoSavePublishTopic, autoSavePayload, this.autoSavePublishGlobal);
          }
       },

--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -598,6 +598,13 @@ define(["dojo/_base/declare",
             // Process the configuration...
             this.processConfig(instanceVar, config);
          }
+         else if (config.copyRule && config.copyRule.targetId)
+         {
+            var topic = "_valueChangeOf_" + config.copyRule.targetId;
+            this.alfSubscribe(topic, lang.hitch(this, function(payload) {
+               this.setValue(payload.value);
+            }));
+         }
          else
          {
             this.alfLog("warn", "An autoset configuration element was provided without both 'rulePassValue' and 'ruleFailValue' attribute", config, this);

--- a/aikau/src/main/resources/alfresco/forms/controls/DateRange.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateRange.js
@@ -95,14 +95,19 @@ define(["dojo/_base/declare",
          if (value)
          {
             var valueTokens = value.split(this.dateSeparator);
-            var fromValue = valueTokens[0];
-            var toValue = valueTokens[1];
-            if (fromValue !== "null" && toValue !== "null") 
+            var fromValue = "";
+            var toValue = "";
+            if (valueTokens.length === 2)
+            {
+               fromValue = valueTokens[0];
+               toValue = valueTokens[1];
+            }
+            if (fromValue !== "" && toValue !== "") 
             {
                // If both pickers have a date, compare the values...
                isValid = new Date(fromValue) < new Date(toValue);
             }
-            else if (fromValue === "null" && toValue === "null")
+            else if (fromValue === "" && toValue === "")
             {
                // If neither picker has a value, it's fine...
                isValid = true;
@@ -185,8 +190,15 @@ define(["dojo/_base/declare",
          toValue = this.convertStringValuesToBoolean(toValue);
          toValue = this.processDateValue(toValue);
 
+         // Convert "null" to empty string...
+         !fromValue && (fromValue = "");
+         !toValue && (toValue = "");
+
          // Concatenate them together...
-         return fromValue + this.dateSeparator + toValue;
+         var value = fromValue + this.dateSeparator + toValue;
+         (value === "|") && (value = "");
+
+         return value;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/search/AlfSearchList.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchList.js
@@ -324,6 +324,7 @@ define(["dojo/_base/declare",
        */
       onAdvancedSearch: function alfresco_search_AlfSearchList__onAdvancedSearch(payload) {
          this.resetResultsList();
+         this.alfCleanFrameworkAttributes(payload, true);
          this.searchTerm = payload.searchTerm;
          delete payload.searchTerm;
          this.query = payload;

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -136,7 +136,10 @@ define(["dojo/_base/declare",
                }
             },
             "/org/alfresco/components/form/controls/daterange.ftl": {
-               name: "alfresco/forms/controls/DateRange"
+               name: "alfresco/forms/controls/DateRange",
+               config: {
+                  valueFormatSelector: "datetime"
+               }
             },
             "/org/alfresco/components/form/controls/workflow/email-notification.ftl": {
                name: "alfresco/forms/controls/CheckBox"
@@ -294,6 +297,24 @@ define(["dojo/_base/declare",
          workflow: {
             create: {
 
+            }
+         }
+      },
+
+      /**
+       * This has been added to support the slightly unsual scenarios where the configured
+       * parameter name in the form is not the parameter name that should be substitued. This
+       * was originally added to support the case of "Advanced Search" forms where the
+       * "prop_cm_modified" parameter name should be modified to be "prop_cm_modified-date-range"
+       * 
+       * @instance
+       * @type {object}
+       * @since 1.0.91
+       */
+      propertyNameMapping: {
+         type: {
+            edit: {
+               prop_cm_modified: "prop_cm_modified-date-range"
             }
          }
       },
@@ -595,7 +616,7 @@ define(["dojo/_base/declare",
                var okButtonLabel = lang.getObject("formConfig.okButtonLabel", false, originalRequestConfig);
                var widgetsBefore = lang.getObject("formConfig.widgetsBefore", false, originalRequestConfig) || [];
 
-               var formControls = widgetsBefore;
+               var formControls = lang.clone(widgetsBefore);
                var formConfig = {
                   id: formId,
                   name: "alfresco/forms/Form",
@@ -835,14 +856,18 @@ define(["dojo/_base/declare",
                            this.getMappedControl(formConfig, targetField, controlTemplate, this.controlMappings);
          if (formControl)
          {
+            var kind = formConfig["arguments"].itemKind;
+            var mode = formConfig.mode;
+            var name = lang.getObject(kind + "." + mode + "." + targetField.name, false, this.propertyNameMapping) || targetField.name;
+
             widget = lang.clone(formControl);
             var data = {
                id: targetField.name.toUpperCase(),
                config: {
                   currentItem: formConfig.data,
                   fieldId: targetField.name.toUpperCase(),
-                  propertyToRender: targetField.name, // NOTE: Hedging bets for renderers
-                  name: targetField.name,
+                  propertyToRender: name, // NOTE: Hedging bets for renderers
+                  name: name,
                   label: targetField.label,
                   description: targetField.description
                }

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -593,8 +593,9 @@ define(["dojo/_base/declare",
 
                var okButtonPublishTopic = lang.getObject("formConfig.okButtonPublishTopic", false, originalRequestConfig);
                var okButtonLabel = lang.getObject("formConfig.okButtonLabel", false, originalRequestConfig);
+               var widgetsBefore = lang.getObject("formConfig.widgetsBefore", false, originalRequestConfig) || [];
 
-               var formControls = [];
+               var formControls = widgetsBefore;
                var formConfig = {
                   id: formId,
                   name: "alfresco/forms/Form",

--- a/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
+++ b/aikau/src/main/resources/alfresco/services/FormsRuntimeService.js
@@ -613,7 +613,6 @@ define(["dojo/_base/declare",
                formSubmissionPayloadMixin && lang.mixin(okButtonPublishPayload, formSubmissionPayloadMixin);
 
                var okButtonPublishTopic = lang.getObject("formConfig.okButtonPublishTopic", false, originalRequestConfig);
-               var okButtonLabel = lang.getObject("formConfig.okButtonLabel", false, originalRequestConfig);
                var widgetsBefore = lang.getObject("formConfig.widgetsBefore", false, originalRequestConfig) || [];
 
                var formControls = lang.clone(widgetsBefore);
@@ -623,7 +622,6 @@ define(["dojo/_base/declare",
                   config: {
                      showOkButton: response.showSubmitButton,
                      showCancelButton: response.showCancelButton,
-                     okButtonLabel: okButtonLabel,
                      okButtonPublishTopic: okButtonPublishTopic || (response.method === "post" ? "ALF_CRUD_CREATE" : "ALF_CRUD_UPDATE"),
                      okButtonPublishPayload: okButtonPublishPayload,
                      okButtonPublishGlobal: true,
@@ -632,6 +630,12 @@ define(["dojo/_base/declare",
                      formSubmissionTriggerTopic: topics.TRIGGER_FORM_SUBMISSION
                   }
                };
+
+               var okButtonLabel = lang.getObject("formConfig.okButtonLabel", false, originalRequestConfig);
+               if (okButtonLabel)
+               {
+                  formConfig.config.okButtonLabel = okButtonLabel;
+               }
 
                // Iterate over the structure array and add the the form controls for all of the fields
                // that it contains...

--- a/aikau/src/main/resources/alfresco/services/i18n/FormsRuntimeService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/FormsRuntimeService.properties
@@ -1,1 +1,2 @@
 formsruntimeservice.properties=Properties
+formsruntimeservice.unknown.mimetype=Unknown

--- a/aikau/src/main/resources/webscripts/forms-runtime-tester.get.js
+++ b/aikau/src/main/resources/webscripts/forms-runtime-tester.get.js
@@ -60,6 +60,9 @@ model.jsonModel = {
                                                       },
                                                       {
                                                          label: "Task", value: "task"
+                                                      },
+                                                      {
+                                                         label: "Type", value: "type"
                                                       }
                                                    ]
                                                 }

--- a/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/AutoSetTest.js
@@ -51,7 +51,7 @@ define(["module",
       "Check the initial post (source field)": function() {
          return this.remote.findByCssSelector(selectors.form.confirmationButton)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("POST_FORM")
             .then(function(payload) {
@@ -65,18 +65,18 @@ define(["module",
       "Check the updated post (source field)": function() {
          return this.remote.findByCssSelector(selectors.select.openIcon)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.select.secondOption)
             .click()
-            .end()
+         .end()
 
          .clearLog()
 
          // Post the form, check the hidden field is set and the visible field isn't
          .findByCssSelector(selectors.form.confirmationButton)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("POST_FORM")
             .then(function(payload) {
@@ -90,27 +90,27 @@ define(["module",
          // Set the drop-down to 2...
          return this.remote.findByCssSelector(selectors.select.openIcon)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.select.secondOption)
             .click()
-            .end()
+         .end()
 
          // Set the drop-down to 3...
          .findByCssSelector(selectors.select.openIcon)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.select.thirdOption)
             .click()
-            .end()
+         .end()
 
          .clearLog()
 
          // Post the form, check the hidden field is not set and the visible field is...
          .findByCssSelector(selectors.form.confirmationButton)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("POST_FORM")
             .then(function(payload) {
@@ -123,17 +123,24 @@ define(["module",
       "Check that hidden field value can be set by form value update": function() {
          return this.remote.findByCssSelector(selectors.button)
             .click()
-            .end()
+         .end()
 
          .clearLog()
 
          .findByCssSelector(selectors.form.confirmationButton)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("POST_FORM")
             .then(function(payload) {
                assert.propertyVal(payload, "hidden2", "Value Set", "Second hidden field not posted correctly");
+            });
+      },
+
+      "Value is copied": function() {
+         return this.remote.getLastPublish("POST_FORM")
+            .then(function(payload) {
+               assert.propertyVal(payload, "copied", "3");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/AutoSet.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/AutoSet.get.js
@@ -102,6 +102,20 @@ model.jsonModel = {
                   config: {
                      name: "hidden2"
                   }
+               },
+               {
+                  id: "COPY",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     name: "copied",
+                     autoSetConfig: [
+                        {
+                           copyRule: {
+                              targetId: "SOURCE_FIELD"
+                           }
+                        }
+                     ]
+                  }
                }
             ]
          }


### PR DESCRIPTION
This PR relates to https://issues.alfresco.com/jira/browse/AKU-1014 and makes additional updates to the FormsRuntimeService to ensure that it is possible to reconfigure the form submission button label and publish topic. It also sorts MIME types and switches to the FilteringSelect to make it easier to find a MIME type.