### PR TITLE
RM-6273: Fix DateTextBox to use Alfresco dateFormat mask

### DIFF
--- a/aikau/src/main/resources/alfresco/core/TemporalUtils.js
+++ b/aikau/src/main/resources/alfresco/core/TemporalUtils.js
@@ -19,7 +19,7 @@
 
 /**
  * This is a mixin that provides time and date related utility functions.
- * 
+ *
  * @module alfresco/core/TemporalUtils
  * @mixes module:alfresco/core/Core
  * @author Richard Smith
@@ -28,16 +28,16 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "alfresco/core/Core",
         "dojo/date/stamp",
-        "dojo/query"], 
+        "dojo/query"],
         function(declare, lang, AlfCore, stamp, query) {
-    
+
    var cachedDateFormatsByI18nScope = {};
 
    return declare([AlfCore], {
 
       /**
        * An array of the i18n files to use with this widget.
-       * 
+       *
        * @instance
        * @type {object[]}
        * @default [{i18nFile: "./i18n/TemporalUtils.properties"}]
@@ -46,13 +46,13 @@ define(["dojo/_base/declare",
 
       /**
        * Constructor
-       * 
+       *
        * @param {object} config Config to mixin
        */
       constructor: function alfresco_core_TemporalUtils__constructor(config) {
 
          lang.mixin(this, config);
-         
+
          // check already resolved dateFormats before doing
          var lookupKey = this.i18nScope || "default";
          if (cachedDateFormatsByI18nScope.hasOwnProperty(lookupKey))
@@ -84,7 +84,7 @@ define(["dojo/_base/declare",
                 dayNames: this.dateFormats.DAY_NAMES,
                 monthNames: this.dateFormats.MONTH_NAMES
              };
-             
+
              // cache
              cachedDateFormatsByI18nScope[lookupKey] = JSON.stringify(this.dateFormats);
          }
@@ -95,7 +95,8 @@ define(["dojo/_base/declare",
        *
        * @instance
        * @param {Date|String} from JavaScript Date object or ISO8601-formatted date string
-       * @param {Date|String} [to] JavaScript Date object or ISO8601-formatted date string, defaults to now if not supplied
+       * @param {Date|String} [to] JavaScript Date object or ISO8601-formatted date string, defaults to now if not
+       *    supplied
        * @return {String} Relative time description
        */
       getRelativeTime: function alfresco_core_TemporalUtils__getRelativeTime(from, to) {
@@ -256,7 +257,7 @@ define(["dojo/_base/declare",
        *    With code by Scott Trenda (Z and o flags, and enhanced brevity)
        *
        * http://blog.stevenlevithan.com/archives/date-time-format
-       * 
+       *
        * @instance
        * @return {String}
        */
@@ -271,7 +272,7 @@ define(["dojo/_base/declare",
           */
          var _this = this,
              dateFormat = (function() {
-            
+
             var token        = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloZ]|"[^"]*"|'[^']*'/g,
                 timezone     = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,
                 timezoneClip = /[^-+\dA-Z]/g,
@@ -420,7 +421,28 @@ define(["dojo/_base/declare",
          query("span.relativeTime", id).forEach(function(node){
             node.innerHTML = this.getRelativeTime(node.innerHTML);
          });
-      }
+      },
 
+      /**
+       * Return the Unicode compatible date formatting mask
+       *
+       * Converts from the mask format Alfresco uses (see this.formatDate3rd) to the Unicode compatible one Dojo uses
+       * see http://cldr.unicode.org/translation/date-time-patterns
+       *
+       * Limitations: only does dates. Time format conversion is harder as handling of AM/PM & timezones differ.
+       */
+      getUnicodeDateMask: function alfresco_core_TemporalUtils__getUnicodeDateMask(mask) {
+         var unicodeMask = mask;
+         // minutes and months have swapped.
+         unicodeMask = unicodeMask.replace("m", "M");
+         // Full day of the week name
+         unicodeMask = unicodeMask.replace("dddd", "EEEE");
+         // Three letter day of the week abbreviation
+         unicodeMask = unicodeMask.replace("ddd", "EEE");
+
+         this.alfLog("info", "TemporalUtils.getUnicodeDateMask converted from: " + mask + " to: " + unicodeMask);
+
+         return unicodeMask;
+      }
    });
 });

--- a/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
+++ b/aikau/src/main/resources/alfresco/forms/controls/DateTextBox.js
@@ -43,9 +43,11 @@ define(["dojo/_base/declare",
         "dojo/date/stamp",
         "dijit/form/DateTextBox",
         "dojo/dom-class",
-        "alfresco/core/ObjectTypeUtils"],
-        function(declare, BaseFormControl, TextBoxValueChangeMixin, lang, stamp, DateTextBox, domClass, ObjectTypeUtils) {
-   return declare([BaseFormControl, TextBoxValueChangeMixin], {
+        "alfresco/core/ObjectTypeUtils",
+        "alfresco/core/TemporalUtils"],
+        function(declare, BaseFormControl, TextBoxValueChangeMixin, lang, stamp, DateTextBox, domClass, ObjectTypeUtils,
+                 TemporalUtils) {
+   return declare([BaseFormControl, TextBoxValueChangeMixin, TemporalUtils], {
 
       /**
        * The value to return when no date has been selected. By default this will return null, however some
@@ -175,6 +177,14 @@ define(["dojo/_base/declare",
        */
       createFormControl: function alfresco_forms_controls_DateTextBox__createFormControl(config) {
          domClass.add(this.domNode, "alfresco-forms-controls-DateTextBox");
+
+         // Explicitly set datePattern to ensure dates rendered here match dates rendered elsewhere in Alfresco
+         // Use the Unicode compatible date pattern as they differ slightly to Alfresco's dateFormat masks
+         var datePattern = this.getUnicodeDateMask(this.dateFormats.masks.shortDate);
+         config.constraints = {
+            datePattern: datePattern
+         };
+
          var dateTextBox = new DateTextBox(config);
          dateTextBox.validate = lang.hitch(this, function(){
             setTimeout(lang.hitch(this, this.validate), 0);


### PR DESCRIPTION
DateTextBox was displaying dates differently depending on user's browser's locale settings (as per default Dojo config) - I've changed it so it now uses the standard Alfresco date formatting strings (respecting our locale behaviour).

I've also had to add an extra temporalUtil method to convert between the Dojo date format and the Alfresco one. See comments for details.