### PR TITLE
AKU-1145, AKU-1147: Performance update pattern

### DIFF
--- a/aikau/src/main/resources/aikau/core/BaseWidget.js
+++ b/aikau/src/main/resources/aikau/core/BaseWidget.js
@@ -18,13 +18,18 @@
  */
 
 /**
- * Provides a base for all Aikau widgets to extend. It is not essential that a widget extends
+ * <p><b>This widget is in the "aikau" package and does not adhere to the backwards compatibility standards
+ * of the "alfresco" package. The code in this package is intended to form the basis of the next major release
+ * of Aikau and will remain in an unstable state until ready for release. Please evaluate and feedback on this
+ * module but do not rely on it in production!</b></p>
+ * 
+ * <p>Provides a base for all Aikau widgets to extend. It is not essential that a widget extends
  * this module but it can provide significant performance benefits if hundreds or thousands
  * of instances of the widget need to be rendered at a time. Any widget that does extend this
- * base must either define a [templateString]{@link module:alfresco/core/BaseWidget#templateString}
- * or override [createWidgetDom]{@link module:alfresco/core/BaseWidget#createWidgetDom}.
+ * base must either define a [templateString]{@link module:aikau/core/BaseWidget#templateString}
+ * or override [createWidgetDom]{@link module:aikau/core/BaseWidget#createWidgetDom}.</p>
  * 
- * @module alfresco/core/BaseWidget
+ * @module aikau/core/BaseWidget
  * @extends external:dijit/_WidgetBase
  * @mixes external:dojo/_TemplatedMixin
  * @mixes module:alfresco/core/Core
@@ -43,7 +48,7 @@ define(["dojo/_base/declare",
        * The template that defines the DOM for the widget. If configured this will 
        * result in the capabilities of dijit/_TemplatedMixin being used to construct the 
        * DOM. Ideally this should be left as the default value of null and the 
-       * [createWidgetDom]{@link module:alfresco/core/BaseWidget#createWidgetDom} function
+       * [createWidgetDom]{@link module:aikau/core/BaseWidget#createWidgetDom} function
        * will be called - this function should be implemented to use the native capabilities
        * of the browser to build a DOM for the widget.
        * 
@@ -58,7 +63,7 @@ define(["dojo/_base/declare",
        * attributes from being applied. This changes the default widget behaviour in order
        * to gain performance improvements. Any parameters that do need to be applied can
        * be provided by overriding 
-       * [getParametersToApply]{@link module:alfresco/core/BaseWidget#getParametersToApply}.
+       * [getParametersToApply]{@link module:aikau/core/BaseWidget#getParametersToApply}.
        * 
        * @instance
        */
