### PR TITLE
AKU-1129: Added config for showing all options in FilteringSelect

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/ComboBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/ComboBox.js
@@ -82,7 +82,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.96
        */
-      showAllOptionsOnOpen: true,
+      showAllOptionsOnOpen: false,
 
       /**
        * @instance
@@ -116,7 +116,7 @@ define(["dojo/_base/declare",
             autoComplete: this.autoComplete
          });
          this.addIcon(comboBox);
-         this.showAllOptionsOnOpen && this.showOptionsBasedOnValue(comboBox);
+         !this.showAllOptionsOnOpen && this.showOptionsBasedOnValue(comboBox);
          return comboBox;
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/ComboBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/ComboBox.js
@@ -73,6 +73,18 @@ define(["dojo/_base/declare",
       placeHolder: null,
 
       /**
+       * Indicates whether opening the drop-down menu should show all available options
+       * or just those that match the current value of the control. Defaults to true
+       * (meaning that only filtered results are displayed).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.96
+       */
+      showAllOptionsOnOpen: true,
+
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_ComboBox__getWidgetConfig() {
@@ -104,7 +116,7 @@ define(["dojo/_base/declare",
             autoComplete: this.autoComplete
          });
          this.addIcon(comboBox);
-         this.showOptionsBasedOnValue(comboBox);
+         this.showAllOptionsOnOpen && this.showOptionsBasedOnValue(comboBox);
          return comboBox;
       },
 

--- a/aikau/src/main/resources/alfresco/forms/controls/FilteringSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilteringSelect.js
@@ -49,6 +49,18 @@ define(["alfresco/forms/controls/BaseFormControl",
                         {cssFile:"./css/ComboBox.css"}],
 
       /**
+       * Indicates whether opening the drop-down menu should show all available options
+       * or just those that match the current value of the control. Defaults to true
+       * (meaning that only filtered results are displayed).
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.96
+       */
+      showAllOptionsOnOpen: true,
+
+      /**
        * @instance
        */
       getWidgetConfig: function alfresco_forms_controls_FilteringSelect__getWidgetConfig() {
@@ -77,7 +89,7 @@ define(["alfresco/forms/controls/BaseFormControl",
             queryExpr: "${0}"
          });
          this.addIcon(filteringSelect);
-         this.showOptionsBasedOnValue(filteringSelect);
+         this.showAllOptionsOnOpen && this.showOptionsBasedOnValue(filteringSelect);
 
          // It's necessary to override the standard Dojo validation message handling here.
          filteringSelect.displayMessage = lang.hitch(this, this.onFilteringValidation);

--- a/aikau/src/main/resources/alfresco/forms/controls/FilteringSelect.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/FilteringSelect.js
@@ -58,7 +58,7 @@ define(["alfresco/forms/controls/BaseFormControl",
        * @default
        * @since 1.0.96
        */
-      showAllOptionsOnOpen: true,
+      showAllOptionsOnOpen: false,
 
       /**
        * @instance
@@ -89,7 +89,7 @@ define(["alfresco/forms/controls/BaseFormControl",
             queryExpr: "${0}"
          });
          this.addIcon(filteringSelect);
-         this.showAllOptionsOnOpen && this.showOptionsBasedOnValue(filteringSelect);
+         !this.showAllOptionsOnOpen && this.showOptionsBasedOnValue(filteringSelect);
 
          // It's necessary to override the standard Dojo validation message handling here.
          filteringSelect.displayMessage = lang.hitch(this, this.onFilteringValidation);

--- a/aikau/src/test/resources/alfresco/forms/controls/FilteringSelectTest.js
+++ b/aikau/src/test/resources/alfresco/forms/controls/FilteringSelectTest.js
@@ -39,18 +39,46 @@ define(["module",
       },
 
       "Value assigned to control is selected": function() {
-         this.remote.findByCssSelector("#FILTERING_SELECT_1_CONTROL")
-            .getVisibleText()
+         return this.remote.findByCssSelector("#FILTERING_SELECT_1_CONTROL")
+            .getProperty("value")
             .then(function(text) {
                assert.equal(text, "abeecher");
             });
       },
 
       "Value assigned to form is selected": function() {
-         this.remote.findByCssSelector("#FILTERING_SELECT_2_CONTROL")
-            .getVisibleText()
+         return this.remote.findByCssSelector("#FILTERING_SELECT_2_CONTROL")
+            .getProperty("value")
             .then(function(text) {
                assert.equal(text, "abeecher");
+            });
+      },
+
+      "Only value matched options are shown": function() {
+         return this.remote.findByCssSelector("#widget_FILTERING_SELECT_1_CONTROL .dijitArrowButton")
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector("#FILTERING_SELECT_1_CONTROL_popup")
+         .end()
+
+         .findAllByCssSelector("#FILTERING_SELECT_1_CONTROL_popup .dijitMenuItem")
+            .then(function(elements) {
+               assert.lengthOf(elements, 3); // NOTE including previous and next items!
+            });
+      },
+
+      "All options are shown": function() {
+         return this.remote.findByCssSelector("#widget_FILTERING_SELECT_2_CONTROL .dijitArrowButton")
+            .click()
+         .end()
+
+         .findDisplayedByCssSelector("#FILTERING_SELECT_2_CONTROL_popup")
+         .end()
+
+         .findAllByCssSelector("#FILTERING_SELECT_2_CONTROL_popup .dijitMenuItem")
+            .then(function(elements) {
+               assert.lengthOf(elements, 8); // NOTE including previous and next items!
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
@@ -18,6 +18,7 @@ model.jsonModel = {
       {
          name: "alfresco/forms/Form",
          config: {
+            pubSubScope: "FORM_",
             okButtonPublishTopic: "SAVE_FORM",
             okButtonLabel: "Save",
             value: {
@@ -54,6 +55,7 @@ model.jsonModel = {
                      fieldId: "FILTERING_SELECT_2",
                      name: "person2",
                      label: "Select a person (FilteringSelect form value)",
+                     showAllOptionsOnOpen: false,
                      optionsConfig: {
                         queryAttribute: "label",
                         labelAttribute: "label",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/forms/controls/FilteringSelect.get.js
@@ -55,7 +55,7 @@ model.jsonModel = {
                      fieldId: "FILTERING_SELECT_2",
                      name: "person2",
                      label: "Select a person (FilteringSelect form value)",
-                     showAllOptionsOnOpen: false,
+                     showAllOptionsOnOpen: true,
                      optionsConfig: {
                         queryAttribute: "label",
                         labelAttribute: "label",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1129 and #1295 to provide a new configuration option that makes it possible for FilteringSelect and ComboBox widgets to support the ability to show all available options when their drop-down menus are revealed by clicking on the open icon (rather than through typing). The default behaviour is retained for backwards compatibility, but the `showAllOptionsOnOpen` can be configured to be true to support showing all options.