### PR TITLE
AKU-1097: Made mark element colour for highlighting themeable

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -9,6 +9,8 @@
 @alternate-background-color: #ccc;
 @alternate-font-color: @primary-font-color;
 
+@text-highlight-color: #F8CF65;
+
 // Header widget colours
 // These are used for the "alfresco/header" packaged widgets which are primarily extensions
 // to the "alfresco/menus" widgets. You can override these variables to make theme specific header

--- a/aikau/src/main/resources/alfresco/renderers/css/Property.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/Property.css
@@ -1,6 +1,7 @@
 .alfresco-renderers-Property {
    mark {
       display: inline-block;
+      background-color: @text-highlight-color;
    }
 
    color: @general-font-color;


### PR DESCRIPTION
This is a further update to https://issues.alfresco.com/jira/browse/AKU-1097 to ensure that the mark element background colour is fully themeable. The default colour has also been toned down a little