### PR TITLE
Move LESS variable to correct location

### DIFF
--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -32,6 +32,8 @@
 @sub-header-stripe-background-color: @alternate-background-color;
 @sub-header-stripe-font-color: @alternate-font-color;
 
+@shareTitleBG: blue;
+
 // General palette
 @primary-title-color: #fff;
 @primary-theme-color: #eee;

--- a/aikau/src/main/resources/alfresco/css/less/defaults.less
+++ b/aikau/src/main/resources/alfresco/css/less/defaults.less
@@ -32,7 +32,8 @@
 @sub-header-stripe-background-color: @alternate-background-color;
 @sub-header-stripe-font-color: @alternate-font-color;
 
-@shareTitleBG: blue;
+// This is the colour of the title bar in Share
+@shareTitleBG: #fafafa;
 
 // General palette
 @primary-title-color: #fff;

--- a/aikau/src/main/resources/alfresco/header/css/Title.css
+++ b/aikau/src/main/resources/alfresco/header/css/Title.css
@@ -1,5 +1,3 @@
-@shareTitleBG: #fafafa;
-
 .@{alfresco} {
    h1.alfresco-header-Title {
       font-size: 185%;


### PR DESCRIPTION
This PR moves the LESS default for the Share header title to the defaults.less file where it should have been all along. 