### PR TITLE
AKU-1135: Improved Property trim

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -572,7 +572,7 @@ define(["dojo/_base/declare",
 
          if (value && this.trimValue && typeof value.trim === "function")
          {
-            value = value.trim();
+            value = value.replace(/&nbsp;/g, " ").trim();
          }
 
          return value;


### PR DESCRIPTION
This PR is an update to the previous changes made for https://issues.alfresco.com/jira/browse/AKU-1135 (see #1316). This additional change swaps the "\&nbsp;" character for a normal whitespace to enable normal trimming to work.