### PR TITLE
AKU-1097: Update mark element colour

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -9,7 +9,7 @@
 @alternate-background-color: #ccc;
 @alternate-font-color: @primary-font-color;
 
-@text-highlight-color: #F8CF65;
+@text-highlight-color: #ffd180;
 
 // Header widget colours
 // These are used for the "alfresco/header" packaged widgets which are primarily extensions


### PR DESCRIPTION
This PR is a minor update to https://issues.alfresco.com/jira/browse/AKU-1097 to change the default highlight colour after an update from the XD team