### PR TITLE
AKU-1112: FilePicker requirement validation fix

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilePicker.js
@@ -424,6 +424,7 @@ define(["dojo/_base/declare",
                         this.selectedFiles = tmpSelectedFiles;
                         this.value = tmpValue;
                         this.updateSelectedFiles(this.showSelectedFilesTopic);
+                        this.onValueChangeEvent(this.name, null, tmpValue);
                      }
                   }), true);
 

--- a/aikau/src/test/resources/alfresco/forms/controls/FilePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/FilePickerTest.js
@@ -92,8 +92,8 @@ define(["module",
                assert.isArray(payload.singleFile);
                assert.lengthOf(payload.singleFile, 0);
                assert.isArray(payload.multiFile);
-               assert.include(payload.multiFile, {nodeRef :"workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4" });
-               assert.include(payload.multiFile, {nodeRef :"workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5" });
+               assert.include(payload.multiFile[0], "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4");
+               assert.include(payload.multiFile[1], "workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5");
                assert.equal(payload.delimitedValue, "workspace://SpacesStore/62e6c83c-f239-4f85-b1e8-6ba0fd50fac4,workspace://SpacesStore/a4fc4392-27f6-49fd-8b6e-20b953c59ff5");
                assert.equal(payload.delimited_added, "");
                assert.equal(payload.delimited_removed, "");

--- a/aikau/src/test/resources/alfresco/services/FormsRuntimeServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/FormsRuntimeServiceTest.js
@@ -30,12 +30,15 @@ define(["module",
    var buttonSelectors = TestCommon.getTestSelectors("alfresco/buttons/AlfButton");
    var formSelectors = TestCommon.getTestSelectors("alfresco/forms/Form");
    var multiSelectInputSelectors = TestCommon.getTestSelectors("alfresco/forms/controls/MultiSelectInput");
+   var dialogSelectors = TestCommon.getTestSelectors("alfresco/dialogs/AlfDialog");
+   
 
    var selectors = {
       buttons: {
          editNode: TestCommon.getTestSelector(buttonSelectors, "button.label", ["EDIT_NODE"]),
          viewNode: TestCommon.getTestSelector(buttonSelectors, "button.label", ["VIEW_NODE"]),
-         createWorkflow: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_WORKFLOW"])
+         createWorkflow: TestCommon.getTestSelector(buttonSelectors, "button.label", ["CREATE_WORKFLOW"]),
+         editDataListItem: TestCommon.getTestSelector(buttonSelectors, "button.label", ["EDIT_DATA_LIST_ITEM"])
       },
       authoritySelector: {
          control: TestCommon.getTestSelector(multiSelectInputSelectors, "control", ["ASSOC_BPM_ASSIGNEE"]),
@@ -57,6 +60,13 @@ define(["module",
             confirmationButton: TestCommon.getTestSelector(formSelectors, "confirmation.button", ["CREATE_WORKFLOW_FORM"])
          }
       },
+      dialogs: {
+         editDataListItem: {
+            confirmationButton: TestCommon.getTestSelector(dialogSelectors, "form.dialog.confirmation.button", ["EDIT_DLI_FORM"]),
+            disabledConfirmationButton: TestCommon.getTestSelector(dialogSelectors, "disabled.form.dialog.confirmation.button", ["EDIT_DLI_FORM"]),
+            displayed: TestCommon.getTestSelector(dialogSelectors, "visible.dialog", ["EDIT_DLI_FORM"]),
+         }
+      }
    };
 
    defineSuite(module, {
@@ -92,6 +102,23 @@ define(["module",
 
          // ...which should result in the scoped reload request
          .getLastPublish("CREATE_WORKFLOW_SCOPE_ALF_DOCLIST_RELOAD_DATA");
+      },
+
+      "Mandatory file association with initial value provided does not disable form": function() {
+         return this.remote.findByCssSelector(selectors.buttons.editDataListItem)
+            .click()
+         .end()
+
+         .findByCssSelector(selectors.dialogs.editDataListItem.displayed)
+         .end()
+
+         .findDisplayedByCssSelector(selectors.dialogs.editDataListItem.confirmationButton)
+         .end()
+
+         .findAllByCssSelector(selectors.dialogs.editDataListItem.disabledConfirmationButton)
+            .then(function(elements) {
+               assert.lengthOf(elements, 0);
+            });
       }
    });
 });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
@@ -83,6 +83,27 @@ model.jsonModel = {
          }
       },
       {
+         id: "EDIT_DATA_LIST_ITEM",
+         name: "alfresco/buttons/AlfButton",
+         config: {
+            label: "Edit data list item",
+            publishTopic: "ALF_FORM_REQUEST",
+            publishPayload: {
+               itemKind: "node",
+               itemId: "workspace://SpacesStore/7778cf88-836f-4833-a0df-3056d2b20e7a",
+               mode: "edit",
+               formConfig: {
+                  useDialog: true,
+                  formId: "EDIT_DLI_FORM",
+                  dialogTitle: "Edit Task",
+                  formSubmissionPayloadMixin: {
+                     alfResponseScope: "EDIT_DLI_SCOPE_"
+                  }
+               }
+            }
+         }
+      },
+      {
          name: "alfresco/layout/DynamicWidgets",
          config: {
             subscriptionTopic: "ALF_FORM_REQUEST_SUCCESS"

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/services/FormsRuntimeService.get.js
@@ -12,7 +12,8 @@ model.jsonModel = {
       "alfresco/services/FormsRuntimeService",
       "alfresco/services/DialogService",
       "alfresco/services/UserService",
-      "alfresco/services/CrudService"
+      "alfresco/services/CrudService",
+      "alfresco/services/DocumentService"
    ],
    widgets: [
       {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
@@ -33,9 +33,10 @@ define(["dojo/_base/declare",
         "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflow.json",
         "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflowSuccess.json",
         "dojo/text!./responseTemplates/FormsRuntime/EditTask.json",
-        "dojo/text!./responseTemplates/FormsRuntime/EditDataListItem.json"], 
+        "dojo/text!./responseTemplates/FormsRuntime/EditDataListItem.json",
+        "dojo/text!./responseTemplates/previews/PDF.json"], 
         function(declare, MockXhr, webScriptDefaults, lang, Authorities, EditDocLibSimpleMetadata, ViewNodeDefault, 
-                 CreateWorkflow, CreateWorkflowSuccess, EditTask, EditDataListItem) {
+                 CreateWorkflow, CreateWorkflowSuccess, EditTask, EditDataListItem, pdfNodeData) {
    
    return declare([MockXhr], {
 
@@ -88,6 +89,12 @@ define(["dojo/_base/declare",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      EditDataListItem]);
+
+            this.server.respondWith("GET",
+                                    /\/aikau\/service\/components\/documentlibrary\/data\/node\/workspace\/SpacesStore\/1a0b110f-1e09-4ca2-b367-fe25e4964a4e(.*)/,
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     pdfNodeData]);
          }
          catch(e)
          {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/FormsRuntimeMockXhr.js
@@ -32,9 +32,10 @@ define(["dojo/_base/declare",
         "dojo/text!./responseTemplates/FormsRuntime/ViewNodeDefault.json",
         "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflow.json",
         "dojo/text!./responseTemplates/FormsRuntime/CreateWorkflowSuccess.json",
-        "dojo/text!./responseTemplates/FormsRuntime/EditTask.json"], 
+        "dojo/text!./responseTemplates/FormsRuntime/EditTask.json",
+        "dojo/text!./responseTemplates/FormsRuntime/EditDataListItem.json"], 
         function(declare, MockXhr, webScriptDefaults, lang, Authorities, EditDocLibSimpleMetadata, ViewNodeDefault, 
-                 CreateWorkflow, CreateWorkflowSuccess, EditTask) {
+                 CreateWorkflow, CreateWorkflowSuccess, EditTask, EditDataListItem) {
    
    return declare([MockXhr], {
 
@@ -81,6 +82,12 @@ define(["dojo/_base/declare",
                                     [200,
                                      {"Content-Type":"application/json;charset=UTF-8"},
                                      EditTask]);
+
+            this.server.respondWith("GET",
+                                    "/aikau/service/aikau/" + webScriptDefaults.WEBSCRIPT_VERSION + "/form?itemKind=node&itemId=workspace://SpacesStore/7778cf88-836f-4833-a0df-3056d2b20e7a&formId=null&mode=edit",
+                                    [200,
+                                     {"Content-Type":"application/json;charset=UTF-8"},
+                                     EditDataListItem]);
          }
          catch(e)
          {

--- a/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/EditDataListItem.json
+++ b/aikau/src/test/resources/testApp/js/aikau/testing/mockservices/responseTemplates/FormsRuntime/EditDataListItem.json
@@ -1,0 +1,216 @@
+{
+   "enctype": "multipart/form-data",
+   "method": "post",
+   "data": {
+      "prop_dl_todoDueDate": "2011-02-01T00:00:00.000Z",
+      "prop_dl_todoStatus": "Complete",
+      "prop_dl_todoTitle": "Contract",
+      "assoc_dl_attachments": "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+      "prop_dl_todoPriority": 2,
+      "assoc_dl_assignee": "",
+      "prop_dl_todoNotes": ""
+   },
+   "editTemplate": "../data-lists/forms/dataitem.ftl",
+   "constraints": [{
+      "validationHandler": "Alfresco.forms.validation.mandatory",
+      "id": "MANDATORY",
+      "event": "keyup,change",
+      "message": "The value cannot be empty.",
+      "params": {},
+      "fieldId": "prop_dl_todoTitle"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.mandatory",
+      "id": "MANDATORY",
+      "event": "change",
+      "message": "No attachments.",
+      "params": {},
+      "fieldId": "assoc_dl_attachments"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.number",
+      "id": "NUMBER",
+      "event": "keyup",
+      "message": "Value is not a number.",
+      "params": {},
+      "fieldId": "prop_dl_todoPriority"
+   }, {
+      "validationHandler": "Alfresco.forms.validation.inList",
+      "id": "LIST",
+      "event": "blur",
+      "message": "Value is not in list.",
+      "params": {
+         "allowedValues": ["Not Started|Not Started", "In Progress|In Progress", "Complete|Complete", "On Hold|On Hold"],
+         "sorted": false,
+         "caseSensitive": true
+      },
+      "fieldId": "prop_dl_todoStatus"
+   }],
+   "structure": [{
+      "children": [{
+         "kind": "field",
+         "id": "prop_dl_todoTitle"
+      }, {
+         "kind": "field",
+         "id": "prop_dl_todoDueDate"
+      }, {
+         "kind": "field",
+         "id": "prop_dl_todoPriority"
+      }, {
+         "kind": "field",
+         "id": "prop_dl_todoStatus"
+      }, {
+         "kind": "field",
+         "id": "prop_dl_todoNotes"
+      }, {
+         "kind": "field",
+         "id": "assoc_dl_assignee"
+      }, {
+         "kind": "field",
+         "id": "assoc_dl_attachments"
+      }],
+      "id": "",
+      "event": "form.default.set.label",
+      "fieldId": "set"
+   }],
+   "showCancelButton": false,
+   "mode": "edit",
+   "showResetButton": false,
+   "showSubmitButton": true,
+   "arguments": {
+      "itemKind": "node",
+      "formId": "null",
+      "itemId": "workspace://SpacesStore/7778cf88-836f-4833-a0df-3056d2b20e7a"
+   },
+   "showCaption": true,
+   "submissionUrl": "/share/proxy/alfresco/api/node/workspace/SpacesStore/7778cf88-836f-4833-a0df-3056d2b20e7a/formprocessor",
+   "fields": {
+      "prop_dl_todoDueDate": {
+         "configName": "dl:todoDueDate",
+         "endpointType": "datetime",
+         "kind": "field",
+         "dataType": "datetime",
+         "dataKeyName": "prop_dl_todoDueDate",
+         "name": "prop_dl_todoDueDate",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/date.ftl",
+            "params": {
+               "showTime": "true"
+            }
+         },
+         "id": "prop_dl_todoDueDate",
+         "label": "Due Date",
+         "type": "property",
+         "value": "2011-02-01T00:00:00.000Z",
+         "helpEncodeHtml": true
+      },
+      "prop_dl_todoStatus": {
+         "configName": "dl:todoStatus",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "dataKeyName": "prop_dl_todoStatus",
+         "name": "prop_dl_todoStatus",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/selectone.ftl",
+            "params": {
+               "options": "Not Started|Not Started#alf#In Progress|In Progress#alf#Complete|Complete#alf#On Hold|On Hold",
+               "optionSeparator": "#alf#"
+            }
+         },
+         "id": "prop_dl_todoStatus",
+         "label": "Status",
+         "type": "property",
+         "value": "Complete",
+         "helpEncodeHtml": true
+      },
+      "prop_dl_todoTitle": {
+         "configName": "dl:todoTitle",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "dataKeyName": "prop_dl_todoTitle",
+         "name": "prop_dl_todoTitle",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/textfield.ftl",
+            "params": {}
+         },
+         "id": "prop_dl_todoTitle",
+         "label": "Title",
+         "type": "property",
+         "value": "Contract",
+         "helpEncodeHtml": true
+      },
+      "assoc_dl_attachments": {
+         "configName": "dl:attachments",
+         "endpointType": "cm:cmobject",
+         "kind": "field",
+         "dataType": "cm:cmobject",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/association.ftl",
+            "params": {
+               "startLocation": "{doclib}"
+            }
+         },
+         "label": "Attachments",
+         "type": "association",
+         "endpointDirection": "TARGET",
+         "dataKeyName": "assoc_dl_attachments",
+         "name": "assoc_dl_attachments",
+         "id": "assoc_dl_attachments",
+         "value": "workspace://SpacesStore/1a0b110f-1e09-4ca2-b367-fe25e4964a4e",
+         "helpEncodeHtml": true
+      },
+      "prop_dl_todoPriority": {
+         "configName": "dl:todoPriority",
+         "endpointType": "int",
+         "kind": "field",
+         "dataType": "int",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/number.ftl",
+            "params": {}
+         },
+         "label": "Priority",
+         "type": "property",
+         "help": "form.field.constraint.number",
+         "dataKeyName": "prop_dl_todoPriority",
+         "name": "prop_dl_todoPriority",
+         "id": "prop_dl_todoPriority",
+         "value": 2,
+         "helpEncodeHtml": true
+      },
+      "assoc_dl_assignee": {
+         "configName": "dl:assignee",
+         "endpointType": "cm:person",
+         "kind": "field",
+         "dataType": "cm:person",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/authority.ftl",
+            "params": {}
+         },
+         "label": "Assignee",
+         "type": "association",
+         "endpointDirection": "TARGET",
+         "dataKeyName": "assoc_dl_assignee",
+         "name": "assoc_dl_assignee",
+         "id": "assoc_dl_assignee",
+         "value": "",
+         "helpEncodeHtml": true
+      },
+      "prop_dl_todoNotes": {
+         "configName": "dl:todoNotes",
+         "endpointType": "text",
+         "kind": "field",
+         "dataType": "text",
+         "dataKeyName": "prop_dl_todoNotes",
+         "name": "prop_dl_todoNotes",
+         "control": {
+            "template": "/org/alfresco/components/form/controls/textarea.ftl",
+            "params": {}
+         },
+         "id": "prop_dl_todoNotes",
+         "label": "Notes",
+         "type": "property",
+         "value": "",
+         "helpEncodeHtml": true
+      }
+   }
+}


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1112 / #1270 to ensure that FilePicker widgets that are configured to be required do not disable a form when a value is provided. The unit tests have been updated to verify this change.