### PR TITLE
AKU-1108: Ensure SiteService favourites created sites

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -1027,11 +1027,6 @@ define(["dojo/_base/declare",
             site: originalRequestConfig.data.shortName,
             user: AlfConstants.USERNAME
          });
-
-         this.alfServicePublish(topics.SITE_CREATION_SUCCESS);
-         this.alfServicePublish(topics.NAVIGATE_TO_PAGE, {
-            url: "site/" + originalRequestConfig.data.shortName + "/dashboard"
-         });
       },
 
       /**


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1108 to fix the problem of the SiteService not favouriting sites that it had created (this was only showing on Firefox on Windows). The problem was because I'd foolishly failed to remove the old code in the previous fix!