### PR TITLE
AKU-1135: Search term highlighting configuration options

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -245,6 +245,16 @@ define(["dojo/_base/declare",
       renderSize: "medium",
 
       /**
+       * Indicates whether or not string values should be trimmed.
+       *
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.99
+       */
+      trimValue: false,
+
+      /**
        * Indicates whether or not a message should be displayed in place of the 
        * [propertyToRender]{@link module:alfresco/renderers/Property#propertyToRender} when it is not available.
        * This defaults to false but if configured to be true then the 
@@ -558,6 +568,11 @@ define(["dojo/_base/declare",
          else if (value && this.highlightPrefix && this.highlightPostfix)
          {
             value = value.replace(new RegExp(this.highlightPrefix, "g"), "<mark>").replace(new RegExp(this.highlightPostfix, "g"), "</mark>");
+         }
+
+         if (value && this.trimValue && typeof value.trim === "function")
+         {
+            value = value.trim();
          }
 
          return value;

--- a/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
+++ b/aikau/src/main/resources/alfresco/search/AlfSearchResult.js
@@ -374,7 +374,8 @@ define(["dojo/_base/declare",
                   renderedValueSuffix: "...\"",
                   highlightValue: this.highlightValue,
                   highlightPrefix: this.showSearchTermHighlights ? this.highlightPrefix : null,
-                  highlightPostfix: this.showSearchTermHighlights ? this.highlightPostfix : null
+                  highlightPostfix: this.showSearchTermHighlights ? this.highlightPostfix : null,
+                  trimValue: true
                }, this.contentNode);
             }
          }

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -78,7 +78,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.99
        */
-      highlightFragmentSize: 100,
+      highlightFragmentSize: 255,
 
       /**
        * The number of characters to search into the content for the search term.
@@ -98,7 +98,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.99
        */
-      highlightSnippetCount: 255,
+      highlightSnippetCount: 250,
       
       /**
        * Whether to use SpanScorer to highlight phrase terms only when they appear within the query phrase in 

--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -61,6 +61,68 @@ define(["dojo/_base/declare",
       autoSuggestAPI: AlfConstants.PROXY_URI + "slingshot/auto-suggest",
 
       /**
+       * A comma-delimited string of the properties to apply search term highlighting to.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.99
+       */
+      highlightFields: "cm:name,cm:description,cm:title,content,ia:descriptionEvent,ia:whatEvent,lnk:title",
+      
+      /**
+       * The number of characters to include in a highlight fragment of the content
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.99
+       */
+      highlightFragmentSize: 100,
+
+      /**
+       * The number of characters to search into the content for the search term.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.99
+       */
+      highlightMaxAnalyzedChars: 1000,
+
+      /**
+       * The number of characters to include in a highlight snippet.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.99
+       */
+      highlightSnippetCount: 255,
+      
+      /**
+       * Whether to use SpanScorer to highlight phrase terms only when they appear within the query phrase in 
+       * the document.
+       * 
+       * @instance
+       * @type {number}
+       * @default
+       * @since 1.0.99
+       */
+      highlightUsePhraseHighlighter: true,
+
+      /**
+       * Collapse contiguous fragments into a single fragment. If the value is true it indicates that contiguous 
+       * fragments will be collapsed into single fragment.
+       * 
+       * @instance
+       * @type {boolean}
+       * @default
+       * @since 1.0.99
+       */
+      highlightMergeContiguous: false,
+
+      /**
        * This is the default number of items to return as a single page of result data. This value will be used if
        * a specific value isn't supplied in a search request.
        *
@@ -250,9 +312,12 @@ define(["dojo/_base/declare",
                spellcheck: payload.spellcheck || false,
                highlightPrefix: "\u0000",
                highlightPostfix: "\u0003",
-               highlightFields: "cm:name,cm:description,cm:title,content,ia:descriptionEvent,ia:whatEvent,lnk:title",
-               highlightSnippetCount: 30,
-               highlightMergeContiguous: false
+               highlightFields: this.highlightFields,
+               highlightFragmentSize: this.highlightFragmentSize,
+               highlightSnippetCount: this.highlightSnippetCount,
+               highlightMergeContiguous: this.highlightMergeContiguous,
+               highlightMaxAnalyzedChars: this.highlightMaxAnalyzedChars,
+               highlightUsePhraseHighlighter: this.highlightUsePhraseHighlighter
             };
             var config = {
                requestId: payload.requestId,


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1135 to provide better options for configuring the search term highlighting through the SiteService. This means that it will be easy to tweak the settings via an extension module applied to the faceted search page in Share. The Property renderer and AlfSearchResult have also been tweaked to support trimming of whitespace.