### PR TITLE
AKU-1125: Ensure AlfSelectDocumentListItems is disabled on -1 reported results

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/AlfSelectDocumentListItems.js
@@ -155,7 +155,7 @@ define(["dojo/_base/declare",
          {
             this.documentsAvailable = payload.documents.length;
          }
-         this.set("disabled", (payload && payload.totalRecords === 0));
+         this.set("disabled", (payload && (payload.totalRecords === 0 || payload.totalRecords === -1)));
       },
       
       /**


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1125 to ensure that the AlfSelectDocumentListItems menu is disabled when there are no options to select from (additional check against -1 results as well as 0 results).