@@ -70,7 +75,7 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * This is called from [_applyAttributes]{@link module:alfresco/core/BaseWidget#_applyAttributes}
+       * This is called from [_applyAttributes]{@link module:aikau/core/BaseWidget#_applyAttributes}
        * to get an object of the parameters that should be applied to the widget. This should only
        * be implemented as necessary. The more parameters applied the worse the performance at scale.
        * 
@@ -93,8 +98,8 @@ define(["dojo/_base/declare",
       /**
        * Extends the function inherited from dijit/_WidgetBase to only make use of the template
        * rendering capabilities provided by dijit/_TemplatedMixin when a
-       * [templateString]{@link module:alfresco/core/BaseWidget#templateString} is provided. Otherwise
-       * the [createWidgetDom]{@link module:alfresco/core/BaseWidget#createWidgetDom} will be called
+       * [templateString]{@link module:aikau/core/BaseWidget#templateString} is provided. Otherwise
+       * the [createWidgetDom]{@link module:aikau/core/BaseWidget#createWidgetDom} will be called
        * to build the DOM for the widget.
        * 
        * @instance
@@ -114,8 +119,8 @@ define(["dojo/_base/declare",
        * This function can be overridden to create the DOM model for the widget. Ideally this 
        * should construct the DOM using the native capabilities of the browser (i.e. 
        * making calls to document.createElement, etc). This function is called from 
-       * [buildRendering]{@link module:alfresco/core/BaseWidget#buildRendering} when no
-       * [templateString]{@link module:alfresco/core/BaseWidget#templateString} is defined.
+       * [buildRendering]{@link module:aikau/core/BaseWidget#buildRendering} when no
+       * [templateString]{@link module:aikau/core/BaseWidget#templateString} is defined.
        * 
        * @instance
        * @overridable

--- a/aikau/src/main/resources/alfresco/core/BaseWidget.js
+++ b/aikau/src/main/resources/alfresco/core/BaseWidget.js
@@ -64,7 +64,7 @@ define(["dojo/_base/declare",
        */
       _applyAttributes: function alfresco_core_BaseWidget___applyAttributes() {
          var originalParams = this.params;
-         this.params = this.getParametersToApply();
+         this.params = this.getParametersToApply(originalParams);
          this.inherited(arguments);
          this.params = originalParams;
       },
@@ -80,7 +80,14 @@ define(["dojo/_base/declare",
        * @return {object} An object of key/value pair parameters to be applied. 
        */
       getParametersToApply: function alfresco_core_BaseWidget__getParametersToApply(/*jshint unused:false*/ originalParams) {
-         return null;
+         var params = null;
+         if (originalParams.style)
+         {
+            params = {
+               style: originalParams.style
+            };
+         }
+         return params;
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/core/BaseWidget.js
+++ b/aikau/src/main/resources/alfresco/core/BaseWidget.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Provides a base for all Aikau widgets to extend. It is not essential that a widget extends
+ * this module but it can provide significant performance benefits if hundreds or thousands
+ * of instances of the widget need to be rendered at a time. Any widget that does extend this
+ * base must either define a [templateString]{@link module:alfresco/core/BaseWidget#templateString}
+ * or override [createWidgetDom]{@link module:alfresco/core/BaseWidget#createWidgetDom}.
+ * 
+ * @module alfresco/core/BaseWidget
+ * @extends external:dijit/_WidgetBase
+ * @mixes external:dojo/_TemplatedMixin
+ * @mixes module:alfresco/core/Core
+ * @author Dave Draper
+ * @since 1.0.100
+ */
+define(["dojo/_base/declare",
+        "dijit/_WidgetBase", 
+        "dijit/_TemplatedMixin",
+        "dojo/text!./templates/Label.html",
+        "alfresco/core/Core"], 
+        function(declare, _WidgetBase, _TemplatedMixin, template, Core) {
+   
+   return declare([_WidgetBase, _TemplatedMixin, Core], {
+
+      /**
+       * The template that defines the DOM for the widget. If configured this will 
+       * result in the capabilities of dijit/_TemplatedMixin being used to construct the 
+       * DOM. Ideally this should be left as the default value of null and the 
+       * [createWidgetDom]{@link module:alfresco/core/BaseWidget#createWidgetDom} function
+       * will be called - this function should be implemented to use the native capabilities
+       * of the browser to build a DOM for the widget.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       */
+      templateString: null,
+
+      /**
+       * This extends the function provided by the dijit/_WidgetBase module to prevent any 
+       * attributes from being applied. This changes the default widget behaviour in order
+       * to gain performance improvements. Any parameters that do need to be applied can
+       * be provided by overriding 
+       * [getParametersToApply]{@link module:alfresco/core/BaseWidget#getParametersToApply}.
+       * 
+       * @instance
+       */
+      _applyAttributes: function alfresco_core_BaseWidget___applyAttributes() {
+         var originalParams = this.params;
+         this.params = this.getParametersToApply();
+         this.inherited(arguments);
+         this.params = originalParams;
+      },
+
+      /**
+       * This is called from [_applyAttributes]{@link module:alfresco/core/BaseWidget#_applyAttributes}
+       * to get an object of the parameters that should be applied to the widget. This should only
+       * be implemented as necessary. The more parameters applied the worse the performance at scale.
+       * 
+       * @instance
+       * @overridable
+       * @param {object} originalParams The original parameters provided to the widget.
+       * @return {object} An object of key/value pair parameters to be applied. 
+       */
+      getParametersToApply: function alfresco_core_BaseWidget__getParametersToApply(/*jshint unused:false*/ originalParams) {
+         return null;
+      },
+
+      /**
+       * Extends the function inherited from dijit/_WidgetBase to only make use of the template
+       * rendering capabilities provided by dijit/_TemplatedMixin when a
+       * [templateString]{@link module:alfresco/core/BaseWidget#templateString} is provided. Otherwise
+       * the [createWidgetDom]{@link module:alfresco/core/BaseWidget#createWidgetDom} will be called
+       * to build the DOM for the widget.
+       * 
+       * @instance
+       */
+      buildRendering: function alfresco_core_BaseWidget__buildRendering() {
+         if (this.templateString)
+         {
+            this.inherited(arguments);
+         }
+         else
+         {
+            this.createWidgetDom();
+         }
+      },
+
+      /**
+       * This function can be overridden to create the DOM model for the widget. Ideally this 
+       * should construct the DOM using the native capabilities of the browser (i.e. 
+       * making calls to document.createElement, etc). This function is called from 
+       * [buildRendering]{@link module:alfresco/core/BaseWidget#buildRendering} when no
+       * [templateString]{@link module:alfresco/core/BaseWidget#templateString} is defined.
+       * 
+       * @instance
+       * @overridable
+       */
+      createWidgetDom: function alfresco_core_BaseWidget__createWidgetDom() {
+         this.alfLog("warn", "The 'createWidgetDom' function has not been implemented", this);
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/core/BaseWidget.js
+++ b/aikau/src/main/resources/alfresco/core/BaseWidget.js
@@ -34,9 +34,8 @@
 define(["dojo/_base/declare",
         "dijit/_WidgetBase", 
         "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Label.html",
         "alfresco/core/Core"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, Core) {
+        function(declare, _WidgetBase, _TemplatedMixin, Core) {
    
    return declare([_WidgetBase, _TemplatedMixin, Core], {
 

--- a/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
+++ b/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
@@ -23,11 +23,11 @@
  * snippet that can be used in a Surf Extension to find the widget in the model in order to work with it.
  * 
  * @module alfresco/debug/WidgetInfo
- * @extends module:alfresco/core/BaseWidget
+ * @extends module:aikau/core/BaseWidget
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/BaseWidget",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "dojo/text!./templates/WidgetInfoData.html",
         "dijit/TooltipDialog",
@@ -55,7 +55,7 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/WidgetInfo.properties"}],
       
       /**
-       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
        * to construct the DOM for the widget using native browser capabilities.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
+++ b/aikau/src/main/resources/alfresco/debug/WidgetInfo.js
@@ -23,24 +23,20 @@
  * snippet that can be used in a Surf Extension to find the widget in the model in order to work with it.
  * 
  * @module alfresco/debug/WidgetInfo
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:alfresco/core/BaseWidget
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "alfresco/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
-        "dojo/text!./templates/WidgetInfo.html",
         "dojo/text!./templates/WidgetInfoData.html",
-        "alfresco/core/Core",
         "dijit/TooltipDialog",
         "dijit/popup",
+        "dojo/_base/lang",
         "dojo/string"], 
-        function(declare, _Widget, _Templated, _OnDijitClickMixin, template, dataTemplate, AlfCore, TooltipDialog, popup, string) {
+        function(declare, BaseWidget, _OnDijitClickMixin, dataTemplate, TooltipDialog, popup, lang, string) {
    
-   return declare([_Widget, _Templated, _OnDijitClickMixin, AlfCore], {
+   return declare([BaseWidget, _OnDijitClickMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -59,12 +55,25 @@ define(["dojo/_base/declare",
       i18nRequirements: [{i18nFile: "./i18n/WidgetInfo.properties"}],
       
       /**
-       * The HTML template to use for the widget.
+       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
        * @instance
-       * @type {String}
+       * @since 1.0.100
        */
-      templateString: template,
-      
+      createWidgetDom: function alfresco_debug_WidgetInfo__createWidgetDom() {
+         this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-debug-WidgetInfo");
+         
+         var imgNode = document.createElement("img");
+         imgNode.classList.add("image");
+         imgNode.setAttribute("src", this.imgSrc);
+         imgNode.setAttribute("alt", this.altText);
+         this._attach(imgNode, "ondijitclick", lang.hitch(this, this.showInfo));
+
+         this.domNode.appendChild(imgNode);
+      },
+
       /**
        * Sets up the image source and it's alt text.
        * 

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -21,12 +21,12 @@
  * Use this widget to render a single cell within a [Row]{@link module:alfresco/lists/views/layouts/Row}
  * 
  * @module alfresco/lists/views/layouts/Cell
- * @extends module:alfresco/core/BaseWidget
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/BaseWidget",
+        "aikau/core/BaseWidget",
         "alfresco/lists/views/layouts/_LayoutMixin",
         "dojo/dom-class",
         "dojo/dom-style",
@@ -73,7 +73,7 @@ define(["dojo/_base/declare",
       width: null,
 
       /**
-       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
        * to construct the DOM for the widget using native browser capabilities.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -21,24 +21,19 @@
  * Use this widget to render a single cell within a [Row]{@link module:alfresco/lists/views/layouts/Row}
  * 
  * @module alfresco/lists/views/layouts/Cell
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:alfresco/core/BaseWidget
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Cell.html",
-        "alfresco/core/Core",
+        "alfresco/core/BaseWidget",
         "alfresco/lists/views/layouts/_LayoutMixin",
         "dojo/dom-class",
         "dojo/dom-style",
         "dojo/dom-attr"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, _LayoutMixin, domClass, domStyle, domAttr) {
+        function(declare, BaseWidget, _LayoutMixin, domClass, domStyle, domAttr) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _LayoutMixin], {
+   return declare([BaseWidget, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -48,14 +43,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Cell.css"}]
        */
       cssRequirements: [{cssFile:"./css/Cell.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * 
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
       
       /**
        * Any additional CSS classes that should be applied to the rendered DOM element.
@@ -84,6 +71,18 @@ define(["dojo/_base/declare",
        * @default
        */
       width: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.100
+       */
+      createWidgetDom: function alfresco_renderers_Cell__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("td");
+         this.domNode.classList.add("alfresco-lists-views-layouts-Cell");
+      },
 
       /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -21,14 +21,14 @@
  * Use this widget to render a row of [cells]{@link module:alfresco/lists/views/layouts/Cell}
  * 
  * @module alfresco/lists/views/layouts/Row
- * @extends module:alfresco/core/BaseWidget
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/BaseWidget",
+        "aikau/core/BaseWidget",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/lists/views/layouts/_LayoutMixin",
@@ -104,7 +104,7 @@ define(["dojo/_base/declare",
       zebraStriping: false,
 
       /**
-       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
        * to construct the DOM for the widget using native browser capabilities.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -21,29 +21,25 @@
  * Use this widget to render a row of [cells]{@link module:alfresco/lists/views/layouts/Cell}
  * 
  * @module alfresco/lists/views/layouts/Row
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:alfresco/core/BaseWidget
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
- * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Row.html",
+        "alfresco/core/BaseWidget",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
-        "alfresco/core/Core",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/lists/views/layouts/_LayoutMixin",
         "alfresco/documentlibrary/_AlfDndDocumentUploadMixin",
         "dojo/dom-class",
-        "dojo/_base/event"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, _PublishPayloadMixin,
-                 _LayoutMixin, _AlfDndDocumentUploadMixin, domClass, event) {
+        "dojo/_base/event",
+        "dojo/_base/lang"], 
+        function(declare, BaseWidget, _MultiItemRendererMixin, _PublishPayloadMixin, _LayoutMixin, 
+                 _AlfDndDocumentUploadMixin, domClass, event, lang) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, _PublishPayloadMixin, _LayoutMixin, _AlfDndDocumentUploadMixin], {
+   return declare([BaseWidget, _MultiItemRendererMixin, _PublishPayloadMixin, _LayoutMixin, _AlfDndDocumentUploadMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -53,14 +49,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Row.css"}]
        */
       cssRequirements: [{cssFile:"./css/Row.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * 
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
       
       /**
        * Any additional CSS classes that should be applied to the rendered DOM element.
@@ -114,6 +102,20 @@ define(["dojo/_base/declare",
        * @default
        */
       zebraStriping: false,
+
+      /**
+       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.100
+       */
+      createWidgetDom: function alfresco_renderers_Row__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("tr");
+         this.domNode.classList.add("alfresco-lists-views-layouts-Row");
+         this.domNode.setAttribute("tabindex", "0");
+         this._attach(this.domNode, "onclick", lang.hitch(this, this.onFocusClick));
+      },
 
       /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}

--- a/aikau/src/main/resources/alfresco/renderers/ActivitySummary.js
+++ b/aikau/src/main/resources/alfresco/renderers/ActivitySummary.js
@@ -107,7 +107,8 @@ define(["alfresco/renderers/Property",
        * @override
        */
       postMixInProperties: function alfresco_renderers_ActivitySummary__postMixInProperties() {
-
+         this.inherited(arguments);
+         
          // Ensure we have a valid item
          if (this.currentItem && this.currentItem.activityType) {
 

--- a/aikau/src/main/resources/alfresco/renderers/Boolean.js
+++ b/aikau/src/main/resources/alfresco/renderers/Boolean.js
@@ -122,6 +122,7 @@ define(["dojo/_base/declare",
       postMixInProperties: function alfresco_renderers_Boolean__postMixInProperties() {
          /*jshint maxcomplexity:false*/
 
+         this.inherited(arguments);
          if(typeof this.displayTypeOptions.get(this.displayType) === "undefined")
          {
             this.alfLog("log", "Unknown displayType '" + this.displayType + "'. Please select displayType from: " + this.displayTypeOptions.enums, this);
@@ -192,6 +193,5 @@ define(["dojo/_base/declare",
             }
          }
       }
-
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -24,14 +24,14 @@
  * of different configuration options that control how the property is ultimately displayed.
  *
  * @module alfresco/renderers/Property
- * @extends module:alfresco/core/BaseWidget
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/renderers/_JsNodeMixin
  * @mixes module:alfresco/renderers/_ItemLinkMixin
  * @mixes module:alfresco/core/ValueDisplayMapMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/BaseWidget",
+        "aikau/core/BaseWidget",
         "alfresco/renderers/_JsNodeMixin", 
         "alfresco/core/ValueDisplayMapMixin", 
         "alfresco/core/ObjectTypeUtils", 
@@ -291,7 +291,7 @@ define(["dojo/_base/declare",
       _tooltipPositions: ["below-centered", "above-centered"],
 
       /**
-       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
        * to construct the DOM for the widget using native browser capabilities.
        *
        * @instance

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -24,21 +24,16 @@
  * of different configuration options that control how the property is ultimately displayed.
  *
  * @module alfresco/renderers/Property
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:alfresco/core/BaseWidget
  * @mixes module:alfresco/renderers/_JsNodeMixin
  * @mixes module:alfresco/renderers/_ItemLinkMixin
  * @mixes module:alfresco/core/ValueDisplayMapMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin", 
+        "alfresco/core/BaseWidget",
         "alfresco/renderers/_JsNodeMixin", 
         "alfresco/core/ValueDisplayMapMixin", 
-        "alfresco/core/Core", 
-        "dojo/text!./templates/Property.html", 
         "alfresco/core/ObjectTypeUtils", 
         "alfresco/core/UrlUtilsMixin", 
         "alfresco/core/TemporalUtils", 
@@ -47,10 +42,10 @@ define(["dojo/_base/declare",
         "dojo/dom-style", 
         "dijit/Tooltip", 
         "dojo/on"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _JsNodeMixin, ValueDisplayMapMixin, AlfCore, template, 
-            ObjectTypeUtils, UrlUtilsMixin, TemporalUtils, lang, domClass, domStyle, Tooltip, on) {
+        function(declare, BaseWidget, _JsNodeMixin, ValueDisplayMapMixin, ObjectTypeUtils, UrlUtilsMixin, 
+                 TemporalUtils, lang, domClass, domStyle, Tooltip, on) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _JsNodeMixin, ValueDisplayMapMixin, TemporalUtils, UrlUtilsMixin], {
+   return declare([BaseWidget, _JsNodeMixin, ValueDisplayMapMixin, TemporalUtils, UrlUtilsMixin], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -73,13 +68,6 @@ define(["dojo/_base/declare",
       cssRequirements: [{
          cssFile: "./css/Property.css"
       }],
-
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
 
       /**
        * This is the object that the property to be rendered will be retrieved from.
@@ -303,6 +291,36 @@ define(["dojo/_base/declare",
       _tooltipPositions: ["below-centered", "above-centered"],
 
       /**
+       * Overrides [the inherited function]{@link module:alfresco/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.100
+       */
+      createWidgetDom: function alfresco_renderers_Property__createWidgetDom() {
+         this.renderedValueNode = this.domNode = document.createElement("span");
+         this.renderedValueClassArray.forEach(function(className) {
+            this.domNode.classList.add(className);
+         }, this);
+         this.domNode.setAttribute("tabindex", "0");
+
+         var innerSpan = document.createElement("span");
+         innerSpan.classList.add("inner");
+
+         var labelSpan = document.createElement("span");
+         labelSpan.classList.add("label");
+         labelSpan.textContent = this.label;
+
+         var valueSpan = document.createElement("span");
+         valueSpan.classList.add("value");
+         valueSpan.innerHTML = this.renderedValue;
+
+         innerSpan.appendChild(labelSpan);
+         innerSpan.appendChild(valueSpan);
+         this.domNode.appendChild(innerSpan);
+      },
+
+      /**
        * Updates CSS classes based on the current state of the renderer. Currently this only
        * addressed warning message states.
        * 
@@ -436,12 +454,14 @@ define(["dojo/_base/declare",
        * @instance
        */
       updateRenderedValueClass: function alfresco_renderers_Property__updateRenderedValueClass() {
-         this.renderedValueClass = this.renderedValueClass + " " + this.renderSize;
-         if (this.renderOnNewLine === true) {
-            this.renderedValueClass = this.renderedValueClass + " block";
+         this.renderedValueClassArray = ["alfresco-renderers-Property", this.renderedValueClass,this.renderSize];
+         if (this.renderOnNewLine === true) 
+         {
+            this.renderedValueClassArray.push("block");
          }
-         if (this.deemphasized === true) {
-            this.renderedValueClass = this.renderedValueClass + " deemphasized";
+         if (this.deemphasized === true) 
+         {
+            this.renderedValueClassArray.push("deemphasize");
          }
       },
 

--- a/aikau/src/test/resources/alfresco/renderers/BooleanTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/BooleanTest.js
@@ -26,191 +26,177 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!expect",
-        "require",
-        "alfresco/TestCommon"],
-        function(module, defineSuite, expect, require, TestCommon) {
+        "intern/chai!expect"],
+        function(module, defineSuite, expect) {
 
    defineSuite(module, {
       name: "Boolean Tests",
       testPage: "/Boolean",
 
-      "Tests": function() {
-         var testname = "BooleanTest";
+      "Check there are 60 cells as described in the model": function() {
          return this.remote.findAllByCssSelector("span.alfresco-renderers-Property")
             .then(function(booleans) {
-               TestCommon.log(testname, "Check there are 60 cells as described in the model");
                expect(booleans).to.have.length(60, "There should be 60 cells rendered");
-            })
-            .end()
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(1) td:first-of-type")
+      "Row one, column one should say 'Yes'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(1) td:first-of-type")
             .getVisibleText()
             .then(function(result1) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result1).to.equal("Yes", "Row one, column one should say 'Yes'");
-            })
-            .end()
+               expect(result1).to.equal("Yes");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(1) td:nth-of-type(2)")
+      "Row one, column two should say 'True'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(1) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result2) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result2).to.equal("True", "Row one, column two should say 'True'");
-            })
-            .end()
+               expect(result2).to.equal("True");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(2) td:first-of-type")
+      "Row two, column one should say 'Yes'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(2) td:first-of-type")
             .getVisibleText()
             .then(function(result3) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result3).to.equal("Yes", "Row two, column one should say 'Yes'");
-            })
-            .end()
+               expect(result3).to.equal("Yes");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(2) td:nth-of-type(2)")
+      "Row two, column two should say 'True'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(2) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result4) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result4).to.equal("True", "Row two, column two should say 'True'");
-            })
-            .end()
+               expect(result4).to.equal("True");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(3) td:first-of-type")
+      "Row three, column one should say 'Yes'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(3) td:first-of-type")
             .getVisibleText()
             .then(function(result5) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result5).to.equal("Yes", "Row three, column one should say 'Yes'");
-            })
-            .end()
+               expect(result5).to.equal("Yes");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(3) td:nth-of-type(2)")
+      "Row three, column two should say 'True'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(3) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result6) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result6).to.equal("True", "Row three, column two should say 'True'");
-            })
-            .end()
+               expect(result6).to.equal("True");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(4) td:first-of-type")
+      "Row four, column one should say 'Yes'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(4) td:first-of-type")
             .getVisibleText()
             .then(function(result7) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result7).to.equal("Yes", "Row four, column one should say 'Yes'");
-            })
-            .end()
+               expect(result7).to.equal("Yes");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(4) td:nth-of-type(2)")
+      "Row four, column two should say 'True'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(4) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result8) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result8).to.equal("True", "Row four, column two should say 'True'");
-            })
-            .end()
+               expect(result8).to.equal("True", "");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(5) td:first-of-type")
+      "Row five, column one should say 'No'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(5) td:first-of-type")
             .getVisibleText()
             .then(function(result9) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result9).to.equal("No", "Row five, column one should say 'No'");
-            })
-            .end()
+               expect(result9).to.equal("No");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(5) td:nth-of-type(2)")
+      "Row five, column two should say 'False'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(5) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result10) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result10).to.equal("False", "Row five, column two should say 'False'");
-            })
-            .end()
+               expect(result10).to.equal("False");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(6) td:first-of-type")
+      "Row six, column one should say 'No'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(6) td:first-of-type")
             .getVisibleText()
             .then(function(result11) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result11).to.equal("No", "Row six, column one should say 'No'");
-            })
-            .end()
+               expect(result11).to.equal("No");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(6) td:nth-of-type(2)")
+      "Row six, column two should say 'False'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(6) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result12) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result12).to.equal("False", "Row six, column two should say 'False'");
-            })
-            .end()
+               expect(result12).to.equal("False");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(7) td:first-of-type")
+      "Row seven, column one should say 'No'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(7) td:first-of-type")
             .getVisibleText()
             .then(function(result13) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result13).to.equal("No", "Row seven, column one should say 'No'");
-            })
-            .end()
+               expect(result13).to.equal("No");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(7) td:nth-of-type(2)")
+      "Row seven, column two should say 'False'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(7) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result14) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result14).to.equal("False", "Row seven, column two should say 'False'");
-            })
-            .end()
+               expect(result14).to.equal("False");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(8) td:first-of-type")
+      "Row eight, column one should say 'No'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(8) td:first-of-type")
             .getVisibleText()
             .then(function(result15) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result15).to.equal("No", "Row eight, column one should say 'No'");
-            })
-            .end()
+               expect(result15).to.equal("No");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(8) td:nth-of-type(2)")
+      "Row eight, column two should say 'False'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(8) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result16) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result16).to.equal("False", "Row eight, column two should say 'False'");
-            })
-            .end()
+               expect(result16).to.equal("False");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(9) td:first-of-type")
+      "Row nine, column one should say 'Unknown'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(9) td:first-of-type")
             .getVisibleText()
             .then(function(result17) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result17).to.equal("Unknown", "Row nine, column one should say 'Unknown'");
