### PR TITLE
Demonstrate overhead of multiple widget config properties

### DIFF
--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
@@ -10,22 +10,33 @@ for (var j=0; j < 100; j++)
    items.push(item);
 }
 
-var rowModel = [];
+var rowModel = [], cellModel, propertyModel;
 for (var i=0; i<50; i++)
 {
-   rowModel.push({
+   propertyModel = {
+      name: "alfresco/renderers/Property",
+      config: {
+         propertyToRender: "p" + i
+      }
+   };
+   cellModel = {
       name: "alfresco/lists/views/layouts/Cell",
       config: {
          widgets: [
-            {
-               name: "alfresco/renderers/Property",
-               config: {
-                  propertyToRender: "p" + i
-               }
-            }
+            propertyModel
          ]
       }
-   });
+   };
+   
+   // simulate a somewhat high number of config properties
+   // non-functional so should only highlight performance issues in config handling
+   for (var j=0; j<50; j++)
+   {
+       propertyModel.config['configKey_' + j] = 'configValue_' + j;
+       cellModel.config['configKey_' + j] = 'configValue_' + j;
+   }
+   
+   rowModel.push(cellModel);
 }
 
 model.jsonModel = {


### PR DESCRIPTION
This PR extends the performance test to showcase scaling issues with more complex widget configurations. All the properties being set are non-functional for the widget but current handling (most prominently the inherited _applyAttributes from Dojo/Diji _WidgetBase) adds significant overhead.