### PR TITLE
Improve DebugLog data sanitation

### DIFF
--- a/aikau/src/main/resources/alfresco/logging/DebugLog.js
+++ b/aikau/src/main/resources/alfresco/logging/DebugLog.js
@@ -46,9 +46,11 @@ define(["alfresco/core/ObjectTypeUtils",
       "dojo/dom-class",
       "dojo/dom-construct",
       "dojo/on",
-      "dojo/text!./templates/DebugLog.html"
+      "dojo/text!./templates/DebugLog.html",
+      "dijit/_WidgetBase",
+      "alfresco/services/BaseService"
    ],
-   function(ObjectTypeUtils, SubscriptionLog, array, declare, lang, dateLocale, domClass, domConstruct, on, template) {
+   function(ObjectTypeUtils, SubscriptionLog, array, declare, lang, dateLocale, domClass, domConstruct, on, template, _WidgetBase, BaseService) {
       /*jshint devel:true*/
 
       return declare([SubscriptionLog], {
@@ -410,6 +412,11 @@ define(["alfresco/core/ObjectTypeUtils",
                      return makeSafe(unsafeChild, ancestors);
                   }));
 
+               } else if (unsafe === window) {
+
+                   // Ignore the global window object
+                   safeValue = "[window]";
+
                } else if (unsafe.nodeType === Node.ELEMENT_NODE) {
 
                   // Display information about which element this is
@@ -431,11 +438,18 @@ define(["alfresco/core/ObjectTypeUtils",
                   // Un-handled node type
                   safeValue = "[" + unsafe.nodeName + "]";
 
-               } else if (unsafe._attachPoints) {
+               } else if (typeof unsafe.isInstanceOf === 'function' && unsafe.isInstanceOf(_WidgetBase)) {
 
                   // Ignore widgets
-                  safeValue = "[widget]";
+                  safeValue = "[widget";
+                  safeValue += unsafe.id ? " id=" + unsafe.id + "]" : "]";
+                  
+               } else if (typeof unsafe.isInstanceOf === 'function' && unsafe.isInstanceOf(BaseService)) {
 
+                   // Ignore services
+                   safeValue = "[service";
+                   safeValue += unsafe.alfServiceName ? " alfServiceName=" + unsafe.alfServiceName + "]" : "]";
+                  
                } else if (ancestors.indexOf(unsafe) !== -1) {
 
                   // Recursion avoidance!


### PR DESCRIPTION
I am currently tracking down an issue with infinite scrolling on an AlfFilteredList in an Aikau-ified Surf component (not a hybrid or full page web script - in this case I am replacing the people-finder component in the page of that name via a sub-component) using the InfiniteScrollingService. During debugging I noticed that immediately after the initial page load and a single scroll action, the PubSubLog was extremely slow to open. Looking for ALF_EVENTS_SCROLL revealed that the payload published contains a reference to the window object which is currently not detected in the sanitation code. As a result, the entire window object and all the data accessible through it have been recursively processed. This even included data from localStorage, which - among other data - contained a very large script I recently executed via the JavaScript console.

This PR adds an extra check to avoid processing the window object. Additionally, this PR improves on the check for widget instances - the _attachPoints previously checked originate from the _AttachMixin that not all widgets may have mixed in (at PRODYNA I avoided that mixin due to the overhead it introduced in complex widget structures). Finally, I added a check for any services that may be reference in payload in a similar manner to the check for widget instances.

Apply these changes to my instance dramatically improved the "snappiness" of the PubSubLog after long durations of scroll testing.