### PR TITLE
Fix not to escape html of copyrightLabel

### DIFF
--- a/aikau/src/main/resources/alfresco/footer/templates/AlfShareFooter.html
+++ b/aikau/src/main/resources/alfresco/footer/templates/AlfShareFooter.html
@@ -4,6 +4,6 @@
          <img src="${logoImageSrc}" alt="${altText}" border="0"/>
       </a>
       <span class="licenseHolder" data-dojo-attach-point="licenseHolderNode">${licensedToLabel} ${licenseLabel}<br></span>
-      <span>${copyrightLabel}</span>
+      <span>${!copyrightLabel}</span>
    </span>
 </div>


### PR DESCRIPTION

![footer](https://user-images.githubusercontent.com/170831/101610925-35d4dc00-3a4c-11eb-8295-a5d61e256437.png)
Share search page shows escaped html in footer.
copyrightLabel that defined in properties has html tags.