### PR TITLE
AKU-1148: Renderer and list layout conversion

### DIFF
--- a/aikau/src/main/resources/aikau/core/BaseWidget.js
+++ b/aikau/src/main/resources/aikau/core/BaseWidget.js
@@ -86,7 +86,7 @@ define(["dojo/_base/declare",
        */
       getParametersToApply: function aikau_core_BaseWidget__getParametersToApply(/*jshint unused:false*/ originalParams) {
          var params = null;
-         if (originalParams.style)
+         if (originalParams && originalParams.style)
          {
             params = {
                style: originalParams.style

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Cell.js
@@ -79,7 +79,7 @@ define(["dojo/_base/declare",
        * @instance
        * @since 1.0.100
        */
-      createWidgetDom: function alfresco_renderers_Cell__createWidgetDom() {
+      createWidgetDom: function alfresco_lists_views_layouts_Cell__createWidgetDom() {
          this.containerNode = this.domNode = document.createElement("td");
          this.domNode.classList.add("alfresco-lists-views-layouts-Cell");
       },

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/CellContainer.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/CellContainer.js
@@ -24,28 +24,25 @@
  * [AlfGalleryView]{@link module:alfresco/documentlibrary/AlfGalleryView}.
  * 
  * @module alfresco/lists/views/layouts/CellContainer
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
+ * @mixes external:dijit/_OnDijitClickMixin
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
- * @mixes module:alfresco/core/Core
  * @author Dave Draper
  * @since 1.0.44
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/lists/views/layouts/_LayoutMixin",
-        "alfresco/core/Core",
-        "dojo/text!./templates/CellContainer.html",
         "dojo/_base/event",
         "dojo/_base/lang",
         "dojo/dom-style"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, Core, 
-                 template, event, lang, domStyle) {
+        function(declare, BaseWidget, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, 
+                 event, lang, domStyle) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin, Core], {
+   return declare([BaseWidget, _OnDijitClickMixin, _PublishPayloadMixin, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -55,14 +52,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/CellContainer.css"}]
        */
       cssRequirements: [{cssFile:"./css/CellContainer.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * 
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
       
       /**
        * The minimum height for each container in pixels.
@@ -81,6 +70,24 @@ define(["dojo/_base/declare",
        * @default
        */
       widgets: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_lists_views_layouts_CellContainer__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("tr");
+         this.domNode.classList.add("alfresco-lists-views-layouts-CellContainer");
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onClick));
+
+         this.widgetsNode = document.createElement("div");
+         this.widgetsNode.classList.add("alfresco-lists-views-layouts-CellContainer__widgets");
+
+         this.domNode.appendChild(this.widgetsNode);
+      },
 
       /**
        * 
@@ -113,7 +120,10 @@ define(["dojo/_base/declare",
          domStyle.set(this.domNode, "minHeight", this.minHeight + "px");
          if (this.widgets)
          {
-            this.processWidgets(this.widgets, this.widgetsNode);
+            this.createChildren({
+               widgets: this.widgets,
+               targetNode: this.widgetsNode
+            });
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Column.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Column.js
@@ -21,22 +21,18 @@
  * Use this widget to render a column. Every widget rendered within it will be "stacked" vertically.
  * 
  * @module alfresco/lists/views/layouts/Column
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Column.html",
-        "alfresco/core/Core",
+        "aikau/core/BaseWidget",
         "alfresco/lists/views/layouts/_LayoutMixin",
+        "dojo/_base/lang",
         "dojo/dom-construct"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, _LayoutMixin, domConstruct) {
+        function(declare, BaseWidget, _LayoutMixin, lang, domConstruct) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _LayoutMixin], {
+   return declare([BaseWidget, _LayoutMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -48,13 +44,19 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/Column.css"}],
       
       /**
-       * The HTML template to use for the widget.
-       * 
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
        * @instance
-       * @type {String}
+       * @since 1.0.101
        */
-      templateString: template,
-      
+      createWidgetDom: function alfresco_lists_views_layouts_CellContainer__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("table");
+         this.domNode.classList.add("alfresco-lists-views-layouts-Column");
+         this.domNode.setAttribute("cellspacing", "0");
+         this.domNode.setAttribute("cellpadding", "0");
+      },
+
       /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        * 

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
@@ -20,25 +20,20 @@
 /**
  * 
  * @module alfresco/lists/views/layouts/HeaderCell
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/HeaderCell.html",
-        "alfresco/core/Core",
+        "aikau/core/BaseWidget",
         "alfresco/core/topics",
         "alfresco/util/hashUtils",
         "dojo/_base/lang",
         "dojo/dom-class",
         "dojo/query",
         "dojo/dom-attr"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, topics, hashUtils, lang, domClass, query, domAttr) {
+        function(declare, BaseWidget, topics, hashUtils, lang, domClass, query, domAttr) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
+   return declare([BaseWidget], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -58,14 +53,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/HeaderCell.css"}]
        */
       cssRequirements: [{cssFile:"./css/HeaderCell.css"}],
-
-      /**
-       * The HTML template to use for the widget.
-       * 
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
 
       /**
        * Optional accessibility scope.
@@ -163,6 +150,35 @@ define(["dojo/_base/declare",
        * @since 1.0.56
        */
       useHash: false,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_lists_views_layouts_Row__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("th");
+         this.domNode.classList.add("alfresco-lists-views-layouts-HeaderCell");
+         this.domNode.setAttribute("tabindex", "0");
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onSortClick));
+
+         this.labelNode = document.createElement("span");
+         this.labelNode.classList.add("label");
+         this.labelNode.textContent = this.label;
+         this.domNode.appendChild(this.labelNode);
+
+         this.ascendingSortNode = document.createElement("img");
+         this.ascendingSortNode.classList.add("ascendingSort");
+         this.ascendingSortNode.setAttribute("src", this.transparentImageUrl);
+         this.domNode.appendChild(this.ascendingSortNode);
+
+         this.descendingSortNode = document.createElement("img");
+         this.descendingSortNode.classList.add("descendingSort");
+         this.descendingSortNode.setAttribute("src", this.transparentImageUrl);
+         this.domNode.appendChild(this.descendingSortNode);
+      },
 
       /**
        * @instance

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Row.js
@@ -110,7 +110,7 @@ define(["dojo/_base/declare",
        * @instance
        * @since 1.0.100
        */
-      createWidgetDom: function alfresco_renderers_Row__createWidgetDom() {
+      createWidgetDom: function alfresco_lists_views_layouts_Row__createWidgetDom() {
          this.containerNode = this.domNode = document.createElement("tr");
          this.domNode.classList.add("alfresco-lists-views-layouts-Row");
          this.domNode.setAttribute("tabindex", "0");

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/Table.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/Table.js
@@ -21,23 +21,16 @@
  * Use this widget to render a table of [rows]{@link module:alfresco/lists/views/layouts/Row}
  *
  * @module alfresco/lists/views/layouts/Table
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
- * @mixes module:alfresco/core/Core
- * @mixes module:alfresco/core/CoreWidgetProcessing
+ * @extends module:aikau/core/BaseWidget
+ * @mixes module:alfresco/lists/views/layouts/_LayoutMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Table.html",
-        "alfresco/lists/views/layouts/_MultiItemRendererMixin",
-        "alfresco/core/Core",
-        "alfresco/core/CoreWidgetProcessing"],
-        function(declare, _WidgetBase, _TemplatedMixin, template, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing) {
+        "aikau/core/BaseWidget",
+        "alfresco/lists/views/layouts/_LayoutMixin"],
+        function(declare, BaseWidget, _LayoutMixin) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, AlfCore, CoreWidgetProcessing], {
+   return declare([BaseWidget, _LayoutMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -49,12 +42,16 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/Table.css"}],
 
       /**
-       * The HTML template to use for the widget.
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
        *
        * @instance
-       * @type {String}
+       * @since 1.0.101
        */
-      templateString: template,
+      createWidgetDom: function alfresco_lists_views_layouts_Table__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("table");
+         this.domNode.classList.add("alfresco-lists-views-layouts-Table");
+      },
 
       /**
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
@@ -64,7 +61,10 @@ define(["dojo/_base/declare",
       postCreate: function alfresco_lists_views_layouts_Table__postCreate() {
          if (this.widgets)
          {
-            this.processWidgets(this.widgets, this.containerNode);
+            this.createChildren({
+               widgets: this.widgets,
+               targetNode: this.containerNode
+            });
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/renderers/Actions.js
+++ b/aikau/src/main/resources/alfresco/renderers/Actions.js
@@ -87,15 +87,14 @@
  * }
  * 
  * @module alfresco/renderers/Actions
- * @extends module:alfresco/menus/AlfMenuBar
+ * @extends module:aikau/core/BaseWidget
+ * @mixes dijit/_HasDropDown
  * @mixes module:alfresco/renderers/_ActionsMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_HasDropDown",
-        "dojo/text!./templates/Actions.html",
         "alfresco/renderers/_ActionsMixin",
         "alfresco/buttons/AlfButton",
         "alfresco/menus/AlfMenuGroups",
@@ -105,10 +104,10 @@ define(["dojo/_base/declare",
         "dojo/_base/event",
         "dojo/_base/lang",
         "dojo/keys"],
-        function(declare, _WidgetBase, _TemplatedMixin, _HasDropDown, template, _ActionsMixin, AlfButton, 
+        function(declare, BaseWidget, _HasDropDown, _ActionsMixin, AlfButton, 
                  AlfMenuGroups, AlfMenuGroup, Menu, domClass, Event, lang, keys) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _HasDropDown, _ActionsMixin], {
+   return declare([BaseWidget, _HasDropDown, _ActionsMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -128,15 +127,6 @@ define(["dojo/_base/declare",
        */
       i18nRequirements: [{i18nFile: "./i18n/Actions.properties"}],
 
-      /**
-       * The HTML template to use for the widget.
-       * 
-       * @instance
-       * @type {string}
-       * @since 1.0.46
-       */
-      templateString: template,
-      
       /**
        * Indicates that this should only be displayed when the item (note: NOT the renderer) is
        * hovered over.
@@ -169,6 +159,18 @@ define(["dojo/_base/declare",
        * @since 1.0.62
        */
       _button: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Actions__createWidgetDom() {
+         this.bannerNode = this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-Actions");
+      },
 
       /**
        * Ensures that the [menu]{@link module:alfresco/renderers/Actions#_menu} is destroyed.

--- a/aikau/src/main/resources/alfresco/renderers/Actions.js
+++ b/aikau/src/main/resources/alfresco/renderers/Actions.js
@@ -168,7 +168,7 @@ define(["dojo/_base/declare",
        * @since 1.0.101
        */
       createWidgetDom: function alfresco_renderers_Actions__createWidgetDom() {
-         this.bannerNode = this.domNode = document.createElement("div");
+         this.domNode = document.createElement("div");
          this.domNode.classList.add("alfresco-renderers-Actions");
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/Banner.js
+++ b/aikau/src/main/resources/alfresco/renderers/Banner.js
@@ -74,7 +74,7 @@ define(["dojo/_base/declare",
        * @since 1.0.101
        */
       createWidgetDom: function alfresco_renderers_Banner__createWidgetDom() {
-         this.domNode = document.createElement("span");
+         this.bannerNode = this.domNode = document.createElement("span");
          this.domNode.classList.add("alfresco-renderers-Banner");
          this.domNode.classList.add("hidden");
          this.domNode.textContent = this.bannerMessage;

--- a/aikau/src/main/resources/alfresco/renderers/Banner.js
+++ b/aikau/src/main/resources/alfresco/renderers/Banner.js
@@ -19,22 +19,17 @@
 
 /**
  * @module alfresco/renderers/Banner
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/renderers/_ItemLinkMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Banner.html",
-        "alfresco/core/Core",
+        "aikau/core/BaseWidget",
         "alfresco/renderers/_ItemLinkMixin",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore, _ItemLinkMixin, domClass) {
+        function(declare, BaseWidget, _ItemLinkMixin, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, _ItemLinkMixin], {
+   return declare([BaseWidget, _ItemLinkMixin], {
       
       
       /**
@@ -64,13 +59,6 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/Banner.css"}],
       
       /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
-      
-      /**
        * The message to display in the banner
        * @instance
        * @type {string} 
@@ -78,6 +66,20 @@ define(["dojo/_base/declare",
        */
       bannerMessage: "",
       
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Banner__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Banner");
+         this.domNode.classList.add("hidden");
+         this.domNode.textContent = this.bannerMessage;
+      },
+
       /**
        * Removes the "hidden" class if there is a message to render
        * 

--- a/aikau/src/main/resources/alfresco/renderers/Category.js
+++ b/aikau/src/main/resources/alfresco/renderers/Category.js
@@ -75,7 +75,7 @@ define(["dojo/_base/declare",
 
          var icon = document.createElement("span");
          icon.classList.add("icon");
-         icon.textContent = "&nbsp;";
+         icon.innerHTML = "&nbsp;";
          this.domNode.appendChild(icon);
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/Category.js
+++ b/aikau/src/main/resources/alfresco/renderers/Category.js
@@ -62,6 +62,24 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/Category.css"}],
       
       /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Category__createWidgetDom() {
+         this.categoryNode = this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-Property");
+         this.domNode.classList.add("alfresco-renderers-Category");
+
+         var icon = document.createElement("span");
+         icon.classList.add("icon");
+         icon.textContent = "&nbsp;";
+         this.domNode.appendChild(icon);
+      },
+
+      /**
        * @instance
        */
       postMixInProperties: function alfresco_renderers_Category__postMixInProperties() {

--- a/aikau/src/main/resources/alfresco/renderers/Comments.js
+++ b/aikau/src/main/resources/alfresco/renderers/Comments.js
@@ -26,29 +26,27 @@
  * standard Document Library [Detailed View]{@link module:alfresco/documentlibrary/views/AlfDetailedView}
  * uses the [VerticalReveal]{@link module:alfresco/layout/VerticalReveal} approach to allow inline commenting.
  * 
- * @module alfresco/renderers/Comments
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @module aikau/core/BaseWidget
+ * @mixes external:dijit/_OnDijitClickMixin
  * @mixes module:alfresco/core/UrlUtilsMixin
+ * @mixes module:alfresco/renderers/_JsNodeMixin
+ * @mixes module:alfresco/navigation/_HtmlAnchorMixin
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_JsNodeMixin",
         "alfresco/navigation/_HtmlAnchorMixin",
         "alfresco/renderers/_PublishPayloadMixin",
-        "dojo/text!./templates/Comments.html",
-        "alfresco/core/Core",
-        "dojo/_base/lang",
         "alfresco/core/UrlUtilsMixin",
+        "dojo/_base/lang",
         "dojo/dom-class"],
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin,
-                 _HtmlAnchorMixin, _PublishPayloadMixin, template, AlfCore, lang, UrlUtilsMixin, domClass) {
+        function(declare, BaseWidget, _OnDijitClickMixin, _JsNodeMixin, _HtmlAnchorMixin, 
+                 _PublishPayloadMixin, UrlUtilsMixin, lang, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _HtmlAnchorMixin, AlfCore, UrlUtilsMixin, _PublishPayloadMixin], {
+   return declare([BaseWidget, _OnDijitClickMixin, _JsNodeMixin, _HtmlAnchorMixin, UrlUtilsMixin, _PublishPayloadMixin], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -67,13 +65,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Comments.css"}]
        */
       cssRequirements: [{cssFile:"./css/Comments.css"}],
-
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
 
       /**
        * The dot-notation property to use for the count of comments. Can be overridden.
@@ -112,6 +103,33 @@ define(["dojo/_base/declare",
        * @default
        */
       subscriptionTopic: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Comments__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Comments");
+
+         var linkNode = document.createElement("span");
+         linkNode.classList.add("comment-link");
+         linkNode.setAttribute("tabindex", "0");
+         linkNode.setAttribute("title", this.title);
+         linkNode.textContent = this.commentLabel;
+         this._attach(linkNode, "ondijitclick", lang.hitch(this, this.onCommentClick));
+
+         this.countNode = document.createElement("span");
+         this.countNode.classList.add("count");
+         this.countNode.classList.add("hidden");
+         this.coundNode.textContent = this.commentCount;
+
+         this.domNode.appendChild(linkNode);
+         this.domNode.appendChild(this.countNode);
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/Comments.js
+++ b/aikau/src/main/resources/alfresco/renderers/Comments.js
@@ -125,7 +125,7 @@ define(["dojo/_base/declare",
          this.countNode = document.createElement("span");
          this.countNode.classList.add("count");
          this.countNode.classList.add("hidden");
-         this.coundNode.textContent = this.commentCount;
+         this.countNode.textContent = this.commentCount;
 
          this.domNode.appendChild(linkNode);
          this.domNode.appendChild(this.countNode);

--- a/aikau/src/main/resources/alfresco/renderers/DateLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/DateLink.js
@@ -29,19 +29,11 @@ define(["dojo/_base/declare",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/navigation/LinkClickMixin",
-        "dojo/text!./templates/DateLink.html",
         "dojo/_base/event",
         "dojo/_base/lang"], 
-        function(declare, Date, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin, template, event, lang) {
+        function(declare, Date, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin, event, lang) {
 
    return declare([Date, _OnDijitClickMixin, _PublishPayloadMixin, LinkClickMixin], {
-
-      /**
-       * Overriddes the default HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
 
       /**
        * If this is set to true then the current item will be published when the link is clicked. If set to
@@ -52,6 +44,35 @@ define(["dojo/_base/declare",
        * @default
        */
       useCurrentItemAsPayload: true,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_DateLink__createWidgetDom() {
+         this.renderedValueNode = this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-DateLink");
+
+         var innerNode = document.createElement("span");
+         innerNode.classList.add("inner");
+         innerNode.setAttribute("tabindex", "0");
+         this._attach(innerNode, "ondijitclick", lang.hitch(this, this.onLinkClick));
+
+         var label = document.createElement("span");
+         label.classList.add("label");
+         label.textContent = this.label;
+
+         var value = document.createElement("span");
+         value.classList.add("value");
+         value.innerHTML = this.renderedValue;
+
+         innerNode.appendChild(label);
+         innerNode.appendChild(value);
+         this.domNode.appendChild(innerNode);
+      },
 
       /**
        * Handles the date being clicked. This stops the click event from propogating

--- a/aikau/src/main/resources/alfresco/renderers/EditTag.js
+++ b/aikau/src/main/resources/alfresco/renderers/EditTag.js
@@ -22,25 +22,21 @@
  * added tag that can be removed by either giving the tag focus and clicking "SPACE" or "ENTER" or by clicking the "X" icon.
  * 
  * @module alfresco/renderers/EditTag
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes external:dojo/_OnDijitClickMixin
  * @mixes external:dojo/_FocusMixin
- * @mixes module:alfresco/core/Core
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "dijit/_FocusMixin",
-        "dojo/text!./templates/EditTag.html",
-        "alfresco/core/Core",
+        "dojo/_base/lang",
         "dojo/on",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _FocusMixin, template, AlfCore, on, domClass) {
+        function(declare, BaseWidget, _OnDijitClickMixin, _FocusMixin, lang, on, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _FocusMixin, AlfCore], {
+   return declare([BaseWidget, _OnDijitClickMixin, _FocusMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -50,13 +46,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/EditTag.css"}]
        */
       cssRequirements: [{cssFile:"./css/EditTag.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
       
       /**
        * The display name for the tag.
@@ -76,6 +65,31 @@ define(["dojo/_base/declare",
        */
       tagValue: null,
       
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_EditTag__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-EditTag");
+         this.domNode.setAttribute("tabindex", "0");
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onRemoveTag));
+         
+         this.tagNameNode = document.createElement("span");
+         this.tagNameNode.classList.add("tagName");
+         this.tagNameNode.textContent = this.tagName;
+
+         this.tagDeleteNode = document.createElement("span");
+         this.tagDeleteNode.classList.add("tagDelete");
+         this.tagDeleteNode.innerHTML = "&nbsp;";
+
+         this.domNode.appendChild(this.tagNameNode);
+         this.domNode.appendChild(this.tagDeleteNode);
+      },
+
       /**
        * Set up the attributes to be used when rendering the template.
        * 

--- a/aikau/src/main/resources/alfresco/renderers/EditableComment.js
+++ b/aikau/src/main/resources/alfresco/renderers/EditableComment.js
@@ -26,28 +26,22 @@
  * [CommentsList renderer]{@link module:alfresco/renderers/CommentsList}.
  *
  * @module alfresco/renderers/EditableComment
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/core/CoreWidgetProcessing
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "alfresco/core/Core",
+        "aikau/core/BaseWidget",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/renderers/_PublishPayloadMixin",
-        "dojo/text!./templates/EditableComment.html",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-construct",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, _PublishPayloadMixin, template, 
-                 array, lang, domConstruct, domClass) {
+        function(declare, BaseWidget, CoreWidgetProcessing, _PublishPayloadMixin, array, lang, domConstruct, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore, CoreWidgetProcessing, _PublishPayloadMixin], {
+   return declare([BaseWidget, CoreWidgetProcessing, _PublishPayloadMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -66,13 +60,6 @@ define(["dojo/_base/declare",
        * @default [{i18nFile: "./i18n/EditableComment.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/EditableComment.properties"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
       
       /**
        * This will be instantiated as a map of the controls used by the widget. It has been added in order
@@ -181,6 +168,31 @@ define(["dojo/_base/declare",
        * @default
        */
       subscriptionTopic: "ALF_EDIT_COMMENT",
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_EditableComment__createWidgetDom() {
+         this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-EditableComment");
+         this.domNode.classList.add(this._mode);
+
+         this.readNode = document.createElement("div");
+         this.readNode.classList.add("read");
+
+         this.editNode = document.createElement("div");
+         this.editNode.classList.add("edit");
+
+         this.formNode = document.createElement("div");
+
+         this.editNode.appendChild(this.formNode);
+         this.domNode.appendChild(this.readNode);
+         this.domNode.appendChild(this.editNode);
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/FileType.js
+++ b/aikau/src/main/resources/alfresco/renderers/FileType.js
@@ -21,28 +21,17 @@
  * This renders an image that represents the type of file that the assigned node represents.
  *
  * @module alfresco/renderers/FileType
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/renderers/_JsNodeMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "alfresco/renderers/_JsNodeMixin",
-        "dojo/text!./templates/FileType.html",
-        "alfresco/core/Core",
         "dojo/_base/lang"],
-        function(declare, _WidgetBase, _TemplatedMixin, _JsNodeMixin, template, AlfCore, lang) {
+        function(declare, BaseWidget, _JsNodeMixin, lang) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _JsNodeMixin, AlfCore], {
-
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
+   return declare([BaseWidget, _JsNodeMixin], {
 
       /**
        * The size of the image. By default this will be "large" but can be set to "small" or "medium". The default widget has 3 image
@@ -72,6 +61,24 @@ define(["dojo/_base/declare",
        * @default require.toUrl("alfresco/renderers/css/images/filetypes/{prefix}-{type}-{size}.png")
        */
       imageUrl: "alfresco/renderers/css/images/filetypes/{prefix}-{type}-{size}.png",
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_FileType__createWidgetDom() {
+         this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-FileType");
+
+         this.imgNode = document.createElement("img");
+         this.imgNode.setAttribute("src", this.img);
+         this.imgNode.setAttribute("alt", this.altText);
+
+         this.domNode.appendChild(this.imgNode);
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
@@ -106,7 +106,7 @@ define(["dojo/_base/declare",
          this.titleNode.classList.add("share-hidden");
          
          this.selectBarNode = document.createElement("div");
-         this.titleBarNode.appendChild(this.selectBarNode);
+         this.titleNode.appendChild(this.selectBarNode);
          
          this.displayNameNode = document.createElement("div");
          this.displayNameNode.classList.add("displayName");

--- a/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/GalleryThumbnail.js
@@ -28,7 +28,6 @@
  */
 define(["dojo/_base/declare",
         "alfresco/renderers/Thumbnail",
-        "dojo/text!./templates/GalleryThumbnail.html",
         "dojo/_base/lang",
         "dojo/dom-style",
         "dojo/dom-class",
@@ -37,7 +36,7 @@ define(["dojo/_base/declare",
         // These items required for building only
         "alfresco/renderers/Selector",
         "alfresco/renderers/MoreInfo"], 
-        function(declare, Thumbnail, template, lang, domStyle, domClass, LeftAndRight) {
+        function(declare, Thumbnail, lang, domStyle, domClass, LeftAndRight) {
 
    return declare([Thumbnail], {
       
@@ -49,13 +48,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/GalleryThumbnail.css"}]
        */
       cssRequirements: [{cssFile:"./css/GalleryThumbnail.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
       
       /**
        * Overrides the [inherited default]{@link module:alfresco/renderers/Thumbnail#cropToFit} to
@@ -95,6 +87,54 @@ define(["dojo/_base/declare",
        * @since 1.0.40
        */
       updateOnSelection: true,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_GalleryThumbnail__createWidgetDom() {
+         this.thumbnailNode = this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Thumbnail");
+         domClass.add(this.domNode, this.customClasses);
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onLinkClick));
+
+         this.titleNode = document.createElement("div");
+         this.titleNode.classList.add("selectBar");
+         this.titleNode.classList.add("share-hidden");
+         
+         this.selectBarNode = document.createElement("div");
+         this.titleBarNode.appendChild(this.selectBarNode);
+         
+         this.displayNameNode = document.createElement("div");
+         this.displayNameNode.classList.add("displayName");
+
+         var displayNameContent = document.createElement("div");
+         displayNameContent.classList.add("displayName__content");
+         displayNameContent.setAttribute("title", this.imgTitle);
+         displayNameContent.textContent = this.imgTitle;
+
+         this.displayNameNode.appendChild(displayNameContent);
+         
+         this.frameNode = document.createElement("span");
+         this.frameNode.classList.add("alfresco-renderers-Thumbnail__frame");
+
+         this.imgNode = document.createElement("img");
+         this.imgNode.classList.add("alfresco-renderers-Thumbnail__image");
+         this.imgNode.setAttribute("id", this.imgId);
+         this.imgNode.setAttribute("src", this.thumbnailUrl);
+         this.imgNode.setAttribute("alt", this.imgAltText);
+         this.imgNode.setAttribute("title", this.imgTitle);
+         this._attach(this.imgNode, "onload", lang.hitch(this, this.getNaturalImageSize));
+
+         this.frameNode.appendChild(this.imgNode);
+
+         this.domNode.appendChild(this.titleNode);
+         this.domNode.appendChild(this.displayNameNode);
+         this.domNode.appendChild(this.frameNode);
+      },
 
       /**
        * @instance

--- a/aikau/src/main/resources/alfresco/renderers/Indicators.js
+++ b/aikau/src/main/resources/alfresco/renderers/Indicators.js
@@ -50,26 +50,22 @@
  * }
  *
  * @module alfresco/renderers/Indicators
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  * @author Martin Doyle
  */
 define(["dojo/_base/declare", 
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin", 
+        "aikau/core/BaseWidget",
         "alfresco/renderers/_PublishPayloadMixin", 
-        "dojo/text!./templates/Indicators.html", 
-        "alfresco/core/Core", 
         "service/constants/Default",
         "dojo/_base/array", 
         "dojo/_base/lang", 
         "dojo/dom-construct", 
         "dojo/on"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _PublishPayloadMixin, template, AlfCore, AlfConstants, array, lang, domConstruct, on) {
+        function(declare, BaseWidget, _PublishPayloadMixin, AlfConstants, array, lang, domConstruct, on) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _PublishPayloadMixin, AlfCore], {
+   return declare([BaseWidget, _PublishPayloadMixin], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -92,13 +88,6 @@ define(["dojo/_base/declare",
       cssRequirements: [{
          cssFile: "./css/Indicators.css"
       }],
-
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
 
       /**
        * An object that can map each icon attribute to a custom source file for the indicator image. All mappings
@@ -182,6 +171,18 @@ define(["dojo/_base/declare",
        * @type {object[]}
        */
       _currentIndicators: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Indicators__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-Indicators");
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -45,7 +45,6 @@ define(["dojo/_base/declare",
         "dojo/_base/array",
         "dojo/Deferred",
         "dojo/dom-class",
-        "dojo/html",
         "dojo/dom-attr",
         "dojo/keys",
         "dojo/_base/event",
@@ -55,7 +54,7 @@ define(["dojo/_base/declare",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
         function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin,
-                 lang, array, Deferred, domClass, html, domAttr, keys, event, query) {
+                 lang, array, Deferred, domClass, domAttr, keys, event, query) {
 
    return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin], {
       
@@ -671,7 +670,7 @@ define(["dojo/_base/declare",
        */
       reRenderProperty: function alfresco_renderers_InlineEditProperty__reRenderProperty() {
          this.renderedValue = this.generateRendering(this.renderedValue);
-         html.set(this.renderedValueNode, this.renderedValue);
+         this.renderedValueNode.textContent = this.renderedValue;
          domClass.remove(this.renderedValueNode, "hidden");
          domClass.add(this.editNode, "hidden");
          this.updateCssClasses();

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -79,13 +79,6 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/InlineEditProperty.css"}],
       
       /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
-      
-      /**
        * This is the message or message key that will be used for the cancel link text.
        *
        * @instance
@@ -259,6 +252,63 @@ define(["dojo/_base/declare",
        * @since 1.0.83
        */
       updateInProgressItemLabelProperty: "displayName",
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.100
+       */
+      createWidgetDom: function alfresco_renderers_InlineEditProperty__createWidgetDom() {
+         // jshint maxstatements:false
+         this.domNode = document.createElement("span");
+         this.renderedValueClassArray.forEach(function(className) {
+            this.domNode.classList.add(className);
+         }, this);
+
+         this.domNode.classList.add("alfresco-renderers-InlineEditProperty");
+         
+         var labelSpan = document.createElement("span");
+         labelSpan.classList.add("label");
+         labelSpan.textContent = this.label;
+         this.domNode.appendChild(labelSpan);
+
+         this.renderedValueNode = document.createElement("span");
+         this.renderedValueNode.classList.add("inlineEditValue");
+         this.renderedValueClassArray.forEach(function(className) {
+            this.renderedValueNode.classList.add(className);
+         }, this);
+         this.renderedValueNode.setAttribute("tabindex", "0");
+         this.renderedValueNode.innerHTML = this.renderedValue;
+         this._attach(this.renderedValueNode, "onkeypress", lang.hitch(this, this.onKeyPress));
+         this._attach(this.renderedValueNode, "ondijitclick", lang.hitch(this, this.onClickRenderedValue));
+         this.domNode.appendChild(this.renderedValueNode);
+
+         this.editNode = document.createElement("span");
+         this.editNode.classList.add("editor");
+         this.editNode.classList.add("hidden");
+         this._attach(this.editNode, "onkeypress", lang.hitch(this, this.onValueEntryKeyPress));
+         this._attach(this.editNode, "onclick", lang.hitch(this, this.suppressFocusRequest));
+
+         this.formWidgetNode = document.createElement("span");
+         this.editNode.appendChild(this.formWidgetNode);
+         this.domNode.appendChild(this.editNode);
+
+         this.editIconNode = document.createElement("img");
+         this.editIconNode.classList.add("editIcon");
+         this.editIconNode.setAttribute("src", this.editIconImageSrc);
+         this.editIconNode.setAttribute("alt", this.editAltText);
+         this.editIconNode.setAttribute("title", this.editAltText);
+         this._attach(this.editIconNode, "ondijitclick", lang.hitch(this, this.onEditClick));
+         this.domNode.appendChild(this.editIconNode);
+
+         var progressNode = document.createElement("img");
+         progressNode.classList.add("alfresco-renderers-InlineEditProperty__progress");
+         progressNode.setAttribute("src", this.updateInProgressImgSrc);
+         progressNode.setAttribute("alt", this.updateInProgressAltText);
+         this.domNode.appendChild(progressNode);
+      },
 
       /**
        * The topic to publish when a property edit should be persisted. For convenience it is assumed that document

--- a/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
+++ b/aikau/src/main/resources/alfresco/renderers/InlineEditProperty.js
@@ -41,7 +41,6 @@ define(["dojo/_base/declare",
         "alfresco/core/CoreWidgetProcessing",
         "alfresco/renderers/_PublishPayloadMixin",
         "alfresco/lists/KeyboardNavigationSuppressionMixin",
-        "dojo/text!./templates/InlineEditProperty.html",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/Deferred",
@@ -56,7 +55,7 @@ define(["dojo/_base/declare",
         "alfresco/forms/controls/DojoValidationTextBox",
         "alfresco/forms/controls/HiddenValue"], 
         function(declare, Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin,
-                 template, lang, array, Deferred, domClass, html, domAttr, keys, event, query) {
+                 lang, array, Deferred, domClass, html, domAttr, keys, event, query) {
 
    return declare([Property, _OnDijitClickMixin, CoreWidgetProcessing, _PublishPayloadMixin, KeyboardNavigationSuppressionMixin], {
       

--- a/aikau/src/main/resources/alfresco/renderers/Item.js
+++ b/aikau/src/main/resources/alfresco/renderers/Item.js
@@ -59,33 +59,23 @@
  * }
  * 
  * @module alfresco/renderers/Item
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/lists/views/layouts/_MultiItemRendererMixin
  * @mixes module:alfresco/core/CoreWidgetProcessing
  * @author Dave Draper
  * @since 1.0.86
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "alfresco/lists/views/layouts/_MultiItemRendererMixin",
         "alfresco/renderers/_PublishPayloadMixin",
-        "dojo/text!./templates/Item.html",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dijit/registry",
         "dojo/dom-construct"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, _PublishPayloadMixin, template, lang, array, registry, domConstruct) {
+        function(declare, BaseWidget, _MultiItemRendererMixin, _PublishPayloadMixin, lang, array, registry, domConstruct) {
    
-   return declare([_WidgetBase, _TemplatedMixin, _MultiItemRendererMixin, _PublishPayloadMixin], {
-      
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
+   return declare([BaseWidget, _MultiItemRendererMixin, _PublishPayloadMixin], {
       
       /**
        * This is a dot-notation property that can be set to look up a specific location in the 
@@ -191,6 +181,21 @@ define(["dojo/_base/declare",
        * @default
        */
       widgets: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Item__createWidgetDom() {
+         this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-Item");
+
+         this.containerNode = document.createElement("div");
+         this.domNode.appendChild(this.containerNode);
+      },
 
       /**
        * Subscribes to the document load topic

--- a/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
+++ b/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
@@ -151,7 +151,7 @@ define(["dojo/_base/declare",
          this.domNode.setAttribute("tabindex", "0");
          this.domNode.setAttribute("alt", this.alfText);
          this.domNode.setAttribute("title", this.title);
-         this.domNode.textContent = "&nbsp;";
+         this.domNode.innerHTML = "&nbsp;";
          this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onMoreInfo));
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
+++ b/aikau/src/main/resources/alfresco/renderers/MoreInfo.js
@@ -20,29 +20,26 @@
 /**
  *
  * @module alfresco/renderers/MoreInfo
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes external:dojo/_OnDijitClickMixin
  * @mixes module:alfresco/core/Core
  * @mixes module:alfresco/core/ObjectTypeUtils
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_XhrActionsMixin",
         "alfresco/core/ObjectProcessingMixin",
         "alfresco/core/ObjectTypeUtils",
-        "dojo/text!./templates/MoreInfo.html",
-        "alfresco/core/Core",
         "alfresco/lists/views/layouts/Popup",
         "dojo/_base/lang",
         "dojo/dom-class",
         "dojo/_base/event"],
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _XhrActionsMixin, ObjectProcessingMixin, ObjectTypeUtils, template, AlfCore, Popup, lang, domClass, event) {
+        function(declare, BaseWidget, _OnDijitClickMixin, _XhrActionsMixin, ObjectProcessingMixin, 
+                 ObjectTypeUtils, Popup, lang, domClass, event) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _XhrActionsMixin, ObjectProcessingMixin, AlfCore], {
+   return declare([BaseWidget, _OnDijitClickMixin, _XhrActionsMixin, ObjectProcessingMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -61,13 +58,6 @@ define(["dojo/_base/declare",
        * @default [{i18nFile: "./i18n/MoreInfo.properties"}]
        */
       i18nRequirements: [{i18nFile: "./i18n/MoreInfo.properties"}],
-
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
 
       /**
        * This is the object that the property to be rendered will be retrieved from.
@@ -147,6 +137,23 @@ define(["dojo/_base/declare",
        * @default
        */
       propertyToRender: "displayName",
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_MoreInfo__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-MoreInfo");
+         this.domNode.setAttribute("tabindex", "0");
+         this.domNode.setAttribute("alt", this.alfText);
+         this.domNode.setAttribute("title", this.title);
+         this.domNode.textContent = "&nbsp;";
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onMoreInfo));
+      },
 
       /**
        * Gets the correct localized alt and title text.

--- a/aikau/src/main/resources/alfresco/renderers/Progress.js
+++ b/aikau/src/main/resources/alfresco/renderers/Progress.js
@@ -25,21 +25,18 @@
  * <p>The [requestProgressTopic]{@link module:alfresco/renderers/Progress#requestProgressTopic} should be configured
  * as the topic to publish to begin requesting progress information to be generated.</p>
  *
- * @module alfresco/renderers/Progress
- * @extends external:dijit/_WidgetBase
+ * @module alfresco/renderers/ProgressActions
+ * @extends module:aikau/core/BaseWidget
  * @author David Webster
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
-        "alfresco/core/Core",
-        "dojo/text!./templates/Progress.html",
+        "aikau/core/BaseWidget",
         "dojo/_base/lang",
         "dojo/dom-style"],
-        function(declare, _WidgetBase, _TemplatedMixin, AlfCore, template, lang, domStyle) {
+        function(declare, BaseWidget, lang, domStyle) {
 
-   return declare([_WidgetBase, AlfCore, _TemplatedMixin], {
+   return declare([BaseWidget], {
 
       /**
        * An array of the i18n files to use with this widget.
@@ -58,14 +55,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Progress.css"}]
        */
       cssRequirements: [{cssFile:"./css/Progress.css"}],
-
-      /**
-       * The HTML template to use for the widget.
-       *
-       * @instance
-       * @type {String}
-       */
-      templateString: template,
 
       /**
        * renderProgressUI
@@ -125,6 +114,31 @@ define(["dojo/_base/declare",
        * @default
        */
       completedMessage: "renderer.progress.complete",
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Progress__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-Progress");
+
+         this.labelNode = document.createElement("p");
+         this.labelNode.classList.add("alfProgressBarLabel");
+
+         var progressContainer = document.createElement("div");
+         progressContainer.classList.add("alfProgressBarContainer");
+
+         this.progressNode = document.createElement("div");
+         this.progressNode.classList.add("alfProgressBarProgress");
+
+         progressContainer.appendChild(this.progressNode);
+         this.domNode.appendChild(this.labelNode);
+         this.domNode.appendChild(progressContainer);
+      },
 
       /**
        * Sets up the form specific configuration for the dialog.

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -304,8 +304,8 @@ define(["dojo/_base/declare",
          }, this);
          this.domNode.setAttribute("tabindex", "0");
 
-         var innerSpan = document.createElement("span");
-         innerSpan.classList.add("inner");
+         this.innerSpan = document.createElement("span");
+         this.innerSpan.classList.add("inner");
 
          var labelSpan = document.createElement("span");
          labelSpan.classList.add("label");
@@ -315,9 +315,9 @@ define(["dojo/_base/declare",
          valueSpan.classList.add("value");
          valueSpan.innerHTML = this.renderedValue;
 
-         innerSpan.appendChild(labelSpan);
-         innerSpan.appendChild(valueSpan);
-         this.domNode.appendChild(innerSpan);
+         this.innerSpan.appendChild(labelSpan);
+         this.innerSpan.appendChild(valueSpan);
+         this.domNode.appendChild(this.innerSpan);
       },
 
       /**

--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -28,6 +28,8 @@
  * @mixes module:alfresco/renderers/_JsNodeMixin
  * @mixes module:alfresco/renderers/_ItemLinkMixin
  * @mixes module:alfresco/core/ValueDisplayMapMixin
+ * @mixes module:alfresco/core/UrlUtilsMixin
+ * @mixes module:alfresco/core/TemporalUtils
  * @author Dave Draper
  */
 define(["dojo/_base/declare",

--- a/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
+++ b/aikau/src/main/resources/alfresco/renderers/PropertyLink.js
@@ -67,6 +67,19 @@ define(["dojo/_base/declare",
       useCurrentItemAsPayload: true,
 
       /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.100
+       */
+      createWidgetDom: function alfresco_renderers_PropertyLink__createWidgetDom() {
+         this.inherited(arguments);
+         this.domNode.classList.add("alfresco-renderers-PropertyLink");
+         this._attach(this.innerSpan, "ondijitclick", lang.hitch(this, this.onLinkClick));
+      },
+
+      /**
        * Handles the property being clicked. This stops the click event from propogating
        * further through the DOM (to prevent any wrapping anchor elements from triggering
        * browser navigation) and then publishes the configured topic and payload.

--- a/aikau/src/main/resources/alfresco/renderers/PublishAction.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishAction.js
@@ -24,25 +24,26 @@
  * selected and unselected.</p>
  *
  * @module alfresco/renderers/PublishAction
- * @extends module:alfresco/renderers/Property
+ * @extends module:aikau/core/BaseWidget
+ * @mixes external:dijit/_OnDijitClickMixin
+ * @mixes module:alfresco/renderers/_JsNodeMixin
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_JsNodeMixin",
         "alfresco/renderers/_PublishPayloadMixin",
-        "dojo/text!./templates/PublishAction.html",
         "alfresco/enums/urlTypes", 
         "alfresco/util/urlUtils",
-        "alfresco/core/Core",
+        "dojo/_base/lang",
         "dojo/dom-class",
         "dojo/_base/event"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, 
-                 template, urlTypes, urlUtils, AlfCore, domClass, event) {
+        function(declare, BaseWidget, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, 
+                 urlTypes, urlUtils, lang, domClass, event) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin, AlfCore], {
+   return declare([BaseWidget, _OnDijitClickMixin, _JsNodeMixin, _PublishPayloadMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -54,13 +55,6 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/PublishAction.css"}],
 
       /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
-
-       /**
        * The alt-text for the action.
        *
        * @instance
@@ -134,6 +128,33 @@ define(["dojo/_base/declare",
        * @since 1.0.68
        */
       srcType: urlTypes.REQUIRE_PATH,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_PublishAction__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-PublishAction");
+         this.domNode.setAttribute("tabindex", "0");
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onClick));
+
+         var imageNode = document.createElement("img");
+         imageNode.classList.add("alfresco-renderers-PublishAction__image");
+         imageNode.setAttribute("src", this.imageSrc);
+         imageNode.setAttribute("alt", this.altText);
+         imageNode.setAttribute("title", this.altText);
+
+         var labelNode = document.createElement("span");
+         labelNode.classList.add("alfresco-renderers-PublishAction__label");
+         labelNode.textContent = this.label;
+
+         this.domNode.appendChild(imageNode);
+         this.domNode.appendChild(labelNode);
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
+++ b/aikau/src/main/resources/alfresco/renderers/PublishingDropDownMenu.js
@@ -22,27 +22,23 @@
  * widget that when changed will publish information about the change in value for the current rendered item.
  *
  * @module alfresco/renderers/PublishingDropDownMenu
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
+ * @mixes external:dijit/_OnDijitClickMixin
  * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "alfresco/renderers/_PublishPayloadMixin",
-        "dojo/text!./templates/PublishingDropDownMenu.html",
-        "alfresco/core/Core",
         "alfresco/core/ObjectTypeUtils",
         "alfresco/forms/controls/Select",
         "dojo/_base/lang",
         "dojo/dom-class"],
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _PublishPayloadMixin, template, AlfCore, ObjectTypeUtils, 
+        function(declare, BaseWidget, _OnDijitClickMixin, _PublishPayloadMixin, ObjectTypeUtils, 
                  Select, lang, domClass) {
 
-   return declare([_WidgetBase, _OnDijitClickMixin, _TemplatedMixin, AlfCore, _PublishPayloadMixin], {
+   return declare([BaseWidget, _OnDijitClickMixin, _PublishPayloadMixin], {
 
       /**
        * An array of the CSS files to use with this widget.
@@ -60,13 +56,6 @@ define(["dojo/_base/declare",
        * @type {Array}
        */
       i18nRequirements: [{i18nFile: "./i18n/PublishingDropDownMenu.properties"}],
-
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
 
       /**
        * Optional override for the title text to be displayed when hovering over the cancel "button"
@@ -117,6 +106,43 @@ define(["dojo/_base/declare",
        * @since 1.0.35
        */
       disablementProperty: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_PublishingDropDownMenu__createWidgetDom() {
+         this.containerNode = this.domNode = document.createElement("div");
+         this.domNode.classList.add("alfresco-renderers-PublishingDropDownMenu");
+
+         this.processingNode = document.createElement("div");
+         this.processingNode.classList.add("indicator");
+         this.processingNode.classList.add("processing");
+         this.processingNode.classList.add("hidden");
+         this.processingNode.setAttribute("tabindex", "0");
+         this.processingNode.setAttribute("title", this.cancelPublishLabel);
+         this._attach(this.processingNode, "ondijitclick", lang.hitch(this, this.onChangeCancel));
+         
+         this.warningNode = document.createElement("div");
+         this.warningNode.classList.add("indicator");
+         this.warningNode.classList.add("warning");
+         this.warningNode.classList.add("hidden");
+         
+         this.successNode = document.createElement("div");
+         this.successNode.classList.add("indicator");
+         this.successNode.classList.add("success");
+         this.successNode.classList.add("hidden");
+
+         this.dropDownNode = document.createElement("div");
+
+         this.domNode.appendChild(this.processingNode);
+         this.domNode.appendChild(this.warningNode);
+         this.domNode.appendChild(this.successNode);
+         this.domNode.appendChild(this.dropDownNode);
+      },
 
       /**
        *

--- a/aikau/src/main/resources/alfresco/renderers/ReadOnlyTag.js
+++ b/aikau/src/main/resources/alfresco/renderers/ReadOnlyTag.js
@@ -22,23 +22,18 @@
  * representation of a previously added tag.
  *  
  * @module alfresco/renderers/ReadOnlyTag
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes module:alfresco/services/_NavigationServiceTopicMixin
- * @mixes module:alfresco/core/Core
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "alfresco/services/_NavigationServiceTopicMixin",
-        "dojo/text!./templates/ReadOnlyTag.html",
-        "alfresco/core/Core",
         "alfresco/enums/urlTypes",
         "alfresco/navigation/Link"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _NavigationServiceTopicMixin, template, AlfCore, urlTypes, Link) {
+        function(declare, BaseWidget, _NavigationServiceTopicMixin, urlTypes, Link) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _NavigationServiceTopicMixin, AlfCore], {
+   return declare([BaseWidget, _NavigationServiceTopicMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -59,13 +54,6 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/ReadOnlyTag.css"}],
       
       /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
-      
-      /**
        * The display name for the tag.
        * 
        * @instance
@@ -83,6 +71,18 @@ define(["dojo/_base/declare",
        */
       tagValue: null,
       
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_ReadOnlyTag__createWidgetDom() {
+         this.tagNode = this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-ReadOnlyTag");
+      },
+
       /**
        * Determines whether or not the property should only be displayed when the item is hovered over.
        * 

--- a/aikau/src/main/resources/alfresco/renderers/Selector.js
+++ b/aikau/src/main/resources/alfresco/renderers/Selector.js
@@ -24,25 +24,21 @@
  * [ItemSelectionMixin]{@link module:alfresco/lists/ItemSelectionMixin} module.
  * 
  * @module alfresco/renderers/Selector
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes external:dojo/_OnDijitClickMixin
  * @mixes module:alfresco/lists/ItemSelectionMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "dijit/_OnDijitClickMixin",
         "alfresco/lists/ItemSelectionMixin",
-        "dojo/text!./templates/Selector.html",
         "dojo/_base/array",
         "dojo/_base/lang",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin, template, 
-                 array, lang, domClass) {
+        function(declare,BaseWidget, _OnDijitClickMixin, ItemSelectionMixin, array, lang, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, ItemSelectionMixin], {
+   return declare([BaseWidget, _OnDijitClickMixin, ItemSelectionMixin], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -52,13 +48,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Selector.css"}]
        */
       cssRequirements: [{cssFile:"./css/Selector.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
       
       /**
        * The dot-notation property to use in the 
@@ -84,6 +73,20 @@ define(["dojo/_base/declare",
        * @since 1.0.70
        */
       disabledOnValues: null,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Actions__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Selector");
+         this.domNode.setAttribute("tabindex", "0");
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onSelectionClick));
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/Separator.js
+++ b/aikau/src/main/resources/alfresco/renderers/Separator.js
@@ -19,19 +19,14 @@
 
 /**
  * @module alfresco/renderers/Separator
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
-        "dojo/text!./templates/Separator.html",
-        "alfresco/core/Core"], 
-        function(declare, _WidgetBase, _TemplatedMixin, template, AlfCore) {
+        "aikau/core/BaseWidget"], 
+        function(declare, BaseWidget) {
 
-   return declare([_WidgetBase, _TemplatedMixin, AlfCore], {
+   return declare([BaseWidget], {
       
       /**
        * An array of the CSS files to use with this widget.
@@ -43,10 +38,15 @@ define(["dojo/_base/declare",
       cssRequirements: [{cssFile:"./css/Separator.css"}],
       
       /**
-       * The HTML template to use for the widget.
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
        * @instance
-       * @type {String}
+       * @since 1.0.101
        */
-      templateString: template
+      createWidgetDom: function alfresco_renderers_Separator__createWidgetDom() {
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Separator");
+      }
    });
 });

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -518,10 +518,10 @@ define(["dojo/_base/declare",
 
          this.imgNode = document.createElement("img");
          this.imgNode.classList.add("alfresco-renderers-Thumbnail__image");
-         this.imgNode.setAtttribute("id", this.imgId);
-         this.imgNode.setAtttribute("src", this.thumbnailUrl);
-         this.imgNode.setAtttribute("alt", this.imgAltText);
-         this.imgNode.setAtttribute("title", this.imgTitle);
+         this.imgNode.setAttribute("id", this.imgId);
+         this.imgNode.setAttribute("src", this.thumbnailUrl);
+         this.imgNode.setAttribute("alt", this.imgAltText);
+         this.imgNode.setAttribute("title", this.imgTitle);
          this._attach(this.imgNode, "onload", lang.hitch(this, this.getNaturalImageSize));
 
          this.frameNode.appendChild(this.imgNode);

--- a/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
+++ b/aikau/src/main/resources/alfresco/renderers/Thumbnail.js
@@ -85,8 +85,7 @@
  * }
  * 
  * @module alfresco/renderers/Thumbnail
- * @extends external:dijit/_WidgetBase
- * @mixes external:dijit/_TemplatedMixin
+ * @extends module:aikau/core/BaseWidget
  * @mixes external:dijit/_OnDijitClickMixin
  * @mixes module:alfresco/renderers/_JsNodeMixin
  * @mixes module:alfresco/node/DraggableNodeMixin
@@ -96,8 +95,7 @@
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase",
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "alfresco/renderers/_JsNodeMixin",
         "alfresco/node/DraggableNodeMixin",
         "alfresco/node/NodeDropTargetMixin",
@@ -105,8 +103,6 @@ define(["dojo/_base/declare",
         "dijit/_OnDijitClickMixin",
         "alfresco/lists/ItemSelectionMixin",
         "alfresco/navigation/LinkClickMixin",
-        "dojo/text!./templates/Thumbnail.html",
-        "alfresco/core/Core",
         "alfresco/renderers/_ItemLinkMixin",
         "service/constants/Default",
         "alfresco/core/topics",
@@ -119,12 +115,12 @@ define(["dojo/_base/declare",
         "dojo/window",
         "dojo/Deferred",
         "dojo/when"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _JsNodeMixin, DraggableNodeMixin, NodeDropTargetMixin, 
-                 _PublishPayloadMixin, _OnDijitClickMixin, ItemSelectionMixin, LinkClickMixin, template, AlfCore, _ItemLinkMixin,
+        function(declare, BaseWidget, _JsNodeMixin, DraggableNodeMixin, NodeDropTargetMixin, 
+                 _PublishPayloadMixin, _OnDijitClickMixin, ItemSelectionMixin, LinkClickMixin, _ItemLinkMixin,
                  AlfConstants, topics, array, lang, event, domClass, domStyle, NodeUtils, win, Deferred, when) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _OnDijitClickMixin, _JsNodeMixin, DraggableNodeMixin, NodeDropTargetMixin, 
-                   AlfCore, _ItemLinkMixin, _PublishPayloadMixin, ItemSelectionMixin, LinkClickMixin], {
+   return declare([BaseWidget, _OnDijitClickMixin, _JsNodeMixin, DraggableNodeMixin, NodeDropTargetMixin, 
+                   _ItemLinkMixin, _PublishPayloadMixin, ItemSelectionMixin, LinkClickMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -143,14 +139,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Thumbnail.css"}]
        */
       cssRequirements: [{cssFile:"./css/Thumbnail.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * 
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
       
       /**
        * Some APIs provide very little information other than the nodeRef, however if we really
@@ -513,6 +501,34 @@ define(["dojo/_base/declare",
       width: null,
 
       /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Thumbnail__createWidgetDom() {
+         this.thumbnailNode = this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Thumbnail");
+         domClass.add(this.domNode, this.customClasses);
+
+         this.frameNode = document.createElement("span");
+         this.frameNode.classList.add("alfresco-renderers-Thumbnail__frame");
+         this._attach(this.frameNode, "ondijitclick", lang.hitch(this, this.onLinkClick));
+
+         this.imgNode = document.createElement("img");
+         this.imgNode.classList.add("alfresco-renderers-Thumbnail__image");
+         this.imgNode.setAtttribute("id", this.imgId);
+         this.imgNode.setAtttribute("src", this.thumbnailUrl);
+         this.imgNode.setAtttribute("alt", this.imgAltText);
+         this.imgNode.setAtttribute("title", this.imgTitle);
+         this._attach(this.imgNode, "onload", lang.hitch(this, this.getNaturalImageSize));
+
+         this.frameNode.appendChild(this.imgNode);
+         this.domNode.appendChild(this.frameNode);
+      },
+
+      /**
        * Overrides the [inherited function]{@link module:alfresco/lists/ItemSelectionMixin#getSelectionPublishGlobal}
        * to return [selectionPublishGlobal]{@link module:alfresco/renderers/Thumbnail#selectionPublishGlobal} to
        * avoid conflicts with scope configuration for other events (such as linking and showing previews).
@@ -521,7 +537,7 @@ define(["dojo/_base/declare",
        * @overridable
        * @return {boolean} A boolean indicating whether or not to publish and subscribe to selection topics globally.
        */
-      getSelectionPublishGlobal: function alfresco_lists_ItemSelectionMixin__getSelectionPublishGlobal() {
+      getSelectionPublishGlobal: function alfresco_lists_Thumbnail__getSelectionPublishGlobal() {
          return this.selectionPublishGlobal;
       },
 
@@ -534,7 +550,7 @@ define(["dojo/_base/declare",
        * @overridable
        * @return {boolean}  A boolean indicating whether or not to publish and subscribe to selection topics to the parent scope.
        */
-      getSelectionPublishToParent: function alfresco_lists_ItemSelectionMixin__getSelectionPublishToParent() {
+      getSelectionPublishToParent: function alfresco_lists_Thumbnail__getSelectionPublishToParent() {
          return this.selectionPublishToParent;
       },
 

--- a/aikau/src/main/resources/alfresco/renderers/Toggle.js
+++ b/aikau/src/main/resources/alfresco/renderers/Toggle.js
@@ -19,28 +19,25 @@
 
 /**
  * @module alfresco/renderers/Toggle
- * @extends external:dijit/_WidgetBase
- * @mixes external:dojo/_TemplatedMixin
- * @mixes module:alfresco/core/Core
+ * @extends module:aikau/core/BaseWidget
+ * @mixes module:alfresco/renderers/_JsNodeMixin
  * @mixes module:alfresco/renderers/_ItemLinkMixin
+ * @mixes module:alfresco/renderers/_PublishPayloadMixin
  * @mixes external:dojo/_OnDijitClickMixin
  * @author Dave Draper
  */
 define(["dojo/_base/declare",
-        "dijit/_WidgetBase", 
-        "dijit/_TemplatedMixin",
+        "aikau/core/BaseWidget",
         "alfresco/renderers/_JsNodeMixin",
-        "dojo/text!./templates/Toggle.html",
-        "alfresco/core/Core",
         "alfresco/renderers/_ItemLinkMixin",
         "alfresco/renderers/_PublishPayloadMixin",
         "dijit/_OnDijitClickMixin",
         "dojo/_base/lang",
         "dojo/dom-class"], 
-        function(declare, _WidgetBase, _TemplatedMixin, _JsNodeMixin, template, AlfCore, _ItemLinkMixin, _PublishPayloadMixin,
+        function(declare, BaseWidget, _JsNodeMixin, _ItemLinkMixin, _PublishPayloadMixin,
                  _OnDijitClickMixin, lang, domClass) {
 
-   return declare([_WidgetBase, _TemplatedMixin, _JsNodeMixin, AlfCore, _ItemLinkMixin, _PublishPayloadMixin, _OnDijitClickMixin], {
+   return declare([BaseWidget, _JsNodeMixin, _ItemLinkMixin, _PublishPayloadMixin, _OnDijitClickMixin], {
       
       /**
        * An array of the i18n files to use with this widget.
@@ -59,13 +56,6 @@ define(["dojo/_base/declare",
        * @default [{cssFile:"./css/Toggle.css"}]
        */
       cssRequirements: [{cssFile:"./css/Toggle.css"}],
-      
-      /**
-       * The HTML template to use for the widget.
-       * @instance
-       * @type {string}
-       */
-      templateString: template,
       
       /**
        * The label to show when the toggle is on
@@ -319,6 +309,53 @@ define(["dojo/_base/declare",
        * @since 1.0.86
        */
       toggleOffPublishPayloadItemMixin: false,
+
+      /**
+       * Overrides [the inherited function]{@link module:aikau/core/BaseWidget#createWidgetDom}
+       * to construct the DOM for the widget using native browser capabilities.
+       *
+       * @instance
+       * @since 1.0.101
+       */
+      createWidgetDom: function alfresco_renderers_Toggle__createWidgetDom() {
+         // jshint maxstatements:false
+         this.domNode = document.createElement("span");
+         this.domNode.classList.add("alfresco-renderers-Toggle");
+         this._attach(this.domNode, "ondijitclick", lang.hitch(this, this.onClick));
+
+         this.processingNode = document.createElement("span");
+         this.processingNode.classList.add("processing");
+         this.processingNode.classList.add(this.toggleClass);
+         this.processingNode.classList.add("hidden");
+
+         this.onNode = document.createElement("a");
+         this.onNode.classList.add("on");
+         this.onNode.classList.add(this.toggleClass);
+         this.onNode.classList.add("hidden");
+         this.onNode.setAttribute("title", this.onTooltip);
+         this.onNode.setAttribute("alt", this.onTooltip);
+         this.onNode.setAttribute("tabindex", "0");
+         this.onNode.textContent = this.onLabel;
+
+         this.offNode = document.createElement("a");
+         this.offNode.classList.add("off");
+         this.offNode.classList.add(this.toggleClass);
+         this.offNode.classList.add("hidden");
+         this.offNode.setAttribute("title", this.offTooltip);
+         this.offNode.setAttribute("alt", this.offTooltip);
+         this.offNode.setAttribute("tabindex", "0");
+         this.offNode.textContent = this.offLabel;
+
+         this.warningNode = document.createElement("span");
+         this.warningNode.classList.add("warning");
+         this.warningNode.classList.add(this.toggleClass);
+         this.warningNode.classList.add("hidden");
+
+         this.domNode.appendChild(this.processingNode);
+         this.domNode.appendChild(this.onNode);
+         this.domNode.appendChild(this.offNode);
+         this.domNode.appendChild(this.warningNode);
+      },
 
       /**
        * Set up the attributes to be used when rendering the template.

--- a/aikau/src/main/resources/alfresco/renderers/Toggle.js
+++ b/aikau/src/main/resources/alfresco/renderers/Toggle.js
@@ -332,6 +332,7 @@ define(["dojo/_base/declare",
          this.onNode.classList.add("on");
          this.onNode.classList.add(this.toggleClass);
          this.onNode.classList.add("hidden");
+         this.onNode.classList.add("enabled");
          this.onNode.setAttribute("title", this.onTooltip);
          this.onNode.setAttribute("alt", this.onTooltip);
          this.onNode.setAttribute("tabindex", "0");

--- a/aikau/src/test/resources/alfresco/renderers/MultiFavouriteTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/MultiFavouriteTest.js
@@ -30,7 +30,9 @@ define(["module",
       testPage: "/MultiFavourite",
 
       "Check that nothing is shown as a favourite on page load": function() {
-         return this.remote.findAllByCssSelector(".alfresco-renderers-Toggle .favourite.on.hidden")
+         return this.remote.getLastPublish("ALF_VIEW_RENDERING_COMPLETE")
+
+         .findAllByCssSelector(".alfresco-renderers-Toggle .favourite.on.hidden")
             .then(function(elements) {
                assert.lengthOf(elements, 6, "Unexpected number of unfavorited items");
             });

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Banner.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Banner.get.js
@@ -8,8 +8,7 @@ model.jsonModel = {
                all: true
             }
          }
-      },
-      "alfresco/services/ErrorReporter"
+      }
    ],
    widgets:[
       {
@@ -80,10 +79,7 @@ model.jsonModel = {
          }
       },
       {
-         name: "alfresco/logging/SubscriptionLog"
-      },
-      {
-         name: "aikauTesting/TestCoverageResults"
+         name: "alfresco/logging/DebugLog"
       }
    ]
 };


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1148 to update the renderers and list layout widgets to use the new BaseWidget module to create their DOM natively and to use the createChildren function provided by ChildProcessing where appropriate.