### PR TITLE
AKU-1108: Ensure site is favourited by default when created

### DIFF
--- a/aikau/src/main/resources/alfresco/core/topics.js
+++ b/aikau/src/main/resources/alfresco/core/topics.js
@@ -44,6 +44,20 @@ define([],function() {
       ADD_FAVOURITE_NODE: "ALF_PREFERENCE_ADD_DOCUMENT_FAVOURITE",
 
       /**
+       * This can be published to request to add a site as a favourite.
+       *
+       * @instance
+       * @type {String}
+       * @default
+       * @since 1.0.94
+       * 
+       * @event
+       * @property {string} site The shortName of the site to add as a favourite
+       * @property {string} user The username of the user to make the site a favourite of
+       */
+      ADD_FAVOURITE_SITE: "ALF_ADD_FAVOURITE_SITE",
+
+      /**
        * Triggered when the progress request has failed
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -106,6 +106,7 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @since 1.0.32
+       * @listens module:alfresco/core/topics#ADD_FAVOURITE_SITE
        * @listens module:alfresco/core/topics#BECOME_SITE_MANAGER
        * @listens module:alfresco/core/topics#CREATE_SITE
        * @listens module:alfresco/core/topics#DELETE_SITE
@@ -133,7 +134,7 @@ define(["dojo/_base/declare",
          this.alfSubscribe(topics.EDIT_SITE, lang.hitch(this, this.editSite));
          this.alfSubscribe(topics.SITE_EDIT_REQUEST, lang.hitch(this, this.editEditSiteData));
          this.alfSubscribe(topics.DELETE_SITE, lang.hitch(this, this.onActionDeleteSite));
-         this.alfSubscribe("ALF_ADD_FAVOURITE_SITE", lang.hitch(this, this.addSiteAsFavourite));
+         this.alfSubscribe(topics.ADD_FAVOURITE_SITE, lang.hitch(this, this.addSiteAsFavourite));
          this.alfSubscribe("ALF_REMOVE_FAVOURITE_SITE", lang.hitch(this, this.removeSiteFromFavourites));
          this.alfSubscribe(topics.GET_RECENT_SITES, lang.hitch(this, this.getRecentSites));
          this.alfSubscribe(topics.GET_FAVOURITE_SITES, lang.hitch(this, this.getFavouriteSites));
@@ -944,10 +945,17 @@ define(["dojo/_base/declare",
        * @param  {object} response The response from the request to create the site
        * @param  {object} originalRequestConfig The configuration for the request to create the site
        * @since 1.0.55
+       * @fires module:alfresco/core/topics#ADD_FAVOURITE_SITE
        * @fires module:alfresco/core/topics#SITE_CREATION_SUCCESS
        * @fires module:alfresco/core/topics#NAVIGATE_TO_PAGE
        */
       onSiteCreationSuccess: function alfresco_services_SiteService__onSiteCreationSuccess(/*jshint unused:false*/ response, originalRequestConfig) {
+         // Mark the new site as a favourite...
+         this.alfServicePublish(topics.ADD_FAVOURITE_SITE, {
+            site: originalRequestConfig.data.shortName,
+            user: AlfConstants.USERNAME
+         });
+
          this.alfServicePublish(topics.SITE_CREATION_SUCCESS);
          this.alfServicePublish(topics.NAVIGATE_TO_PAGE, {
             url: "site/" + originalRequestConfig.data.shortName + "/dashboard"
@@ -1098,7 +1106,7 @@ define(["dojo/_base/declare",
       onSiteEditSuccess: function alfresco_services_SiteService__onSiteEditSuccess(/*jshint unused:false*/ response, originalRequestConfig) {
          this.alfServicePublish(topics.SITE_EDIT_SUCCESS);
          this.alfServicePublish(topics.NAVIGATE_TO_PAGE, {
-            url: "site/" + originalRequestConfig.data.shortName
+            url: "site/" + originalRequestConfig.data.shortName + this.userHomePage
          });
       },
 

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -140,11 +140,12 @@ define(["module",
          .end()
 
          .getLastPublish("ALF_SITE_CREATION_REQUEST")
-            .getLastPublish("ALF_SITE_CREATION_SUCCESS")
-            .getLastPublish("ALF_NAVIGATE_TO_PAGE")
-            .then(function(payload) {
-               assert.propertyVal(payload, "url", "site/pass/dashboard");
-            });
+         .getLastPublish("ALF_ADD_FAVOURITE_SITE")
+         .getLastPublish("ALF_SITE_CREATION_SUCCESS")
+         .getLastPublish("ALF_NAVIGATE_TO_PAGE")
+         .then(function(payload) {
+            assert.propertyVal(payload, "url", "site/pass/dashboard");
+         });
       },
 
       "Edit site": function() {
@@ -175,7 +176,7 @@ define(["module",
             .getLastPublish("ALF_SITE_EDIT_SUCCESS")
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.propertyVal(payload, "url", "site/site1");
+               assert.propertyVal(payload, "url", "site/site1/home");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -12,7 +12,7 @@ model.jsonModel = {
       {
          name: "alfresco/services/SiteService",
          config: {
-            userHomePage: "home",
+            userHomePage: "/home",
             legacyMode: false
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1108 to ensure that sites are favourited by default when created (through the SiteService). The unit tests have been updated to verify this change. I've also made a minor change related to https://issues.alfresco.com/jira/browse/AKU-1106 to make use of the "userHomePage" configuration attribute to ensure the SiteService can be used for creating sites on versions of Alfresco Share prior to 5.2