### PR TITLE
AKU-1148: New ListView and ListRenderer

### DIFF
--- a/aikau/src/main/resources/aikau/core/BaseWidget.js
+++ b/aikau/src/main/resources/aikau/core/BaseWidget.js
@@ -67,7 +67,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      _applyAttributes: function alfresco_core_BaseWidget___applyAttributes() {
+      _applyAttributes: function aikau_core_BaseWidget___applyAttributes() {
          var originalParams = this.params;
          this.params = this.getParametersToApply(originalParams);
          this.inherited(arguments);
@@ -84,7 +84,7 @@ define(["dojo/_base/declare",
        * @param {object} originalParams The original parameters provided to the widget.
        * @return {object} An object of key/value pair parameters to be applied. 
        */
-      getParametersToApply: function alfresco_core_BaseWidget__getParametersToApply(/*jshint unused:false*/ originalParams) {
+      getParametersToApply: function aikau_core_BaseWidget__getParametersToApply(/*jshint unused:false*/ originalParams) {
          var params = null;
          if (originalParams.style)
          {
@@ -104,7 +104,7 @@ define(["dojo/_base/declare",
        * 
        * @instance
        */
-      buildRendering: function alfresco_core_BaseWidget__buildRendering() {
+      buildRendering: function aikau_core_BaseWidget__buildRendering() {
          if (this.templateString)
          {
             this.inherited(arguments);
@@ -125,7 +125,7 @@ define(["dojo/_base/declare",
        * @instance
        * @overridable
        */
-      createWidgetDom: function alfresco_core_BaseWidget__createWidgetDom() {
+      createWidgetDom: function aikau_core_BaseWidget__createWidgetDom() {
          this.alfLog("warn", "The 'createWidgetDom' function has not been implemented", this);
       }
    });

--- a/aikau/src/main/resources/aikau/lists/views/ListRenderer.js
+++ b/aikau/src/main/resources/aikau/lists/views/ListRenderer.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p><b>This widget is in the "aikau" package and does not adhere to the backwards compatibility standards
+ * of the "alfresco" package. The code in this package is intended to form the basis of the next major release
+ * of Aikau and will remain in an unstable state until ready for release. Please evaluate and feedback on this
+ * module but do not rely on it in production!</b></p>
+ *
+ * @module aikau/lists/views/ListRenderer
+ * @extends module:alfresco/lists/views/ListRenderer
+ * @mixes module:aikau/lists/views/layouts/MultiItemRendererMixin
+ * @author Dave Draper
+ * @since 1.0.100
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/views/ListRenderer",
+        "aikau/lists/views/layouts/MultiItemRendererMixin"], 
+        function(declare, ListRenderer, MultiItemRendererMixin) {
+   
+   return declare([ListRenderer, MultiItemRendererMixin], {
+   });
+});

--- a/aikau/src/main/resources/aikau/lists/views/layouts/MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/aikau/lists/views/layouts/MultiItemRendererMixin.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2005-2016 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * <p><b>This widget is in the "aikau" package and does not adhere to the backwards compatibility standards
+ * of the "alfresco" package. The code in this package is intended to form the basis of the next major release
+ * of Aikau and will remain in an unstable state until ready for release. Please evaluate and feedback on this
+ * module but do not rely on it in production!</b></p>
+ *
+ * @module aikau/lists/views/layouts/MultiItemRendererMixin
+ * @extends module:alfresco/lists/views/layouts/_MultiItemRendererMixin
+ * @author Dave Draper
+ * @since 1.0.100
+ */
+define(["dojo/_base/declare",
+        "alfresco/lists/views/layouts/_MultiItemRendererMixin",
+        "alfresco/lists/views/RenderAppendixSentinel",
+        "dojo/_base/lang",
+        "dojo/dom-style"], 
+        function(declare, _MultiItemRendererMixin, RenderAppendixSentinel, lang, domStyle) {
+
+   return declare([_MultiItemRendererMixin], {
+
+      renderData: function aikau_lists_views_layout_MultiItemRendererMixin__renderData() {
+         var promisedData = new Promise(lang.hitch(this, function(resolve) {
+            
+            this._renderedItemWidgets = [];
+
+            // Ensure that an array is created to hold the root widget subscriptions...
+            if (!this.rootWidgetSubscriptions)
+            {
+               this.rootWidgetSubscriptions = [];
+            }
+
+            // Iterate over any previously created subscriptions for last data set and remove them...
+            // It is important that this it carried out to clean up the previous data set. By default
+            // the only subscriptions that will be present are those for selecting items, but extending
+            // classes could have added additional subscriptions. If the subscriptions aren't cleaned 
+            // up properly then destroyed widgets will try to be actioned.
+            this.rootWidgetSubscriptions && this.rootWidgetSubscriptions.forEach(function(handle) {
+               if (typeof handle.remove === "function")
+               {
+                  handle.remove();
+               }
+            });
+            
+            if (this.currentData && this.currentData.items)
+            {
+               // Set current Index to previousItemCount (so rendering starts at new items)
+               this.currentIndex = this.currentData.previousItemCount || 0;
+               this.currentItem = this.currentData.items[this.currentIndex];
+               
+               // Add in the index...
+               if (this.currentItem && typeof this.currentItem.index === "undefined")
+               {
+                  this.currentItem.index = this.currentIndex;
+               }
+
+               var itemsToRender = (this.currentIndex)? this.currentData.items.slice(this.currentIndex): this.currentData.items;
+               
+               var promisedItems = [];
+               itemsToRender.forEach(function(item, index) {
+                  var promisedItem = this.renderNextItem(item, index);
+                  promisedItem && promisedItems.push(promisedItem);
+               }, this);
+               
+               return Promise.all(promisedItems).then(lang.hitch(this, function(renderedItems) {
+                  this._renderedItemWidgets = renderedItems;
+                  this.allItemsRendered();
+                  resolve(renderedItems);
+               }));
+            }
+            else
+            {
+               resolve([]);
+            }
+         }));
+         return promisedData;
+      },
+
+      /**
+       * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets} to instantiate the widgets
+       * defined in the JSON model for [currentItem]{@link module:alfresco/lists/views/layouts/_MultiItemRendererMixin#currentItem}
+       * 
+       * @instance
+       * @param {object} itemToRender The item to render next
+       * @param {number} index The index of the item to render within the array of items to be rendered
+       */
+      renderNextItem: function aikau_lists_views_layout_MultiItemRendererMixin__renderNextItem(itemToRender, index) {
+         this.currentItem = itemToRender;
+         this.currentIndex = index;
+         if (typeof this.currentItem.index === "undefined")
+         {
+            this.currentItem.index = index;
+         }
+         if (itemToRender === RenderAppendixSentinel && this.widgetsForAppendix)
+         {
+            // The current item is a marker to render an "appendix". This is a non-data entry into the list
+            // of items to be rendered, the original use case is for some kind of "Add" style control that
+            // can be used to create a new entry...
+            return this.createChildren({
+               widgets: this.widgetsForAppendix,
+               targetNode: this.containerNode
+            });
+         }
+         else
+         {
+            // Process the widgets defined using the current item as the data to go into those widgets...
+            // Mark the current item with an attribute indicating that it is the last item.
+            // This is done for the benefit of renderers that need to know if they are the last item.
+            this.currentData.items[index].isLastItem = (this.currentItem.index === this.currentData.items.length -1);
+
+            // Set a width if provided...
+            if (this.width)
+            {
+               domStyle.set(this.domNode, "width", this.width);
+            }
+            
+            if (this.containerNode)
+            {
+               // It is necessary to clone the widget definition to prevent them being modified for future iterations...
+               // Intentionally switched from lang.clone to native JSON approach to cloning for performance...
+               var clonedWidgets = JSON.parse(JSON.stringify(this.widgets));
+               return this.createChildren({
+                  widgets: clonedWidgets,
+                  targetNode: this.containerNode
+               })
+               .then(lang.hitch(this, function(widgets) {
+                  widgets.forEach(this.rootWidgetProcessing, this);
+                  this.allWidgetsProcessed(widgets);
+                  return widgets;
+               }));
+            }
+            else
+            {
+               this.alfLog("warn", "There is no 'containerNode' for adding an item to");
+            }
+         }
+      }
+   });
+});

--- a/aikau/src/main/resources/alfresco/core/Page.js
+++ b/aikau/src/main/resources/alfresco/core/Page.js
@@ -130,7 +130,12 @@ define(["alfresco/core/ProcessWidgets",
             {
                // Make sure to process widgets if there are no services...
                // Otherwise they will be processed once all the services are instantiated...
-               this.processWidgets(this.widgets, this.containerNode);
+               this.createChildren({
+                  widgets: this.widgets,
+                  targetNode: this.containerNode
+               }).then(lang.hitch(this, function(widgets) {
+                  this.allWidgetsProcessed(widgets);
+               }));
             }
          }
          catch (e)
@@ -330,7 +335,12 @@ define(["alfresco/core/ProcessWidgets",
          {
             // Make sure to process widgets if there are no services...
             // Otherwise they will be processed once all the services are instantiated...
-            this.processWidgets(this.widgets, this.containerNode);
+            this.createChildren({
+               widgets: this.widgets,
+               targetNode: this.containerNode
+            }).then(lang.hitch(this, function(widgets) {
+               this.allWidgetsProcessed(widgets);
+            }));
          }
          else
          {

--- a/aikau/src/main/resources/alfresco/core/ProcessWidgets.js
+++ b/aikau/src/main/resources/alfresco/core/ProcessWidgets.js
@@ -22,23 +22,19 @@
  * instantiate the defined widgets. 
  * 
  * @module alfresco/core/ProcessWidgets
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
- * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @extends module:aikau/core/BaseWidget
+ * @mixes module:aikau/core/ChildProcessing
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing",
-        "dojo/text!./templates/ProcessWidgets.html",
+        "aikau/core/BaseWidget",
+        "aikau/core/ChildProcessing",
+        "dojo/_base/lang",
         "dojo/dom-construct",
         "dojo/dom-class"], 
-        function(declare, _Widget, _Templated, AlfCore, CoreWidgetProcessing, template, domConstruct, domClass) {
+        function(declare, BaseWidget, ChildProcessing, lang, domConstruct, domClass) {
    
-   return declare([_Widget, _Templated, AlfCore, CoreWidgetProcessing], {
+   return declare([BaseWidget, ChildProcessing], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -49,13 +45,6 @@ define(["dojo/_base/declare",
        */
       cssRequirements: [{cssFile:"./css/ProcessWidgets.css"}],
 
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
-      
       /**
        * @instance
        * @type {Object}
@@ -79,6 +68,18 @@ define(["dojo/_base/declare",
       baseClass: "widgets",
       
       /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.100
+       */
+      createWidgetDom: function alfresco_core_ProcessWidgets__createWidgetDom() {
+         this.domNode = this.containerNode = document.createElement("div");
+         this.domNode.className = "alfresco-core-ProcessWidgets " + this.baseClass || "";
+      },
+
+      /**
        * Implements the Dojo widget lifecycle function to call [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        * @instance postCreate
        */
@@ -86,7 +87,12 @@ define(["dojo/_base/declare",
          domClass.add(this.domNode, this.additionalCssClasses || "");
          if (this.widgets)
          {
-            this.processWidgets(this.widgets, this.containerNode);
+            this.createChildren({
+               widgets: this.widgets,
+               targetNode: this.containerNode
+            }).then(lang.hitch(this, function(widgets) {
+               this.allWidgetsProcessed(widgets);
+            }));
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
+++ b/aikau/src/main/resources/alfresco/layout/FixedHeaderFooter.js
@@ -289,7 +289,12 @@ define(["alfresco/core/ProcessWidgets",
                node = widgetInfo.node;
             if (widgets && widgets.length) 
             {
-               this.processWidgets(widgets, node);
+               this.createChildren({
+                  widgets: widgets,
+                  targetNode: node
+               }).then(lang.hitch(this, function(createdWidgets) {
+                  this.allWidgetsProcessed(createdWidgets);
+               }));
             } 
             else 
             {

--- a/aikau/src/main/resources/alfresco/layout/StripedContent.js
+++ b/aikau/src/main/resources/alfresco/layout/StripedContent.js
@@ -113,18 +113,17 @@ define(["alfresco/core/ProcessWidgets",
           * @param {string} rootClassName A string containing one or more space separated CSS classes to set on the DOM node
           */
          createWidgetDomNode: function alfresco_core_CoreWidgetProcessing__createWidgetDomNode(widgetConfig, rootNode, /*jshint unused:false*/ rootClassName) {
-
             // Create the stripe node and a new node for the widget
             var stripeNode = domConstruct.create("div", {
-                  className: this.baseClass + "__stripe",
-                  style: widgetConfig.stripeStyle || ""
-               }, rootNode),
-               contentNode = domConstruct.create("div", {
-                  className: this.baseClass + "__stripe__content",
-                  style: {
-                     maxWidth: this.contentWidth
-                  }
-               }, stripeNode);
+               className: this.baseClass + "__stripe",
+               style: widgetConfig.stripeStyle || ""
+            }, rootNode);
+            var contentNode = domConstruct.create("div", {
+               className: this.baseClass + "__stripe__content",
+               style: {
+                  maxWidth: this.contentWidth
+               }
+            }, stripeNode);
 
             // Add custom CSS
             if (widgetConfig.stripeClass) {

--- a/aikau/src/main/resources/alfresco/lists/AlfHashList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfHashList.js
@@ -353,15 +353,18 @@ define(["dojo/_base/declare",
       },
 
       /**
-       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#onDataLoadSuccess} to check
+       * Extends the [inherited function]{@link module:alfresco/lists/AlfList#onViewShown} to check
        * whether or not a URL hash parameter is set to indicate a particular item to bring into view.
        * This URL hash parameter checked is the "currentItem" and if this is found it will publish the
        * value on the "ALF_BRING_ITEM_INTO_VIEW" topic.
-       * 
-       * @param  {object} payload The payload containing the loaded data.
+       *
+       * @instance
+       * @param {object} payload
+       * @param {object} payload.view The view that has been shown
        * @fires module:alfresco/lists/views/ListRenderer~event:ALF_BRING_ITEM_INTO_VIEW
+       * @since 1.0.100
        */
-      onDataLoadSuccess: function alfresco_lists_AlfHashList__onDataLoadSuccess(/*jshint unused:false*/ payload) {
+      onViewShown: function alfresco_lists_AlfHashList__onViewShown(/*jshint unused:false*/ view) {
          this.inherited(arguments);
          var currHash = hashUtils.getHash();
          if (currHash.currentItem)

--- a/aikau/src/main/resources/alfresco/lists/AlfList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfList.js
@@ -610,6 +610,8 @@ define(["dojo/_base/declare",
             this.alfSubscribe(this.scrollNearBottom, lang.hitch(this, this.onScrollNearBottom));
          }
          this.createSelectedItemSubscriptions();
+
+         this.alfSubscribe("ALF_VIEW_SHOWN", lang.hitch(this, this.onViewShown));
       },
 
       /**
@@ -1275,6 +1277,22 @@ define(["dojo/_base/declare",
       },
 
       /**
+       * Called whenever a view reports that it has finished rendering.
+       * 
+       * @instance
+       * @param {object} payload
+       * @param {object} payload.view The view that has been shown
+       * @since 1.0.100
+       */
+      onViewShown: function alfresco_lists_AlfList__onViewShown(payload) {
+         // Attempt to focus a specific item if requested...
+         if (this._focusItemKey && payload.view)
+         {
+            payload.view.focusOnItem(this._focusItemKey);
+         }
+      },
+
+      /**
        * Handles requests to reload the current list data by clearing all the previous data and then calling
        * [loadData]{@link module:alfresco/lists/AlfList#loadData}.
        *
@@ -1479,12 +1497,6 @@ define(["dojo/_base/declare",
                this.currentData = view.getData();
                view.renderView(this.useInfiniteScroll);
                this.showView(view);
-
-               // Attempt to focus a specific item if requested...
-               if (this._focusItemKey)
-               {
-                  view.focusOnItem(this._focusItemKey);
-               }
             }
             else
             {

--- a/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
+++ b/aikau/src/main/resources/alfresco/lists/views/AlfListView.js
@@ -507,6 +507,10 @@ define(["dojo/_base/declare",
          {
             this.renderNoDataDisplay();
          }
+
+         this.alfPublish("ALF_VIEW_SHOWN", {
+            view: this
+         });
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -104,7 +104,10 @@ define(["dojo/_base/declare",
          }
          if (this.widgets)
          {
-            this.processWidgets(this.widgets, this.containerNode);
+            this.createChildren({
+               widgets: this.widgets,
+               targetNode: this.containerNode
+            });
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -130,7 +130,10 @@ define(["dojo/_base/declare",
             {
                this.processObject(this.widgetModelModifiers, this.widgets);
             }
-            this.processWidgets(this.widgets, this.containerNode);
+            this.createChildren({
+               widgets: this.widgets,
+               targetNode: this.containerNode
+            });
          }
 
          if (this.hasUploadPermissions() === true)

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_LayoutMixin.js
@@ -27,14 +27,14 @@
  * to prevent duplications.
  * 
  * @module alfresco/lists/views/layouts/_LayoutMixin
- * @extends module:alfresco/core/CoreWidgetProcessing
+ * @extends module:aikau/core/ChildProcessing
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/CoreWidgetProcessing"], 
-        function(declare, CoreWidgetProcessing) {
+        "aikau/core/ChildProcessing"], 
+        function(declare, ChildProcessing) {
    
-   return declare([CoreWidgetProcessing], {
+   return declare([ChildProcessing], {
 
       /**
        * Extends the [inherited function]{@link module:alfresco/core/CoreWidgetProcessing#processWidgetConfig}

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/_MultiItemRendererMixin.js
@@ -28,11 +28,12 @@
  * attribute (if applicable).
  * 
  * @module alfresco/lists/views/layouts/_MultiItemRendererMixin
- * @extends module:alfresco/core/Core
+ * @extends module:aikau/core/ChildProcessing
+ * @mixes module:alfresco/documentlibrary/_AlfDocumentListTopicMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "alfresco/core/CoreWidgetProcessing",
+        "aikau/core/ChildProcessing",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/core/JsNode",
         "alfresco/documentlibrary/_AlfDocumentListTopicMixin",
@@ -43,10 +44,10 @@ define(["dojo/_base/declare",
         "dojo/dom-style",
         "dojo/on",
         "dojo/_base/event"], 
-        function(declare, CoreWidgetProcessing, ObjectTypeUtils, JsNode, _AlfDocumentListTopicMixin, 
+        function(declare, ChildProcessing, ObjectTypeUtils, JsNode, _AlfDocumentListTopicMixin, 
                  RenderAppendixSentinel, domClass, array, lang, domStyle, on, event) {
    
-   return declare([CoreWidgetProcessing, _AlfDocumentListTopicMixin], {
+   return declare([ChildProcessing, _AlfDocumentListTopicMixin], {
 
       /**
        * An array of the CSS files to use with this widget.

--- a/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
@@ -23,12 +23,9 @@
  */
 define(["module",
         "alfresco/defineSuite",
-        "intern/chai!expect",
         "intern/chai!assert",
-        "require",
-        "alfresco/TestCommon",
         "intern/dojo/node!leadfoot/keys"],
-        function(module, defineSuite, expect, assert, require, TestCommon, keys) {
+        function(module, defineSuite, assert, keys) {
 
    defineSuite(module, {
       name: "Property Tests",
@@ -89,7 +86,7 @@ define(["module",
             .then(element => {
                this.remote.moveMouseTo(element);
             })
-            .end()
+         .end()
 
          .findByCssSelector("#HOVER_ITEM_0 .inner")
             .isDisplayed()
@@ -103,7 +100,7 @@ define(["module",
             .then(element => {
                this.remote.moveMouseTo(element);
             })
-            .end()
+         .end()
 
          .findByCssSelector("#HOVER_ITEM_0 .value")
             .isDisplayed()
@@ -129,7 +126,7 @@ define(["module",
             .then(function(truncated) {
                assert.isTrue(truncated, "Long property not truncated properly");
             })
-            .end()
+         .end()
 
          .findById("MAX_LENGTH_ITEM_0")
             .then(function(elem) {
@@ -138,7 +135,7 @@ define(["module",
             .then(function(size) {
                assert.equal(size.width, 300, "Long property width incorrect");
             })
-            .end()
+         .end()
 
          .screenie(); // For visual verification of ellipsis if required
       },
@@ -174,7 +171,7 @@ define(["module",
       "Truncated property displays full text on mouseover": function() {
          return this.remote.findById("MAX_LENGTH_ITEM_0")
             .moveMouseTo()
-            .end()
+         .end()
 
          .findByCssSelector(".dijitTooltip")
             .isDisplayed()

--- a/aikau/src/test/resources/config/Suites.js
+++ b/aikau/src/test/resources/config/Suites.js
@@ -27,11 +27,14 @@ define(function() {
 
    // Whether to run all tests or just a few
    var runAllTests = true;
-   // runAllTests = false; // Comment/uncomment this line to toggle
+   runAllTests = false; // Comment/uncomment this line to toggle
 
    // This is the collection to change when only some tests are required
    var someTests = [
-      "alfresco/renderers/ToggleTest"
+      // "alfresco/layout/FixedHeaderFooterTest",
+      // "alfresco/lists/AlfSortablePaginatedListTest",
+      "alfresco/renderers/PropertyTest"
+
 
       // THESE TESTS REGULARLY, BUT INTERMITTENTLY, FAIL WHEN RUNNING FULL SUITES - INVESTIGATE
       // "alfresco/preview/PdfJsPreviewFaultsTest",

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/core/Performance.get.js
@@ -60,7 +60,7 @@ model.jsonModel = {
             },
             widgets: [
                {
-                  name: "alfresco/lists/views/AlfListView",
+                  name: "aikau/lists/views/ListView",
                   config: {
                      widgets: [
                         {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Property.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Property.get.js
@@ -159,7 +159,7 @@ model.jsonModel = {
                            config: {
                               widgets: [
                                  {
-                                    id: "MAX_LENGTH",
+                                    id: "HIGHLIGHT",
                                     name: "alfresco/renderers/Property",
                                     config: {
                                        propertyToRender: "name",


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1148 to provide new ListView and ListRenderer modules in the "aikau" package. It has not been possible to convert **all** of the existing list views and renderers to use ChildProcessing so this provides an initial option for view rendering. It brings the performance test page down to under 10 seconds in production mode.