### PR TITLE
Avoid _applyAttributes overhead by "hiding" complex Aikau widget configuration

### DIFF
--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -93,6 +93,21 @@ define(["dojo/_base/declare",
             this.domNode.classList.add("alfresco-lists-views-layouts-Cell");
          }
       },
+      
+      /**
+       * @instance
+       * @since 1.0.NEXT
+       */
+      postMixInProperties : function alfresco_lists_views_layouts_Cell__postMixInProperties() {
+          // this widget (as all Aikau widgets) can be configured with countless config attributes
+          // _applyAttributes causes significant overhead since it processes all "as if" they can be mapped to DOM
+          // most Aikau widgets would probably do good to prevent that
+          // those that extend Dojo/Dijit widgets may want to provide a reduced set
+          var paramsOriginal = this.params;
+          this.params = null;
+          
+          this.inherited(arguments);
+      },
 
       /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
@@ -100,6 +115,10 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_lists_views_layouts_Cell__postCreate() {
+         // restore params for anyone that needs it later
+         this.params = this._paramsOriginal;
+         delete this._paramsOriginal;
+          
          if (this.colspan)
          {
             domAttr.set(this.domNode, "colspan", this.colspan);

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -125,6 +125,21 @@ define(["dojo/_base/declare",
             this._attach(this.domNode, "onclick", lang.hitch(this, this.onFocusClick));
          }
       },
+      
+      /**
+       * @instance
+       * @since 1.0.NEXT
+       */
+      postMixInProperties : function alfresco_lists_views_layouts_Row__postMixInProperties() {
+          // this widget (as all Aikau widgets) can be configured with countless config attributes
+          // _applyAttributes causes significant overhead since it processes all "as if" they can be mapped to DOM
+          // most Aikau widgets would probably do good to prevent that
+          // those that extend Dojo/Dijit widgets may want to provide a reduced set
+          this._paramsOriginal = this.params;
+          this.params = null;
+          
+          this.inherited(arguments);
+      },
 
       /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
@@ -132,6 +147,10 @@ define(["dojo/_base/declare",
        * @instance postCreate
        */
       postCreate: function alfresco_lists_views_layouts_Row__postCreate() {
+         // restore params for anyone that needs it later
+         this.params = this._paramsOriginal;
+         delete this._paramsOriginal;
+          
          domClass.add(this.domNode, this.additionalCssClasses ? this.additionalCssClasses : "");
          if (this.widgets)
          {

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -329,7 +329,7 @@ define(["dojo/_base/declare",
             this.domNode.appendChild(innerSpan);
          }
       },
-
+      
       /**
        * Updates CSS classes based on the current state of the renderer. Currently this only
        * addressed warning message states.
@@ -423,6 +423,13 @@ define(["dojo/_base/declare",
        * @instance
        */
       postMixInProperties: function alfresco_renderers_Property__postMixInProperties() {
+         // this widget (as all Aikau widgets) can be configured with countless config attributes
+         // _applyAttributes causes significant overhead since it processes all "as if" they can be mapped to DOM
+         // most Aikau widgets would probably do good to prevent that
+         // those that extend Dojo/Dijit widgets may want to provide a reduced set
+         this._paramsOriginal = this.params;
+         this.params = null;
+          
          if (this.label) 
          {
             this.label = this.message(this.label) + ": ";
@@ -481,6 +488,10 @@ define(["dojo/_base/declare",
        * @instance
        */
       postCreate: function alfresco_renderers_Property__postCreate() {
+         // restore params for anyone that needs it later
+         this.params = this._paramsOriginal;
+         delete this._paramsOriginal;
+          
          this.updateCssClasses();
          if (this.maxWidth) 
          {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
@@ -10,22 +10,33 @@ for (var j=0; j < 100; j++)
    items.push(item);
 }
 
-var rowModel = [];
+var rowModel = [], cellModel, propertyModel;
 for (var i=0; i<50; i++)
 {
-   rowModel.push({
+   propertyModel = {
+      name: "alfresco/renderers/Property",
+      config: {
+         propertyToRender: "p" + i
+      }
+   };
+   cellModel = {
       name: "alfresco/lists/views/layouts/Cell",
       config: {
          widgets: [
-            {
-               name: "alfresco/renderers/Property",
-               config: {
-                  propertyToRender: "p" + i
-               }
-            }
+            propertyModel
          ]
       }
-   });
+   };
+   
+   // simulate a somewhat high number of config properties
+   // non-functional so should only highlight performance issues in config handling
+   for (var j=0; j<50; j++)
+   {
+       propertyModel.config['configKey_' + j] = 'configValue_' + j;
+       cellModel.config['configKey_' + j] = 'configValue_' + j;
+   }
+   
+   rowModel.push(cellModel);
 }
 
 model.jsonModel = {


### PR DESCRIPTION
Aikau widget configurations can contain an arbitrary number of configuration attributes. The way these are handled currently includes them in the "param" object which _applyAttributes in Dijit _WidgetBase processes. This is meant to apply any attributes that can be mapped to DOM or a widget-internal setXY operation, which does not apply for 99+% of Aikau attributes. All the lookup / looping over Aikau properties can introduce significant overhead for non-trivial widgets.

This PR adds extra handling to postMixInProperties and postCreate of Row, Cell and Property modules to avoid such overhead. For some reason it was not possible to simply override _applyAttributes to achieve the same.
It is not ideal that this is added in the "leaf" widget modules but unfortunately Aikau does not really use a common "base widget" module at this time. Also some widget modules like AlfMenuItem that extend non-trivial Dijit widgets may need to expose a sub-set of the configuration properties to _applyAttributes. Ideally either a new common "base widget" module or ChildProcessing could add logic to handle this without each widget having to do it itself or remember to include some mixin.

This PR is based on #1322 to be able to observe before/after performance measurements.