### PR TITLE
Actually apply the editSiteDialog overrides

### DIFF
--- a/aikau/src/main/resources/alfresco/services/SiteService.js
+++ b/aikau/src/main/resources/alfresco/services/SiteService.js
@@ -216,6 +216,7 @@ define(["dojo/_base/declare",
          }
 
          this.applyWidgetOverrides(this.widgetsForCreateSiteDialog, this.widgetsForCreateSiteDialogOverrides);
+         this.applyWidgetOverrides(this.widgetsForEditSiteDialog, this.widgetsForEditSiteDialogOverrides);
       },
 
       /**


### PR DESCRIPTION
Based on the [last blog post on create and edit site customization](https://community.alfresco.com/community/ecm/blog/2016/11/23/create-and-edit-site-customization) I started to implement such customization for [Acosix/alfresco-site-hierarchy](https://github.com/Acosix/alfresco-site-hierarchy) for compatibility with 5.2 / 201612 GA. While the widgetsForCreateSiteDialogOverrides are applied the same call for widgetsForEditSiteDialogOverrides is missing.
This PR adds the missing 2nd call to applyWidgetOverrides.