### PR TITLE
AKU-1132: Fix blur issue on form dialog validation

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/utilities/TextBoxValueChangeMixin.js
@@ -104,7 +104,7 @@ define(["alfresco/core/topics",
        * @since 1.0.49
        */
       fireChangeEvent: function alfresco_forms_controls_utilities_TextBoxValueChangeMixin__fireChangeEvent(name, oldValue, newValue) {
-         if (oldValue !== newValue) {
+         if (oldValue !== newValue && newValue !== this.__oldValue) {
             this.onValueChangeEvent(name, oldValue, newValue);
          }
       },

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -172,8 +172,6 @@ define(["module",
 
          .findById("EDIT_SITE_DIALOG_OK_label")
             .click()
-            .click() // For some reason in automated testing a second click is required here
-                     // Adding a long pause and a manual click and it works fine...
          .end()
 
          .findByCssSelector("#EDIT_SITE_DIALOG.dialogHidden")


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1132 to ensure that the create and edit site dialogs can be submitted via the "OK" button without having lost focus on the fields. Unit tests updated