### PR TITLE
AKU-1133: Improve initial rendering of create site dialog

### DIFF
--- a/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
+++ b/aikau/src/main/resources/alfresco/dialogs/AlfDialog.js
@@ -510,8 +510,6 @@ define(["dojo/_base/declare",
 
          this.alfPublishResizeEvent(this.domNode);
          domClass.remove(this.domNode, "dialogHidden");
-         domClass.add(this.domNode, "dialogDisplayed");
-         // TODO: We could optionally reveal the dialog after resizing to prevent any resizing jumping?
          
          // Publish the widgets ready
          this.alfPublish(topics.PAGE_WIDGETS_READY, {}, true);
@@ -536,6 +534,8 @@ define(["dojo/_base/declare",
                });
             }));
          }
+
+         domClass.add(this.domNode, "dialogDisplayed");
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
+++ b/aikau/src/main/resources/alfresco/dialogs/css/AlfDialog.css
@@ -5,6 +5,8 @@
 
 .alfresco-dialog-AlfDialog {
    &.dijitDialog {
+      opacity: 0;
+
       border: @standard-border;
       border-radius: 4px 4px 4px 4px;
       box-shadow: 0 3px 8px rgba(0,0,0,.1);
@@ -41,6 +43,9 @@
          border: @standard-border;
          font-weight: normal;
       }
+   }
+   &.dialogDisplayed {
+      opacity: 1;
    }
    &--no-min-width {
       &.dijitDialog {

--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -65,6 +65,33 @@ define(["dojo/_base/declare",
       additionalSitePresets: null,
 
       /**
+       * In order to get a smoother initial rendering of the create site dialog a fixed height
+       * is configured. However when customizing the contents of the create site dialog it may
+       * be advisable to set an alternative height (or configure to be null and allow natural
+       * sizing to occur).
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.99
+       */
+      createSiteDialogHeight: "500px",
+
+      /**
+       * In order to get a smoother initial rendering of the create site dialog a fixed width
+       * is configured. However when customizing the contents of the create site dialog it may
+       * be advisable to set an alternative width (or configure to be null and allow natural
+       * sizing to occur).
+       * 
+       * @instance
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.99
+       */
+      createSiteDialogWidth: "670px",
+
+      /**
        * This is an optional topic that can be configured to allow the create site dialog to have a value
        * set on it. This can be useful when needing to pre-fill fields based changing data within the form
        * (for example a custom preset). The use case is when a custom field needs to make an XHR request
@@ -980,7 +1007,8 @@ define(["dojo/_base/declare",
                dialogTitle: "create-site.dialog.title",
                dialogConfirmationButtonTitle: "create-site-dialog.name.create.label",
                dialogCloseTopic: topics.SITE_CREATION_SUCCESS,
-               contentHeight: "500px",
+               contentHeight: this.createSiteDialogHeight,
+               contentWidth: this.createSiteDialogWidth,
                formSubmissionTopic: topics.SITE_CREATION_REQUEST,
                formSubmissionGlobal: true,
                showValidationErrorsImmediately: false,


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1133 to try to improve the initial rendering of the Create Site dialog (provided by the SiteService). There was previously some "jumping" as the dialog resized once displayed. To mitigate this problem a fixed width has been provided (the width and height have also been made configurable on the service) and the opacity of the dialog is set to 0 until it has been given focus. This allows for initial resizing to occur unseen by the user.