### PR TITLE
AKU-1117: Added additional message for site creation failure

### DIFF
--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -53,9 +53,16 @@ edit-site-dialog.name.save.label=Save
 edit-site.dialog.title=Edit Site Details
 edit-site.saving=Site details are being saved...
 
+
 create-site.failure.dialog.title=We couldn't create the site
 edit-site.failure.dialog.title=We couldn't save the site info
+
+# Error keys returned by the XHR request to the server
+error.unableToCreate=This site name is already used by another site. Check to see if there's an existing site with this name (it might have been deleted and be in a trashcan) or try another name.
 error.duplicateShortName=We couldn't create the site because the URL is already used
+error.loggedOut=Your user session has timed out, please login and try again
+error.noPermissions=Could not create site. You do not have permissions to perform this operation.
+error.create=Could not create the site at this time. Please try again later.
 
 # Following four messages added as part of AKU-860
 message.cancel-join-request-success=Successfully cancelled request to join site {0}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1117 to add in missing error message for failure to create sites.