-            })
-            .end()
+               expect(result17).to.equal("Unknown");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(9) td:nth-of-type(2)")
+      "Row nine, column two should say 'Unknown'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(9) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result18) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result18).to.equal("Unknown", "Row nine, column two should say 'Unknown'");
-            })
-            .end()
+               expect(result18).to.equal("Unknown");
+            });
+      },
 
-         // Check each row
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(10) td:first-of-type")
+      "Row ten, column one should say 'Unknown'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(10) td:first-of-type")
             .getVisibleText()
             .then(function(result19) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result19).to.equal("Unknown", "Row ten, column one should say 'Unknown'");
-            })
-            .end()
+               expect(result19).to.equal("Unknown");
+            });
+      },
 
-         .findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(10) td:nth-of-type(2)")
+      "Row ten, column two should say 'Unknown'": function() {
+         return this.remote.findByCssSelector("tr.alfresco-lists-views-layouts-Row:nth-of-type(10) td:nth-of-type(2)")
             .getVisibleText()
             .then(function(result20) {
-               TestCommon.log(testname, "Check the value of a boolean");
-               expect(result20).to.equal("Unknown", "Row ten, column two should say 'Unknown'");
+               expect(result20).to.equal("Unknown");
             });
       }
    });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
@@ -32,8 +32,8 @@ for (var i=0; i<50; i++)
    // non-functional so should only highlight performance issues in config handling
    for (var j=0; j<50; j++)
    {
-       propertyModel.config['configKey_' + j] = 'configValue_' + j;
-       cellModel.config['configKey_' + j] = 'configValue_' + j;
+       propertyModel.config["configKey_" + j] = "configValue_" + j;
+       cellModel.config["configKey_" + j] = "configValue_" + j;
    }
    
    rowModel.push(cellModel);

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Boolean.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Boolean.get.js
@@ -8,8 +8,7 @@ model.jsonModel = {
                all: true
             }
          }
-      },
-      "alfresco/services/ErrorReporter"
+      }
    ],
    widgets:[
       {
@@ -170,10 +169,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1145 and https://issues.alfresco.com/jira/browse/AKU-1147 to define a more performant approach for building widgets that removes the overhead of the _applyAttributes function and provides a new life-cycle function to be used to build the widget DOM natively (but still support extending widgets to provide templates). Although this doesn't tackle all Aikau widgets, it addresses the main widgets in the performance test page to try to demonstrate a path forwards that provides a rendering boost.

@AFaust I'd appreciate you taking a look at this.