### PR TITLE
AKU-1152: Handle white space in renderedValueClass

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -456,8 +456,11 @@ define(["dojo/_base/declare",
       updateRenderedValueClass: function alfresco_renderers_Property__updateRenderedValueClass() {
          // Need to set both renderedValueClassArray (for widgets without a template) and
          // renderedValueClass (for those that do)...
-         var renderedValueClass = this.renderedValueClass;
-         this.renderedValueClassArray = ["alfresco-renderers-Property", renderedValueClass, this.renderSize];
+         var renderedValueClass = this.renderedValueClass || "";
+         
+         // See AKU-1152 - handle spaces in arrays...
+         this.renderedValueClassArray = renderedValueClass.replace(/\s+/g, " ").trim().split(" ");
+         this.renderedValueClassArray = this.renderedValueClassArray.concat(["alfresco-renderers-Property", this.renderSize]);
          this.renderedValueClass = this.renderedValueClass + " " + this.renderSize;
          if (this.renderOnNewLine === true) 
          {

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Property.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Property.get.js
@@ -37,7 +37,8 @@ model.jsonModel = {
                                     id: "BASIC",
                                     name: "alfresco/renderers/Property",
                                     config: {
-                                       propertyToRender: "name"
+                                       propertyToRender: "name",
+                                       renderedValueClass: "one two"
                                     }
                                  },
                                  {


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1152 to ensure that multiple classes set in the `renderedValueClass` attribute of the Property renderer will be honoured. This property shouldn't really be used like this but an example was added to CMM using this so we need to ensure it continues to work for backwards compatibility. The issue was introduced with the rendering performance improvements.