### PR TITLE
AKU-1116: Confirm dialog on enter

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/AlfButton.js
+++ b/aikau/src/main/resources/alfresco/buttons/AlfButton.js
@@ -212,13 +212,21 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Cause this button to respond as if it had been clicked.
+       * Cause this button to respond as if it had been clicked. The button will only 
+       * act as though it has been clicked if it is not disabled when the function is called.
        *
        * @instance
        * @since 1.0.49
        */
       activate: function alfresco_buttons_AlfButton__activate() {
-         this.onClick();
+         if (this.get("disabled"))
+         {
+            this.alfLog("log", "Button not activated when disabled", this);
+         }
+         else
+         {
+            this.onClick();
+         }
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -624,6 +624,25 @@ define(["dojo/_base/declare",
             // When creating the buttons, attach the handler to each created...
             this._buttons = [];
             array.forEach(widgets, lang.hitch(this, this.attachButtonHandler));
+
+            // See AKU-1116... 
+            // Forms support the ability to submit on the publication of a topic, but form
+            // dialogs hide the standard form buttons. This section of code will handle events
+            // emitted by forms when no form buttons can be found. It allows the form dialogs
+            // to be submitted on enter...
+            on(this.domNode, "onFormSubmit", lang.hitch(this, function() {
+               if (this._buttons)
+               {
+                  array.some(this._buttons, function(button) {
+                     if (domClass.contains(button.domNode, "confirmationButton"))
+                     {
+                        button.activate();
+                        return true;
+                     }
+                     return false;
+                  });
+               }
+            }));
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/forms/Form.js
+++ b/aikau/src/main/resources/alfresco/forms/Form.js
@@ -1100,9 +1100,21 @@ define(["dojo/_base/declare",
        * @since 1.0.49
        */
       submitOkButton: function alfresco_forms_Form__submitOkButton() {
-         if(!this.okButton) {
+         if(!this.okButton) 
+         {
             this.alfLog("warn", "Cannot submit OK button as button not defined");
-         } else {
+
+            // See AKU-1116
+            // If no buttons can be found then the likely scenario is that we are within
+            // a form dialog. Therefore emit a custom event requesting that the form be
+            // submitted...
+            on.emit(this.domNode, "onFormSubmit", {
+               bubbles: true,
+               cancelable: true
+            });
+         }
+         else 
+         {
             this.okButton.activate();
          }
       },

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -878,7 +878,7 @@ define(["dojo/_base/declare",
        * @param {object} payload The payload published with the request to create a site
        * @fires module:alfresco/core/topics#CREATE_FORM_DIALOG
        */
-      createSite: function alfresco_services_SiteService__editSite(config) {
+      createSite: function alfresco_services_SiteService__createSite(config) {
          this.alfLog("log", "A request has been made to create a site: ", config);
          if (this.legacyMode)
          {
@@ -904,6 +904,9 @@ define(["dojo/_base/declare",
                formSubmissionTopic: topics.SITE_CREATION_REQUEST,
                formSubmissionGlobal: true,
                showValidationErrorsImmediately: false,
+               customFormConfig: {
+                  publishValueSubscriptions: [topics.ENTER_KEY_PRESSED]
+               },
                widgets: dialogWidgets
             });
          }
@@ -1058,6 +1061,9 @@ define(["dojo/_base/declare",
                formSubmissionGlobal: true,
                formValue: response,
                showValidationErrorsImmediately: false,
+               customFormConfig: {
+                  publishValueSubscriptions: [topics.ENTER_KEY_PRESSED]
+               },
                widgets: dialogWidgets
             });
          }

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -130,14 +130,6 @@ define(["module",
          .clearLog()
          .pressKeys(keys.ENTER)
 
-         
-         // .findByCssSelector(selectors.dialogs.createSite.confirmationButton)
-         //    .clearLog()
-         //    .click()
-         //    .click() // For some reason in automated testing a second click is required here
-         //             // Adding a long pause and a manual click and it works fine...
-         // .end()
-
          .findByCssSelector(selectors.dialogs.createSite.hidden)
          .end()
 

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -25,8 +25,9 @@
 define(["module",
         "alfresco/TestCommon",
         "alfresco/defineSuite",
-        "intern/chai!assert"],
-        function(module, TestCommon, defineSuite, assert) {
+        "intern/chai!assert",
+        "intern/dojo/node!leadfoot/keys"],
+        function(module, TestCommon, defineSuite, assert, keys) {
 
    var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
    var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
@@ -126,12 +127,16 @@ define(["module",
          .waitForDeletedByCssSelector(selectors.dialogs.createSite.disabledConfirmationButton)
          .end()
 
-         .findByCssSelector(selectors.dialogs.createSite.confirmationButton)
-            .clearLog()
-            .click()
-            .click() // For some reason in automated testing a second click is required here
-                     // Adding a long pause and a manual click and it works fine...
-         .end()
+         .clearLog()
+         .pressKeys(keys.ENTER)
+
+         
+         // .findByCssSelector(selectors.dialogs.createSite.confirmationButton)
+         //    .clearLog()
+         //    .click()
+         //    .click() // For some reason in automated testing a second click is required here
+         //             // Adding a long pause and a manual click and it works fine...
+         // .end()
 
          .findByCssSelector(selectors.dialogs.createSite.hidden)
          .end()


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1116 to add support for form dialogs being submitted on enter key presses. In particular this adds support for create and edit site form dialogs to be submitted on enter (if the form is in a valid state). The unit tests have been updated.