### PR TITLE
Make hard-coded topics for sort requests / field selection configurable

### DIFF
--- a/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
+++ b/aikau/src/main/resources/alfresco/documentlibrary/_AlfDocumentListTopicMixin.js
@@ -225,7 +225,7 @@ define(["dojo/_base/declare",
       sortRequestTopic: topics.SORT_LIST,
       
       /**
-       * @event
+       * @event sortFieldSelectionTopic
        * @instance
        * @type {string} 
        * @default [UPDATE_LIST_SORT_FIELD]{@link module:alfresco/core/topics#UPDATE_LIST_SORT_FIELD}

--- a/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
+++ b/aikau/src/main/resources/alfresco/lists/AlfSortablePaginatedList.js
@@ -53,7 +53,7 @@
  * [sortAscending]{@link module:alfresco/lists/AlfSortablePaginatedList#sortAscending} to true
  * or false as appropriate. The sort field and direction can be changed by 
  * widgets (such as menus or buttons) publishing on the
- * ["ALF_DOCLIST_SORT"]{@link module:alfresco/core/topics~SORT_LIST} topic.</p>
+ * [sortRequestTopic]{@link module:alfresco/lists/AlfSortablePaginatedList#sortRequestTopic} topic.</p>
  *
  * @example <caption>AlfSortablePaginatedList with associated sort and pagination widgets</caption>
  * {
@@ -185,6 +185,15 @@ define(["dojo/_base/declare",
        * @since 1.0.73
        */
       sortFieldLabel: "",
+      
+      /**
+       * @event sortRequestTopic
+       * @instance
+       * @type {string}
+       * @default [SORT_LIST]{@link module:alfresco/core/topics#SORT_LIST}
+       * @since 1.0.102
+       */
+      sortRequestTopic: topics.SORT_LIST,
 
       /**
        * Extends the [inherited function]{@link module:alfresco/lists/AlfList#showView} to set the sort data for
@@ -193,14 +202,14 @@ define(["dojo/_base/declare",
        * 
        * @instance
        * @since 1.0.59
-       * @fires module:alfresco/core/topics#SORT_LIST
+       * @fires module:alfresco/lists//AlfSortablePaginatedList#sortRequestTopic
        */
       showView: function alfresco_lists_AlfSortablePaginatedList__showView() {
          this.inherited(arguments);
          if (!this.useHash)
          {
             this.alfLog("info", "Really should publish sort data");
-            this.alfPublish(topics.SORT_LIST, {
+            this.alfPublish(this.sortRequestTopic, {
                direction: (this.sortAscending) ? "ascending" : "descending",
                value: this.sortField,
                label: this.sortFieldLabel,

--- a/aikau/src/main/resources/alfresco/lists/SortFieldSelect.js
+++ b/aikau/src/main/resources/alfresco/lists/SortFieldSelect.js
@@ -101,7 +101,7 @@ define(["dojo/_base/declare",
                      label: label,
                      value: option.value,
                      group: "ALF_SORT_FIELD_SELECTION_GROUP",
-                     publishTopic: topics.UPDATE_LIST_SORT_FIELD,
+                     publishTopic: this.selectionTopic,
                      checked: option.selected || false,
                      publishPayload: {
                         label: label,

--- a/aikau/src/main/resources/alfresco/lists/SortOrderToggle.js
+++ b/aikau/src/main/resources/alfresco/lists/SortOrderToggle.js
@@ -78,36 +78,41 @@ define(["dojo/_base/declare",
        * @default
        */
       subscriptionTopic: topics.SORT_LIST,
-      
+
       /**
-       * Overrides and explicitly sets the [onConfig]{@link module:alfresco/menus/AlfMenuBarToggle#onConfig}
-       * for sorting.
-       * 
+       * Extends the [inherited function]{@link module:alfresco/menus/AlfMenuBarToggle#postMixInProperties}
+       * to set the proper default [onConfig]{@link module:alfresco/menus/AlfMenuBarToggle#onConfig} and
+       * [offConfig]{@link module:alfresco/menus/AlfMenuBarToggle#offConfig} values unless externally configured.
+       *
        * @instance
-       * @type {object}
-       * @default
+       * @since 1.0.102
        */
-      onConfig: {
-         iconClass: "alf-sort-ascending-icon",
-         publishTopic: topics.SORT_LIST,
-         publishPayload: {
-            direction: "ascending"
+      postMixInProperties : function alfresco_lists_SortOrderToggle__postMixInProperties() {
+         this.inherited(arguments);
+
+         // update default value (if not overridden via configuration) to our defaults
+         // must be done in postMixInProperties instead of overriding property due to
+         // dependency on subscriptionTopic which may have been configured
+         if (this.onConfig === null || this.onConfig.label === "default.on.label")
+         {
+            this.onConfig = {
+               iconClass: "alf-sort-ascending-icon",
+               publishTopic: this.subscriptionTopic,
+               publishPayload: {
+                  direction: "ascending"
+               }
+            };
          }
-      },
-      
-      /**
-       * Overrides and explicitly sets the [offConfig]{@link module:alfresco/menus/AlfMenuBarToggle#offConfig}
-       * for sorting.
-       * 
-       * @instance
-       * @type {object}
-       * @default
-       */
-      offConfig: {
-         iconClass: "alf-sort-descending-icon",
-         publishTopic: topics.SORT_LIST,
-         publishPayload: {
-            direction: "descending"
+         
+         if (this.offConfig === null || this.offConfig.label === "default.off.label")
+         {
+            this.offConfig = {
+               iconClass: "alf-sort-descending-icon",
+               publishTopic: this.subscriptionTopic,
+               publishPayload: {
+                  direction: "descending"
+               }
+            };
          }
       }
    });

--- a/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
+++ b/aikau/src/main/resources/alfresco/lists/views/layouts/HeaderCell.js
@@ -73,6 +73,24 @@ define(["dojo/_base/declare",
       sortable: false,
 
       /**
+       * @event sortRequestTopic
+       * @instance
+       * @type {string}
+       * @default [SORT_LIST]{@link module:alfresco/core/topics#SORT_LIST}
+       * @since 1.0.102
+       */
+      sortRequestTopic: topics.SORT_LIST,
+
+      /**
+       * @event sortFieldSelectionTopic
+       * @instance
+       * @type {string}
+       * @default [UPDATE_LIST_SORT_FIELD]{@link module:alfresco/core/topics#UPDATE_LIST_SORT_FIELD}
+       * @since 1.0.102
+       */
+      sortFieldSelectionTopic: topics.UPDATE_LIST_SORT_FIELD,
+
+      /**
        * Optional alt text for the sort ascending icon. An optional {0} token can be provided to
        * insert the [label]{@link module:alfresco/lists/views/layouts/HeaderCell#label}
        *
@@ -208,8 +226,8 @@ define(["dojo/_base/declare",
        * Calls [processWidgets]{@link module:alfresco/core/Core#processWidgets}
        * 
        * @instance postCreate
-       * @listens module:alfresco/core/topics#SORT_LIST
-       * @listens module:alfresco/core/topics#UPDATE_LIST_SORT_FIELD
+       * @listens module:alfresco/lists/views/layouts/HeaderCell#sortRequestTopic
+       * @listens module:alfresco/lists/views/layouts/HeaderCell#sortFieldSelectionTopic
        */
       postCreate: function alfresco_lists_views_layouts_HeaderCell__postCreate() {
          if (this.useHash && this.sortable)
@@ -222,8 +240,8 @@ define(["dojo/_base/declare",
             }
          }
 
-         this.alfSubscribe(topics.SORT_LIST, lang.hitch(this, this.onExternalSortRequest));
-         this.alfSubscribe(topics.UPDATE_LIST_SORT_FIELD, lang.hitch(this, this.onExternalSortRequest));
+         this.alfSubscribe(this.sortRequestTopic, lang.hitch(this, this.onExternalSortRequest));
+         this.alfSubscribe(this.sortFieldSelectionTopic, lang.hitch(this, this.onExternalSortRequest));
 
          domAttr.set(this.ascendingSortNode, "alt", this.sortAscAlt ? this.sortAscAlt : "");
          domAttr.set(this.descendingSortNode, "alt", this.sortDescAlt ? this.sortDescAlt : "");
@@ -298,10 +316,10 @@ define(["dojo/_base/declare",
 
       /**
        * @instance
-       * @fires module:alfresco/core/topics#SORT_LIST
+       * @fires module:alfresco/lists/views/layouts/HeaderCell#sortRequestTopic
        */
       publishSortRequest: function alfresco_lists_views_layouts_HeaderCell__publishSortRequest() {
-         this.alfPublish(topics.SORT_LIST, {
+         this.alfPublish(this.sortRequestTopic, {
             direction: (this.sortedAscending) ? "ascending" : "descending",
             value: this.sortValue,
             requester: this,


### PR DESCRIPTION
Resolves #1352

This PR addresses the points I reported in #1352. I have update all relevant references to topics.SORT_LIST to use an instance-configurable property instead which is by default initialised to the value of the topic constant, thus keeping backwards compatibility. In one instance I also corrected an incorrect use of the topics.UPDATE_LIST_SORT_FIELD constant when a relevant instance-level property already existed. For the SortOrderToggle module I had to move the ```onConfig```/```offConfig``` default override into a new ```postMixInProperties``` to deal with the configurable ```selectionTopic``` so users of this module are not forced to override/configure those two properties just because they configured a different ```selectionTopic```.