### PR TITLE
AKU-1170: Change popup menu item image role from "presentation" to "button"

### DIFF
--- a/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
+++ b/aikau/src/main/resources/alfresco/menus/AlfMenuBarPopup.js
@@ -134,7 +134,7 @@ define(["dojo/_base/declare",
                src: (this.iconSrc ? this.iconSrc : require.toUrl("alfresco/menus/css/images/transparent-20.png")),
                title: this.message(this.iconAltText),
                alt: this.message(this.iconAltText),
-               role: "presentation"
+               role: "button"
             }, this.focusNode, "first");
             if (this.label)
             {


### PR DESCRIPTION
This fixes https://issues.alfresco.com/jira/browse/AKU-1170