### PR TITLE
AKU-1141: Moved search thumbnail tooltip fix to appropriate mixin module

### DIFF
--- a/aikau/src/main/resources/alfresco/search/SearchThumbnail.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnail.js
@@ -45,28 +45,6 @@ define(["dojo/_base/declare",
       hasShadow: true,
 
       /**
-       * The prefix string that indicates the start of text to highlight.
-       * 
-       * @instance
-       * @type {string}
-       * @default
-       * @since 1.0.95
-       */
-      highlightPrefix: "\u0000",
-
-      /**
-       * This is the property within the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#highlightProperty}
-       * that should be used to identify the content with in the 
-       * [renderedValue]{@link module:alfresco/renderers/Property#renderedValue} to highlight.
-       * 
-       * @instance
-       * @type {string}
-       * @default 
-       * @since 1.0.95
-       */
-      highlightPostfix: "\u0003",
-
-      /**
        * Overrides the [inherited default]{@link module:alfresco/renderers/Thumbnail#horizontalAlignment} to
        * align the image to the right
        * 
@@ -84,21 +62,6 @@ define(["dojo/_base/declare",
        * @type {string}
        * @default
        */
-      lastThumbnailModificationProperty: "lastThumbnailModification",
-
-      /**
-       * Extends the [inherited function]{@link module:alfresco/renderers/Thumbnail#setImageTitle}
-       * to ensure that image titles have search term highlighting delineation removed.
-       *
-       * @instance
-       * @since 1.0.95
-       */
-      setImageTitle: function alfresco_search_SearchThumbnail__setImageTitle() {
-         this.inherited(arguments);
-         if (this.imgTitle)
-         {
-            this.imgTitle = this.imgTitle.replace(new RegExp(this.highlightPrefix, "g"), "").replace(new RegExp(this.highlightPostfix, "g"), "");
-         }
-      }
+      lastThumbnailModificationProperty: "lastThumbnailModification"
    });
 });

--- a/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
+++ b/aikau/src/main/resources/alfresco/search/SearchThumbnailMixin.js
@@ -46,6 +46,28 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/SearchThumbnailMixin.properties"}],
 
       /**
+       * The prefix string that indicates the start of text to highlight.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.95
+       */
+      highlightPrefix: "\u0000",
+
+      /**
+       * This is the property within the [currentItem]{@link module:alfresco/core/CoreWidgetProcessing#highlightProperty}
+       * that should be used to identify the content with in the 
+       * [renderedValue]{@link module:alfresco/renderers/Property#renderedValue} to highlight.
+       * 
+       * @instance
+       * @type {string}
+       * @default 
+       * @since 1.0.95
+       */
+      highlightPostfix: "\u0003",
+
+      /**
        * Overrides the [inherited default configuration]{@link module:alfresco/node/DraggableNodeMixin#isDraggable}
        * to prevent search result thumbnails from being draggable.
        * 
@@ -161,6 +183,21 @@ define(["dojo/_base/declare",
             // the standard search result linking behaviour...
             this.publishPayload = this.getGeneratedPayload(false, null);
             this.alfPublish(this.publishTopic, this.publishPayload, publishGlobal, publishToParent);
+         }
+      },
+
+      /**
+       * Extends the [inherited function]{@link module:alfresco/renderers/Thumbnail#setImageTitle}
+       * to ensure that image titles have search term highlighting delineation removed.
+       *
+       * @instance
+       * @since 1.0.95
+       */
+      setImageTitle: function alfresco_search_SearchThumbnail__setImageTitle() {
+         this.inherited(arguments);
+         if (this.imgTitle)
+         {
+            this.imgTitle = this.imgTitle.replace(new RegExp(this.highlightPrefix, "g"), "").replace(new RegExp(this.highlightPostfix, "g"), "");
          }
       }
    });


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1141 to ensure that all search thumbnails will have properly encoded tooltips. The previous fix was moved to the appropriate mixin module.