### PR TITLE
AKU-1156: Remove default for STH max analyzed chars

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SearchService.js
+++ b/aikau/src/main/resources/alfresco/services/SearchService.js
@@ -88,7 +88,7 @@ define(["dojo/_base/declare",
        * @default
        * @since 1.0.99
        */
-      highlightMaxAnalyzedChars: 500,
+      highlightMaxAnalyzedChars: null,
 
       /**
        * The number of characters to include in a highlight snippet.


### PR DESCRIPTION
This PR addresses https://issues.alfresco.com/jira/browse/AKU-1156 to remove the default configuration for max analyzed characters from the search term highlighting configuration.