### PR TITLE
AKU-1099: Re-introduce backwards compatibility for validationTopic

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/FormControlValidationMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FormControlValidationMixin.js
@@ -699,8 +699,17 @@ define(["dojo/_base/declare",
             // Duplicate the alfResponseTopic...
             payload.alfSuccessTopic = payload.alfResponseTopic;
             payload.alfFailureTopic = this.generateUuid();
-            payload.alfResponseScope = this.generateUuid();
 
+            payload.alfResponseScope = ""; // This effectively defaults to global scope...
+            if (validationConfig.scopeValidation)
+            {
+               // See AKU-1099 - it is better to scope responses to ensure that validation of
+               // one field does not impact another, however - for backwards compability support
+               // for RM 2.5 it is necessary to depend on the opt-in "scopeValidation" attribute
+               // which should be a boolean.
+               payload.alfResponseScope = this.generateUuid();
+            }
+            
             // Set the validation value as required...
             if (validationConfig.validationValueProperty)
             {

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1365,6 +1365,7 @@ define(["dojo/_base/declare",
                      errorMessage: "create-site.dialog.name.maxLength"
                   },
                   {
+                     scopeValidation: true,
                      warnOnly: true,
                      validation: "validationTopic",
                      validationTopic: topics.VALIDATE_SITE_IDENTIFIER,
@@ -1411,6 +1412,7 @@ define(["dojo/_base/declare",
                      errorMessage: "create-site.dialog.urlname.regex"
                   },
                   {
+                     scopeValidation: true,
                      validation: "validationTopic",
                      validationTopic: topics.VALIDATE_SITE_IDENTIFIER,
                      validationValueProperty: "shortName",
@@ -1492,6 +1494,7 @@ define(["dojo/_base/declare",
                      errorMessage: "create-site.dialog.name.maxLength"
                   },
                   {
+                     scopeValidation: true,
                      warnOnly: true,
                      validation: "validationTopic",
                      validationTopic: topics.VALIDATE_SITE_IDENTIFIER,

--- a/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ValidationTest.js
@@ -52,6 +52,10 @@ define(["module",
             input: TestCommon.getTestSelector(textBoxSelectors, "input", ["TOPIC_VALIDATION"]),
             validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["TOPIC_VALIDATION"])
          },
+         scopedTopicValidation: {
+            input: TestCommon.getTestSelector(textBoxSelectors, "input", ["SCOPED_TOPIC_VALIDATION"]),
+            validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["SCOPED_TOPIC_VALIDATION"])
+         },
          matchTarget: {
             input: TestCommon.getTestSelector(textBoxSelectors, "input", ["MATCH_TARGET"]),
             validationMessage: TestCommon.getTestSelector(formControlSelectors, "validation.message", ["MATCH_TARGET"])
@@ -290,6 +294,27 @@ define(["module",
 
       "Test validationTopic returns success": function() {
          return this.remote.findByCssSelector(selectors.textBoxes.topicValidation.input)
+            .clearValue()
+            .type("success")
+         .end()
+
+         .findAllByCssSelector(selectors.form.disabledConfirmationButton)
+            .then(function(elements) {
+               assert.lengthOf(elements, 0, "The forms confirmation button should be enabled");
+            });
+      },
+
+      "Test scoped validationTopic returns a failure": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.scopedTopicValidation.input)
+            .clearValue()
+            .type("#fail")
+         .end()
+
+         .findByCssSelector(selectors.form.disabledConfirmationButton);
+      },
+
+      "Test scoped validationTopic returns success": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.scopedTopicValidation.input)
             .clearValue()
             .type("success")
          .end()

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/Validation.get.js
@@ -13,8 +13,7 @@ model.jsonModel = {
       },
       "alfresco/services/DialogService",
       "alfresco/services/SiteService",
-      "aikauTesting/mockservices/FormControlValidationTestService",
-      "alfresco/services/ErrorReporter"
+      "aikauTesting/mockservices/FormControlValidationTestService"
    ],
    widgets: [
       {
@@ -119,6 +118,24 @@ model.jsonModel = {
                         {
                            validation: "validationTopic",
                            validationTopic: "ALF_VALIDATE_TOPIC_TEST",
+                           errorMessage: "Value should not be #fail"
+                        }
+                     ]
+                  }
+               },
+               {
+                  id: "SCOPED_TOPIC_VALIDATION",
+                  name: "alfresco/forms/controls/TextBox",
+                  config: {
+                     fieldId: "SCOPED_TOPIC_VALIDATION",
+                     label: "Validation Topic (Scoped response)",
+                     description: "Enter #fail as value to put into error state",
+                     value: "",
+                     validationConfig: [
+                        {
+                           scopeValidation: true,
+                           validation: "validationTopic",
+                           validationTopic: "ALF_VALIDATE_TOPIC_SCOPED_TEST",
                            errorMessage: "Value should not be #fail"
                         }
                      ]

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormControlValidationTestService.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormControlValidationTestService.js
@@ -60,6 +60,7 @@ define(["dojo/_base/declare",
             this.alfSubscribe("BLOCK_RESPONSES", lang.hitch(this, this.onBlockResponses));
             this.alfSubscribe("UNBLOCK_RESPONSES", lang.hitch(this, this.onUnblockResponses));
             this.alfSubscribe("ALF_VALIDATE_TOPIC_TEST", lang.hitch(this, this.onValidateTopicTest));
+            this.alfSubscribe("ALF_VALIDATE_TOPIC_SCOPED_TEST", lang.hitch(this, this.onValidateTopicScopedTest));
          },
 
          /**
@@ -123,7 +124,19 @@ define(["dojo/_base/declare",
           */
          onValidateTopicTest: function alfresco_testing_mockservices_FormControlValidationTestService__onValidateTopicTest(payload) {
             var isValid = (payload.value !== "#fail");
-            this.alfPublish(payload.alfResponseTopic, {isValid: isValid}, false, false, payload.alfResponseScope);
+            this.alfPublish(payload.alfResponseTopic, {isValid: isValid}, true);
+         },
+
+         /**
+          * Validation fails when value provided is "#fail" - responseTopic is published on
+          * responseScope provided.
+          * 
+          * @instance
+          * @since 1.0.91
+          */
+         onValidateTopicScopedTest: function alfresco_testing_mockservices_FormControlValidationTestService__onValidateTopicScopedTest(payload) {
+            var isValid = (payload.value !== "#fail");
+            this.alfPublish(payload.alfResponseTopic, {isValid: isValid},  false, false, payload.alfResponseScope);
          }
       });
    });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1099 to re-introduce backwards compatibility on "validationTopic" form validation. For the Site create/edit updates we had previously introduced scoped validation responses (to prevent cross-pollution of validation data) without realising that RM was dependent upon the previous implementation. This PR re-introduces backwards compatibility but provides an "opt-in" configuration of "scopeValidation" that allows validation to be scoped (which would be recommended). Unit tests have been updated.