### PR TITLE
AKU-1128: Only request options for form controls once

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/BaseFormControl.js
@@ -737,25 +737,36 @@ define(["dojo/_base/declare",
                }
             }
 
-            // Generate the initial set of options in the following precedence...
-            // 1) PubSub Config
-            // 2) Callback function
-            // 3) Fixed options
-            var pubSub = lang.getObject("publishTopic", false, config),
-                callback = lang.getObject("callback", false, config),
-                fixed = lang.getObject("fixed", false, config);
-            if (pubSub && this.getPubSubOptionsImmediately)
-            {
-               this.getPubSubOptions(config);
-            }
-            else if (callback)
-            {
-               this.processCallbackOptions(callback, config);
-            }
-            else if (fixed)
-            {
-               this.processFixedOptions(fixed);
-            }
+            this.getInitialOptions(config);
+         }
+      },
+
+      /**
+       * Generate the initial set of options in the following precedence: 
+       * 
+       * <ol><li>PubSub Config</li>
+       * <li>Callback function</li>
+       * <li>Fixed options</li></ol>
+       *  
+       * @instance
+       * @param {object} config The options configuration
+       * @since 1.0.96
+       */
+      getInitialOptions: function alfresco_forms_controls_BaseFormControl__getInitialOptions(config) {
+         var pubSub = lang.getObject("publishTopic", false, config),
+             callback = lang.getObject("callback", false, config),
+             fixed = lang.getObject("fixed", false, config);
+         if (pubSub && this.getPubSubOptionsImmediately)
+         {
+            this.getPubSubOptions(config);
+         }
+         else if (callback)
+         {
+            this.processCallbackOptions(callback, config);
+         }
+         else if (fixed)
+         {
+            this.processFixedOptions(fixed);
          }
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/ComboBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/ComboBox.js
@@ -96,7 +96,6 @@ define(["dojo/_base/declare",
          var comboBox = new ComboBox({
             id: this.id + "_CONTROL",
             name: this.name,
-            value: this.value,
             placeHolder: placeHolder,
             store: serviceStore,
             searchAttr: serviceStore.queryAttribute,

--- a/aikau/src/main/resources/alfresco/forms/controls/FilteringSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilteringSelect.js
@@ -71,7 +71,6 @@ define(["alfresco/forms/controls/BaseFormControl",
          var filteringSelect = new FilteringSelect({
             id: this.id + "_CONTROL",
             name: this.name,
-            value: this.value,
             store: serviceStore,
             searchAttr: serviceStore.queryAttribute,
             labelAttribute: serviceStore.labelAttribute,

--- a/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MultiSelectInput.js
@@ -24,97 +24,95 @@
  * @mixes alfresco/forms/controls/utilities/UseServiceStoreMixin
  * @author Martin Doyle
  */
-define([
-      "alfresco/core/CoreWidgetProcessing",
-      "alfresco/forms/controls/BaseFormControl",
-      "alfresco/forms/controls/utilities/IconMixin",
-      "alfresco/forms/controls/utilities/UseServiceStoreMixin",
-      "dojo/_base/declare",
-      "dojo/_base/lang",
-      "alfresco/forms/controls/MultiSelect"
-   ],
-   function(CoreWidgetProcessing, BaseFormControl, IconMixin, UseServiceStoreMixin, declare, lang) {
+define(["alfresco/core/CoreWidgetProcessing",
+        "alfresco/forms/controls/BaseFormControl",
+        "alfresco/forms/controls/utilities/IconMixin",
+        "alfresco/forms/controls/utilities/UseServiceStoreMixin",
+        "dojo/_base/declare",
+        "dojo/_base/lang",
+        "alfresco/forms/controls/MultiSelect"],
+        function(CoreWidgetProcessing, BaseFormControl, IconMixin, UseServiceStoreMixin, declare, lang) {
 
-      return declare([BaseFormControl, CoreWidgetProcessing, UseServiceStoreMixin, IconMixin], {
+   return declare([BaseFormControl, CoreWidgetProcessing, UseServiceStoreMixin, IconMixin], {
 
-         /**
-          * Override the [inherited value]{@link module:alfresco/forms/controls/BaseFormControl#getPubSubOptionsImmediately}
-          * to suppress the initial retrieval of pubSubOptions for this control.
-          *
-          * @instance
-          * @override
-          * @type {boolean}
-          * @default
-          * @since 1.0.33
-          */
-         getPubSubOptionsImmediately: false,
+      /**
+       * Override the [inherited value]{@link module:alfresco/forms/controls/BaseFormControl#getPubSubOptionsImmediately}
+       * to suppress the initial retrieval of pubSubOptions for this control.
+       *
+       * @instance
+       * @override
+       * @type {boolean}
+       * @default
+       * @since 1.0.33
+       */
+      getPubSubOptionsImmediately: false,
 
-          /**
-          * An optional token that can be provided for splitting the supplied value. This should be configured
-          * when the value is provided as a string that needs to be converted into an array.
-          * 
-          * @instance
-          * @type {string}
-          * @default
-          * @since 1.0.77
-          */
-         valueDelimiter: null,
+       /**
+       * An optional token that can be provided for splitting the supplied value. This should be configured
+       * when the value is provided as a string that needs to be converted into an array.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.77
+       */
+      valueDelimiter: null,
 
-         /**
-          * @override
-          * @instance
-          */
-         getWidgetConfig: function alfresco_forms_controls_MultiSelectInput__getWidgetConfig() {
+      /**
+       * @override
+       * @instance
+       */
+      getWidgetConfig: function alfresco_forms_controls_MultiSelectInput__getWidgetConfig() {
 
-            // Setup the widget config
-            var widgetConfig = {
-               id: this.id + "_CONTROL",
-               name: this.name,
-               width: this.width,
-               choiceCanWrap: this.optionsConfig.choiceCanWrap,
-               choiceMaxWidth: this.optionsConfig.choiceMaxWidth,
-               labelFormat: this.optionsConfig.labelFormat,
-               valueDelimiter: this.valueDelimiter
+         // Setup the widget config
+         var widgetConfig = {
+            id: this.id + "_CONTROL",
+            name: this.name,
+            width: this.width,
+            choiceCanWrap: this.optionsConfig.choiceCanWrap,
+            choiceMaxWidth: this.optionsConfig.choiceMaxWidth,
+            labelFormat: this.optionsConfig.labelFormat,
+            valueDelimiter: this.valueDelimiter
 
-               // NOTE: This is not currently enabled, as it would create inconsistencies between
-               // controls' abilities, however the intention is at some point to use this control
-               // as a template to enable this option across all controls that take options (as
-               // long as it's deemed appropriate to do so when we next look at it)
-               // 
-               // inferMissingProperties: this.optionsConfig.inferMissingProperties
-            };
+            // NOTE: This is not currently enabled, as it would create inconsistencies between
+            // controls' abilities, however the intention is at some point to use this control
+            // as a template to enable this option across all controls that take options (as
+            // long as it's deemed appropriate to do so when we next look at it)
+            // 
+            // inferMissingProperties: this.optionsConfig.inferMissingProperties
+         };
 
-            // Don't want to pass through undefined values (will override defaults)
-            if (!widgetConfig.choiceCanWrap && widgetConfig.choiceCanWrap !== false) {
-               delete widgetConfig.choiceCanWrap;
-            }
-            if (!widgetConfig.choiceMaxWidth) {
-               delete widgetConfig.choiceMaxWidth;
-            }
-
-            // Pass back the config
-            return widgetConfig;
-         },
-
-         /**
-          * Creates a new [ServiceStore]{@link module:alfresco/forms/controls/utilities/ServiceStore} object to use for
-          * retrieving and filtering the available options to be included in the control and then instantiates and returns
-          * the MultiSelect widget that is configured to use it.
-          *
-          * @override
-          * @instance
-          * @param    {object} config Configuration for the control
-          * @returns  {object} The new control
-          */
-         createFormControl: function alfresco_forms_controls_MultiSelectInput__createFormControl(config) {
-            var serviceStore = this.createServiceStore(),
-               widgetConfig = lang.mixin({
-                  store: serviceStore
-               }, config);
-            return this.createWidget({
-               name: "alfresco/forms/controls/MultiSelect",
-               config: widgetConfig
-            });
+         // Don't want to pass through undefined values (will override defaults)
+         if (!widgetConfig.choiceCanWrap && widgetConfig.choiceCanWrap !== false) {
+            delete widgetConfig.choiceCanWrap;
          }
-      });
+         if (!widgetConfig.choiceMaxWidth) {
+            delete widgetConfig.choiceMaxWidth;
+         }
+
+         // Pass back the config
+         return widgetConfig;
+      },
+
+      /**
+       * Creates a new [ServiceStore]{@link module:alfresco/forms/controls/utilities/ServiceStore} object to use for
+       * retrieving and filtering the available options to be included in the control and then instantiates and returns
+       * the MultiSelect widget that is configured to use it.
+       *
+       * @override
+       * @instance
+       * @param    {object} config Configuration for the control
+       * @returns  {object} The new control
+       */
+      createFormControl: function alfresco_forms_controls_MultiSelectInput__createFormControl(config) {
+         var serviceStore = this.createServiceStore(),
+            widgetConfig = lang.mixin({
+               store: serviceStore
+            }, config);
+         return this.createWidget({
+            name: "alfresco/forms/controls/MultiSelect",
+            config: widgetConfig
+         });
+      }
    });
+});

--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/UseServiceStoreMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/UseServiceStoreMixin.js
@@ -68,6 +68,19 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Overrides the [inherited function]{@link module:alfresco/forms/controls/BaseFormControl#getInitialOptions}
+       * to intentionally do nothing as the [ServiceStore]{@link module:alfresco/forms/controls/utilities/ServiceStore}
+       * will retrieve the initial options.
+       * 
+       * @instance
+       * @param {object} config The options configuration
+       * @since 1.0.96
+       */
+      getInitialOptions: function alfresco_forms_controls_utilities_UseServiceStoreMixin__getInitialOptions(config) {
+         // Do nothing intentionally. Do not call the inherited function.
+      },
+
+      /**
        * In vanilla Dojo, when you open either a ComboBox or FilteringSelect you will
        * get all options, not those filtered on the current form control value. This
        * function can be called to override the default _startSearchAll function

--- a/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/ContainerPickerTest.js
@@ -22,9 +22,8 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!expect",
         "intern/chai!assert"],
-        function(module, defineSuite, expect, assert) {
+        function(module, defineSuite, assert) {
 
    defineSuite(module, {
       name: "ContainerPicker Tests",
@@ -33,30 +32,19 @@ define(["module",
       "Test picker dialog can be displayed": function() {
          return this.remote.findByCssSelector("#FOLDER_PICKER .alfresco-layout-VerticalWidgets > span > span > span")
             .click()
-            .end()
-            .findByCssSelector(".alfresco-pickers-Picker")
-            .then(
-               function() {},
-               function() {
-                  assert(false, "The dialog has NOT opened with the picker");
-               }
-            );
+         .end()
+       
+         .findDisplayedByCssSelector(".alfresco-pickers-Picker");
       },
 
       "Test Recent Sites sub-picker is shown": function() {
          // Select "Recent Sites" (the results for this are mocked)
-         return this.remote.findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:first-child .dijitMenuItem:nth-child(1)")
-            .click()
-            .end()
-            .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
-            .then(function(elements) {
-               assert.lengthOf(elements, 2, "The Recent Sites sub-picker was not shown");
-            });
+         return this.remote.findDisplayedByCssSelector(".alfresco-pickers-SingleItemPicker");
       },
 
       "Test Recent Sites result count": function() {
          // Count the mocked results...
-         return this.remote.findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(2) .alfresco-menus-AlfMenuBar .dijitMenuItem")
+         return this.remote.findAllByCssSelector(".alfresco-pickers-SingleItemPicker .alfresco-menus-_AlfMenuItemMixin")
             .then(function(elements) {
                assert.lengthOf(elements, 2, "Unexpected number of Recent Sites shown");
             });
@@ -66,8 +54,9 @@ define(["module",
          // Count the mocked results...
          return this.remote.findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(2) .alfresco-menus-AlfMenuBar .dijitMenuItem:first-child")
             .click()
-            .end()
-            .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
+         .end()
+         
+         .findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div")
             .then(function(elements) {
                assert.lengthOf(elements, 3, "The tree sub-picker was not shown");
             });
@@ -75,11 +64,13 @@ define(["module",
 
       "Test selecting a container": function() {
          // Using implicit wait of findAll... here...
-         return this.remote.findAllByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(3) .dijitTreeNodeContainer .dijitTreeRow .dijitTreeLabel").end()
-            .findByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(3) .dijitTreeNodeContainer .dijitTreeRow .dijitTreeLabel")
+         return this.remote.getLastPublish("ALF_RESIZE_SIDEBAR").findDisplayedByCssSelector(".alfresco-pickers-Picker .sub-pickers > div:nth-child(3) .dijitTreeNodeContainer .dijitTreeRow .dijitTreeLabel")
             .click()
-            .end()
-            .findAllByCssSelector(".alfresco-pickers-Picker .picked-items tr")
+         .end()
+
+         
+         
+         .findAllByCssSelector(".alfresco-pickers-Picker .picked-items tr")
             .then(function(elements) {
                assert.lengthOf(elements, 1, "The container was not picked");
             });

--- a/aikau/src/test/resources/alfresco/forms/controls/SelectedListItemsTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SelectedListItemsTest.js
@@ -67,7 +67,7 @@ define(["module",
       "Publish initial form value": function() {
          return this.remote.findByCssSelector(selectors.form.confirmationButton)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("FORMSAVE")
             .then(function(payload) {
@@ -78,16 +78,21 @@ define(["module",
       "Check fifth and post form": function() {
          return this.remote.findByCssSelector(selectors.selectors.fifth.element)
             .click()
-            .end()
+         .end()
 
          .findByCssSelector(selectors.selectors.fifth.checked)
-            .end()
+         .end()
 
          .clearLog()
 
+         .getLastPublish("FORMALF_FORM_VALIDITY")
+            .then(function(payload) {
+               assert.propertyVal(payload, "valid", true);
+            })
+
          .findByCssSelector(selectors.form.confirmationButton)
             .click()
-            .end()
+         .end()
 
          .getLastPublish("FORMSAVE")
             .then(function(payload) {

--- a/aikau/src/test/resources/alfresco/forms/controls/SitePickerTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/SitePickerTest.js
@@ -33,33 +33,36 @@ define(["module",
       "Can choose single site": function() {
          return this.remote.findByCssSelector("#SITE_PICKER .alfresco-forms-controls-Picker__add-button .dijitButtonNode")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector(".dijitMenuItem[aria-label^=\"Recent Sites\"]")
+         .findDisplayedByCssSelector(".dijitMenuItem[aria-label^=\"Recent Sites\"]")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
-         .findByCssSelector(".alfresco-lists-AlfList tr:nth-child(2) .alfresco-renderers-PublishAction")
-            .click()
-            .end()
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
-         .findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) .alfresco-renderers-PublishAction")
+         .findDisplayedByCssSelector(".alfresco-lists-AlfList tr:nth-child(2) .alfresco-renderers-PublishAction")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonNode")
+         .findDisplayedByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) .alfresco-renderers-PublishAction")
             .click()
-            .end()
+         .end()
+
+         .findDisplayedByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonNode")
+            .click()
+         .end()
 
          .getLastPublish("ALF_ITEMS_SELECTED") // Helps ensure dialog has closed
-            .end()
+         .end()
 
-         .findByCssSelector("#SITE_PICKER_FORM .buttons .confirmationButton .dijitButtonNode")
+         .findDisplayedByCssSelector("#SITE_PICKER_FORM .buttons .confirmationButton .dijitButtonNode")
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SITE_PICKED")
             .then(function(payload) {
@@ -72,33 +75,36 @@ define(["module",
       "Can choose multiple sites": function() {
          return this.remote.findByCssSelector("#SITES_PICKER .alfresco-forms-controls-Picker__add-button .dijitButtonNode")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector(".dijitMenuItem[aria-label^=\"Favorite Sites\"]")
+         .findDisplayedByCssSelector(".dijitMenuItem[aria-label^=\"Favorite Sites\"]")
             .clearLog()
             .click()
-            .end()
+         .end()
 
          .getLastPublish("ALF_DOCLIST_REQUEST_FINISHED")
 
-         .findByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) .alfresco-renderers-PublishAction")
-            .click()
-            .end()
+         .waitForDeletedByCssSelector(".alfresco-lists-AlfList--loading")
+         .end()
 
-         .findByCssSelector(".alfresco-lists-AlfList tr:nth-child(2) .alfresco-renderers-PublishAction")
+         .findDisplayedByCssSelector(".alfresco-lists-AlfList tr:nth-child(1) .alfresco-renderers-PublishAction")
             .click()
-            .end()
+         .end()
 
-         .findByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonNode")
+         .findDisplayedByCssSelector(".alfresco-lists-AlfList tr:nth-child(2) .alfresco-renderers-PublishAction")
             .click()
-            .end()
+         .end()
+
+         .findDisplayedByCssSelector(".footer .alfresco-buttons-AlfButton:nth-child(1) .dijitButtonNode")
+            .click()
+         .end()
 
          .getLastPublish("ALF_ITEMS_SELECTED") // Helps ensure dialog has closed
-            .end()
+         .end()
 
-         .findByCssSelector("#SITES_PICKER_FORM .buttons .confirmationButton .dijitButtonNode")
+         .findDisplayedByCssSelector("#SITES_PICKER_FORM .buttons .confirmationButton .dijitButtonNode")
             .click()
-            .end()
+         .end()
 
          .getLastPublish("SITES_PICKED")
             .then(function(payload) {

--- a/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
+++ b/aikau/src/test/resources/alfresco/lists/FilteredListTest.js
@@ -34,6 +34,13 @@ define(["module",
       name: "FilteredList Tests",
       testPage: "/FilteredList",
 
+      "Only one XHR request should be made for each control": function() {
+         return this.remote.getXhrEntries({ method: "GET" })
+            .then(function(entries) {
+               assert.lengthOf(entries, 3);
+            });
+      },
+
       "Check that results are loaded initially": function() {
          return this.remote.findAllByCssSelector("#SEPARATE .alfresco-lists-views-layouts-Row")
             .then(function(elements) {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ContainerPicker.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/ContainerPicker.get.js
@@ -27,7 +27,7 @@ model.jsonModel = {
          name: "aikauTesting/mockservices/ContainerListPickerMockXhr"
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1128 (and part of #1295) to ensure that only a single XHR request for options is made for FilteringSelect (and other form controls that use the ServiceStore module). A unit test has been added to verify the improvement (along with some tweaks to other tests to improve reliability)