### PR TITLE
AKU-1154: Updated duplicate site id dialog error message

### DIFF
--- a/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
+++ b/aikau/src/main/resources/alfresco/services/i18n/SiteService.properties
@@ -59,7 +59,7 @@ edit-site.failure.dialog.title=We couldn't save the site info
 
 # Error keys returned by the XHR request to the server
 error.unableToCreate=This site name is already used by another site. Check to see if there's an existing site with this name (it might have been deleted and be in a trashcan) or try another name.
-error.duplicateShortName=We couldn't create the site because the URL is already used
+error.duplicateShortName=This Site ID isn't available. Try a different one.
 error.loggedOut=Your user session has timed out, please login and try again
 error.noPermissions=Could not create site. You do not have permissions to perform this operation.
 error.create=Could not create the site at this time. Please try again later.


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1154 to update the error message that is displayed via a dialog when attempting to create a site with an existing shortName. The dialog is only displayed as a result of eventual consistency causing the validator to not find the duplicate. This only occurs if the user attempts to create the duplicate site immediately after just creating it (which is an unlikely eventuality).