### PR TITLE
AKU-1107: Ensure that site names and titles get trimmed

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -255,6 +255,17 @@ define(["dojo/_base/declare",
       options: null,
 
       /**
+       * Indicates whether or not values should be trimmed of whitespace (this only applies to 
+       * values that are strings).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.94
+       */
+      trimValue: false,
+
+      /**
        * The value to submit as the value of the field when the form is submitted.
        *
        * @instance
@@ -1584,6 +1595,10 @@ define(["dojo/_base/declare",
             {
                this.alfLog("log", "An exception was thrown retrieving the value for field: '" + this.fieldId + "'");
             }
+         }
+         if (this.trimValue && value && typeof value.trim === "function")
+         {
+            value = value.trim();
          }
          value = this.convertStringValuesToBoolean(value);
          return value;

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1363,6 +1363,7 @@ define(["dojo/_base/declare",
                fieldId: "TITLE",
                label: "create-site.dialog.name.label",
                name: "title",
+               trimValue: true,
                requirementConfig: {
                   initialValue: true
                },
@@ -1402,6 +1403,7 @@ define(["dojo/_base/declare",
                      flags: "g"
                   }
                ],
+               trimValue: true,
                label: "create-site.dialog.urlname.label",
                description: "create-site.dialog.urlname.description",
                name: "shortName",

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -100,7 +100,7 @@ define(["module",
       "Create site (duplicate shortName)": function() {
          return this.remote.findByCssSelector(selectors.textBoxes.createSiteTitle.input)
             .clearValue()
-            .type("used")
+            .type(" used")
          .end()
 
          .findDisplayedByCssSelector("#CREATE_SITE_FIELD_TITLE .alfresco-forms-controls-BaseFormControl__validation-warning")


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1107 to ensure that site names and titles are trimmed prior to validation and submission. A new "trimValue" has been added to BaseFormControl to support trimming of values when requested to achieve this. The unit tests have been updated.