### PR TITLE
AKU-1106: Update SiteService so that navigation on edit is correct

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1098,7 +1098,7 @@ define(["dojo/_base/declare",
       onSiteEditSuccess: function alfresco_services_SiteService__onSiteEditSuccess(/*jshint unused:false*/ response, originalRequestConfig) {
          this.alfServicePublish(topics.SITE_EDIT_SUCCESS);
          this.alfServicePublish(topics.NAVIGATE_TO_PAGE, {
-            url: "site/" + originalRequestConfig.data.shortName + "/dashboard"
+            url: "site/" + originalRequestConfig.data.shortName
          });
       },
 

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -175,7 +175,7 @@ define(["module",
             .getLastPublish("ALF_SITE_EDIT_SUCCESS")
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.propertyVal(payload, "url", "site/site1/dashboard");
+               assert.propertyVal(payload, "url", "site/site1");
             });
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1106 to ensure that when editing the details of a site that the user is redirected to the appropriate location (namely the home page for that site). Effectively it no longer defaults to "dashboard". Unit tests have been updated.