### PR TITLE
AKU-1136: MoreInfo styling improvements

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
+++ b/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
@@ -232,7 +232,8 @@ define(["dojo/_base/declare",
          this.moreInfoDialog = new Popup({
             title: title,
             currentItem: this.currentItem,
-            widgetsContent: widgetsContent
+            widgetsContent: widgetsContent,
+            handleOverflow: false
          });
          this.moreInfoDialog.show();
       },

--- a/aikau/src/main/resources/alfresco/renderers/css/MoreInfo.css
+++ b/aikau/src/main/resources/alfresco/renderers/css/MoreInfo.css
@@ -3,13 +3,13 @@
    width: 16px;
    height: 16px;
    display: inline-block;
+   cursor: pointer;
 }
 
 .alfresco-renderers-MoreInfo.darkIcon {
    background-image: url(./images/info-16.png);
 }
 
-.alfresco-dialog-AlfDialog .alfresco-renderers-Thumbnail img {
-   max-width: 330px;
-   max-height: 240px;
+.alfresco-lists-views-layouts-Row:focus {
+   outline: none;
 }


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1136 to make some improvements to the MoreInfo widget. The cursor has been corrected as have the size of the the thumbnails (to take into account the unknown image size) and scrollbars are hidden.