### PR TITLE
AKU-1118: Update PathTree to be more tolerant of missing "/" prefix

### DIFF
--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -183,13 +183,14 @@ define(["dojo/_base/declare",
          {
             this.alfLog("log", "Filter updated", payload);
 
-            if (payload.path[0] !== "/")
+            // See AKU-1118... add a forward slash prefix if missing...
+            var path = payload.path;
+            if (path[0] !== "/")
             {
-               payload.path = "/" + payload.path;
+               path = "/" + path;
             }
 
-            var pathElements = payload.path.split("/");
-            
+            var pathElements = path.split("/");
             if (this.tree !== null && this.tree !== undefined && pathElements.length > 0)
             {
                var rootNode = this.tree.getChildren()[0];

--- a/aikau/src/main/resources/alfresco/navigation/PathTree.js
+++ b/aikau/src/main/resources/alfresco/navigation/PathTree.js
@@ -182,6 +182,12 @@ define(["dojo/_base/declare",
          if (payload && payload.path !== null && payload.path !== undefined)
          {
             this.alfLog("log", "Filter updated", payload);
+
+            if (payload.path[0] !== "/")
+            {
+               payload.path = "/" + payload.path;
+            }
+
             var pathElements = payload.path.split("/");
             
             if (this.tree !== null && this.tree !== undefined && pathElements.length > 0)

--- a/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
+++ b/aikau/src/test/resources/alfresco/navigation/PathTreeTest.js
@@ -56,8 +56,9 @@ define(["module",
       "Test that clicking on TREE1 publishes path": function() {
          return this.remote.findByCssSelector("#TREE1 .dijitTreeIsRoot > div.dijitTreeRow .dijitTreeLabel")
             .click()
-            .end()
-            .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
+         .end()
+         
+         .getLastPublish("ALF_DOCUMENTLIST_PATH_CHANGED")
             .then(function(payload) {
                assert.propertyVal(payload, "path", "/", "Clicking on the root of TREE1 did not publish the expected path");
             });
@@ -66,8 +67,9 @@ define(["module",
       "Test that clicking on TREE2 publishes custom topic": function() {
          return this.remote.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeLabel")
             .click()
-            .end()
-            .getLastPublish("ALF_ITEM_SELECTED", "The topic published by clicking on TREE2 nodes is not requested custom topic");
+         .end()
+         
+         .getLastPublish("ALF_ITEM_SELECTED", "The topic published by clicking on TREE2 nodes is not requested custom topic");
       },
 
       "Test that TREE1 has NOT filtered site containers": function() {
@@ -102,8 +104,9 @@ define(["module",
       "Test that opening a node loads its children": function() {
          return this.remote.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeRow .dijitTreeExpando")
             .click()
-            .end()
-            .findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
+         .end()
+         
+         .findAllByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > *")
             .then(function(elements) {
                assert.lengthOf(elements, 4, "The child nodes of the Document Library in TREE2 were not loaded when requested");
             });
@@ -112,8 +115,9 @@ define(["module",
       "Test that paths are correct for child nodes": function() {
          return this.remote.findByCssSelector("#TREE2 .dijitTreeIsRoot > div.dijitTreeNodeContainer div.dijitTreeNodeContainer > div:first-child div.dijitTreeRow .dijitTreeLabel")
             .click()
-            .end()
-            .getLastPublish("ALF_ITEM_SELECTED")
+         .end()
+   
+         .getLastPublish("ALF_ITEM_SELECTED")
             .then(function(payload) {
                assert.propertyVal(payload, "path", "/documentLibrary/Agency Files/", "Clicking on a child node of TREE2 did not publish the expected path");
             });
@@ -122,23 +126,37 @@ define(["module",
       "Publish hash change": function() {
          return this.remote.findById("SET_HASH_label")
             .click()
-            .end()
-            .findAllByCssSelector("#TREE1 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+         .end()
+      
+         .findAllByCssSelector("#TREE1 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Setting the hash did not expand the first tree");
             })
-            .end()
-            .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+         .end()
+  
+         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
             .then(function(elements) {
                assert.lengthOf(elements, 0, "Setting the hash should not have expanded the second tree");
+            });
+      },
+
+      "Publish path change (no slash prefix)": function() {
+         return this.remote.findById("SET_PATH_NO_SLASH_label")
+            .click()
+         .end()
+       
+         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+            .then(function(elements) {
+               assert.lengthOf(elements, 4, "Setting the path did not expand the second tree");
             });
       },
 
       "Publish path change": function() {
          return this.remote.findById("SET_PATH_label")
             .click()
-            .end()
-            .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
+         .end()
+       
+         .findAllByCssSelector("#TREE2 .dijitTreeNode .dijitTreeNode .dijitTreeNode .dijitTreeNode")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "Setting the path did not expand the second tree");
             });
@@ -154,7 +172,7 @@ define(["module",
          return this.remote.findById("ADD_FOLDER_label")
             .clearXhrLog()
             .click()
-            .end()
+         .end()
 
          .getLastXhr()
             .then(function(xhr) {
@@ -167,7 +185,7 @@ define(["module",
          return this.remote.findById("DELETE_FOLDER_label")
             .clearXhrLog()
             .click()
-            .end()
+         .end()
 
          .getLastXhr()
             .then(function(xhr) {
@@ -181,7 +199,7 @@ define(["module",
          return this.remote.findById("ADD_FOLDER_AT_ROOT_label")
             .clearXhrLog()
             .click()
-            .end()
+         .end()
 
          .getLastXhr()
             .then(function(xhr) {
@@ -194,7 +212,7 @@ define(["module",
          return this.remote.findById("DELETE_FOLDER_AT_ROOT_label")
             .clearXhrLog()
             .click()
-            .end()
+         .end()
 
          .getLastXhr()
             .then(function(xhr) {

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,7 +27,7 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   runAllTests = false; // Comment/uncomment this line to toggle
+   // runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,12 +27,11 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   // runAllTests = false; // Comment/uncomment this line to toggle
+   runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/forms/controls/TreeTest",
-      "alfresco/services/CloudSyncServiceTest"
+      "alfresco/navigation/PathTreeTest"
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/navigation/PathTree.get.js
@@ -42,6 +42,17 @@ model.jsonModel = {
                                     }
                                  },
                                  {
+                                    id: "SET_PATH_NO_SLASH",
+                                    name: "alfresco/buttons/AlfButton",
+                                    config: {
+                                       label: "Set path (no slash)",
+                                       publishTopic: "ALF_DOCUMENTLIST_PATH_CHANGED",
+                                       publishPayload: {
+                                          path: "documentLibrary"
+                                       }
+                                    }
+                                 },
+                                 {
                                     id: "SET_PATH",
                                     name: "alfresco/buttons/AlfButton",
                                     config: {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1118 to update the PathTree to be more tolerant of missing "/" prefixes when handling path change publications. The unit test has been updated to verify the change.