### PR TITLE
AKU-1138: Improve PDF.js previewer height calculations for dialog

### DIFF
--- a/aikau/src/main/resources/alfresco/preview/PdfJs/PdfJs.js
+++ b/aikau/src/main/resources/alfresco/preview/PdfJs/PdfJs.js
@@ -597,7 +597,7 @@ define(["dojo/_base/declare",
          computedStyle = domStyle.getComputedStyle(this.controls);
          var controlRegion = domGeom.getContentBox(this.controls, computedStyle);
          var controlHeight = !this.fullscreen ? controlRegion.h : 0;
-         var newHeight = previewRegion.h - controlHeight -1; // Allow for bottom border
+         var newHeight = previewRegion.h - controlHeight - 6; // Allow for bottom border
          
          if (newHeight === 0)
          {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1138 to improve the height calculations for the PDF.js previewer in dialogs to ensure that horizontal scrollbars are not clipped at all.