### PR TITLE
AKU-1115: Site service fixes

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -85,6 +85,18 @@ define(["dojo/_base/declare",
       userHomePage: "/dashboard",
 
       /**
+       * The prefix to apply to site locations to complete the URL for site home pages. Prior to 
+       * version 5.1 of Share this would be "/dashboard" but from Share 5.1 onwards the site
+       * home page is configurable so should be configured to be the empty string.
+       *
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.95
+       */
+      siteHomePage: "/dashboard",
+
+      /**
        * Ensures that default [sitePresets]{@link module:alfresco/services/SiteService#sitePresets} are configured
        * if no custom values have been provided.
        * 
@@ -1106,7 +1118,7 @@ define(["dojo/_base/declare",
       onSiteEditSuccess: function alfresco_services_SiteService__onSiteEditSuccess(/*jshint unused:false*/ response, originalRequestConfig) {
          this.alfServicePublish(topics.SITE_EDIT_SUCCESS);
          this.alfServicePublish(topics.NAVIGATE_TO_PAGE, {
-            url: "site/" + originalRequestConfig.data.shortName + this.userHomePage
+            url: "site/" + originalRequestConfig.data.shortName + this.siteHomePage
          });
       },
 

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -176,7 +176,7 @@ define(["module",
             .getLastPublish("ALF_SITE_EDIT_SUCCESS")
             .getLastPublish("ALF_NAVIGATE_TO_PAGE")
             .then(function(payload) {
-               assert.propertyVal(payload, "url", "site/site1/home");
+               assert.propertyVal(payload, "url", "site/site1");
             });
       },
 

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -13,6 +13,7 @@ model.jsonModel = {
          name: "alfresco/services/SiteService",
          config: {
             userHomePage: "/home",
+            siteHomePage: "",
             legacyMode: false
          }
       },


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1115 to resolve an introduce that was previously introduced to ensure that site home and user home are independently configured. The unit tests have been updated and this has been verified on Share.