### PR TITLE
AKU-1120 - CLONE - User is redirected to site Document Library when clicking on any of the Live Search scope options

### DIFF
--- a/aikau/src/main/resources/alfresco/header/SearchBox.js
+++ b/aikau/src/main/resources/alfresco/header/SearchBox.js
@@ -937,6 +937,7 @@ define(["dojo/_base/declare",
                this.siteContext = false;
                this.lastSearchText = "";
                this.onSearchBoxKeyUp(evt);
+               evt.preventDefault();
             }));
             on(this._LiveSearch.contextSiteNode, "click", lang.hitch(this, function(evt) {
                // change context to site
@@ -945,6 +946,7 @@ define(["dojo/_base/declare",
                this.siteContext = true;
                this.lastSearchText = "";
                this.onSearchBoxKeyUp(evt);
+               evt.preventDefault();
             }));
 
             // event handlers to hide/show the panel


### PR DESCRIPTION
Prevent event from changing # url parameters. Fixes issue SHA-1896.