### PR TITLE
AKU-1119: Improve SiteService preset configuration options

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -80,8 +80,10 @@ define(["dojo/_base/declare",
       /**
        * This is an array of site preset options that will be displayed when creating a site (when the service
        * is not configured to be in [legacyMode]{@link module:alfresco/services/SiteService#legacyMode}). The
-       * default configuration just contains the "Collaboration Site", but this can be re-configured to contain
-       * additional site presets. Any additional presets must have values that map to presets in the Surf configuration.
+       * default configuration just contains the "Collaboration Site", but this can be overridden here. Any 
+       * presets must have values that map to presets in the Surf configuration. Note that 
+       * [additionalSitePresets]{@link module:alfresco/services/SiteService#additionalSitePresets} can be used
+       * to augment the default list rather than replacing it completely.
        * 
        * @instance
        * @type {object[]}

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -49,6 +49,21 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/SiteService.properties"}],
 
       /**
+       * This can be configured to be an array of additional site presets that will be 
+       * added to the default set (which will just be the "Collaboration Site"). Rather
+       * than configuring the [sitePresets]{@link module:alfresco/services/SiteService#sitePresets}
+       * it may be better to define additional presets. Each element in the array should be
+       * an object with "label" and "value" attributes where the value matches a preset
+       * configured in Share.
+       * 
+       * @instance
+       * @type {object[]}
+       * @default
+       * @since 1.0.95
+       */
+      additionalSitePresets: null,
+
+      /**
        * Indicates whether or not the Site Service is running in legacy mode. When configured in this mode
        * the service will attempt to use the YUI2 based dialogs provided by Alfresch Share for creating and
        * editing sites. If this is configured to be false then the 
@@ -73,6 +88,20 @@ define(["dojo/_base/declare",
        * @since 1.0.55
        */
       sitePresets: null,
+
+      /**
+       * This can be configured to be a string array of the site preset values to be removed
+       * from both [sitePresets]{@link module:alfresco/services/SiteService#sitePresets} and
+       * [additionalSitePresets]{@link module:alfresco/services/SiteService#additionalSitePresets}.
+       * Note that unlike those attributes this is just a string array rather than an object
+       * array because only the site preset values (not labels) are matched.
+       *
+       * @instance
+       * @type {string[]}
+       * @default
+       * @since 1.0.95
+       */
+      sitePresetsToRemove: null,
 
       /**
        * The standard home page for a user
@@ -110,6 +139,20 @@ define(["dojo/_base/declare",
             this.sitePresets = [
                { label: "create-site.dialog.type.collaboration", value: "site-dashboard" }
             ];
+         }
+
+         if (this.additionalSitePresets && this.additionalSitePresets.length)
+         {
+            this.sitePresets = this.sitePresets.concat(this.additionalSitePresets);
+         }
+
+         if (this.sitePresetsToRemove && this.sitePresetsToRemove.length)
+         {
+            this.sitePresets = array.filter(this.sitePresets, function(preset) {
+               return !array.some(this.sitePresetsToRemove, function(presetToRemove) {
+                  return preset.value === presetToRemove;
+               });
+            }, this);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -143,7 +143,9 @@ define(["dojo/_base/declare",
             ];
          }
 
-         if (this.additionalSitePresets && this.additionalSitePresets.length)
+         if (this.additionalSitePresets && 
+             ObjectTypeUtils.isArray(this.additionalSitePresets) && 
+             this.additionalSitePresets.length)
          {
             this.sitePresets = this.sitePresets.concat(this.additionalSitePresets);
          }

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -32,6 +32,7 @@ define(["module",
    var textBoxSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/TextBox");
    var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
    var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+   var selectSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/Select");
 
    var selectors = {
       buttons: {
@@ -51,6 +52,15 @@ define(["module",
          },
          createSiteShortName: {
             input: TestCommon.getTestSelector(textBoxSelectors, "input", ["CREATE_SITE_FIELD_SHORTNAME"])
+         }
+      },
+      selectControls: {
+         sitePresets: {
+            dropDown: TestCommon.getTestSelector(selectSelectors, "option.menu", ["CREATE_SITE_FIELD_PRESET"]),
+            openIcon: TestCommon.getTestSelector(selectSelectors, "open.menu.icon", ["CREATE_SITE_FIELD_PRESET"]),
+            options: TestCommon.getTestSelector(selectSelectors, "options", ["CREATE_SITE_FIELD_PRESET"]),
+            option1: TestCommon.getTestSelector(selectSelectors, "nth.option.label", ["CREATE_SITE_FIELD_PRESET", "1"]),
+            option2: TestCommon.getTestSelector(selectSelectors, "nth.option.label", ["CREATE_SITE_FIELD_PRESET", "2"])
          }
       }
    };
@@ -302,6 +312,118 @@ define(["module",
          .end()
 
          .getLastPublish("ALF_RELOAD_PAGE");
+      }
+   });
+
+   defineSuite(module, {
+      name: "SiteService Tests (Reconfigured presets)",
+      testPage: "/SiteService?sitePresets=configured",
+
+      "Reconfigured site presets are correct": function() {
+         return this.remote.setFindTimeout(5000)
+
+         .findByCssSelector(selectors.buttons.createSite)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.createSite.visible)
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.openIcon)
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector(selectors.selectControls.sitePresets.dropDown)
+         .end()
+
+         .findAllByCssSelector(selectors.selectControls.sitePresets.options)
+            .then(function(options) {
+               assert.lengthOf(options, 1);
+            })
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.option1)
+            .getVisibleText()
+            .then(function(sitePresetLabel) {
+               assert.equal(sitePresetLabel, "Custom");
+            });
+      }
+   });
+
+   defineSuite(module, {
+      name: "SiteService Tests (Additional presets)",
+      testPage: "/SiteService?sitePresets=additional",
+
+      "Reconfigured site presets are correct": function() {
+         return this.remote.setFindTimeout(5000)
+
+         .findByCssSelector(selectors.buttons.createSite)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.createSite.visible)
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.openIcon)
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector(selectors.selectControls.sitePresets.dropDown)
+         .end()
+
+         .findAllByCssSelector(selectors.selectControls.sitePresets.options)
+            .then(function(options) {
+               assert.lengthOf(options, 2);
+            })
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.option1)
+            .getVisibleText()
+            .then(function(sitePresetLabel) {
+               assert.equal(sitePresetLabel, "Collaboration Site");
+            })
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.option2)
+            .getVisibleText()
+            .then(function(sitePresetLabel) {
+               assert.equal(sitePresetLabel, "Additional Custom");
+            });
+      }
+   });
+
+   defineSuite(module, {
+      name: "SiteService Tests (Removed presets)",
+      testPage: "/SiteService?sitePresets=remove",
+
+      "Reconfigured site presets are correct": function() {
+         return this.remote.setFindTimeout(5000)
+
+         .findByCssSelector(selectors.buttons.createSite)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.createSite.visible)
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.openIcon)
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector(selectors.selectControls.sitePresets.dropDown)
+         .end()
+
+         .findAllByCssSelector(selectors.selectControls.sitePresets.options)
+            .then(function(options) {
+               assert.lengthOf(options, 1);
+            })
+         .end()
+
+         .findByCssSelector(selectors.selectControls.sitePresets.option1)
+            .getVisibleText()
+            .then(function(sitePresetLabel) {
+               assert.equal(sitePresetLabel, "Additional Custom");
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/SiteService.get.js
@@ -1,3 +1,32 @@
+var siteService = {
+   name: "alfresco/services/SiteService",
+   config: {
+      userHomePage: "/home",
+      siteHomePage: "",
+      legacyMode: false
+   }
+};
+
+/* global page */
+/* jshint sub:true */
+if (page.url.args["sitePresets"])
+{
+   switch (page.url.args["sitePresets"]) {
+      case "configured": 
+         siteService.config.sitePresets = [{ label: "Custom", value: "custom_preset" } ];
+         break;
+
+      case "additional": 
+         siteService.config.additionalSitePresets = [{ label: "Additional Custom", value: "custom_preset" } ];
+         break;
+
+      case "remove":
+         siteService.config.additionalSitePresets = [{ label: "Additional Custom", value: "custom_preset" } ];
+         siteService.config.sitePresetsToRemove = [ "site-dashboard" ];
+         break;
+   }
+}
+
 model.jsonModel = {
    services: [
       {
@@ -9,14 +38,7 @@ model.jsonModel = {
             }
          }
       },
-      {
-         name: "alfresco/services/SiteService",
-         config: {
-            userHomePage: "/home",
-            siteHomePage: "",
-            legacyMode: false
-         }
-      },
+      siteService,
       "alfresco/services/DialogService",
       "alfresco/services/NotificationService",
       "alfresco/services/ErrorReporter"


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1119 to improve the configuration options for site presets in the create site dialog. It is now possible to replace the default options, add to the default options or remove from default and added options. Unit tests have been added to verify all the various configuration options.