### PR TITLE
AKU-1166: Add support for title on Property

### DIFF
--- a/aikau/src/main/resources/alfresco/renderers/Property.js
+++ b/aikau/src/main/resources/alfresco/renderers/Property.js
@@ -235,6 +235,17 @@ define(["dojo/_base/declare",
       renderSize: "medium",
 
       /**
+       * A title attribute to apply to the property to set an HTML title attribute on the outer
+       * element of the widget. The value will be displayed in a tooltip when hovered over.
+       * 
+       * @instance
+       * @type {string}
+       * @default
+       * @since 1.0.102
+       */
+      title: null,
+
+      /**
        * Indicates whether or not string values should be trimmed.
        *
        * @instance
@@ -320,6 +331,12 @@ define(["dojo/_base/declare",
          this.innerSpan.appendChild(labelSpan);
          this.innerSpan.appendChild(valueSpan);
          this.domNode.appendChild(this.innerSpan);
+
+         // See AKU-1166
+         if (this.title)
+         {
+            this.domNode.setAttribute("title", this.title);
+         }
       },
 
       /**

--- a/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
+++ b/aikau/src/test/resources/alfresco/renderers/PropertyTest.js
@@ -31,6 +31,11 @@ define(["module",
       name: "Property Tests",
       testPage: "/Property",
 
+      // See AKU-1166
+      "Title attribute is added": function() {
+         return this.remote.findByCssSelector("#BASIC_ITEM_0[title]");
+      },
+
       "Check standard property is rendered correctly": function() {
          return this.remote
             .findByCssSelector("#BASIC_ITEM_0 .value")

--- a/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Property.get.js
+++ b/aikau/src/test/resources/testApp/WEB-INF/classes/alfresco/site-webscripts/alfresco/renderers/Property.get.js
@@ -38,7 +38,8 @@ model.jsonModel = {
                                     name: "alfresco/renderers/Property",
                                     config: {
                                        propertyToRender: "name",
-                                       renderedValueClass: "one two"
+                                       renderedValueClass: "one two",
+                                       title: "Seen on hover"
                                     }
                                  },
                                  {


### PR DESCRIPTION
This addresses https://issues.alfresco.com/jira/browse/AKU-1166 to add support for a "title" attribute on the Property widget. The unit tests have been updated to verify this and prevent future regressions.