### PR TITLE
AKU-1114: Remove search highlighting delineation from thumbnail

### DIFF
--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -701,7 +701,9 @@ define(["dojo/_base/declare",
             pubSubScope: this.pubSubScope,
             showDocumentPreview: true,
             newTabOnMiddleOrCtrlClick: this.newTabOnMiddleOrCtrlClick,
-            defaultNavigationTarget: this.navigationTarget
+            defaultNavigationTarget: this.navigationTarget,
+            highlightPrefix: this.showSearchTermHighlights ? this.highlightPrefix : null,
+            highlightPostfix: this.showSearchTermHighlights ? this.highlightPostfix : null
          };
          if (this.navigationTarget)
          {

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnail.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnail.js
@@ -45,6 +45,28 @@ define(["dojo/_base/declare",
       hasShadow: true,
 
       /**
+       * The prefix string that indicates the start of text to highlight.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.95
+       */
+      highlightPrefix: "\u0000",
+
+      /**
+       * This is the property within the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#highlightProperty}
+       * that should be used to identify the content with in the 
+       * [renderedValue]{@link module:alfresco/renderers/Property#renderedValue} to highlight.
+       * 
+       * @instance
+       * @type {string}
+       * @default 
+       * @since 1.0.95
+       */
+      highlightPostfix: "\u0003",
+
+      /**
        * Overrides the [inherited default]{@link module:alfresco/renderers/Thumbnail#horizontalAlignment} to
        * align the image to the right
        * 
@@ -62,6 +84,21 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      lastThumbnailModificationProperty: "lastThumbnailModification"
+      lastThumbnailModificationProperty: "lastThumbnailModification",
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/renderers/Thumbnail#setImageTitle}
+       * to ensure that image titles have search term highlighting delineation removed.
+       *
+       * @instance
+       * @since 1.0.95
+       */
+      setImageTitle: function alfresco_search_SearchThumbnail__setImageTitle() {
+         this.inherited(arguments);
+         if (this.imgTitle)
+         {
+            this.imgTitle = this.imgTitle.replace(new RegExp(this.highlightPrefix, "g"), "").replace(new RegExp(this.highlightPostfix, "g"), "");
+         }
+      }
    });
 });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1114 to remove the search term highlighting prefix and postfix characters from thumbnail titles.