### PR TITLE
AKU-1137: Ensure MaskingTextBox validation error displays on value

### DIFF
--- a/aikau/src/main/resources/alfresco/forms/controls/MaskingTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/MaskingTextBox.js
@@ -214,6 +214,11 @@ define(["dojo/_base/declare",
                }
             });
             this.setValue(maskedValue);
+
+            if (payload.value)
+            {
+               this._hadFocus = true;
+            }
          }
       }
    });

--- a/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
+++ b/aikau/src/test/resources/alfresco/services/SiteServiceTest.js
@@ -96,6 +96,16 @@ define(["module",
             });
       },
 
+      // See AKU-1137 - site short name should also show as invalid...
+      "Create site (shortName error shows even before focus)": function() {
+         return this.remote.findByCssSelector(selectors.textBoxes.createSiteTitle.input)
+            .clearValue()
+            .type("used")
+         .end()
+
+         .findDisplayedByCssSelector("#CREATE_SITE_FIELD_SHORTNAME .alfresco-forms-controls-BaseFormControl__validation-error");
+      },
+
       "Create Site (edit shortName stops auto updating)": function() {
          return this.remote.findByCssSelector(selectors.textBoxes.createSiteShortName.input)
             .clearValue()


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1137 to ensure that the MaskingTextBox used for the site shortName value in the Create Site dialog has it's validation error shown appropriately when it has a value derived from the site title field **before** the user has focused on it. The validation is only displayed when an actual value (i.e. not the empty string) is set. The unit tests have been updated.