### PR TITLE
AKU-1121: Prevent button enablement from "flashing"

### DIFF
--- a/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
+++ b/aikau/src/main/resources/alfresco/buttons/css/AlfButton.css
@@ -63,6 +63,11 @@
       border-radius: @call-to-action-button-border-radius;
       margin: @call-to-action-button-margin;
       padding: @call-to-action-button-padding;
+
+      transition-property: background border;
+      transition-duration: 0s;
+      transition-delay: 0.1s;
+         
       .dijitButtonText {
          font-family: @call-to-action-button-font-family;
          font-size: @call-to-action-button-font-size;
@@ -71,6 +76,10 @@
          margin: @call-to-action-button-text-margin;
       }
       .dijitReset.dijitInline.dijitButtonNode {
+         transition-duration: 0s;
+         transition-property: color;
+         transition-delay: 0.1s;
+            
          color: @call-to-action-button-font-color;
       }
       &.dijitButtonFocused, &.dijitButtonHover {

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
@@ -72,18 +72,25 @@ define(["alfresco/core/topics",
          // error messages can be displayed without relying on focus being lost
          this._hadUserUpdate = true;
          
-         if (this.publishTopicOnEnter && evt.keyCode === keys.ENTER) {
+         if (this.publishTopicOnEnter && evt.keyCode === keys.ENTER) 
+         {
             this.alfPublish(this.publishTopicOnEnter, {
                fieldId: this.id
             });
             evt.preventDefault();
-         } else {
+         } 
+         else 
+         {
             this._oldValue = this.__oldValue; // Set the old value as the last buffer...
             this.__oldValue = this.getValue(); // Make the last buffer the current value being set
 
-            this.alfLog("log", "keyup - OLD value: " + this._oldValue + ", NEW value: " + this.getValue());
-            this.formControlValueChange(this.name, this._oldValue, this.getValue());
-            this.validate();
+            // See AKU-1121 - only validate on actual changes...
+            if (this._oldValue !== this.__oldValue)
+            {
+               this.alfLog("log", "keyup - OLD value: " + this._oldValue + ", NEW value: " + this.getValue());
+               this.formControlValueChange(this.name, this._oldValue, this.getValue());
+               this.validate();
+            }
          }
       },
 


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1121 to ensure that the asynchronous validation checking of a form does not cause the button confirmation button to flash (as it goes to disabled state as soon as validation commences and if the response is fast the button appears to flash). This has been resolved by ignoring non-change key strokes and setting a transition delay on the button.